### PR TITLE
feat: add NavigationMenu component

### DIFF
--- a/src/lib/NavigationMenu/NavigationMenu.svelte
+++ b/src/lib/NavigationMenu/NavigationMenu.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import type { NavigationMenuProperties } from './properties';
+
+  let {
+    items,
+    selectedId,
+    testId,
+    classes,
+    ariaLabel = 'Navigation',
+    onselect
+  }: NavigationMenuProperties = $props();
+</script>
+
+<nav class="navigation-menu {classes ?? ''}" aria-label={ariaLabel} data-pw={testId}>
+  <ul class="navigation-menu-list" role="list">
+    {#each items as item (item.id)}
+      <li class="navigation-menu-list-item">
+        <button
+          class="navigation-menu-item"
+          class:navigation-menu-item-selected={item.id === selectedId}
+          data-pw={item.id}
+          disabled={item.disabled}
+          aria-current={item.id === selectedId ? 'page' : null}
+          onclick={() => onselect?.(item.id)}
+        >
+          {#if item.icon}
+            <img class="navigation-menu-item-icon" src={item.icon} alt="" aria-hidden="true" />
+          {/if}
+          <span class="navigation-menu-item-label">{item.label}</span>
+          {#if item.statusDot}
+            <span class="navigation-menu-dot" aria-hidden="true"></span>
+          {/if}
+        </button>
+      </li>
+    {/each}
+  </ul>
+</nav>
+
+<style>
+  .navigation-menu {
+    width: var(--navigation-menu-width, 240px);
+    padding: var(--navigation-menu-padding, 8px);
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .navigation-menu-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--navigation-menu-gap, 2px);
+    overflow-y: auto;
+  }
+
+  .navigation-menu-list-item {
+    display: contents;
+  }
+
+  .navigation-menu-item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: var(--navigation-menu-item-padding, 8px 12px);
+    border-radius: var(--navigation-menu-item-radius, 8px);
+    border: none;
+    background: transparent;
+    color: var(--navigation-menu-item-color, inherit);
+    cursor: pointer;
+    text-align: left;
+    box-sizing: border-box;
+  }
+
+  .navigation-menu-item:hover:not(:disabled) {
+    background-color: var(--navigation-menu-item-hover-background, rgba(0, 0, 0, 0.06));
+  }
+
+  .navigation-menu-item:focus-visible {
+    outline: 2px solid var(--navigation-menu-item-selected-background, currentColor);
+    outline-offset: 2px;
+  }
+
+  .navigation-menu-item-selected {
+    background-color: var(--navigation-menu-item-selected-background, rgba(0, 0, 0, 0.1));
+    color: var(--navigation-menu-item-selected-color, inherit);
+  }
+
+  .navigation-menu-item:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .navigation-menu-item-icon {
+    width: var(--navigation-menu-item-icon-size, 20px);
+    height: var(--navigation-menu-item-icon-size, 20px);
+    flex-shrink: 0;
+    object-fit: contain;
+  }
+
+  .navigation-menu-item-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .navigation-menu-dot {
+    flex-shrink: 0;
+    width: var(--navigation-menu-dot-size, 8px);
+    height: var(--navigation-menu-dot-size, 8px);
+    border-radius: 50%;
+    background-color: var(--navigation-menu-dot-color, #22c55e);
+  }
+</style>

--- a/src/lib/NavigationMenu/properties.ts
+++ b/src/lib/NavigationMenu/properties.ts
@@ -1,0 +1,16 @@
+export type NavigationMenuItem = {
+  id: string;
+  label: string;
+  icon?: string;
+  statusDot?: boolean;
+  disabled?: boolean;
+};
+
+export type NavigationMenuProperties = {
+  items: NavigationMenuItem[];
+  selectedId?: string;
+  testId?: string;
+  classes?: string;
+  ariaLabel?: string;
+  onselect?: (id: string) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as NavigationMenu } from './NavigationMenu/NavigationMenu.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './NavigationMenu/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- New `NavigationMenu` primitive: a vertical sidebar navigation panel built with Svelte 5 runes
- Exports `NavigationMenu` (default) and `NavigationMenuProperties` / `NavigationMenuItem` types from the library root
- Fully backward-compatible addition — no existing exports modified

## API

### Props (`NavigationMenuProperties`)

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `items` | `NavigationMenuItem[]` | — (required) | List of nav items |
| `selectedId` | `string` | — | ID of the currently selected item |
| `testId` | `string` | — | Renders as `data-pw` on the root `<nav>` |
| `classes` | `string` | — | Appended to root element class list |
| `ariaLabel` | `string` | `'Navigation'` | `aria-label` for the `<nav>` element |
| `onselect` | `(id: string) => void` | — | Called when a non-disabled item is clicked |

### `NavigationMenuItem`

| Field | Type | Description |
|-------|------|-------------|
| `id` | `string` | Unique identifier; also used as `data-pw` on the button |
| `label` | `string` | Display text |
| `icon` | `string?` | URL rendered as `<img>` |
| `statusDot` | `boolean?` | Shows a colored dot badge |
| `disabled` | `boolean?` | Disables the button |

### CSS custom properties

| Variable | Default | Controls |
|----------|---------|----------|
| `--navigation-menu-width` | `240px` | Panel width |
| `--navigation-menu-padding` | `8px` | Root padding |
| `--navigation-menu-gap` | `2px` | Gap between items |
| `--navigation-menu-item-padding` | `8px 12px` | Item button padding |
| `--navigation-menu-item-radius` | `8px` | Item border-radius |
| `--navigation-menu-item-color` | `inherit` | Item text color |
| `--navigation-menu-item-hover-background` | `rgba(0,0,0,0.06)` | Hover background |
| `--navigation-menu-item-selected-background` | `rgba(0,0,0,0.1)` | Selected background |
| `--navigation-menu-item-selected-color` | `inherit` | Selected text color |
| `--navigation-menu-dot-color` | `#22c55e` | Status dot color |
| `--navigation-menu-dot-size` | `8px` | Status dot diameter |
| `--navigation-menu-item-icon-size` | `20px` | Icon width/height |

### DOM structure

```
<nav class="navigation-menu" aria-label="…" data-pw="…">
  <ul class="navigation-menu-list" role="list">
    <li class="navigation-menu-list-item">
      <button class="navigation-menu-item [navigation-menu-item-selected]" data-pw="{id}" aria-current="page|null">
        <img class="navigation-menu-item-icon" />   <!-- optional -->
        <span class="navigation-menu-item-label">Label</span>
        <span class="navigation-menu-dot" />         <!-- optional -->
      </button>
    </li>
    …
  </ul>
</nav>
```

## Notes

- `svelte-check` — **0 errors, 0 warnings**
- `prettier --check` — clean
- `eslint` — clean
- No `font-family`, `font-size`, `font-weight`, or `line-height` hardcoded — all typography deferred to design system / CSS vars
- CSS selectors are kebab-case only (stylelint-compliant)
- `aria-current="page"` set on selected item; `null` otherwise (no `undefined`)
- Item list is `overflow-y: auto` for scrollable panels