### PR TITLE
feat: add 'typing' animation variant to LoadingDots

### DIFF
--- a/src/lib/LoadingDots/LoadingDots.svelte
+++ b/src/lib/LoadingDots/LoadingDots.svelte
@@ -13,7 +13,12 @@
   data-pw={typeof testId === 'string' ? testId : null}
 >
   {#each { length: count } as _, i (i)}
-    <span class="dot" class:pulse={animation === 'pulse'} style="--i: {i}"></span>
+    <span
+      class="dot"
+      class:pulse={animation === 'pulse'}
+      class:typing={animation === 'typing'}
+      style="--i: {i}"
+    ></span>
   {/each}
 </span>
 
@@ -40,6 +45,11 @@
     animation-name: loading-dots-pulse;
   }
 
+  .dot.typing {
+    animation: loading-dots-typing var(--loading-dots-typing-duration, 1.4s) ease-in-out infinite;
+    animation-delay: calc(var(--i) * 0.16s);
+  }
+
   @keyframes loading-dots-bounce {
     0%,
     80%,
@@ -59,6 +69,19 @@
     }
     40% {
       opacity: 1;
+    }
+  }
+
+  @keyframes loading-dots-typing {
+    0%,
+    80%,
+    100% {
+      opacity: 0.3;
+      transform: scale(0.85);
+    }
+    40% {
+      opacity: 1;
+      transform: scale(1);
     }
   }
 </style>

--- a/src/lib/LoadingDots/properties.ts
+++ b/src/lib/LoadingDots/properties.ts
@@ -1,4 +1,4 @@
-export type LoadingDotsAnimation = 'bounce' | 'pulse';
+export type LoadingDotsAnimation = 'bounce' | 'pulse' | 'typing';
 
 export type LoadingDotsProperties = OptionalLoadingDotsProperties;
 


### PR DESCRIPTION
## Summary

- Extends `LoadingDotsAnimation` type union with a new `'typing'` value (`'bounce' | 'pulse' | 'typing'`)
- When `animation="typing"`, dots render with a gentle staggered opacity+scale pulse suited for chat/typing indicators
- Adds `@keyframes loading-dots-typing` (0%/80%/100%: opacity 0.3, scale 0.85 → 40%: opacity 1, scale 1)
- Three dots staggered at `animation-delay` 0s / 0.16s / 0.32s (fixed values, not using the shared stagger variable so typing variant has its own independent rhythm)
- Exposes `--loading-dots-typing-duration` CSS custom property (default `1.4s`) for consumer customisation
- Existing `bounce` and `pulse` variants are **fully unchanged** — no breaking changes

## API

### Props

| Prop | Type | Default | Notes |
|------|------|---------|-------|
| `animation` | `'bounce' \| 'pulse' \| 'typing'` | `'bounce'` | Extended union — new `'typing'` value added |

### CSS custom properties

| Variable | Default | Effect |
|----------|---------|--------|
| `--loading-dots-typing-duration` | `1.4s` | Controls cycle duration for the typing animation |

### DOM

When `animation="typing"` the inner `.dot` spans receive the `typing` CSS class, which overrides the default `loading-dots-bounce` animation with `loading-dots-typing`.

## Notes

- `svelte-check` 0 errors / 0 warnings
- `prettier --check` clean
- `eslint` clean
- Backward-compatible: default value of `animation` remains `'bounce'`