### PR TITLE
BZ-25871: fix: add support for selected item padding separately

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -141,7 +141,7 @@
   });
 </script>
 
-{#if properties.label !== null}
+{#if properties.label !== null && properties.label !== ''}
   <label class="label-container" for={properties.label}>
     {properties.label}
   </label>
@@ -295,7 +295,8 @@
     white-space: var(--selected-item-white-space, nowrap);
     overflow: var(--selected-item-overflow, hidden);
     text-overflow: var(--selected-item-text-overflow, ellipsis);
-    max-width: var(--selected-item-max-widhh, 100%);
+    max-width: var(--selected-item-max-width, 100%);
+    padding: var(--selected-item-padding, var(--item-padding, 8px 16px));
   }
 
   .selected-content {


### PR DESCRIPTION
- added support to provide padding separately to selected item.
- select label will not take extra space if empty string is provide in label.
<img width="226" alt="Screenshot 2024-06-25 at 5 56 24 PM" src="https://github.com/juspay/svelte-ui-components/assets/82926719/1bb2ff23-6ec4-48a5-90da-bd32001d48db">