### PR TITLE
BZ-48824: feat: Add blur() to remove focus in Input Component

### DIFF
--- a/docs/Input.md
+++ b/docs/Input.md
@@ -38,6 +38,15 @@ A text input field with built-in validation for email, phone (tel), password, an
 | testId               | `string`                                                                                                                            | No       | `''`     | Value for the data-pw attribute, used for end-to-end testing selectors.                                                                                                                                                   |
 | classes              | `string`                                                                                                                            | No       | `-`      | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                    |
 
+## Methods
+
+Exported methods that can be called via `bind:this` on the component instance.
+
+| Method    | Signature    | Description                                                                           |
+| --------- | ------------ | ------------------------------------------------------------------------------------- |
+| `focus()` | `() => void` | Programmatically focuses the underlying `<input>` or `<textarea>` element.            |
+| `blur()`  | `() => void` | Programmatically removes focus from the underlying `<input>` or `<textarea>` element. |
+
 ## Events
 
 | Event         | Type                                    | Description                                                                                                                                                                                           |

--- a/docs/InputButton.md
+++ b/docs/InputButton.md
@@ -23,6 +23,15 @@ A composite component that combines an Input field with optional left, right, an
 | bottomButtonProperties | `OptionalButtonProperties \| null`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | No       | `-`     | Configuration for the bottom Button (rendered below the input row). Auto-disabled when input validation is not 'Valid'. Set to null to hide.                           |
 | classes                | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
 
+## Methods
+
+Exported methods that can be called via `bind:this` on the component instance.
+
+| Method    | Signature    | Description                                                       |
+| --------- | ------------ | ----------------------------------------------------------------- |
+| `focus()` | `() => void` | Programmatically focuses the underlying input element.            |
+| `blur()`  | `() => void` | Programmatically removes focus from the underlying input element. |
+
 ## Snippets
 
 Svelte 5 Snippet props — pass content blocks to the component.

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -43,6 +43,14 @@
     }
   }
 
+  export function blur() {
+    try {
+      inputElement?.blur();
+    } catch (error) {
+      console.error('Error blurring inputElement:', error);
+    }
+  }
+
   let inputElement: HTMLInputElement | HTMLTextAreaElement | null = $state(null);
 
   let validationState = $derived.by(() => {

--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -53,6 +53,10 @@
   export function focus() {
     inputRef?.focus();
   }
+
+  export function blur() {
+    inputRef?.blur();
+  }
 </script>
 
 <div class="container {classes ?? ''}">


### PR DESCRIPTION
- Added `blur()` function in Input.svelte for removing focus from input and inputButton feild
- Follows the same pattern as the existing `focus()` method 
- Works for both input and textarea elements

