### PR TITLE
BZ-47598: feat: Add css variable for input button label margin

### DIFF
--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -166,7 +166,7 @@
     font-size: var(--input-label-msg-text-size, 12px);
     color: var(--input-label-msg-text-color, #637c95);
     line-height: var(--input-label-msg-text-line-height);
-    margin-bottom: 6px;
+    margin: var(--input-label-msg-text-margin, 0px 0px 6px 0px);
   }
 
   .invalid {


### PR DESCRIPTION
Add css variable for input button label margin 

- Before: 
<img width="606" height="184" alt="image" src="https://github.com/user-attachments/assets/23d3f1d3-4786-44a9-b806-3dda09c19047" />
- After
- passing css variable --input-label-msg-text-margin: 20px 16px 16px 16px;
<img width="618" height="201" alt="image" src="https://github.com/user-attachments/assets/723a0dff-dc2a-4fb9-a411-895539ad4246" />
- Not passing the variable
<img width="598" height="183" alt="image" src="https://github.com/user-attachments/assets/4f57c1e3-74e7-424c-b3fc-23fd54a91260" />
 