### PR TITLE
feat: add CopyButton component

### DIFF
--- a/src/lib/CopyButton/CopyButton.svelte
+++ b/src/lib/CopyButton/CopyButton.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import type { CopyButtonProperties } from './properties';
+
+  let {
+    value,
+    testId,
+    classes,
+    ariaLabel = 'Copy',
+    copiedAriaLabel = 'Copied',
+    timeoutMs = 2000
+  }: CopyButtonProperties = $props();
+
+  let copied = $state(false);
+
+  const handleCopy = async () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      copied = true;
+      setTimeout(() => {
+        copied = false;
+      }, timeoutMs);
+    } catch {
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.style.position = 'fixed';
+      textarea.style.top = '-9999px';
+      textarea.style.left = '-9999px';
+      textarea.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      copied = true;
+      setTimeout(() => {
+        copied = false;
+      }, timeoutMs);
+    }
+  };
+</script>
+
+<button
+  type="button"
+  class="copy-button {classes ?? ''}"
+  aria-label={copied ? copiedAriaLabel : ariaLabel}
+  data-pw={typeof testId === 'string' ? testId : null}
+  onclick={handleCopy}
+>
+  {#if !copied}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
+  {:else}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <polyline points="20 6 9 17 4 12"></polyline>
+    </svg>
+  {/if}
+</button>
+
+<style>
+  .copy-button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    padding: var(--copy-button-padding, 4px);
+    border-radius: var(--copy-button-border-radius, 4px);
+    color: var(--copy-button-color, currentColor);
+  }
+
+  .copy-button:hover {
+    background: var(--copy-button-hover-background, rgba(0, 0, 0, 0.05));
+  }
+
+  .copy-button svg {
+    width: var(--copy-button-size, 16px);
+    height: var(--copy-button-size, 16px);
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+</style>

--- a/src/lib/CopyButton/properties.ts
+++ b/src/lib/CopyButton/properties.ts
@@ -1,0 +1,8 @@
+export type CopyButtonProperties = {
+  value: string;
+  testId?: string;
+  classes?: string;
+  ariaLabel?: string;
+  copiedAriaLabel?: string;
+  timeoutMs?: number;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as CopyButton } from './CopyButton/CopyButton.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './CopyButton/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- New `CopyButton` component: an icon-only copy-to-clipboard button with a transient "Copied" feedback state
- Svelte 5 runes (`$state`, `$props`) following the existing component conventions
- SSR-safe: all clipboard and DOM access is guarded by `typeof window !== 'undefined'`

## API

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `value` | `string` | — (required) | Text copied to clipboard on click |
| `testId` | `string?` | — | `data-pw` attribute on root button |
| `classes` | `string?` | — | Extra CSS classes appended to root |
| `ariaLabel` | `string?` | `'Copy'` | `aria-label` in idle state |
| `copiedAriaLabel` | `string?` | `'Copied'` | `aria-label` while copied feedback is active |
| `timeoutMs` | `number?` | `2000` | Milliseconds before reverting to idle state |

### CSS Custom Properties

| Variable | Default | Controls |
|----------|---------|----------|
| `--copy-button-color` | `currentColor` | Icon / text colour |
| `--copy-button-size` | `16px` | SVG icon width + height |
| `--copy-button-padding` | `4px` | Button padding |
| `--copy-button-hover-background` | `rgba(0,0,0,0.05)` | Hover background |
| `--copy-button-border-radius` | `4px` | Button corner radius |

### DOM

Root element: `<button type="button" class="copy-button {classes}">` with `data-pw={testId}` (only set when `testId` is a string).

Two inline stroke SVGs toggled by the `copied` flag: clipboard glyph (idle) and checkmark (copied). Both are `aria-hidden`.

## Notes

- `svelte-check`: 0 errors, 0 warnings
- `prettier --check`: all files clean
- `eslint`: no issues
- Clipboard fallback uses a hidden `<textarea>` + `document.execCommand('copy')` for environments without the async Clipboard API