### PR TITLE
feat: add segments mode to Progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .playwright-mcp/*
+/test-results
+/playwright-report

--- a/docs/Progress.md
+++ b/docs/Progress.md
@@ -21,6 +21,17 @@ A linear progress bar showing task completion or usage. The `value` prop control
 | showLabel | `boolean` | No       | `false` | Whether to display the rounded percentage text next to the progress bar. Hidden during indeterminate mode.                                                             |
 | testId    | `string`  | No       | `-`     | Value for the data-pw attribute, used for end-to-end testing selectors.                                                                                                |
 | classes   | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| segments  | `number`  | No       | `-`     | When set to a positive integer N, renders the bar as N discrete segments instead of a continuous fill; the first `value` segments are filled. Ideal for count-based progress like "3 of 12 installments paid". When unset or `0`, the continuous bar is used. A negative `value` (indeterminate) is ignored in segmented mode. |
+
+## Segmented mode
+
+Set `segments` to a positive integer to render the bar as that many discrete segments instead of a single continuous fill. The first `value` segments are filled, which makes it ideal for count-based progress such as "3 of 12 installments paid". `max` is still used to compute the optional percentage label.
+
+```svelte
+<Progress value={3} max={12} segments={12} />
+```
+
+When `segments` is unset or `0`, the component renders the original continuous bar — existing usage is unchanged. A negative `value` activates the indeterminate animation only in continuous mode; in segmented mode it simply renders zero filled segments. Segment appearance is controlled by the `--progress-segment-*` variables documented below.
 
 ## CSS Variables
 
@@ -43,6 +54,12 @@ Override these custom properties to theme the component.
 | `--progress-label-color`            | `#333`            | color              | Text color of the percentage label.                           |
 | `--progress-label-font-family`      | `inherit`         | font-family        | Font family of the percentage label.                          |
 | `--progress-label-margin`           | `0`               | margin             | Margin around the percentage label.                           |
+| `--progress-segments-gap`              | `2px`                                    | gap           | Gap between segments in segmented mode. Set to `0` for a fused bar.            |
+| `--progress-segment-radius`            | `0`                                      | border-radius | Corner rounding of the middle segments.                                       |
+| `--progress-segment-radius-end`        | `4px`                                    | border-radius | Corner rounding on the outer edges (left of the first, right of the last segment). |
+| `--progress-segment-filled-background` | `var(--progress-bar-background, #2196f3)` | background    | Background of filled segments. Inherits the continuous bar colour by default. |
+| `--progress-segment-empty-background`  | `var(--progress-track-background, #e0e0e0)` | background  | Background of empty segments. Inherits the continuous track colour by default. |
+| `--progress-segment-transition`        | `background 0.2s ease`                   | transition    | Transition applied when a segment changes fill state.                         |
 
 ## Web Component
 
@@ -50,4 +67,10 @@ Tag: `<sui-progress>`
 
 ```html
 <sui-progress value="60" max="100" show-label></sui-progress>
+```
+
+Segmented mode is available on the web component too via the `segments` attribute:
+
+```html
+<sui-progress value="3" max="12" segments="12"></sui-progress>
 ```

--- a/src/lib/Progress/Progress.svelte
+++ b/src/lib/Progress/Progress.svelte
@@ -1,20 +1,45 @@
 <script lang="ts">
   import type { ProgressProperties } from './properties';
+  import { clampFilledSegments } from './segments';
 
-  let { value, max = 100, showLabel = false, testId, classes }: ProgressProperties = $props();
+  let {
+    value,
+    max = 100,
+    showLabel = false,
+    testId,
+    classes,
+    segments
+  }: ProgressProperties = $props();
 
   let percentage = $derived(Math.min(100, Math.max(0, (value / max) * 100)));
   let isIndeterminate = $derived(value < 0);
+
+  let segmentCount = $derived(segments && segments > 0 ? Math.floor(segments) : 0);
+  let filledSegments = $derived(clampFilledSegments(value, segmentCount));
+  let segmentIndices = $derived([...Array(segmentCount).keys()]);
 </script>
 
 <div class="container {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
-  <div class="track">
-    <div
-      class="bar"
-      class:indeterminate={isIndeterminate}
-      style:width={isIndeterminate ? null : `${percentage}%`}
-    ></div>
-  </div>
+  {#if segmentCount > 0}
+    <div class="segmented-track">
+      {#each segmentIndices as i (i)}
+        <div
+          class="segment"
+          class:filled={i < filledSegments}
+          class:first={i === 0}
+          class:last={i === segmentCount - 1}
+        ></div>
+      {/each}
+    </div>
+  {:else}
+    <div class="track">
+      <div
+        class="bar"
+        class:indeterminate={isIndeterminate}
+        style:width={isIndeterminate ? null : `${percentage}%`}
+      ></div>
+    </div>
+  {/if}
   {#if showLabel && !isIndeterminate}
     <div class="label">{Math.round(percentage)}%</div>
   {/if}
@@ -47,6 +72,34 @@
   .bar.indeterminate {
     width: 30%;
     animation: indeterminate var(--progress-indeterminate-duration, 1.5s) ease-in-out infinite;
+  }
+
+  .segmented-track {
+    flex: 1;
+    display: flex;
+    gap: var(--progress-segments-gap, 2px);
+  }
+
+  .segment {
+    flex: 1;
+    height: var(--progress-track-height, 8px);
+    background: var(--progress-segment-empty-background, var(--progress-track-background, #e0e0e0));
+    border-radius: var(--progress-segment-radius, 0);
+    transition: var(--progress-segment-transition, background 0.2s ease);
+  }
+
+  .segment.filled {
+    background: var(--progress-segment-filled-background, var(--progress-bar-background, #2196f3));
+  }
+
+  .segment.first {
+    border-top-left-radius: var(--progress-segment-radius-end, 4px);
+    border-bottom-left-radius: var(--progress-segment-radius-end, 4px);
+  }
+
+  .segment.last {
+    border-top-right-radius: var(--progress-segment-radius-end, 4px);
+    border-bottom-right-radius: var(--progress-segment-radius-end, 4px);
   }
 
   .label {

--- a/src/lib/Progress/properties.ts
+++ b/src/lib/Progress/properties.ts
@@ -9,4 +9,14 @@ export type OptionalProgressProperties = {
   showLabel?: boolean;
   testId?: string;
   classes?: string;
+  /**
+   * When set to a positive integer N, renders the progress bar as N discrete
+   * segments instead of a continuous fill. The first `value` segments are
+   * styled with the `--progress-bar-background`; the remaining segments use
+   * `--progress-track-background`. Useful for count-based progress like
+   * "3 of 12 installments paid". When unset or 0, renders the continuous bar
+   * (the original behaviour). Indeterminate animation (negative `value`) is
+   * only honoured in continuous mode.
+   */
+  segments?: number;
 };

