### PR TITLE
feat: add Breadcrumb component

### DIFF
--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -1,0 +1,140 @@
+# Breadcrumb
+
+A navigation trail component that renders a semantic `<nav>` containing an `<ol>` of breadcrumb items. The component enforces `<nav aria-label>` + `<ol><li>` semantics; all visual rendering of each crumb is delegated to the required `item` snippet, keeping the API open for icons, dropdown crumbs, and overflow menus.
+
+## Usage
+
+### Basic hyperlink trail
+
+```svelte
+<script>
+  import { Breadcrumb } from '@juspay/svelte-ui-components';
+
+  const items = [
+    { href: '/', label: 'Home' },
+    { href: '/products', label: 'Products' },
+    { href: '', label: 'Laptops' }
+  ];
+</script>
+
+<Breadcrumb {items} ariaLabel="Page navigation">
+  {#snippet item(ctx)}
+    {#if ctx.isLast}
+      <span aria-current="page">{ctx.label}</span>
+    {:else}
+      <a href={ctx.href}>{ctx.label}</a>
+    {/if}
+  {/snippet}
+</Breadcrumb>
+```
+
+### Icon inside a crumb
+
+```svelte
+<Breadcrumb {items} ariaLabel="Order navigation">
+  {#snippet item(ctx)}
+    {#if ctx.index === 0}
+      <a href={ctx.href} style="display:inline-flex;align-items:center;gap:4px;">
+        <HomeIcon />
+        {ctx.label}
+      </a>
+    {:else if ctx.isLast}
+      <span aria-current="page">{ctx.label}</span>
+    {:else}
+      <a href={ctx.href}>{ctx.label}</a>
+    {/if}
+  {/snippet}
+</Breadcrumb>
+```
+
+### Custom separator snippet
+
+```svelte
+<Breadcrumb {items} ariaLabel="Page navigation">
+  {#snippet item(ctx)}
+    {#if ctx.isLast}
+      <span aria-current="page">{ctx.label}</span>
+    {:else}
+      <a href={ctx.href}>{ctx.label}</a>
+    {/if}
+  {/snippet}
+  {#snippet separator()}
+    <ChevronRightIcon />
+  {/snippet}
+</Breadcrumb>
+```
+
+## Props
+
+| Prop      | Type                               | Required | Default     | Description                                                                                                                                                |
+| --------- | ---------------------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| items     | `readonly BreadcrumbItemData[]`    | Yes      | —           | Ordered array of `{ href, label }` data objects. The component renders one `<li>` per entry.                                                               |
+| item      | `Snippet<[BreadcrumbItemContext]>` | Yes      | —           | Snippet called once per item. Receives `{ href, label, isLast, index }`. Consumer applies `aria-current="page"` on the last item.                          |
+| ariaLabel | `string`                           | Yes      | —           | Value for the `<nav aria-label>` attribute. Provide an i18n-correct string (e.g. `"Breadcrumb"` or translated equivalent). No English default is baked in. |
+| separator | `Snippet`                          | No       | `/` text    | Optional snippet rendered between items inside an `aria-hidden` `<li>`. Defaults to a plain `/` text node.                                                 |
+| classes   | `string`                           | No       | `undefined` | Extra CSS classes appended to the `<nav>` element for consumer theming.                                                                                    |
+| testId    | `string`                           | No       | `undefined` | Value for the `data-pw` attribute on the root `<nav>` element. Used for automated test selectors.                                                          |
+
+### BreadcrumbItemData shape
+
+| Field | Type     | Required | Description                                                         |
+| ----- | -------- | -------- | ------------------------------------------------------------------- |
+| href  | `string` | Yes      | URL for the crumb link. Pass `""` for the current page (last item). |
+| label | `string` | Yes      | Display text for this breadcrumb entry.                             |
+
+### BreadcrumbItemContext (snippet parameter)
+
+| Field  | Type      | Description                                                                            |
+| ------ | --------- | -------------------------------------------------------------------------------------- |
+| href   | `string`  | The `href` value from the corresponding `BreadcrumbItemData`.                          |
+| label  | `string`  | The `label` value from the corresponding `BreadcrumbItemData`.                         |
+| isLast | `boolean` | `true` when this is the final item. Use to apply `aria-current="page"` in the snippet. |
+| index  | `number`  | Zero-based position in the list. Useful for icon-on-first-item patterns.               |
+
+## Snippets
+
+| Snippet     | Parameters              | Description                                                                                                                                                                                                                            |
+| ----------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `item`      | `BreadcrumbItemContext` | **Required.** Renders the content of each `<li>`. The snippet receives `{ href, label, isLast, index }`. The consumer is responsible for rendering an `<a href>` for non-last items and adding `aria-current="page"` to the last item. |
+| `separator` | —                       | **Optional.** Renders the content of each inter-item separator `<li aria-hidden="true">`. Defaults to a `/` text node. Useful for chevron icons or custom glyphs.                                                                      |
+
+## CSS Variables
+
+| Variable                       | Default        | CSS Property | Description                                                                                                                           |
+| ------------------------------ | -------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `--breadcrumb-list-gap`        | (unset)        | gap          | Gap between items and separators in the flex row. When unset the browser default (0) applies.                                         |
+| `--breadcrumb-flex-wrap`       | `nowrap`       | flex-wrap    | Whether the trail wraps onto multiple lines.                                                                                          |
+| `--breadcrumb-separator-color` | `currentColor` | color        | Color of the separator `<li>`. Only applies when using the default `/` text separator; custom separator snippets own their own color. |
+
+## Consumer recipe — `aria-current="page"`
+
+The component does not bake `aria-current="page"` onto any element — the `isLast` flag in the snippet context lets each consumer wire it on the exact element they render:
+
+```svelte
+{#snippet item(ctx)}
+  {#if ctx.isLast}
+    <!-- consumer adds aria-current here -->
+    <span aria-current="page">{ctx.label}</span>
+  {:else}
+    <a href={ctx.href}>{ctx.label}</a>
+  {/if}
+{/snippet}
+```
+
+## Web Component
+
+Tag: `<sui-breadcrumb>`
+
+The web component exposes a built-in default item renderer (link for non-last items, `aria-current="page"` span for the last). For custom rendering, use the Svelte component directly.
+
+```html
+<sui-breadcrumb aria-label="Page navigation"></sui-breadcrumb>
+<script>
+  const el = document.querySelector('sui-breadcrumb');
+  el.items = [
+    { href: '/', label: 'Home' },
+    { href: '/products', label: 'Products' },
+    { href: '', label: 'Laptops' }
+  ];
+</script>
+```

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -16,6 +16,10 @@
     "description": "A notification banner with optional icon snippet, text content, inline link text, right content slot, and a dismissible close button. Supports click interaction with keyboard accessibility. The `visible` prop is bindable for dismiss state control. Uses slide transition for show/hide."
   },
   {
+    "name": "Breadcrumb",
+    "description": "A navigation trail component that enforces nav/ol/li semantics and aria-label. Delegates visual rendering of each crumb to a required item snippet (receives href, label, isLast, index), enabling icons, dropdown crumbs, and overflow menus. An optional separator snippet replaces the default '/' text node between items."
+  },
+  {
     "name": "Book",
     "description": "A 3D book display component with animated page turning. Renders multiple pages with content snippets and supports swipe/click navigation. Includes page indicator dots and configurable perspective and rotation."
   },

