### PR TITLE
BZN-49077: fix: sync WC wrappers and docs with actual component APIs

### DIFF
--- a/docs/Avatar.md
+++ b/docs/Avatar.md
@@ -76,5 +76,5 @@ This component uses the following library components internally:
 Tag: `<sui-avatar>`
 
 ```html
-<sui-avatar src="/photo.jpg" alt="User" size="40"></sui-avatar>
+<sui-avatar src="/photo.jpg" alt="User" size="medium"></sui-avatar>
 ```

--- a/docs/Book.md
+++ b/docs/Book.md
@@ -101,4 +101,11 @@ Tag: `<sui-book>`
 <sui-book show-navigation show-page-indicator></sui-book>
 ```
 
+### Slots
+
+| Slot Name       | Maps to Snippet | Description                               |
+| --------------- | --------------- | ----------------------------------------- |
+| `previous-icon` | `previousIcon`  | Custom icon for the previous page button. |
+| `next-icon`     | `nextIcon`      | Custom icon for the next page button.     |
+
 > **Note:** The `pages` prop is an array of objects with Snippet content — set it via JavaScript property, not HTML attribute.

--- a/docs/Calendar.md
+++ b/docs/Calendar.md
@@ -118,4 +118,11 @@ Tag: `<sui-calendar>`
 <sui-calendar mode="single" locale="en-US"></sui-calendar>
 ```
 
+### Slots
+
+| Slot Name             | Maps to Snippet     | Description                                |
+| --------------------- | ------------------- | ------------------------------------------ |
+| `previous-month-icon` | `previousMonthIcon` | Custom icon for the previous month button. |
+| `next-month-icon`     | `nextMonthIcon`     | Custom icon for the next month button.     |
+
 > **Note:** `value`, `rangeStart`, `rangeEnd`, `minDate`, `maxDate`, and `disabledDates` are object props — set them via JavaScript properties.

--- a/docs/Checkbox.md
+++ b/docs/Checkbox.md
@@ -75,3 +75,10 @@ Tag: `<sui-checkbox>`
 ```html
 <sui-checkbox text="Accept terms" checked></sui-checkbox>
 ```
+
+### Slots
+
+| Slot Name            | Maps to Snippet     | Description                              |
+| -------------------- | ------------------- | ---------------------------------------- |
+| `checked-icon`       | `checkedIcon`       | Custom icon for the checked state.       |
+| `indeterminate-icon` | `indeterminateIcon` | Custom icon for the indeterminate state. |

--- a/docs/CommandMenu.md
+++ b/docs/CommandMenu.md
@@ -199,4 +199,10 @@ Tag: `<sui-command-menu>`
 <sui-command-menu open placeholder="Type a command..."></sui-command-menu>
 ```
 
+### Slots
+
+| Slot Name     | Maps to Snippet | Description                       |
+| ------------- | --------------- | --------------------------------- |
+| `search-icon` | `searchIcon`    | Custom icon for the search input. |
+
 > **Note:** The `items` prop is an array and `itemIcon` is a parameterized Snippet — set them via JavaScript properties.

--- a/docs/Gauge.md
+++ b/docs/Gauge.md
@@ -42,5 +42,5 @@ Override these custom properties to theme the component.
 Tag: `<sui-gauge>`
 
 ```html
-<sui-gauge value="75" size="120" show-label></sui-gauge>
+<sui-gauge value="75" show-label></sui-gauge>
 ```

--- a/docs/KeyboardInput.md
+++ b/docs/KeyboardInput.md
@@ -98,7 +98,7 @@ type KeyboardInputEventProperties = {
 Tag: `<sui-keyboard-input>`
 
 ```html
-<sui-keyboard-input separator="+" size="sm"></sui-keyboard-input>
+<sui-keyboard-input separator="+"></sui-keyboard-input>
 ```
 
 > **Note:** The `keys` prop is an array — set it via JavaScript property.

--- a/docs/LoadingDots.md
+++ b/docs/LoadingDots.md
@@ -41,5 +41,5 @@ Override these custom properties to theme the component.
 Tag: `<sui-loading-dots>`
 
 ```html
