### PR TITLE
feat: add testId prop to EmptyState

### DIFF
--- a/src/lib/EmptyState/EmptyState.svelte
+++ b/src/lib/EmptyState/EmptyState.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { EmptyStateProperties } from './properties';
 
-  let { title, description, icon, children, classes }: EmptyStateProperties = $props();
+  let { title, description, icon, children, classes, testId }: EmptyStateProperties = $props();
 </script>
 
-<div class="empty-state {classes ?? ''}">
+<div class="empty-state {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
   {#if typeof icon === 'function'}
     <div class="empty-state-icon">
       {@render icon()}

--- a/src/lib/EmptyState/properties.ts
+++ b/src/lib/EmptyState/properties.ts
@@ -11,4 +11,5 @@ export type OptionalEmptyStateProperties = {
   icon?: Snippet;
   children?: Snippet;
   classes?: string;
+  testId?: string;
 };


### PR DESCRIPTION
## Summary

Adds an optional `testId` prop to `EmptyState` that renders `data-pw={testId}` on the root `.empty-state` element — matching the `testId`→`data-pw` convention already used by `Banner`, `Divider`, `IconStack`, etc.

## Why

`EmptyState` previously had no test hook, forcing consumers to wrap it in an extra `<div data-pw>` for automation. Downstream migrations (Lighthouse `NoData` — 33 call-sites — and `ConnectionErrorState`) need a root test id; this lets them target the component directly.

## Notes
- Backward-compatible (optional prop, `null` when unset).
- `pnpm run check`: **0 errors, 0 warnings**; `prettier` + `eslint` clean.