### PR TITLE
BZ-9976: feat: export Table component and its properties from svelte-…

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,6 +17,7 @@ export { default as Banner } from './Banner/Banner.svelte';
 export { default as Toggle } from './Toggle/Toggle.svelte';
 export { default as Accordion } from './Accordion/Accordion.svelte';
 export { default as CheckListItem } from './CheckListItem/CheckListItem.svelte';
+export { default as Table } from './Table/Table.svelte';
 
 export type { ButtonProperties } from './Button/properties';
 export type { ModalProperties, ModalAlign, ModalSize } from './Modal/properties';
@@ -35,6 +36,7 @@ export type { ToolbarProperties } from './Toolbar/properties';
 export type { CarouselProperties } from './Carousel/properties';
 export type { BadgeProperties } from './Badge/properties';
 export type { BannerProperties } from './Banner/properties';
+export type { TableProperties } from './Table/properties';
 
 export { defaultIconProperties } from './Icon/properties';
 export { defaultButtonProperties } from './Button/properties';

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Welcome to your library project' })).toBeVisible();
 });


### PR DESCRIPTION
BZ-9976: feat: export Table component and its properties from svelte
   - updated index.ts to export Table and its properties
   - updated tests/test.ts to expect for "Welcome to your library project" instead of "Welcome to SvelteKit" as heading