### PR TITLE
feat: add testId, SVG inlining, and transform to Img

### DIFF
--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
   import type { ImgProperties } from './properties';
 
-  let { src, alt, fallback, onerror, classes }: ImgProperties = $props();
+  let {
+    src,
+    alt,
+    fallback,
+    onerror,
+    classes,
+    testId,
+    inlineSvg = false,
+    transform
+  }: ImgProperties = $props();
 
   let currentSrc = $derived(src);
+
+  const isSvgMarkup = $derived(
+    typeof currentSrc === 'string' && currentSrc.trimStart().startsWith('<svg')
+  );
+  const showInline = $derived(inlineSvg && isSvgMarkup);
+  const svgContent = $derived(
+    showInline && typeof transform === 'function' ? transform(currentSrc) : currentSrc
+  );
 
   function handleFallback(): void {
     if (typeof fallback === 'string' && fallback.length > 0 && currentSrc !== fallback) {
@@ -14,7 +31,15 @@
   }
 </script>
 
-<img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} />
+{#if showInline}
+  <span class="img-inline-svg {classes ?? ''}" data-pw={testId} role="img" aria-label={alt}>
+    <!-- eslint-disable svelte/no-at-html-tags -->
+    {@html svgContent}
+    <!-- eslint-enable svelte/no-at-html-tags -->
+  </span>
+{:else}
+  <img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} data-pw={testId} />
+{/if}
 
 <style>
   img {
@@ -28,9 +53,31 @@
     background: var(--image-background);
     border: var(--image-border);
     transition: var(--image-transition);
+    flex-shrink: var(--img-flex-shrink);
   }
 
   img:hover {
+    background: var(--image-hover-background, var(--image-background));
+    border: var(--image-hover-border, var(--image-border));
+  }
+
+  .img-inline-svg {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--image-height, 24px);
+    width: var(--image-width, 24px);
+    padding: var(--image-padding, 0px);
+    border-radius: var(--image-border-radius, 0px);
+    margin: var(--image-margin, 0px);
+    filter: var(--image-filter, none);
+    background: var(--image-background);
+    border: var(--image-border);
+    transition: var(--image-transition);
+    flex-shrink: var(--img-flex-shrink);
+  }
+
+  .img-inline-svg:hover {
     background: var(--image-hover-background, var(--image-background));
     border: var(--image-hover-border, var(--image-border));
   }

--- a/src/lib/Img/properties.ts
+++ b/src/lib/Img/properties.ts
@@ -8,6 +8,9 @@ export type MandatoryImgProperties = {
 export type OptionalImgProperties = {
   fallback?: string | null;
   classes?: string;
+  testId?: string;
+  inlineSvg?: boolean;
+  transform?: (svg: string) => string;
 };
 
 export type ImgEventProperties = {


### PR DESCRIPTION
## Summary

- Add optional `testId?: string` prop that renders as `data-pw` on the root element (both `<img>` and inline-svg `<span>` paths), enabling Playwright test selectors.
- Add optional `inlineSvg?: boolean` (default `false`) — when `true` and `src` is raw SVG markup (starts with `<svg`), renders via `{@html}` inside `<span class="img-inline-svg">` so it inherits `currentColor` and can be CSS-transformed. Falls back to the normal `<img>` path for URLs or when `inlineSvg` is `false`.
- Add optional `transform?: (svg: string) => string` — when `inlineSvg` is active, pipes the raw SVG string through this function before rendering (e.g. rewriting `stroke`/`fill` attributes to `currentColor`).
- Add `--img-flex-shrink` CSS custom property (default unset) on both `<img>` and `.img-inline-svg` so icon-in-flex callers can pin `flex-shrink: 0` without an extra wrapper element.

## API

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `testId` | `string` | — | Renders as `data-pw` attribute |
| `inlineSvg` | `boolean` | `false` | Render raw SVG markup inline |
| `transform` | `(svg: string) => string` | — | Pre-process SVG string before `{@html}` |

| CSS Variable | Default | Description |
|---|---|---|
| `--img-flex-shrink` | unset | Controls `flex-shrink` on the root element |

## Notes

- svelte-check: **0 errors, 0 warnings**
- prettier: **clean**
- eslint: **clean** (`svelte/no-at-html-tags` inline-disabled on the `{@html}` line, matching `Banner.svelte` convention)
- Strictly backward-compatible — all new props are optional; omitting them reproduces existing behavior exactly
- No new npm dependencies added