### PR TITLE
BZ-24962: feat: Add support for reordering elements within button component

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -31,17 +31,13 @@
     disabled={!(properties.enable && !properties.showLoader)}
     type={properties.type}
   >
-    <div>
       {#if properties.showLoader && properties.loaderType === 'Circular'}
-        <Loader />
+        <div class="button-loader"><Loader /></div>
       {/if}
-    </div>
-    <div>
       {#if $$slots.icon}
-      <slot name="icon" />
+      <div class="button-icon"><slot name="icon" /></div>
     {/if}
-    {properties.text}
-    </div>
+    <div class="button-text">{properties.text}</div>
   </button>
 </div>
 
@@ -72,6 +68,18 @@
     flex-direction: var(--button-content-flex-direction, row);;
     gap: var(--button-content-gap, 16px);
     visibility: var(--button-visibility, visible);
+  }
+
+  .button-loader {
+    order: var(--button-loader-order, 1);
+  }
+
+  .button-icon {
+    order: var(--button-icon-order, 2);
+  }
+
+  .button-text {
+    order: var(--button-text-order, 3);
   }
 
   button:hover {


### PR DESCRIPTION
- Introduced CSS variables to control the order property of .button-loader, .button-icon, and .button-text classes in Button.svelte.
- The default order values are 1, 2, and 3 respectively. This change allows for more flexible customization of the order of these elements.