-<sui-loading-dots size="md" animation="bounce"></sui-loading-dots>
+<sui-loading-dots dots="3" animation="bounce"></sui-loading-dots>
 ```

--- a/docs/Menu.md
+++ b/docs/Menu.md
@@ -121,7 +121,7 @@ This component uses the following library components internally:
 Tag: `<sui-menu>`
 
 ```html
-<sui-menu position="bottom-start">
+<sui-menu>
   <button slot="trigger">Open Menu</button>
 </sui-menu>
 ```

--- a/docs/Modal.md
+++ b/docs/Modal.md
@@ -199,7 +199,7 @@ This component uses the following library components internally:
 Tag: `<sui-modal>`
 
 ```html
-<sui-modal size="md" show-overlay>
+<sui-modal size="medium" show-overlay>
   <p>Modal body content</p>
   <div slot="footer">
     <button>Cancel</button>

--- a/docs/Phone.md
+++ b/docs/Phone.md
@@ -70,7 +70,7 @@ Override these custom properties to theme the component.
 Tag: `<sui-phone>`
 
 ```html
-<sui-phone variant="iphone-14" color="black">
+<sui-phone variant="modern">
   <div>Screen content</div>
 </sui-phone>
 ```

--- a/docs/Pill.md
+++ b/docs/Pill.md
@@ -114,3 +114,9 @@ Tag: `<sui-pill>`
 ```html
 <sui-pill text="Active" dismissible></sui-pill>
 ```
+
+### Slots
+
+| Slot Name      | Maps to Snippet | Description                               |
+| -------------- | --------------- | ----------------------------------------- |
+| `dismiss-icon` | `dismissIcon`   | Custom icon for the dismiss/close button. |

--- a/docs/Radio.md
+++ b/docs/Radio.md
@@ -70,5 +70,6 @@ Override these custom properties to theme the component.
 Tag: `<sui-radio>`
 
 ```html
-<sui-radio text="Option A" checked></sui-radio>
+<sui-radio name="color" value="red" text="Red"></sui-radio>
+<sui-radio name="color" value="blue" text="Blue"></sui-radio>
 ```

