### PR TITLE
feat: add InlineAlert component

### DIFF
--- a/src/lib/InlineAlert/InlineAlert.svelte
+++ b/src/lib/InlineAlert/InlineAlert.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import { fade } from 'svelte/transition';
+  import type { InlineAlertProperties } from './properties';
+  import closeSvg from '$lib/assets/close.svg?raw';
+
+  let {
+    text,
+    tone = 'info',
+    icon,
+    children,
+    dismissible = false,
+    visible = $bindable(true),
+    testId,
+    classes,
+    ondismiss
+  }: InlineAlertProperties = $props();
+
+  const handleDismiss = (): void => {
+    visible = false;
+    ondismiss?.();
+  };
+
+  const handleDismissKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleDismiss();
+    }
+  };
+</script>
+
+{#if visible}
+  <div
+    class="inline-alert inline-alert-{tone} {classes ?? ''}"
+    role={tone === 'error' ? 'alert' : 'status'}
+    aria-live={tone === 'error' ? 'assertive' : 'polite'}
+    data-pw={typeof testId === 'string' ? testId : null}
+    transition:fade={{ duration: 150 }}
+  >
+    {#if typeof icon === 'function'}
+      <div class="inline-alert-icon">
+        {@render icon()}
+      </div>
+    {/if}
+
+    <div class="inline-alert-body">
+      {#if typeof children === 'function'}
+        {@render children()}
+      {:else if typeof text === 'string'}
+        {text}
+      {/if}
+    </div>
+
+    {#if dismissible}
+      <button
+        class="inline-alert-dismiss"
+        type="button"
+        aria-label="Dismiss"
+        onclick={handleDismiss}
+        onkeydown={handleDismissKeydown}
+        {...typeof testId === 'string' ? { 'data-pw': `${testId}-dismiss` } : {}}
+      >
+        <!-- eslint-disable svelte/no-at-html-tags -->
+        {@html closeSvg}
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .inline-alert {
+    display: flex;
+    align-items: var(--inline-alert-align-items, center);
+    gap: var(--inline-alert-gap, 8px);
+    padding: var(--inline-alert-padding, 10px 12px);
+    border-radius: var(--inline-alert-radius, 6px);
+    border: var(--inline-alert-border, none);
+    width: var(--inline-alert-width, 100%);
+    box-sizing: border-box;
+  }
+
+  .inline-alert-info {
+    background-color: var(--inline-alert-info-background, #e8f0fe);
+    color: var(--inline-alert-info-color, #1a56a0);
+  }
+
+  .inline-alert-success {
+    background-color: var(--inline-alert-success-background, #dcfce7);
+    color: var(--inline-alert-success-color, #166534);
+  }
+
+  .inline-alert-warning {
+    background-color: var(--inline-alert-warning-background, #fef9c3);
+    color: var(--inline-alert-warning-color, #854d0e);
+  }
+
+  .inline-alert-error {
+    background-color: var(--inline-alert-error-background, #fee2e2);
+    color: var(--inline-alert-error-color, #991b1b);
+  }
+
+  .inline-alert-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    color: var(--inline-alert-icon-color, currentColor);
+  }
+
+  .inline-alert-icon :global(svg) {
+    width: var(--inline-alert-icon-size, 16px);
+    height: var(--inline-alert-icon-size, 16px);
+  }
+
+  .inline-alert-body {
+    flex: 1;
+  }
+
+  .inline-alert-dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: var(--inline-alert-dismiss-padding, 2px);
+    border-radius: var(--inline-alert-dismiss-radius, 4px);
+    color: currentColor;
+    opacity: var(--inline-alert-dismiss-opacity, 0.7);
+  }
+
+  .inline-alert-dismiss:hover {
+    opacity: 1;
+    background-color: var(--inline-alert-dismiss-hover-background, rgba(0, 0, 0, 0.08));
+  }
+
+  .inline-alert-dismiss :global(svg) {
+    width: var(--inline-alert-dismiss-size, 14px);
+    height: var(--inline-alert-dismiss-size, 14px);
+  }
+</style>

--- a/src/lib/InlineAlert/properties.ts
+++ b/src/lib/InlineAlert/properties.ts
@@ -1,0 +1,15 @@
+import type { Snippet } from 'svelte';
+
+export type InlineAlertTone = 'info' | 'success' | 'warning' | 'error';
+
+export type InlineAlertProperties = {
+  text?: string;
+  tone?: InlineAlertTone;
+  icon?: Snippet;
+  children?: Snippet;
+  dismissible?: boolean;
+  visible?: boolean;
+  testId?: string;
+  classes?: string;
+  ondismiss?: () => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as InlineAlert } from './InlineAlert/InlineAlert.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './InlineAlert/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- New `InlineAlert` component — an inline (non-sticky, non-transient) alert/message primitive, distinct from `Banner` (sticky page strip) and `Toast` (transient overlay).
- Four tone variants: `info` (blue-grey), `success` (green), `warning` (amber), `error` (red) — all using soft backgrounds with readable text via per-tone CSS custom properties.
- Dismissible with `$bindable visible` prop and optional `ondismiss` callback; fade transition on enter/leave.

## API

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `text` | `string` | — | Plain text content |
| `tone` | `'info' \| 'success' \| 'warning' \| 'error'` | `'info'` | Visual tone variant |
| `icon` | `Snippet` | — | Optional leading icon slot |
| `children` | `Snippet` | — | Rich body content (overrides `text`) |
| `dismissible` | `boolean` | `false` | Show dismiss button |
| `visible` | `boolean` ($bindable) | `true` | Controls visibility |
| `testId` | `string` | — | Sets `data-pw` on root; dismiss button gets `{testId}-dismiss` |
| `classes` | `string` | — | Extra CSS classes on root element |
| `ondismiss` | `() => void` | — | Called when dismissed |

### CSS Custom Properties

| Variable | Default | Description |
|----------|---------|-------------|
| `--inline-alert-padding` | `10px 12px` | Root padding |
| `--inline-alert-gap` | `8px` | Gap between icon / body / dismiss |
| `--inline-alert-radius` | `6px` | Border radius |
| `--inline-alert-border` | `none` | Border |
| `--inline-alert-width` | `100%` | Width |
| `--inline-alert-icon-size` | `16px` | Icon SVG size |
| `--inline-alert-icon-color` | `currentColor` | Icon color |
| `--inline-alert-dismiss-size` | `14px` | Dismiss icon size |
| `--inline-alert-dismiss-padding` | `2px` | Dismiss button padding |
| `--inline-alert-dismiss-radius` | `4px` | Dismiss button border radius |
| `--inline-alert-dismiss-opacity` | `0.7` | Dismiss button default opacity |
| `--inline-alert-dismiss-hover-background` | `rgba(0,0,0,0.08)` | Dismiss hover background |
| `--inline-alert-info-background` | `#e8f0fe` | Info tone background |
| `--inline-alert-info-color` | `#1a56a0` | Info tone text color |
| `--inline-alert-success-background` | `#dcfce7` | Success tone background |
| `--inline-alert-success-color` | `#166534` | Success tone text color |
| `--inline-alert-warning-background` | `#fef9c3` | Warning tone background |
| `--inline-alert-warning-color` | `#854d0e` | Warning tone text color |
| `--inline-alert-error-background` | `#fee2e2` | Error tone background |
| `--inline-alert-error-color` | `#991b1b` | Error tone text color |

### DOM / Accessibility

- `role="alert"` + `aria-live="assertive"` for `tone="error"`, `role="status"` + `aria-live="polite"` for all others.
- Dismiss button is a native `<button type="button">` with `aria-label="Dismiss"`.
- `data-pw={testId}` on root; `data-pw="{testId}-dismiss"` on dismiss button.

## Notes

- `svelte-check` — **0 errors, 0 warnings**
- `prettier --check` — clean
- `eslint` — clean
- Backward-compatible: new export appended after `SplitInput` in `src/lib/index.ts`
- No hardcoded `font-family`, `font-size`, `font-weight`, or `line-height` in component CSS — all visual properties driven by CSS custom properties
- Svelte 5 runes throughout (`$props`, `$bindable`, `$state` not needed — pure props-driven)