### PR TITLE
feat: add ErrorCard component

### DIFF
--- a/src/lib/ErrorCard/ErrorCard.svelte
+++ b/src/lib/ErrorCard/ErrorCard.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import type { ErrorCardProperties } from './properties';
+
+  let {
+    title,
+    message,
+    icon,
+    action,
+    variant = 'card',
+    testId,
+    classes
+  }: ErrorCardProperties = $props();
+</script>
+
+<div class="error-card error-card-{variant} {classes ?? ''}" role="alert" data-pw={testId}>
+  {#if typeof icon === 'function'}
+    <div class="error-card-icon">
+      {@render icon()}
+    </div>
+  {/if}
+  <div class="error-card-body">
+    {#if title}
+      <div class="error-card-title">{title}</div>
+    {/if}
+    {#if message}
+      <div class="error-card-message">{message}</div>
+    {/if}
+  </div>
+  {#if typeof action === 'function'}
+    <div class="error-card-action">
+      {@render action()}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .error-card {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--error-card-gap, 12px);
+    background: var(--error-card-background, transparent);
+    border-radius: var(--error-card-radius, 8px);
+  }
+
+  .error-card-card {
+    border: var(--error-card-border, 1px solid currentColor);
+    padding: var(--error-card-padding, 16px);
+  }
+
+  .error-card-inline {
+    padding: var(--error-card-padding, 8px 0);
+  }
+
+  .error-card-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--error-card-icon-color, currentColor);
+  }
+
+  .error-card-icon :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .error-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .error-card-title {
+    color: var(--error-card-title-color, inherit);
+    font-weight: var(--error-card-title-font-weight, 600);
+  }
+
+  .error-card-message {
+    color: var(--error-card-message-color, inherit);
+  }
+
+  .error-card-action {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/lib/ErrorCard/properties.ts
+++ b/src/lib/ErrorCard/properties.ts
@@ -1,0 +1,11 @@
+import type { Snippet } from 'svelte';
+
+export type ErrorCardProperties = {
+  title?: string;
+  message?: string;
+  icon?: Snippet;
+  action?: Snippet;
+  variant?: 'card' | 'inline';
+  testId?: string;
+  classes?: string;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as ErrorCard } from './ErrorCard/ErrorCard.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './ErrorCard/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- Adds a new `ErrorCard` primitive (`role="alert"`) distinct from `InlineAlert` (strip) and `EmptyState` (empty content)
- Supports `title`, `message`, optional `icon` snippet, optional `action` snippet, `variant` (`card` | `inline`), `testId` (renders `data-pw`), and `classes`
- `card` variant: bordered, padded card; `inline` variant: compact row layout

## API

```ts
type ErrorCardProperties = {
  title?: string;
  message?: string;
  icon?: Snippet;
  action?: Snippet;
  variant?: 'card' | 'inline'; // default: 'card'
  testId?: string;
  classes?: string;
};
```

Exposed CSS custom properties: `--error-card-background`, `--error-card-border`, `--error-card-radius`, `--error-card-padding`, `--error-card-gap`, `--error-card-icon-color`, `--error-card-title-color`, `--error-card-title-font-weight`, `--error-card-message-color`.

## Notes

- `svelte-check` — **0 errors, 0 warnings**
- `prettier --check` — **clean**
- `eslint` — **clean**
- Backward-compatible: new named export `ErrorCard` and `export type * from './ErrorCard/properties'` added after existing `SplitInput` entries in `index.ts`
- No new npm dependencies introduced
- All font properties exposed as CSS vars only; no hardcoded `font-family`, `font-size`, `font-weight`, or `line-height` in component styles
- CSS selectors are kebab-case only (stylelint-compliant)