### PR TITLE
feat: add LabeledField component

### DIFF
--- a/src/lib/LabeledField/LabeledField.svelte
+++ b/src/lib/LabeledField/LabeledField.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { LabeledFieldProperties } from './properties';
+
+  let { label, value, testId, classes }: LabeledFieldProperties = $props();
+</script>
+
+<div class="labeled-field {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+  <div class="labeled-field-label">{label}</div>
+  <div class="labeled-field-value">{value}</div>
+</div>
+
+<style>
+  .labeled-field {
+    display: flex;
+    flex-direction: var(--labeled-field-direction, column);
+    gap: var(--labeled-field-gap, 4px);
+    align-items: var(--labeled-field-align-items, flex-start);
+  }
+
+  .labeled-field-label {
+    color: var(--labeled-field-label-color, inherit);
+    font-size: var(--labeled-field-label-font-size, 12px);
+    font-weight: var(--labeled-field-label-font-weight, 500);
+  }
+
+  .labeled-field-value {
+    color: var(--labeled-field-value-color, inherit);
+    font-size: var(--labeled-field-value-font-size, 14px);
+    font-weight: var(--labeled-field-value-font-weight, 400);
+  }
+</style>

--- a/src/lib/LabeledField/properties.ts
+++ b/src/lib/LabeledField/properties.ts
@@ -1,0 +1,6 @@
+export type LabeledFieldProperties = {
+  label: string;
+  value: string;
+  testId?: string;
+  classes?: string;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as LabeledField } from './LabeledField/LabeledField.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './LabeledField/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- Adds `LabeledField`, a new single label-value display primitive to the component library
- Exposes 9 CSS custom properties for full layout and typography customization without overriding the design system
- Exports `LabeledField` component and `LabeledFieldProperties` type from the library root (`src/lib/index.ts`)

## API

### Props

| Prop | Type | Required | Description |
|------|------|----------|-------------|
| `label` | `string` | yes | The label text displayed above the value |
| `value` | `string` | yes | The value text displayed below the label |
| `testId` | `string` | no | Sets `data-pw` attribute on the root element |
| `classes` | `string` | no | Additional CSS classes appended to the root element |

### CSS Custom Properties

| Variable | Default | Description |
|----------|---------|-------------|
| `--labeled-field-direction` | `column` | `flex-direction` of the root container |
| `--labeled-field-gap` | `4px` | Gap between label and value |
| `--labeled-field-align-items` | `flex-start` | `align-items` of the root container |
| `--labeled-field-label-color` | `inherit` | Label text color |
| `--labeled-field-label-font-size` | `12px` | Label font size |
| `--labeled-field-label-font-weight` | `500` | Label font weight |
| `--labeled-field-value-color` | `inherit` | Value text color |
| `--labeled-field-value-font-size` | `14px` | Value font size |
| `--labeled-field-value-font-weight` | `400` | Value font weight |

### DOM Structure

```html
<div class="labeled-field {classes}" data-pw="{testId}">
  <div class="labeled-field-label">{label}</div>
  <div class="labeled-field-value">{value}</div>
</div>
```

## Notes

- `svelte-check` found **0 errors and 0 warnings**
- `prettier --check` passes cleanly
- `eslint` exits with code 0 (no issues)
- Font properties are set via CSS custom properties only — no hardcoded typography overrides in the component style block, consistent with the design system contract