### PR TITLE
Fix: Disable button text if text is empty or null

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -37,7 +37,9 @@
     {#if $$slots.icon}
       <div class="button-icon"><slot name="icon" /></div>
     {/if}
-    <div class="button-text">{properties.text}</div>
+    {#if properties.text !== null && properties.text.length > 0}
+      <div class="button-text">{properties.text}</div>
+    {/if}
   </button>
 </div>
 


### PR DESCRIPTION
Added a condition to check if the button text is empty or null, ensuring it will only be displayed when non-empty. Thereby, improving the UI by avoiding unnecessary empty elements from being rendered.