### PR TITLE
BZ-47221: feat: Export Img component

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -23,6 +23,7 @@ export { default as Step } from './Stepper/Step.svelte';
 export { default as Toast } from './Toast/Toast.svelte';
 export { default as GridItem } from './GridItem/GridItem.svelte';
 export { default as IconStack } from './IconStack/IconStack.svelte';
+export { default as Img } from './Img/Img.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -42,5 +43,6 @@ export type * from './Table/properties';
 export type * from './Stepper/properties';
 export type * from './Toast/properties';
 export type * from './IconStack/properties';
+export type * from './Img/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
**Why?**
* The Img component was implemented in the codebase but not exported from src/lib/index.ts
* This prevented consumers of the svelte-ui-components library from importing and using the Img component

Solution:
* Added component export in src/lib/index.ts: `export { default as Img } from './Img/Img.svelte';`
* Added type export in src/lib/index.ts: `export type { ImgProps } from './Img/properties';`