--- a/src/lib/Progress/segments.test.ts
+++ b/src/lib/Progress/segments.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampFilledSegments } from './segments';
+
+describe('clampFilledSegments', () => {
+  it('returns the value when it is within range', () => {
+    expect(clampFilledSegments(3, 12)).toBe(3);
+  });
+
+  it('fills no segments when the value is 0', () => {
+    expect(clampFilledSegments(0, 12)).toBe(0);
+  });
+
+  it('fills every segment when the value equals the segment count', () => {
+    expect(clampFilledSegments(12, 12)).toBe(12);
+  });
+
+  it('clamps to the segment count when the value exceeds it', () => {
+    expect(clampFilledSegments(20, 12)).toBe(12);
+  });
+
+  it('fills no segments for a negative value (indeterminate is ignored when segmented)', () => {
+    expect(clampFilledSegments(-1, 12)).toBe(0);
+  });
+
+  it('floors fractional values to whole filled segments', () => {
+    expect(clampFilledSegments(3.7, 12)).toBe(3);
+  });
+});

--- a/src/lib/Progress/segments.ts
+++ b/src/lib/Progress/segments.ts
@@ -1,0 +1,9 @@
+/**
+ * Number of segments to render as filled in segmented mode.
+ *
+ * Floors fractional input, clamps to the `[0, segments]` range, and treats any
+ * negative value (the continuous-mode indeterminate signal) as zero filled —
+ * indeterminate animation is not honoured for discrete segmented progress.
+ */
+export const clampFilledSegments = (value: number, segments: number): number =>
+  Math.max(0, Math.min(segments, Math.floor(value)));

--- a/src/routes/components/progress/+page.svelte
+++ b/src/routes/components/progress/+page.svelte
@@ -3,6 +3,10 @@
   import Progress from '$lib/Progress/Progress.svelte';
 
   let progressValue = $state(65);
