### PR TITLE
fix: resolve onstatechange input callback not triggered

### DIFF
--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -84,7 +84,13 @@
     return valueValidation;
   });
 
-  const showErrorMessage = $derived(validationState === 'Invalid');
+  const validationStateForCallback = $derived.by(() => {
+    const state = validationState;
+    onStateChange(state);
+    return state;
+  });
+
+  const showErrorMessage = $derived(validationStateForCallback === 'Invalid');
 
   function handleOnInput(event: Event) {
     if (inputElement === null) {
@@ -185,18 +191,9 @@
     onFocusout(event);
     onBlur(event);
   }
-
-  let _validationStateForCallback = $derived.by(() => {
-    const state = validationState;
-    onStateChange(state);
-    return state;
-  });
 </script>
 
-<div
-  class="input-container {classes ?? ''}"
-  class:input-error={validationState === 'Invalid' && !actionInput}
->
+<div class="input-container {classes ?? ''}" class:input-error={showErrorMessage && !actionInput}>
   {#if typeof label === 'string' && label !== '' && !actionInput}
     <label class="label" for={name}>
       {label}


### PR DESCRIPTION
 - svelte never runs derived if the state is not used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation state management in the input component for improved callback execution and error message display reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/svelte-ui-components/pull/189)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->