--- a/docs/Tabs.md
+++ b/docs/Tabs.md
@@ -85,4 +85,11 @@ Tag: `<sui-tabs>`
 <sui-tabs active-index="0"></sui-tabs>
 ```
 
+### Slots
+
+| Slot Name           | Maps to Snippet   | Description                             |
+| ------------------- | ----------------- | --------------------------------------- |
+| `scroll-left-icon`  | `scrollLeftIcon`  | Custom icon for the left scroll arrow.  |
+| `scroll-right-icon` | `scrollRightIcon` | Custom icon for the right scroll arrow. |
+
 > **Note:** The `items` prop is an array — set it via JavaScript property.

--- a/src/wc/components/Book.wc.svelte
+++ b/src/wc/components/Book.wc.svelte
@@ -10,6 +10,8 @@
       showPageIndicator: { type: 'Boolean', reflect: true },
       enableSwipe: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
+      previousIcon: { type: 'Object' },
+      nextIcon: { type: 'Object' },
       classes: { type: 'String' },
       onpagechange: { type: 'Object' }
     }
@@ -21,4 +23,11 @@
   let props = $props();
 </script>
 
-<Book {...props} />
+<Book {...props}>
+  {#snippet previousIcon()}
+    <slot name="previous-icon"></slot>
+  {/snippet}
+  {#snippet nextIcon()}
+    <slot name="next-icon"></slot>
+  {/snippet}
+</Book>

--- a/src/wc/components/Browser.wc.svelte
+++ b/src/wc/components/Browser.wc.svelte
@@ -11,6 +11,7 @@
       shadow: { type: 'Boolean', reflect: true },
       rounded: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
+      lockIcon: { type: 'Object' },
       classes: { type: 'String' }
     }
   }}
@@ -24,5 +25,8 @@
 <Browser {...props}>
   {#snippet children()}
     <slot></slot>
+  {/snippet}
+  {#snippet lockIcon()}
+    <slot name="lock-icon"></slot>
   {/snippet}
 </Browser>

--- a/src/wc/components/Calendar.wc.svelte
+++ b/src/wc/components/Calendar.wc.svelte
@@ -13,6 +13,8 @@
       weekStartsOn: { type: 'Number', reflect: true },
       locale: { type: 'String', reflect: true },
       testId: { type: 'String' },
+      previousMonthIcon: { type: 'Object' },
+      nextMonthIcon: { type: 'Object' },
       classes: { type: 'String' },
       onselect: { type: 'Object' },
       onrangeselect: { type: 'Object' },
@@ -26,4 +28,11 @@
   let props = $props();
 </script>
 
-<Calendar {...props} />
+<Calendar {...props}>
+  {#snippet previousMonthIcon()}
+    <slot name="previous-month-icon"></slot>
+  {/snippet}
+  {#snippet nextMonthIcon()}
+    <slot name="next-month-icon"></slot>
+  {/snippet}
+</Calendar>

--- a/src/wc/components/CheckListItem.wc.svelte
+++ b/src/wc/components/CheckListItem.wc.svelte
@@ -5,7 +5,9 @@
     props: {
       text: { type: 'String', reflect: true },
       checked: { type: 'Boolean', reflect: true },
+      disabled: { type: 'Boolean', reflect: true },
       classes: { type: 'String' },
+      testId: { type: 'String' },
       onclick: { type: 'Object' }
     }
   }}

--- a/src/wc/components/Checkbox.wc.svelte
+++ b/src/wc/components/Checkbox.wc.svelte
@@ -8,6 +8,8 @@
       disabled: { type: 'Boolean', reflect: true },
       indeterminate: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
+      checkedIcon: { type: 'Object' },
+      indeterminateIcon: { type: 'Object' },
       classes: { type: 'String' },
       onclick: { type: 'Object' }
     }
@@ -19,4 +21,11 @@
   let props = $props();
 </script>
 
-<Checkbox {...props} />
+<Checkbox {...props}>
+  {#snippet checkedIcon()}
+    <slot name="checked-icon"></slot>
+  {/snippet}
+  {#snippet indeterminateIcon()}
+    <slot name="indeterminate-icon"></slot>
+  {/snippet}
+</Checkbox>

--- a/src/wc/components/Choicebox.wc.svelte
+++ b/src/wc/components/Choicebox.wc.svelte
@@ -3,9 +3,7 @@
     tag: 'sui-choicebox',
     shadow: 'open',
     props: {
-      text: { type: 'String', reflect: true },
       selected: { type: 'Boolean', reflect: true },
-      description: { type: 'String', reflect: true },
       mode: { type: 'String', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
@@ -21,7 +19,7 @@
 </script>
 
 <Choicebox {...props}>
-  {#snippet icon()}
-    <slot name="icon"></slot>
+  {#snippet children()}
+    <slot></slot>
   {/snippet}
 </Choicebox>

--- a/src/wc/components/CommandMenu.wc.svelte
+++ b/src/wc/components/CommandMenu.wc.svelte
@@ -8,6 +8,7 @@
       placeholder: { type: 'String', reflect: true },
       emptyText: { type: 'String', reflect: true },
       testId: { type: 'String' },
+      searchIcon: { type: 'Object' },
       classes: { type: 'String' },
       onselect: { type: 'Object' },
       onclose: { type: 'Object' }
@@ -20,4 +21,8 @@
   let props = $props();
 </script>
 
-<CommandMenu {...props} />
+<CommandMenu {...props}>
+  {#snippet searchIcon()}
+    <slot name="search-icon"></slot>
+  {/snippet}
+</CommandMenu>

--- a/src/wc/components/Gauge.wc.svelte
+++ b/src/wc/components/Gauge.wc.svelte
@@ -4,8 +4,6 @@
     shadow: 'open',
     props: {
       value: { type: 'Number', reflect: true },
-      size: { type: 'Number', reflect: true },
-      strokeWidth: { type: 'Number', reflect: true },
       showLabel: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' }

--- a/src/wc/components/Img.wc.svelte
+++ b/src/wc/components/Img.wc.svelte
@@ -6,7 +6,8 @@
       src: { type: 'String', reflect: true },
       alt: { type: 'String', reflect: true },
       fallback: { type: 'String', reflect: true },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      onerror: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/KeyboardInput.wc.svelte
+++ b/src/wc/components/KeyboardInput.wc.svelte
@@ -5,7 +5,6 @@
     props: {
       keys: { type: 'Object', reflect: true },
       separator: { type: 'String', reflect: true },
-      size: { type: 'String', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' },
       onclick: { type: 'Object' }

--- a/src/wc/components/LoadingDots.wc.svelte
+++ b/src/wc/components/LoadingDots.wc.svelte
@@ -3,9 +3,8 @@
     tag: 'sui-loading-dots',
     shadow: 'open',
     props: {
-      size: { type: 'String', reflect: true },
+      dots: { type: 'Number', reflect: true },
       animation: { type: 'String', reflect: true },
-      duration: { type: 'Number', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' }
     }

--- a/src/wc/components/Menu.wc.svelte
+++ b/src/wc/components/Menu.wc.svelte
@@ -5,8 +5,6 @@
     props: {
       items: { type: 'Object' },
       open: { type: 'Boolean', reflect: true },
-      position: { type: 'String', reflect: true },
-      maxHeight: { type: 'String', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' },
       onselect: { type: 'Object' },

--- a/src/wc/components/Phone.wc.svelte
+++ b/src/wc/components/Phone.wc.svelte
@@ -4,12 +4,8 @@
     shadow: 'open',
     props: {
       variant: { type: 'String', reflect: true },
-      color: { type: 'String', reflect: true },
-      shadow: { type: 'Boolean', reflect: true },
       showStatusBar: { type: 'Boolean', reflect: true },
       showHomeBar: { type: 'Boolean', reflect: true },
-      orientation: { type: 'String', reflect: true },
-      scale: { type: 'Number', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' }
     }

--- a/src/wc/components/Pill.wc.svelte
+++ b/src/wc/components/Pill.wc.svelte
@@ -7,6 +7,7 @@
       dismissible: { type: 'Boolean', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
+      dismissIcon: { type: 'Object' },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
       ondismiss: { type: 'Object' }
@@ -19,4 +20,8 @@
   let props = $props();
 </script>
 
-<Pill {...props} />
+<Pill {...props}>
+  {#snippet dismissIcon()}
+    <slot name="dismiss-icon"></slot>
+  {/snippet}
+</Pill>

--- a/src/wc/components/Radio.wc.svelte
+++ b/src/wc/components/Radio.wc.svelte
@@ -3,12 +3,14 @@
     tag: 'sui-radio',
     shadow: 'open',
     props: {
+      name: { type: 'String', reflect: true },
+      value: { type: 'String', reflect: true },
+      selectedValue: { type: 'String', reflect: true },
       text: { type: 'String', reflect: true },
-      checked: { type: 'Boolean', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' },
-      onclick: { type: 'Object' }
+      onchange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/RelativeTime.wc.svelte
+++ b/src/wc/components/RelativeTime.wc.svelte
@@ -5,8 +5,9 @@
     props: {
       date: { type: 'Object' },
       locale: { type: 'String', reflect: true },
-      interval: { type: 'Number', reflect: true },
-      showTooltip: { type: 'Boolean', reflect: true },
+      format: { type: 'String', reflect: true },
+      updateInterval: { type: 'Number', reflect: true },
+      tooltip: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' }
     }

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -3,27 +3,15 @@
     tag: 'sui-select',
     shadow: 'open',
     props: {
-      dropDownIconAlt: { type: 'String' },
+      items: { type: 'Object' },
+      value: { type: 'Object' },
+      multiple: { type: 'Boolean', reflect: true },
+      searchable: { type: 'Boolean', reflect: true },
       placeholder: { type: 'String', reflect: true },
-      label: { type: 'String', reflect: true },
-      allItems: { type: 'Object' },
-      selectedItem: { type: 'Object', reflect: true },
-      selectedItemLabel: { type: 'Object' },
-      showSelectedItemInDropdown: { type: 'Boolean' },
-      selectMultipleItems: { type: 'Boolean', reflect: true },
-      hideDropDownIcon: { type: 'Boolean' },
-      dropDownIcon: { type: 'String' },
-      leftIcon: { type: 'Object' },
-      showSingleSelectButton: { type: 'Boolean' },
-      showSelectedItem: { type: 'Boolean' },
-      showSelectedItemCount: { type: 'Boolean' },
+      disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
-      labelTestId: { type: 'String' },
-      itemTestId: { type: 'String' },
       classes: { type: 'String' },
-      onselect: { type: 'Object' },
-      ondropdownClick: { type: 'Object' },
-      onkeydown: { type: 'Object' }
+      onchange: { type: 'Object' }
     }
   }}
 />
@@ -33,11 +21,4 @@
   let props = $props();
 </script>
 
-<Select {...props}>
-  {#snippet leftContent()}
-    <slot name="left-content"></slot>
-  {/snippet}
-  {#snippet bottomContent()}
-    <slot name="bottom-content"></slot>
-  {/snippet}
-</Select>
+<Select {...props} />

--- a/src/wc/components/Shimmer.wc.svelte
+++ b/src/wc/components/Shimmer.wc.svelte
@@ -3,7 +3,8 @@
     tag: 'sui-shimmer',
     shadow: 'open',
     props: {
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      testId: { type: 'String' }
     }
   }}
 />

--- a/src/wc/components/Stepper.wc.svelte
+++ b/src/wc/components/Stepper.wc.svelte
@@ -5,9 +5,8 @@
     props: {
       steps: { type: 'Object' },
       currentStepIndex: { type: 'Number', reflect: true },
-      testId: { type: 'String' },
       classes: { type: 'String' },
-      onclick: { type: 'Object' }
+      onhandleStepClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Tabs.wc.svelte
+++ b/src/wc/components/Tabs.wc.svelte
@@ -7,6 +7,8 @@
       activeIndex: { type: 'Number', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String' },
+      scrollLeftIcon: { type: 'Object' },
+      scrollRightIcon: { type: 'Object' },
       classes: { type: 'String' },
       onchange: { type: 'Object' }
     }
@@ -18,4 +20,11 @@
   let props = $props();
 </script>
 
-<Tabs {...props} />
+<Tabs {...props}>
+  {#snippet scrollLeftIcon()}
+    <slot name="scroll-left-icon"></slot>
+  {/snippet}
+  {#snippet scrollRightIcon()}
+    <slot name="scroll-right-icon"></slot>
+  {/snippet}
+</Tabs>

--- a/src/wc/components/ThemeSwitcher.wc.svelte
+++ b/src/wc/components/ThemeSwitcher.wc.svelte
@@ -3,7 +3,10 @@
     tag: 'sui-theme-switcher',
     shadow: 'open',
     props: {
+      options: { type: 'Object' },
       value: { type: 'String', reflect: true },
+      mode: { type: 'String', reflect: true },
+      storageKey: { type: 'String', reflect: true },
       testId: { type: 'String' },
       classes: { type: 'String' },
       onchange: { type: 'Object' }


### PR DESCRIPTION
Web component wrappers:
- Rewrite Select wrapper — was using old API (allItems, selectedItem, onselect) instead of current (items, value, onchange)
- Rewrite Radio wrapper — was using phantom checked/onclick, now uses name/value/selectedValue/onchange
- Rewrite Choicebox wrapper — remove ghost text/description props and icon snippet, add children snippet
- Rewrite Phone wrapper — remove 4 phantom props (color, shadow, orientation, scale)
- Fix RelativeTime wrapper — rename interval→updateInterval, showTooltip→tooltip, add format
- Fix LoadingDots wrapper — remove ghost size/duration props, add dots
- Fix Stepper wrapper — remove ghost testId/onclick, add onhandleStepClick
- Fix Gauge wrapper — remove ghost size/strokeWidth props
- Fix Menu wrapper — remove ghost position/maxHeight props
- Fix ThemeSwitcher wrapper — add missing options, mode, storageKey props
- Add missing snippet slots to 7 wrappers (Book, Browser, Calendar, Checkbox, CommandMenu, Pill, Tabs)
- Add missing props to 4 wrappers (CheckListItem, Shimmer, Img, KeyboardInput) Docs:
- Fix 8 WC examples using phantom/invalid attributes (Radio, Phone, LoadingDots, Gauge, Menu, KeyboardInput, Modal, Avatar)
- Add missing Slots tables to 6 WC sections (Book, Calendar, Checkbox, CommandMenu, Pill, Tabs)
- Rebuild MCP server with corrected docs