### PR TITLE
BZ-20236: refactor: Set leftIcon property of the Select component nullable by default

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -14,11 +14,7 @@
     selectedItemLabel: null,
     showSelectedItemInDropdown: false,
     selectMultipleItems: false,
-    leftIcon: {
-      src: '',
-      alt: '',
-      fallback: null
-    }
+    leftIcon: null
   };
 
   const applyButtonProps: ButtonProperties = {
@@ -144,7 +140,7 @@
       role="button"
       tabindex="0"
     >
-      {#if properties.leftIcon !== null && properties.leftIcon.src !== ''}
+      {#if properties.leftIcon !== null}
         <div class="icon-container">
           <Img {...properties.leftIcon} />
         </div>


### PR DESCRIPTION
- Set leftIcon property of Select component to be `null` by default.
- This change ensures uniformity in the default values across the codebase, promoting code readability and maintainability.
- Dev proofs:
<img width="235" alt="Screenshot 2024-05-07 at 1 39 20 PM" src="https://github.com/juspay/svelte-ui-components/assets/167853238/5d74fc7a-4670-4c8a-89c5-6f849450769e">
<img width="225" alt="Screenshot 2024-05-07 at 1 39 38 PM" src="https://github.com/juspay/svelte-ui-components/assets/167853238/72fb1392-1d12-4bd4-a97b-e40e92fc5778">

