### PR TITLE
fix: toolbar additional content display

### DIFF
--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -39,7 +39,7 @@
       </div>
     {/if}
   </div>
-  <div class="additional-content">
+  <div class="additional-content" class:hidden={!(typeof additionalContent === 'function')}>
     {#if typeof additionalContent === 'function'}
       {@render additionalContent()}
     {/if}
@@ -82,6 +82,10 @@
     visibility: var(--toolbar-additional-content-visibility, visible);
   }
 
+  .hidden {
+    display: none;
+  }
+
   .back {
     height: var(--toolbar-back-button-height, 20px);
     width: var(--toolbar-back-button-width, 20px);
@@ -100,6 +104,6 @@
   }
 
   .text {
-    font-size: 18px;
+    font-size: var(--toolbar-text-font-size, 18px);
   }
 </style>


### PR DESCRIPTION
- by default toolbar additional display is none
- exposed css var for customising text font size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toolbar additional content visibility to properly hide when no renderable content exists

* **Style**
  * Toolbar text font size is now customizable via CSS variable with 18px default fallback
  * Improved toolbar layout styling with hidden state support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->