### PR TITLE
BZ-21221: feat: svelte ui component dropdown multiple selection

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -55,13 +55,21 @@
       : item !== properties.selectedItem
   );
 
+  function isSelected(selectedItem: string | string[], item: string) {
+    if (Array.isArray(selectedItem)) {
+      return selectedItem.includes(item);
+    } else {
+      return selectedItem.trim() === item.trim();
+    }
+  }
+
   function selectItem(item: string) {
     if (
       properties.selectMultipleItems &&
       Array.isArray(properties.selectedItemLabel) &&
       Array.isArray(properties.selectedItem)
     ) {
-      if (properties.selectedItem.includes(item)) {
+      if (isSelected(properties.selectedItem, item)) {
         properties.selectedItem = properties.selectedItem.filter(
           (selectedItem) => selectedItem !== item
         );
@@ -192,7 +200,7 @@
             on:click={() => {
               selectItem(item);
             }}
-            class="item {properties.selectedItem.includes(item) ? 'selected item-selected' : ''}"
+            class="item {isSelected(properties.selectedItem, item) ? 'selected item-selected' : ''}"
             role="button"
             tabindex="0"
           >


### PR DESCRIPTION
- added a function to handle selected state and behave accordingly to string or array of string
- why?
   - Select component is having multiple selected items because of includes.
- Solution?
   - added a function to handle selected state and behave accordingly to string or array of string
- What to test?
   - test the select component
   
 When setting item or list of items as selected instead of using includes, A function is written to string match after trimming for single item and use includes for list of items.
 These will impact the project in following ways:-

1. Instead of using includes for single items comparison we use string match because if selected item is XYZAB and we check for XYZ behavior was `XYZ` also gets selected which should not be done. (Fixed using the new function)
2.  For the list of items the same behavior of includes is being followed

   
Dev Proofs:-
https://drive.google.com/file/d/1X5jkKWAXpw7NnONBN6bv_HUIAWZCgdEr/view?usp=sharing