### PR TITLE
feat: add key-based items API to Tabs

### DIFF
--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -1,19 +1,44 @@
 <script lang="ts">
-  import type { TabsProperties } from './properties';
+  import type { TabItem, TabsProperties } from './properties';
   import chevronLeftSvg from '$lib/assets/chevron-left.svg?raw';
   import chevronRightSvg from '$lib/assets/chevron-right.svg?raw';
 
   let {
     items,
-    activeIndex = 0,
+    activeIndex = $bindable(0),
+    activeKey,
     disabled = false,
     testId,
     scrollLeftIcon,
     scrollRightIcon,
     tab,
     classes,
-    onchange
+    onchange,
+    onkeychange
   }: TabsProperties = $props();
+
+  const isObjectMode = $derived(items.length > 0 && typeof items.at(0) === 'object');
+
+  function toTabItem(item: string | TabItem): TabItem | null {
+    return typeof item === 'object' ? item : null;
+  }
+
+  function toStringLabel(item: string | TabItem): string {
+    return typeof item === 'string' ? item : item.label;
+  }
+
+  const resolvedActiveIndex = $derived(
+    isObjectMode
+      ? items.findIndex((item) => {
+          const tabItem = toTabItem(item);
+          return tabItem !== null && tabItem.key === activeKey;
+        })
+      : activeIndex
+  );
+
+  function isActiveItem(index: number): boolean {
+    return index === resolvedActiveIndex;
+  }
 
   let scrollContainer: HTMLDivElement | null = null;
   let canScrollLeft = $state(false);
@@ -40,11 +65,30 @@
   }
 
   function handleTabClick(index: number): void {
-    if (disabled || index === activeIndex) {
+    if (disabled) {
       return;
     }
-    activeIndex = index;
-    onchange?.(index, items[index]);
+    if (isObjectMode) {
+      const rawItem = items.at(index);
+      if (typeof rawItem !== 'object') {
+        return;
+      }
+      const tabItem = toTabItem(rawItem)!;
+      if (tabItem.key === activeKey) {
+        return;
+      }
+      onkeychange?.(tabItem.key);
+    } else {
+      if (index === activeIndex) {
+        return;
+      }
+      const rawLabel = items.at(index);
+      if (typeof rawLabel !== 'string') {
+        return;
+      }
+      activeIndex = index;
+      onchange?.(index, rawLabel);
+    }
   }
 
   function handleKeydown(event: KeyboardEvent, index: number): void {
@@ -90,23 +134,26 @@
     use:initOverflow
     onscroll={updateOverflow}
   >
-    {#each items as label, index (index)}
+    {#each items as item, index (isObjectMode ? (toTabItem(item)?.key ?? index) : index)}
+      {@const tabItem = toTabItem(item)}
+      {@const label = toStringLabel(item)}
       <div
         class="tabs-item"
-        class:active={index === activeIndex}
+        class:active={isActiveItem(index)}
         role="tab"
-        aria-selected={index === activeIndex}
+        aria-selected={isActiveItem(index)}
         aria-disabled={disabled ? true : null}
-        tabindex={index === activeIndex ? 0 : -1}
+        tabindex={isActiveItem(index) ? 0 : -1}
+        data-pw={tabItem?.testId}
         onclick={() => handleTabClick(index)}
-        onkeydown={(e) => handleKeydown(e, index)}
+        onkeydown={(event) => handleKeydown(event, index)}
       >
-        {#if tab}
-          {@render tab({ label, index, active: index === activeIndex })}
+        {#if typeof tab === 'function'}
+          {@render tab({ label, index, active: isActiveItem(index), subtitle: tabItem?.subtitle })}
         {:else}
           {label}
         {/if}
-        {#if index === activeIndex}
+        {#if isActiveItem(index)}
           <span class="tabs-indicator"></span>
         {/if}
       </div>

--- a/src/lib/Tabs/properties.ts
+++ b/src/lib/Tabs/properties.ts
@@ -1,21 +1,30 @@
 import type { Snippet } from 'svelte';
 
+export type TabItem = {
+  key: string;
+  label: string;
+  testId?: string;
+  subtitle?: string;
+};
+
 export type TabsProperties = MandatoryTabsProperties & OptionalTabsProperties & TabsEventProperties;
 
 export type MandatoryTabsProperties = {
-  items: string[];
+  items: string[] | TabItem[];
 };
 
 export type OptionalTabsProperties = {
   activeIndex?: number;
+  activeKey?: string;
   disabled?: boolean;
   testId?: string;
   scrollLeftIcon?: Snippet;
   scrollRightIcon?: Snippet;
-  tab?: Snippet<[{ label: string; index: number; active: boolean }]>;
+  tab?: Snippet<[{ label: string; index: number; active: boolean; subtitle?: string }]>;
   classes?: string;
 };
 
 export type TabsEventProperties = {
   onchange?: (index: number, label: string) => void;
+  onkeychange?: (key: string) => void;
 };


### PR DESCRIPTION
## Summary

- Extends `Tabs` with an optional **object-items mode** while keeping the existing string-array mode 100% unchanged
- `items` now accepts `string[] | TabItem[]` where `TabItem = { key: string; label: string; testId?: string; subtitle?: string }`
- Mode is auto-detected by inspecting `typeof items[0]` — no breaking change for existing callers

## API

**New exported type** (`TabItem` in `properties.ts`):
```ts
export type TabItem = {
  key: string;
  label: string;
  testId?: string;
  subtitle?: string;
};
```

**New optional props** on `TabsProperties`:
| Prop | Type | Description |
|------|------|-------------|
| `activeKey` | `string \| undefined` | Active tab key (object mode) |
| `onkeychange` | `(key: string) => void` | Fired when active tab changes (object mode) |

**Updated `tab` snippet** now receives `subtitle?: string` so custom renderers can display subtitles in both modes.

**Existing props** (`items: string[]`, `activeIndex`, `onchange`, etc.) behave identically to before.

## Notes

- `svelte-check` → **0 errors, 0 warnings**
- `prettier --check` → clean
- `eslint` → clean (no `as` casts, no `undefined` references)
- Backward-compatible: all existing usages pass through the string-array path unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs component now supports both simple string labels and rich object-based tab definitions
  * Added support for tab subtitles and unique key identifiers
  * New `activeKey` property to track the active tab by key instead of numeric index
  * Added `onkeychange` callback for key-based tab change events

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/svelte-ui-components/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->