### PR TITLE
feat: add ActionBar component

### DIFF
--- a/src/lib/ActionBar/ActionBar.svelte
+++ b/src/lib/ActionBar/ActionBar.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { ActionBarProperties } from './properties';
+  import Button from '../Button/Button.svelte';
+
+  let {
+    testId,
+    classes,
+    divider = true,
+    primaryButton,
+    secondaryButton,
+    children
+  }: ActionBarProperties = $props();
+</script>
+
+<div class="action-bar {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+  {#if divider}
+    <div class="action-bar-divider"></div>
+  {/if}
+  <div class="action-bar-buttons">
+    {#if typeof children === 'function'}
+      {@render children()}
+    {:else}
+      {#if secondaryButton}
+        <Button {...secondaryButton} />
+      {/if}
+      {#if primaryButton}
+        <Button {...primaryButton} />
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .action-bar {
+    background: var(--action-bar-background, #fff);
+    position: var(--action-bar-position, fixed);
+    bottom: var(--action-bar-bottom, 0);
+    left: var(--action-bar-left, 0);
+    right: var(--action-bar-right, 0);
+    padding: var(--action-bar-padding, 12px 16px);
+    z-index: var(--action-bar-z-index, 50);
+    box-sizing: border-box;
+  }
+
+  .action-bar-divider {
+    height: var(--action-bar-divider-thickness, 1px);
+    background: var(--action-bar-divider-color, rgba(0, 0, 0, 0.08));
+  }
+
+  .action-bar-buttons {
+    display: flex;
+    gap: var(--action-bar-gap, 8px);
+    justify-content: var(--action-bar-justify-content, flex-end);
+  }
+</style>

--- a/src/lib/ActionBar/properties.ts
+++ b/src/lib/ActionBar/properties.ts
@@ -1,0 +1,11 @@
+import type { Snippet } from 'svelte';
+import type { ButtonProperties } from '../Button/properties';
+
+export type ActionBarProperties = {
+  testId?: string;
+  classes?: string;
+  divider?: boolean;
+  primaryButton?: ButtonProperties;
+  secondaryButton?: ButtonProperties;
+  children?: Snippet;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as ActionBar } from './ActionBar/ActionBar.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './ActionBar/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- New `ActionBar` bottom-fixed action bar primitive for primary/secondary form actions
- Exported from `@juspay/svelte-ui-components` as `ActionBar` component and `ActionBarProperties` type
- Follows existing library patterns (Svelte 5 runes, `$props()` destructure, `data-pw` test-id, CSS custom properties)

## API

### Props (`ActionBarProperties`)

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `testId` | `string?` | — | Sets `data-pw` on root element |
| `classes` | `string?` | — | Extra CSS classes appended to root |
| `divider` | `boolean?` | `true` | Renders a top hairline divider |
| `primaryButton` | `ButtonProperties?` | — | Spread onto primary `<Button>` |
| `secondaryButton` | `ButtonProperties?` | — | Spread onto secondary `<Button>` |
| `children` | `Snippet?` | — | Custom slot overrides button pair |

### CSS Custom Properties

| Variable | Default | Description |
|----------|---------|-------------|
| `--action-bar-background` | `#fff` | Root background |
| `--action-bar-position` | `fixed` | CSS position |
| `--action-bar-bottom` | `0` | Bottom offset |
| `--action-bar-left` | `0` | Left offset |
| `--action-bar-right` | `0` | Right offset |
| `--action-bar-padding` | `12px 16px` | Inner padding |
| `--action-bar-gap` | `8px` | Gap between buttons |
| `--action-bar-justify-content` | `flex-end` | Button row alignment |
| `--action-bar-z-index` | `50` | Stacking order |
| `--action-bar-divider-color` | `rgba(0,0,0,0.08)` | Divider line colour |
| `--action-bar-divider-thickness` | `1px` | Divider line height |

### DOM Structure

```html
<div class="action-bar" data-pw="…">
  <div class="action-bar-divider"></div>   <!-- when divider=true -->
  <div class="action-bar-buttons">
    <!-- <Button> pair or children snippet -->
  </div>
</div>
```

## Notes

- `svelte-check` reports **0 errors and 0 warnings**
- `prettier --check` passes (exit 0)
- `eslint` passes (exit 0)
- Button wired via `{...buttonProperties}` spread, matching the Modal footer pattern
- No typography properties (`font-*`, `line-height`) set in component CSS — design system handles those via semantic tags
- CSS class selectors use kebab-case only (stylelint `selector-class-pattern` compliant)