### PR TITLE
BZ:39623 added slots in svelte images

### DIFF
--- a/src/lib/Badge/Badge.svelte
+++ b/src/lib/Badge/Badge.svelte
@@ -7,7 +7,9 @@
 {#if properties !== null}
   <div class="badge-icon">
     <div class="badge-wrap">
-      <img class="icon-img" src={properties.image} alt="" />
+      <slot name='badge-icon-slot'>
+        <img class="icon-img" src={properties.image} alt="" />
+      </slot>
       <div class="badge">{properties.value}</div>
     </div>
   </div>

--- a/src/lib/Banner/Banner.svelte
+++ b/src/lib/Banner/Banner.svelte
@@ -8,7 +8,9 @@
   <div class="banner" on:click on:keydown role="button" tabindex="0">
     {#if properties.icon !== null}
       <div class="banner-image">
-        <img src={properties.icon} alt="" />
+        <slot name="banner-image-slot">
+          <img src={properties.icon} alt="" />
+        </slot>
       </div>
     {/if}
     <div class="banner-text">

--- a/src/lib/BrandLoader/BrandLoader.svelte
+++ b/src/lib/BrandLoader/BrandLoader.svelte
@@ -13,7 +13,9 @@
 
 <div class="background">
   <div class="loader">
-    <img src={properties.brandLogoURL} alt="" />
+    <slot name='brand-loader-icon-slot'>
+      <img src={properties.brandLogoURL} alt="" />
+    </slot>
     <div class="text">{properties.brandText}</div>
     {#if properties.subText}
       <div class="sub-text">{properties.subText}</div>

--- a/src/lib/GridItem/GridItem.svelte
+++ b/src/lib/GridItem/GridItem.svelte
@@ -16,11 +16,15 @@
 
 <div class="container" on:click={onClick} on:keydown role="button" tabindex="0">
   <div class="grid-header">
-    <img src={headerIcon} alt="" class="grid-item-header-icon" />
+    <slot name="grid-header-icon-slot">
+      <img src={headerIcon} alt="" class="grid-item-header-icon" />
+    </slot>
   </div>
   <div class:grid-body-loader={showLoader}>
     <div class="grid-item-body">
-      <img src={icon} alt="" class="grid-item-icon" />
+      <slot name="grid-body-icon-slot">
+        <img src={icon} alt="" class="grid-item-icon" />
+      </slot>
     </div>
   </div>
   <div class="grid-item-footer">{text}</div>

--- a/src/lib/Icon/Icon.svelte
+++ b/src/lib/Icon/Icon.svelte
@@ -6,7 +6,9 @@
 </script>
 
 <div class="icon-container" on:click on:keydown role="button" tabindex="0">
-  <img src={properties.icon} alt="" />
+  <slot name='icon-container-slot'>
+    <img src={properties.icon} alt="" />
+  </slot>
   {#if properties.text !== ''}
     <div class="icon-text">{properties.text}</div>
   {/if}

--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -11,7 +11,9 @@
 </script>
 
 {#if typeof src === 'string' && typeof alt === 'string'}
-  <img {src} {alt} on:error|once={handleFallback} />
+  <slot name='image-slot'>
+    <img {src} {alt} on:error|once={handleFallback} />
+  </slot>
 {/if}
 
 <style>

--- a/src/lib/ListItem/ListItem.svelte
+++ b/src/lib/ListItem/ListItem.svelte
@@ -105,7 +105,9 @@
               role="button"
               tabindex="0"
             >
+            <slot name='right-img-icon'>
               <img class="right-img" src={properties.rightImageUrl} alt="" />
+            </slot>
             </div>
           {/if}
           {#if showRightContentLoader}

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -96,7 +96,9 @@
             <div class="header">
               {#if properties.header.leftImage}
                 <div on:click={handleLeftImageClick} on:keydown role="button" tabindex="0">
-                  <img class="header-left-img" src={properties.header.leftImage} alt="" />
+                  <slot name="header-left-img-slot">
+                    <img class="header-left-img" src={properties.header.leftImage} alt="" />
+                  </slot>
                 </div>
               {/if}
               {#if properties.header.text}
@@ -106,7 +108,9 @@
               {/if}
               {#if properties.header.rightImage}
                 <div role="button" tabindex="0" on:click={handleRightImageClick} on:keydown>
-                  <img class="header-right-img" src={properties.header.rightImage} alt="" />
+                  <slot name="header-right-img-slot">
+                    <img class="header-right-img" src={properties.header.rightImage} alt="" />
+                  </slot>
                 </div>
               {/if}
             </div>

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -187,11 +187,13 @@
         </div>
       {/if}
       {#if !properties.hideDropDownIcon}
-        <img
-          src={dropDownIcon}
-          alt={dropDownIconAlt}
-          class="arrow {isSelectOpen ? 'active' : ''}"
-        />
+        <slot name="dropdown-icon-slot">
+          <img
+            src={dropDownIcon}
+            alt={dropDownIconAlt}
+            class="arrow {isSelectOpen ? 'active' : ''}"
+          />
+        </slot>
       {/if}
     </div>
     <div
@@ -271,6 +273,7 @@
   }
 
   .select:hover {
+    color: var(--select-hover-color, #000);
     background-color: var(--select-hover-bgcolor, #ffffff);
   }
 

--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -21,7 +21,11 @@
 
 <div class="background">
   <div class="order-status">
-    <div class="status-image"><img src={properties.statusIcon} alt="status" /></div>
+    <div class="status-image">
+      <slot namme="status-image-slot">
+        <img src={properties.statusIcon} alt="status" />
+      </slot>
+    </div>
     <div class="status-text">{properties.statusText}</div>
     <div class="status-description">
       <!-- eslint-disable-next-line -->

--- a/src/lib/Stepper/Step.svelte
+++ b/src/lib/Stepper/Step.svelte
@@ -15,7 +15,9 @@
 <div class="step" on:click={handleStepClick} role="button" tabindex="0" on:keydown>
   {#if icon !== null}
     <div class="step-icon-container">
-      <img class="step-icon" src={icon} alt="" />
+      <slot name="step-icon-slot">
+        <img class="step-icon" src={icon} alt="" />
+      </slot>
     </div>
   {:else}
     <div class="step-index-container">

--- a/src/lib/Toast/Toast.svelte
+++ b/src/lib/Toast/Toast.svelte
@@ -100,7 +100,9 @@
   >
     {#if properties.leftIcon}
       <div class="toast-icon-wrapper">
-        <img class="toast-icon" src={properties.leftIcon} alt="toast-icon" />
+        <slot name="toast-icon-slot">
+          <img class="toast-icon" src={properties.leftIcon} alt="toast-icon" />
+        </slot>
       </div>
     {/if}
 
@@ -117,7 +119,9 @@
 
     {#if properties.rightIcon}
       <div class="close-button" tabindex="0" role="button" on:click={hideToast} on:keypress>
-        <img class="toast-icon" src={properties.rightIcon} alt="close-icon" />
+        <slot name='right-icon-slot'>
+          <img class="toast-icon" src={properties.rightIcon} alt="close-icon" />
+        </slot>
       </div>
     {/if}
   </div>

--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -18,7 +18,9 @@
       <slot name="leftContent" />
     {:else if properties.showBackButton && properties.backIcon !== null}
       <div class="back" on:click={handleBackClick} on:keydown role="button" tabindex="0">
-        <img src={properties.backIcon} alt="Back" />
+        <slot name='back-icon-slot'>
+          <img src={properties.backIcon} alt="Back" />
+        </slot>
       </div>
     {/if}
     {#if $$slots.centerContent}


### PR DESCRIPTION
- Added slots to wrap Svelte Image components, enabling image overriding.
- Introduced the `--select-hover-color` CSS variable to customize the hover text color for the select component.