+  let installments = $state(3);
+  let showDividers = $state(true);
+
+  const totalInstallments = 12;
 </script>
 
 <div class="page-header">
@@ -11,7 +15,7 @@
 </div>
 
 <div class="demo-row" style="max-width: 400px; flex-direction: column; gap: 12px;">
-  <Progress value={progressValue} max={100} showLabel />
+  <Progress value={progressValue} max={100} showLabel testId="progress-continuous" />
   <div style="display: flex; gap: 8px;">
     <Button text="-10" onclick={() => (progressValue = Math.max(0, progressValue - 10))} />
     <Button text="+10" onclick={() => (progressValue = Math.min(100, progressValue + 10))} />
@@ -20,5 +24,71 @@
 
 <h2>Indeterminate</h2>
 <div class="demo-row" style="max-width: 400px;">
-  <Progress value={-1} />
+  <Progress value={-1} testId="progress-indeterminate" />
 </div>
+
+<h2>Segmented</h2>
+<p class="demo-caption">
+  Discrete count-based progress — {installments} of {totalInstallments} installments paid.
+</p>
+<div class="demo-row" style="max-width: 400px; flex-direction: column; gap: 12px;">
+  <Progress
+    value={installments}
+    max={totalInstallments}
+    segments={totalInstallments}
+    testId="progress-segmented"
+  />
+  <div style="display: flex; gap: 8px;">
+    <Button text="-1" onclick={() => (installments = Math.max(0, installments - 1))} />
+    <Button
+      text="+1"
+      onclick={() => (installments = Math.min(totalInstallments, installments + 1))}
+    />
+  </div>
+</div>
+
+<h2>Segmented — divider gap</h2>
+<p class="demo-caption">
+  Toggle the inter-segment gap via the <code>--progress-segments-gap</code> variable. Dividers
+  {showDividers ? 'on' : 'off'}.
+</p>
+<div class="demo-row" style="max-width: 400px; flex-direction: column; gap: 12px;">
+  <Progress
+    value={5}
+    max={8}
+    segments={8}
+    classes={showDividers ? 'segments-gap-on' : 'segments-gap-off'}
+    testId="progress-segmented-dividers"
+  />
+  <div style="display: flex; gap: 8px;">
+    <Button
+      text={showDividers ? 'Fuse segments' : 'Show dividers'}
+      onclick={() => (showDividers = !showDividers)}
+    />
+  </div>
+</div>
+
+<h2>Segmented — indeterminate ignored</h2>
+<p class="demo-caption">
+  A negative value renders an empty segmented bar (no sliding animation) rather than the
+  continuous-mode indeterminate effect.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Progress value={-1} max={6} segments={6} testId="progress-segmented-indeterminate" />
+</div>
+
+<style>
+  .demo-caption {
+    margin: 0 0 4px;
+    font-size: 13px;
+    color: var(--doc-text-secondary, #666);
+  }
+
+  :global(.segments-gap-on) {
+    --progress-segments-gap: 6px;
+  }
+
+  :global(.segments-gap-off) {
+    --progress-segments-gap: 0;
+  }
+</style>

--- a/src/wc/components/Progress.wc.svelte
+++ b/src/wc/components/Progress.wc.svelte
@@ -7,7 +7,8 @@
       max: { type: 'Number', reflect: true },
       showLabel: { type: 'Boolean', reflect: true, attribute: 'show-label' },
       testId: { type: 'String', attribute: 'test-id' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      segments: { type: 'Number', reflect: true }
     }
   }}
 />

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/components/progress');
+});
+
+test('segmented mode renders one div per segment with the first `value` filled', async ({
+  page
+}) => {
+  const segmented = page.locator('[data-pw="progress-segmented"]');
+  await expect(segmented.locator('.segment')).toHaveCount(12);
+  await expect(segmented.locator('.segment.filled')).toHaveCount(3);
+});
+
+test('omitting segments falls back to the continuous bar', async ({ page }) => {
+  const continuous = page.locator('[data-pw="progress-continuous"]');
+  await expect(continuous.locator('.track .bar')).toHaveCount(1);
+  await expect(continuous.locator('.segment')).toHaveCount(0);
+});
+
+test('segmented mode ignores the indeterminate animation for negative values', async ({ page }) => {
+  const segmented = page.locator('[data-pw="progress-segmented-indeterminate"]');
+  await expect(segmented.locator('.segment')).toHaveCount(6);
+  await expect(segmented.locator('.segment.filled')).toHaveCount(0);
+  await expect(segmented.locator('.bar.indeterminate')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `segments` prop to the `Progress` component so it can render as a **discrete-segment bar** (N segments, first M filled) alongside its existing continuous / indeterminate modes. Fully backward-compatible, additive change.

```svelte
<Progress value={3} max={12} segments={12} />  <!-- 3 of 12 filled -->
```

## Why — Lighthouse consumer

The Lighthouse merchant dashboard has its own project `ProgressBar` (`src/lib/components/ProgressBar/`) rendering segmented progress across **5 callsites**:

1. `SubscriptionProgressCard` — "X of N installments paid"
2. `SubscriptionPlanProgress/PlanProgressCard` — "X of N active subscriptions"
3. `UnifiedProgressReportCard` — file-processing progress
4–5. `(no-auth)/components` demo — 2 instances

They can't migrate to the library `Progress` until it supports the segmented case. This PR unblocks that migration: once a release ships, Lighthouse can replace `<ProgressBar … />` with `<Progress value max segments />` and delete its local component.

## API additions

- **Prop:** `segments?: number` on `OptionalProgressProperties`. Positive integer N → N discrete segments, first `value` filled. Unset/`0` → continuous bar (unchanged).
- **6 new CSS variables**, each inheriting the continuous-mode defaults so themes apply consistently:

  | Variable | Default |
  |---|---|
  | `--progress-segments-gap` | `2px` |
  | `--progress-segment-radius` | `0` |
  | `--progress-segment-radius-end` | `4px` |
  | `--progress-segment-filled-background` | `var(--progress-bar-background, #2196f3)` |
  | `--progress-segment-empty-background` | `var(--progress-track-background, #e0e0e0)` |
  | `--progress-segment-transition` | `background 0.2s ease` |

- **Web component:** `<sui-progress segments="12">` attribute added (implemented, not deferred).

## Backward compatibility (guaranteed)

- Continuous-mode DOM, classes, animation, and indeterminate handling are **unchanged** when `segments` is unset/0.
- No existing CSS-variable names changed; `--progress-bar-border-radius` default stays `4px`.
- Negative `value` still triggers the indeterminate animation in continuous mode.
- In segmented mode, a negative `value` renders **0 filled segments** — indeterminate is intentionally ignored for discrete progress.
- Fractional/oversize `value` and fractional `segments` are clamped/floored defensively (no crash).

## Test coverage delta

- **Unit (vitest)** — `clampFilledSegments`: in-range, zero, full, oversize-clamp, negative→0, fractional-floor (6 cases, written test-first).
- **e2e (Playwright)** — segmented renders 12 segments with 3 `.filled`; omitting `segments` falls back to continuous `.track .bar`; segmented + negative `value` renders 0 filled and no `.indeterminate`.

## Verification

| Gate | Result |
|------|--------|
| `npm run check` | ✅ exit 0 |
| `npm run lint` | ✅ exit 0 |
| `npm run test:unit` | ✅ exit 0 (7 tests) |
| `npm run build` | ✅ exit 0 (publint clean) |
| `npm run test:integration` | ✅ the 3 new Progress tests pass |

Manual visual verification on `/components/progress` in **light and dark** themes — the segmented bar shows the correct filled count and the fill transition animates. Screenshots captured locally (attached separately).

> ⚠️ `tests/test.ts › index page has expected h1` fails on this branch, **but it also fails on `release`** — a stale baseline test for the old home page, unrelated to this change. This PR touches neither `tests/test.ts` nor the `/` route.

## Notes

- Versioning is left to the release workflow — `package.json` and the changelog are intentionally **not** bumped here. The `feat:` prefix drives the minor bump when the release is cut.
- The MCP server's `get_component_docs({ componentName: "Progress" })` surfaces the new prop + "Segmented mode" section automatically from `docs/Progress.md` (no MCP code change needed).

## Test plan

- [x] Unit + e2e tests added and passing
- [x] `check` / `lint` / `test:unit` / `build` all exit 0
- [x] Visual check in light + dark themes
- [ ] Reviewer: confirm continuous-mode usages elsewhere are unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress component now supports a `segments` property to render discrete segmented progress bars with independent styling per segment.

* **Documentation**
  * Updated Progress documentation with segmented mode behavior, interactive examples, and CSS customization options for segment appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/svelte-ui-components/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->