### PR TITLE
feat: add Divider component

### DIFF
--- a/src/lib/Divider/Divider.svelte
+++ b/src/lib/Divider/Divider.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { DividerProperties } from './properties';
+
+  let { orientation = 'horizontal', testId, classes }: DividerProperties = $props();
+</script>
+
+<div
+  class="divider divider-{orientation} {classes ?? ''}"
+  role="separator"
+  aria-orientation={orientation}
+  data-pw={typeof testId === 'string' ? testId : null}
+></div>
+
+<style>
+  .divider-horizontal {
+    width: var(--divider-length, 100%);
+    border-top: var(--divider-border, 1px solid #e2e8f0);
+    margin: var(--divider-margin, 0);
+  }
+
+  .divider-vertical {
+    height: var(--divider-length, 100%);
+    border-left: var(--divider-border, 1px solid #e2e8f0);
+    margin: var(--divider-margin, 0);
+  }
+</style>

--- a/src/lib/Divider/properties.ts
+++ b/src/lib/Divider/properties.ts
@@ -1,0 +1,5 @@
+export type DividerProperties = {
+  orientation?: 'horizontal' | 'vertical';
+  testId?: string;
+  classes?: string;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as Divider } from './Divider/Divider.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './Divider/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

Adds a standalone `Divider` separator primitive — the library had no divider component, so consumers were hand-rolling `<div>`s with border/margin styles. Lighthouse alone has 92 such usages across 22 files (migration in flight, currently bridged via a local pnpm patch of this exact component).

## API

- `orientation?: 'horizontal' | 'vertical'` (default `horizontal`)
- `testId?: string` → `data-pw`
- `classes?: string` → appended to the root
- Exposed CSS variables: `--divider-border` (shorthand, default `1px solid #e2e8f0`), `--divider-margin` (default `0`), `--divider-length` (default `100%`)
- Renders `role="separator"` + `aria-orientation` for accessibility

## Notes

- Follows the existing component conventions (Svelte 5 runes, `properties.ts`, `index.ts` component + type exports), mirroring `Badge`.
- `pnpm run check` (svelte-kit sync + svelte-check): **0 errors, 0 warnings**. `prettier --check` + `eslint`: clean.
- This is the formalization of the component already validated in a downstream consumer (Lighthouse) via `pnpm patch`; once released, the consumer drops the patch and bumps the version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Divider component available for use in the library. The component offers flexible orientation settings (horizontal and vertical) and supports custom styling and test attributes for enhanced testing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/svelte-ui-components/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->