### PR TITLE
feat: add variant system, showDot, leadingIcon, and size to Pill

### DIFF
--- a/src/lib/Pill/Pill.svelte
+++ b/src/lib/Pill/Pill.svelte
@@ -11,39 +11,43 @@
     dismissIcon,
     onclick,
     ondismiss,
-    classes
+    classes,
+    variant,
+    showDot = false,
+    leadingIcon,
+    size = 'md'
   }: PillProperties = $props();
 
   let interactive = $derived(typeof onclick === 'function');
 
-  function handleClick(event: MouseEvent): void {
+  const handleClick = (event: MouseEvent): void => {
     if (disabled) {
       return;
     }
     onclick?.(event);
-  }
+  };
 
-  function handleKeydown(event: KeyboardEvent): void {
+  const handleKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       if (event.currentTarget instanceof HTMLElement) {
         event.currentTarget.click();
       }
     }
-  }
+  };
 
-  function handleDismiss(event: MouseEvent): void {
+  const handleDismiss = (event: MouseEvent): void => {
     event.stopPropagation();
     if (disabled) {
       return;
     }
     ondismiss?.();
-  }
+  };
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
-  class="pill {classes ?? ''}"
+  class="pill pill-size-{size} {variant ? `pill-variant-${variant}` : ''} {classes ?? ''}"
   class:disabled
   onclick={interactive ? handleClick : null}
   onkeydown={interactive ? handleKeydown : null}
@@ -52,6 +56,12 @@
   aria-disabled={interactive && disabled ? true : null}
   data-pw={typeof testId === 'string' ? testId : null}
 >
+  {#if showDot}
+    <span class="pill-dot" aria-hidden="true"></span>
+  {/if}
+  {#if typeof leadingIcon === 'function'}
+    <span class="pill-leading-icon">{@render leadingIcon()}</span>
+  {/if}
   <span class="pill-text">{text}</span>
   {#if dismissible}
     <div class="pill-dismiss">
@@ -100,10 +110,35 @@
     cursor: var(--pill-disabled-cursor, not-allowed);
   }
 
+  /* size='sm' preset — tighter padding and gap */
+  .pill-size-sm {
+    padding: var(--pill-sm-padding, 3px 8px);
+    gap: var(--pill-sm-gap, 3px);
+  }
+
+  /* size='md' is the default; explicit class allows consumer overrides */
+
   .pill-text {
     overflow: hidden;
     text-overflow: var(--pill-text-overflow, ellipsis);
     white-space: nowrap;
+  }
+
+  /* Leading dot rendered when showDot=true */
+  .pill-dot {
+    display: inline-block;
+    flex-shrink: 0;
+    width: var(--pill-dot-size, 6px);
+    height: var(--pill-dot-size, 6px);
+    border-radius: 50%;
+    background-color: var(--pill-dot-color, currentColor);
+  }
+
+  /* Wrapper for the leadingIcon snippet */
+  .pill-leading-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 
   .pill-dismiss {

--- a/src/lib/Pill/properties.ts
+++ b/src/lib/Pill/properties.ts
@@ -12,6 +12,39 @@ export type OptionalPillProperties = {
   testId?: string;
   dismissIcon?: Snippet;
   classes?: string;
+  /**
+   * Applies the class `pill-variant-{variant}` on the root element so the
+   * consumer can map design tokens to the open-ended CSS custom properties
+   * `--pill-{variant}-background` and `--pill-{variant}-color`.
+   *
+   * Example — in the consuming app's theme:
+   *   .pill-variant-success { --pill-background: var(--pill-success-background, #d4edda); --pill-color: var(--pill-success-color, #155724); }
+   *
+   * No fixed enum of brand colors is shipped in the library; the open-ended
+   * string keeps it forward-compatible with any design-token vocabulary.
+   */
+  variant?: string;
+  /**
+   * When `true`, renders a leading dot (`<span class="pill-dot">`) whose
+   * color and size are controlled by `--pill-dot-color` (defaults to
+   * `currentColor`) and `--pill-dot-size` (defaults to 6px).
+   */
+  showDot?: boolean;
+  /**
+   * A Svelte snippet rendered before the text inside a
+   * `<span class="pill-leading-icon">` wrapper.
+   */
+  leadingIcon?: Snippet;
+  /**
+   * Controls the pill's padding / height preset.
+   * - `'md'` (default) — existing padding, no change.
+   * - `'sm'` — tighter padding via `--pill-sm-padding` (default `3px 8px`)
+   *   and `--pill-sm-gap` (default `3px`).
+   *
+   * The class `pill-size-{size}` is always applied, allowing consumers to
+   * override via CSS if the built-in presets don't fit.
+   */
+  size?: 'sm' | 'md';
 };
 
 export type PillEventProperties = {


### PR DESCRIPTION
## Summary

- **`variant?: string`** — applies `pill-variant-{variant}` on the root; consumers map their own design tokens to the open-ended CSS custom properties `--pill-{variant}-background` and `--pill-{variant}-color`. No fixed brand-color enum is shipped in the library. Example mapping in a consuming app's theme:
  ```css
  .pill-variant-success {
    --pill-background: var(--pill-success-background, #d4edda);
    --pill-color: var(--pill-success-color, #155724);
  }
  ```
- **`showDot?: boolean`** (default `false`) — renders a leading `<span class="pill-dot">` sized via `--pill-dot-size` (default `6px`) and colored via `--pill-dot-color` (default `currentColor`).
- **`leadingIcon?: Snippet`** — renders a Svelte snippet before the text in a `<span class="pill-leading-icon">` wrapper.
- **`size?: 'sm' | 'md'`** (default `'md'`) — applies `pill-size-{size}`; `'sm'` uses tighter padding via `--pill-sm-padding` (default `3px 8px`) and `--pill-sm-gap` (default `3px`). The `pill-size-md` class is always present for consumer overrides.

## API

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `variant` | `string` | `undefined` | Applies `pill-variant-{variant}` class; map colors via `--pill-{variant}-background` / `--pill-{variant}-color` |
| `showDot` | `boolean` | `false` | Renders a leading status dot |
| `leadingIcon` | `Snippet` | `undefined` | Snippet rendered before the text |
| `size` | `'sm' \| 'md'` | `'md'` | Size preset; `'sm'` uses `--pill-sm-padding` / `--pill-sm-gap` |

**CSS custom properties added:**

| Property | Default | Purpose |
|----------|---------|---------|
| `--pill-dot-color` | `currentColor` | Dot fill color |
| `--pill-dot-size` | `6px` | Dot width/height |
| `--pill-sm-padding` | `3px 8px` | Padding when `size='sm'` |
| `--pill-sm-gap` | `3px` | Gap when `size='sm'` |

## Notes

- **Strictly additive** — all new props are optional; omitting them reproduces today's behavior exactly. Existing call-sites are unchanged and keep type-checking.
- `svelte-check` — **0 errors, 0 warnings**
- `prettier --check` — clean
- `eslint` — clean
- No `font-family`, `font-size`, `font-weight`, or `line-height` added to component `<style>`; typography is driven by CSS custom properties and semantic tags only.
- `variant` is an open-ended `string` (not a union) so it is forward-compatible with any design-token vocabulary the consumer defines.