### PR TITLE
feat: add InfoBlock component

### DIFF
--- a/src/lib/InfoBlock/InfoBlock.svelte
+++ b/src/lib/InfoBlock/InfoBlock.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { InfoBlockProperties } from './properties';
+
+  let { items, testId, classes }: InfoBlockProperties = $props();
+</script>
+
+<dl class="info-block {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+  {#each Object.entries(items) as [key, value] (key)}
+    <div class="info-block-item">
+      <dt class="info-block-key">{key}</dt>
+      <dd class="info-block-value">{value}</dd>
+    </div>
+  {/each}
+</dl>
+
+<style>
+  .info-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--info-block-gap, 8px);
+    padding: var(--info-block-padding, 0);
+    margin: 0;
+  }
+
+  .info-block-item {
+    display: flex;
+    justify-content: var(--info-block-item-justify-content, space-between);
+  }
+
+  .info-block-key {
+    margin: 0;
+    color: var(--info-block-key-color, inherit);
+    font-weight: var(--info-block-key-font-weight, 500);
+  }
+
+  .info-block-value {
+    margin: 0;
+    color: var(--info-block-value-color, inherit);
+    font-weight: var(--info-block-value-font-weight, 400);
+    text-align: var(--info-block-value-text-align, right);
+  }
+</style>

--- a/src/lib/InfoBlock/properties.ts
+++ b/src/lib/InfoBlock/properties.ts
@@ -1,0 +1,5 @@
+export type InfoBlockProperties = {
+  items: Record<string, string>;
+  testId?: string;
+  classes?: string;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as InfoBlock } from './InfoBlock/InfoBlock.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './InfoBlock/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- Adds `InfoBlock` — a new definition-list primitive (`<dl>`) that renders metadata key/value pairs
- Exports `InfoBlock` component and `InfoBlockProperties` type from the package root (`src/lib/index.ts`)
- Zero new project-owned dependencies; follows existing Svelte 5 runes pattern (mirrors `Badge`)

## API

### Props (`InfoBlockProperties`)

| Prop | Type | Required | Description |
|------|------|----------|-------------|
| `items` | `Record<string, string>` | yes | Key/value pairs to render |
| `testId` | `string` | no | Sets `data-pw` on the root `<dl>` |
| `classes` | `string` | no | Extra CSS classes appended to root |

### DOM structure

```html
<dl class="info-block {classes}" data-pw="{testId}">
  <div class="info-block-item">
    <dt class="info-block-key">Label</dt>
    <dd class="info-block-value">Value</dd>
  </div>
  …
</dl>
```

### CSS custom properties

| Variable | Default | Controls |
|----------|---------|----------|
| `--info-block-gap` | `8px` | Column gap between rows |
| `--info-block-padding` | `0` | Root padding |
| `--info-block-item-justify-content` | `space-between` | Row flex justify |
| `--info-block-key-color` | `inherit` | Key text colour |
| `--info-block-key-font-weight` | `500` | Key weight (via CSS var, never hardcoded) |
| `--info-block-value-color` | `inherit` | Value text colour |
| `--info-block-value-font-weight` | `400` | Value weight (via CSS var) |
| `--info-block-value-text-align` | `right` | Value text alignment |

## Notes

- `svelte-check` — 0 errors, 0 warnings
- `prettier --check` — all files pass
- `eslint` — 0 errors (each block keyed by property key)
- `dt`/`dd` margins reset to `0`; all selectors are kebab-case only
- `font-weight` is exposed exclusively through CSS custom properties, never hardcoded