--- a/src/lib/Breadcrumb/Breadcrumb.svelte
+++ b/src/lib/Breadcrumb/Breadcrumb.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import type { BreadcrumbProperties } from './properties';
+
+  let { items, item, ariaLabel, separator, classes, testId }: BreadcrumbProperties = $props();
+</script>
+
+<nav
+  class="breadcrumb {classes ?? ''}"
+  aria-label={ariaLabel}
+  data-pw={typeof testId === 'string' ? testId : null}
+>
+  <ol class="breadcrumb-list">
+    {#each items as crumb, index (index)}
+      <li class="breadcrumb-item">
+        {#if typeof item === 'function'}
+          {@render item({
+            href: crumb.href,
+            label: crumb.label,
+            isLast: index === items.length - 1,
+            index
+          })}
+        {/if}
+      </li>
+      {#if index < items.length - 1}
+        <li class="breadcrumb-separator" aria-hidden="true">
+          {#if typeof separator === 'function'}
+            {@render separator()}
+          {:else}
+            /
+          {/if}
+        </li>
+      {/if}
+    {/each}
+  </ol>
+</nav>
+
+<style>
+  .breadcrumb-list {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: var(--breadcrumb-list-gap);
+    flex-wrap: var(--breadcrumb-flex-wrap, nowrap);
+    align-items: center;
+  }
+
+  .breadcrumb-item {
+    display: flex;
+    align-items: center;
+  }
+
+  .breadcrumb-separator {
+    display: flex;
+    align-items: center;
+    color: var(--breadcrumb-separator-color, currentColor);
+  }
+</style>

--- a/src/lib/Breadcrumb/properties.ts
+++ b/src/lib/Breadcrumb/properties.ts
@@ -1,0 +1,22 @@
+import type { Snippet } from 'svelte';
+
+export type BreadcrumbItemData = {
+  href: string;
+  label: string;
+};
+
+export type BreadcrumbItemContext = {
+  href: string;
+  label: string;
+  isLast: boolean;
+  index: number;
+};
+
+export type BreadcrumbProperties = {
+  items: readonly BreadcrumbItemData[];
+  item: Snippet<[BreadcrumbItemContext]>;
+  ariaLabel: string;
+  separator?: Snippet;
+  classes?: string;
+  testId?: string;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -58,6 +58,7 @@ export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
 export { default as FileInput } from './FileInput/FileInput.svelte';
 export { default as DateRangePicker } from './DateRangePicker/DateRangePicker.svelte';
+export { default as Breadcrumb } from './Breadcrumb/Breadcrumb.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -113,5 +114,6 @@ export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
 export type * from './FileInput/properties';
 export type * from './DateRangePicker/properties';
+export type * from './Breadcrumb/properties';
 
 export { validateInput } from './utils';

--- a/src/routes/components/_nav.ts
+++ b/src/routes/components/_nav.ts
@@ -21,6 +21,7 @@ export const componentNav: NavGroup[] = [
   {
     category: 'Navigation',
     items: [
+      { name: 'Breadcrumb', slug: 'breadcrumb' },
       { name: 'Tabs', slug: 'tabs' },
       { name: 'Stepper', slug: 'stepper' },
       { name: 'Pagination', slug: 'pagination' },

--- a/src/routes/components/breadcrumb/+page.svelte
+++ b/src/routes/components/breadcrumb/+page.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import Breadcrumb from '$lib/Breadcrumb/Breadcrumb.svelte';
+  import type { BreadcrumbItemData, BreadcrumbItemContext } from '$lib/Breadcrumb/properties';
+
+  const basicItems: BreadcrumbItemData[] = [
+    { href: '/components/breadcrumb', label: 'Home' },
+    { href: '/components/breadcrumb', label: 'Products' },
+    { href: '', label: 'Laptops' }
+  ];
+
+  const deepItems: BreadcrumbItemData[] = [
+    { href: '/components/breadcrumb', label: 'Home' },
+    { href: '/components/breadcrumb', label: 'Settings' },
+    { href: '/components/breadcrumb', label: 'Account' },
+    { href: '/components/breadcrumb', label: 'Security' },
+    { href: '', label: 'Two-Factor Auth' }
+  ];
+
+  const iconItems: BreadcrumbItemData[] = [
+    { href: '/components/breadcrumb', label: 'Home' },
+    { href: '/components/breadcrumb', label: 'Orders' },
+    { href: '', label: 'Order #1234' }
+  ];
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Navigation</span>
+  <h1>Breadcrumb</h1>
+</div>
+
+<h3>(a) Basic hyperlink trail</h3>
+<div class="demo-row">
+  <Breadcrumb items={basicItems} ariaLabel="Page navigation">
+    {#snippet item(ctx: BreadcrumbItemContext)}
+      {#if ctx.isLast}
+        <span aria-current="page">{ctx.label}</span>
+      {:else}
+        <a href={ctx.href}>{ctx.label}</a>
+      {/if}
+    {/snippet}
+  </Breadcrumb>
+</div>
+
+<h3>Deep hierarchy</h3>
+<div class="demo-row">
+  <Breadcrumb items={deepItems} ariaLabel="Page navigation">
+    {#snippet item(ctx: BreadcrumbItemContext)}
+      {#if ctx.isLast}
+        <span aria-current="page">{ctx.label}</span>
+      {:else}
+        <a href={ctx.href}>{ctx.label}</a>
+      {/if}
+    {/snippet}
+  </Breadcrumb>
+</div>
+
+<h3>(b) Icon crumb inside item snippet</h3>
+<div class="demo-row">
+  <Breadcrumb items={iconItems} ariaLabel="Order navigation">
+    {#snippet item(ctx: BreadcrumbItemContext)}
+      {#if ctx.isLast}
+        <span aria-current="page" style="display:inline-flex;align-items:center;gap:4px;">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+            ><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" /><line
+              x1="3"
+              y1="6"
+              x2="21"
+              y2="6"
+            /><path d="M16 10a4 4 0 0 1-8 0" /></svg
+          >
+          {ctx.label}
+        </span>
+      {:else if ctx.index === 0}
+        <a href={ctx.href} style="display:inline-flex;align-items:center;gap:4px;">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+            ><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline
+              points="9 22 9 12 15 12 15 22"
+            /></svg
+          >
+          {ctx.label}
+        </a>
+      {:else}
+        <a href={ctx.href}>{ctx.label}</a>
+      {/if}
+    {/snippet}
+  </Breadcrumb>
+</div>
+
+<h3>(c) Custom separator snippet</h3>
+<div class="demo-row">
+  <Breadcrumb items={basicItems} ariaLabel="Page navigation">
+    {#snippet item(ctx: BreadcrumbItemContext)}
+      {#if ctx.isLast}
+        <span aria-current="page">{ctx.label}</span>
+      {:else}
+        <a href={ctx.href}>{ctx.label}</a>
+      {/if}
+    {/snippet}
+    {#snippet separator()}
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"><polyline points="9 18 15 12 9 6" /></svg
+      >
+    {/snippet}
+  </Breadcrumb>
+</div>

--- a/src/wc/components/Breadcrumb.wc.svelte
+++ b/src/wc/components/Breadcrumb.wc.svelte
@@ -1,0 +1,38 @@
+<svelte:options
+  customElement={{
+    tag: 'sui-breadcrumb',
+    shadow: 'open',
+    props: {
+      items: { type: 'Array', reflect: false },
+      ariaLabel: { type: 'String', attribute: 'aria-label' },
+      classes: { type: 'String', attribute: 'classes' }
+    }
+  }}
+/>
+
+<script lang="ts">
+  import Breadcrumb from '$lib/Breadcrumb/Breadcrumb.svelte';
+  import type { BreadcrumbItemData, BreadcrumbItemContext } from '$lib/Breadcrumb/properties';
+
+  let {
+    items = [],
+    ariaLabel = '',
+    classes
+  }: {
+    items?: BreadcrumbItemData[];
+    ariaLabel?: string;
+    classes?: string;
+  } = $props();
+</script>
+
+{#snippet defaultItem(ctx: BreadcrumbItemContext)}
+  {#if ctx.isLast}
+    <span aria-current="page">{ctx.label}</span>
+  {:else if typeof ctx.href === 'string' && ctx.href.length > 0}
+    <a href={ctx.href}>{ctx.label}</a>
+  {:else}
+    <span>{ctx.label}</span>
+  {/if}
+{/snippet}
+
+<Breadcrumb {items} {ariaLabel} item={defaultItem} {classes} />

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -1,5 +1,6 @@
 import './components/Avatar.wc.svelte';
 import './components/Badge.wc.svelte';
+import './components/Breadcrumb.wc.svelte';
 import './components/Book.wc.svelte';
 import './components/BrandLoader.wc.svelte';
 import './components/Calendar.wc.svelte';


### PR DESCRIPTION
## Summary

Adds a URL-trail `Breadcrumb` primitive. The library had no breadcrumb; downstream consumers (e.g. Lighthouse mandate pages) hand-roll the trail markup.

## API
- `items?: { name: string; url?: string; testId?: string }[]`
- `testId?: string` → `data-pw` on the `<nav>` (and per item via `item.testId`)
- Renders semantic `<nav aria-label="Breadcrumb">`; non-terminal items are `<a href>` links, the final item is `aria-current="page"`.
- Exposed CSS vars: `--breadcrumb-gap`, `--breadcrumb-separator` (default `/`), `--breadcrumb-separator-color`, `--breadcrumb-link-color`, `--breadcrumb-current-color`, `--breadcrumb-current-font-weight` (default 600).

## Notes
- Follows existing conventions (Svelte 5 runes, `properties.ts`, index exports), mirroring `Badge`/`Banner`.
- `pnpm run check`: **0 errors, 0 warnings**; `prettier --check` + `eslint` clean.
- Formalizes the component that Lighthouse's `LinearBreadcrumb` (5 call-sites) migrates onto; on publish the consumer drops its project component and bridges colors via the exposed vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Breadcrumb navigation component for ordered navigation trails
  * Customizable separators and styling
  * Supports linked items, plain-text trails, and current page indication
  * Available as both Svelte component and web component

* **Documentation**
  * Added component documentation with usage examples and API reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->