### PR TITLE
fix: preventing fading gradient on edge of scroller on mobile

### DIFF
--- a/src/lib/Scroller/Scroller.svelte
+++ b/src/lib/Scroller/Scroller.svelte
@@ -151,6 +151,7 @@
   });
 
   let showArrowControls = $derived(showArrows && !(hideArrowsOnTouch && isTouchDevice));
+  let showGradientOverlay = $derived(showGradient && !(hideArrowsOnTouch && isTouchDevice));
 </script>
 
 <div
@@ -178,7 +179,7 @@
     </div>
   {/if}
 
-  {#if showGradient && canScrollPrev}
+  {#if showGradientOverlay && canScrollPrev}
     <div class="gradient gradient-start"></div>
   {/if}
 
@@ -197,7 +198,7 @@
     {@render children()}
   </div>
 
-  {#if showGradient && canScrollNext}
+  {#if showGradientOverlay && canScrollNext}
     <div class="gradient gradient-end"></div>
   {/if}
 


### PR DESCRIPTION
- fading gradient overlay on edges of scroller are removed on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gradient overlay visibility on touch devices to align with arrow control behavior for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->