### PR TITLE
feat: expose text-wrap CSS vars on Banner

### DIFF
--- a/src/lib/Banner/Banner.svelte
+++ b/src/lib/Banner/Banner.svelte
@@ -122,9 +122,9 @@
   }
 
   .banner-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow: var(--banner-text-overflow, hidden);
+    text-overflow: var(--banner-text-ellipsis, ellipsis);
+    white-space: var(--banner-white-space, nowrap);
   }
 
   .banner-link-text {


### PR DESCRIPTION
## Summary

Exposes `--banner-white-space`, `--banner-text-overflow`, and `--banner-text-ellipsis` on `Banner`'s `.banner-text` so callers can opt out of the default single-line truncation. Defaults preserve current behaviour (`hidden` / `ellipsis` / `nowrap`) — fully backward-compatible.

## Why

`Banner` is a single-line page-banner by default. Inline/card-context usages (e.g. Lighthouse's `Warning` hints, which wrap multi-line in narrow containers) previously had to override the internal `.banner-text` class from the consumer. With these vars they bridge through the public API: `--banner-white-space: normal; --banner-text-overflow: visible; --banner-text-ellipsis: clip;`.

## Notes
- `pnpm run check`: **0 errors, 0 warnings**; `prettier` + `eslint` clean.
- Lets the downstream Warning→Banner migration drop its consumer-side `.banner-text` override.