### PR TITLE
BZ-21738: feat: Input button inside select component

### DIFF
--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -244,6 +244,7 @@
   .input-container {
     display: flex;
     flex-direction: column;
+    margin: var(--input-container-margin);
   }
 
   .label {

--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -28,6 +28,12 @@
     dispatch('leftButtonClick');
   }
 
+  function bottomButtonClick(): void {
+    if (state === 'Valid') {
+      dispatch('bottomButtonClick', { value: properties.inputProperties.value });
+    }
+  }
+
   function triggerRightClickIfValid(event: KeyboardEvent): void {
     if (event?.key === 'Enter') {
       rightButtonClick();
@@ -73,6 +79,11 @@
       </div>
     {/if}
   </div>
+  {#if properties.bottomButtonProperties != null}
+    <div class="bottom-button">
+      <Button properties={properties.bottomButtonProperties} on:click={bottomButtonClick} />
+    </div>
+  {/if}
 </div>
 {#if properties.inputProperties.message.onError !== '' && state === 'Invalid'}
   <div class="error-message">
@@ -116,6 +127,20 @@
     flex: 1;
     min-width: 0px;
     --button-height: 54px;
+  }
+
+  .bottom-button {
+    padding: var(--input-bottom-btn-padding, 10px 0px);
+    --cursor: var(--bottom-button-cursor);
+    --button-color: var(--bottom-button-color);
+    --button-text-color: var(--bottom-button-text-color);
+    --button-font-family: var(--bottom-button-font-family);
+    --button-font-weight: var(--bottom-button-font-weight);
+    --button-font-size: var(--bottom-button-font-size);
+    --button-height: var(--bottom-button-height, 54px);
+    --button-padding: var(--bottom-button-padding);
+    --button-border-radius: var(--bottom-button-border-radius);
+    --button-width: var(--bottom-button-width);
   }
 
   .label {

--- a/src/lib/InputButton/properties.ts
+++ b/src/lib/InputButton/properties.ts
@@ -6,6 +6,7 @@ export type InputButtonProperties = {
   inputProperties: InputProperties;
   rightButtonProperties: ButtonProperties | null;
   leftButtonProperties: ButtonProperties | null;
+  bottomButtonProperties: ButtonProperties | null;
 };
 
 const inputProperties: InputProperties = {
@@ -24,5 +25,6 @@ const rightButtonProperties: ButtonProperties = {
 export const defaultInputButtonProperties: InputButtonProperties = {
   inputProperties,
   rightButtonProperties,
-  leftButtonProperties: null
+  leftButtonProperties: null,
+  bottomButtonProperties: null
 };

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -4,6 +4,7 @@
   import type { ButtonProperties } from '$lib/Button/properties';
   import Img from '$lib/Img/Img.svelte';
   import Button from '$lib/Button/Button.svelte';
+  import { InputButton, defaultInputButtonProperties } from '$lib';
 
   let selectedElementDiv: HTMLDivElement | null = null;
 
@@ -47,6 +48,7 @@
   };
 
   let isSelectOpen = false;
+  let isInput = false;
   const dispatch = createEventDispatcher();
 
   $: nonSelectedItems = properties.allItems.filter((item) =>
@@ -74,6 +76,7 @@
       }
     } else {
       properties.selectedItem = [item];
+      properties.selectedItemLabel=[item];
     }
     if (!properties.selectMultipleItems) {
       toggleSelect();
@@ -107,15 +110,31 @@
       const isApplyButtonClicked = clickedElement.classList.contains('apply-btn');
       const isClearAllButtonClicked = clickedElement.innerText === 'Clear All';
       const isSelectAllButtonClicked = clickedElement.innerText === 'Select All';
+      const isInputSelected = properties.addInputButton && isInput;
       if (
         !isItemClicked &&
         !isApplyButtonClicked &&
         !isClearAllButtonClicked &&
-        !isSelectAllButtonClicked
+        !isSelectAllButtonClicked &&
+        isInputSelected
       ) {
         isSelectOpen = false;
       }
     }
+  }
+
+  function handleSelectInput(event: CustomEvent) {
+    if(event && event.detail) {
+      properties.selectedItem=event.detail.value;
+      properties.selectedItemLabel=event.detail.value;
+    }
+    dispatch('selectInput', event.detail.value);
+    isInput = false;
+    isSelectOpen = false;
+  }
+
+  function toggleIsInput() {
+    isInput = true;
   }
 
   onMount(() => {
@@ -200,6 +219,11 @@
           </div>
         {/each}
       </div>
+      {#if properties.addInputButton && properties.addInputButtonProps}
+        <div class="input-button">
+          <InputButton properties = {{...defaultInputButtonProperties, rightButtonProperties: null, bottomButtonProperties: properties.addInputButtonProps}} on:input={toggleIsInput} on:bottomButtonClick={handleSelectInput}/>
+        </div>
+      {/if}
     </div>
   </div>
 {/if}
@@ -226,6 +250,7 @@
     color: var(--select-color);
     --button-margin: 1px;
     --button-border-radius: 2px;
+    --input-button-margin: 10px;
   }
 
   .select:hover {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -1,3 +1,4 @@
+import type { ButtonProperties } from '$lib/Button/properties';
 import type { ImgProps } from '$lib/Img/properties';
 export type SelectProperties = {
   placeholder: string;
@@ -10,4 +11,6 @@ export type SelectProperties = {
   hideDropDownIcon?: boolean;
   dropDownIcon?: string;
   leftIcon: ImgProps | null;
+  addInputButton?: boolean;
+  addInputButtonProps?: ButtonProperties;
 };


### PR DESCRIPTION
Changelog
- added bottom button in InputButton component
- added InputButton component inside Select component
- added optional props to add InputButton in Select component props

Why?
- Need input in Select for use case in shipping dashboard where the user can either select an option from the list or enter their own value (eg. for paymentMethodGroupId dropdown)

Testing
- Existing inputButton functionality is unaffected in Nimble and LH
- Select component functionality is unaffected in LH (not used in Nimble)
- On enabling inputButtonProps user is able to enter their values 

Dev proof
- https://drive.google.com/file/d/1edPtYJqwWh7H61nocudAE5lHlXJvs7-4/view?usp=sharing


