### PR TITLE
feat: add GradientBlur decorative component

### DIFF
--- a/src/lib/GradientBlur/GradientBlur.svelte
+++ b/src/lib/GradientBlur/GradientBlur.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import type { GradientBlurProperties } from './properties';
+
+  let { testId, classes }: GradientBlurProperties = $props();
+</script>
+
+<div
+  class="gradient-blur {classes ?? ''}"
+  aria-hidden="true"
+  data-pw={typeof testId === 'string' ? testId : null}
+>
+  <div class="gradient-blur-layer gradient-blur-layer-1"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-2"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-3"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-4"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-5"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-6"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-7"></div>
+  <div class="gradient-blur-layer gradient-blur-layer-8"></div>
+</div>
+
+<style>
+  .gradient-blur {
+    position: var(--gradient-blur-position, absolute);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: var(--gradient-blur-height, 80px);
+    pointer-events: none;
+    z-index: var(--gradient-blur-z-index, 10);
+  }
+
+  .gradient-blur-layer {
+    position: absolute;
+    inset: 0;
+  }
+
+  .gradient-blur-layer-1 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 1));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 1));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 0%,
+      rgba(0, 0, 0, 0) 12.5%
+    );
+  }
+
+  .gradient-blur-layer-2 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 2));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 2));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 12.5%,
+      rgba(0, 0, 0, 0) 25%
+    );
+  }
+
+  .gradient-blur-layer-3 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 3));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 3));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 25%,
+      rgba(0, 0, 0, 0) 37.5%
+    );
+  }
+
+  .gradient-blur-layer-4 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 4));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 4));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 37.5%,
+      rgba(0, 0, 0, 0) 50%
+    );
+  }
+
+  .gradient-blur-layer-5 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 5));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 5));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 50%,
+      rgba(0, 0, 0, 0) 62.5%
+    );
+  }
+
+  .gradient-blur-layer-6 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 6));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 6));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 62.5%,
+      rgba(0, 0, 0, 0) 75%
+    );
+  }
+
+  .gradient-blur-layer-7 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 7));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 7));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 75%,
+      rgba(0, 0, 0, 0) 87.5%
+    );
+  }
+
+  .gradient-blur-layer-8 {
+    backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 8));
+    -webkit-backdrop-filter: blur(calc(var(--gradient-blur-strength, 8px) * 8));
+    mask-image: linear-gradient(
+      var(--gradient-blur-direction, to bottom),
+      rgba(0, 0, 0, 1) 87.5%,
+      rgba(0, 0, 0, 0) 100%
+    );
+  }
+</style>

--- a/src/lib/GradientBlur/properties.ts
+++ b/src/lib/GradientBlur/properties.ts
@@ -1,0 +1,4 @@
+export type GradientBlurProperties = {
+  testId?: string;
+  classes?: string;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as GradientBlur } from './GradientBlur/GradientBlur.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './GradientBlur/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- New `GradientBlur` decorative primitive using 8 stacked `<div>` layers with `backdrop-filter` and `mask-image` gradients to produce a smooth progressive blur effect
- No interactivity: `aria-hidden="true"`, `pointer-events: none` throughout
- Fully customisable via CSS custom properties; zero hard-coded visual values in consuming code

## API

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `testId` | `string?` | — | Renders as `data-pw` on root element |
| `classes` | `string?` | `''` | Extra CSS classes appended to root |

### CSS Custom Properties

| Variable | Default | Description |
|----------|---------|-------------|
| `--gradient-blur-height` | `80px` | Height of the blur overlay |
| `--gradient-blur-direction` | `to bottom` | Gradient direction (any valid CSS gradient direction) |
| `--gradient-blur-strength` | `8px` | Base blur amount; layer n applies `strength * n` |
| `--gradient-blur-position` | `absolute` | CSS `position` on root |
| `--gradient-blur-z-index` | `10` | `z-index` on root |

### DOM Structure

```html
<div class="gradient-blur {classes}" aria-hidden="true" data-pw="{testId}">
  <div class="gradient-blur-layer gradient-blur-layer-1"></div>
  <!-- … -->
  <div class="gradient-blur-layer gradient-blur-layer-8"></div>
</div>
```

Each layer `n` applies `backdrop-filter: blur(strength * n)` and a mask gradient covering the `[(n-1)*12.5%, n*12.5%]` band of the overlay height.

## Notes

- `svelte-check` — 0 errors, 0 warnings
- `prettier --check` — all files pass
- `eslint` — no findings
- CSS class names are kebab-case only (`gradient-blur`, `gradient-blur-layer`, `gradient-blur-layer-{n}`) — compliant with `selector-class-pattern`
- No `font-*` or `line-height` overrides in `<style>` block