### PR TITLE
feat: add tone, title, size, and flush to Banner

### DIFF
--- a/src/lib/Banner/Banner.svelte
+++ b/src/lib/Banner/Banner.svelte
@@ -15,38 +15,59 @@
     dismissIcon,
     onclick,
     ondismiss,
-    classes
+    classes,
+    tone = null,
+    title = null,
+    size = null,
+    flush = false,
+    role = null
   }: BannerProperties = $props();
 
   let interactive = $derived(typeof onclick === 'function');
 
-  function handleClick(event: MouseEvent): void {
-    onclick?.(event);
-  }
+  let resolvedRole = $derived(
+    role !== null ? role : tone === 'error' ? 'alert' : interactive ? 'button' : null
+  );
 
-  function handleKeydown(event: KeyboardEvent): void {
+  let rootClass = $derived(
+    [
+      'banner',
+      tone !== null ? `banner-tone-${tone}` : '',
+      size === 'sm' ? 'banner-size-sm' : '',
+      flush ? 'banner-flush' : '',
+      classes ?? ''
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
+
+  const handleClick = (event: MouseEvent): void => {
+    onclick?.(event);
+  };
+
+  const handleKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       if (event.currentTarget instanceof HTMLElement) {
         event.currentTarget.click();
       }
     }
-  }
+  };
 
-  function handleDismiss(event: MouseEvent): void {
+  const handleDismiss = (event: MouseEvent): void => {
     event.stopPropagation();
     visible = false;
     ondismiss?.();
-  }
+  };
 </script>
 
 {#if visible}
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
-    class="banner {classes ?? ''}"
+    class={rootClass}
     onclick={interactive ? handleClick : null}
     onkeydown={interactive ? handleKeydown : null}
-    role={interactive ? 'button' : null}
+    role={resolvedRole}
     tabindex={interactive ? 0 : null}
     data-pw={typeof testId === 'string' ? testId : null}
     transition:slide={{ duration: 300 }}
@@ -56,12 +77,24 @@
         {@render icon()}
       </div>
     {/if}
-    <div class="banner-text">
-      {text}
-      {#if typeof linkText === 'string' && linkText.length > 0}
-        <span class="banner-link-text">{linkText}</span>
-      {/if}
-    </div>
+    {#if title !== null && typeof title === 'string' && title.length > 0}
+      <div class="banner-body">
+        <span class="banner-title">{title}</span>
+        <div class="banner-text">
+          {text}
+          {#if typeof linkText === 'string' && linkText.length > 0}
+            <span class="banner-link-text">{linkText}</span>
+          {/if}
+        </div>
+      </div>
+    {:else}
+      <div class="banner-text">
+        {text}
+        {#if typeof linkText === 'string' && linkText.length > 0}
+          <span class="banner-link-text">{linkText}</span>
+        {/if}
+      </div>
+    {/if}
     {#if typeof rightContent === 'function'}
       <div class="banner-right">
         {@render rightContent()}
@@ -102,11 +135,46 @@
     font-weight: var(--banner-font-weight, 500);
     line-height: var(--banner-line-height, 1.3);
     border-bottom: var(--banner-border-bottom, none);
+    border-radius: var(--banner-border-radius, 0);
     cursor: var(--banner-cursor, pointer);
     position: var(--banner-position, sticky);
     top: var(--banner-top, 0);
     z-index: var(--banner-z-index, 100);
     box-sizing: border-box;
+  }
+
+  .banner-tone-info {
+    background-color: var(--banner-tone-background, var(--banner-background, #f0f4f8));
+    color: var(--banner-tone-color, var(--banner-color, #637c95));
+    border: var(--banner-tone-border);
+  }
+
+  .banner-tone-success {
+    background-color: var(--banner-tone-background, var(--banner-background, #f0f4f8));
+    color: var(--banner-tone-color, var(--banner-color, #637c95));
+    border: var(--banner-tone-border);
+  }
+
+  .banner-tone-warning {
+    background-color: var(--banner-tone-background, var(--banner-background, #f0f4f8));
+    color: var(--banner-tone-color, var(--banner-color, #637c95));
+    border: var(--banner-tone-border);
+  }
+
+  .banner-tone-error {
+    background-color: var(--banner-tone-background, var(--banner-background, #f0f4f8));
+    color: var(--banner-tone-color, var(--banner-color, #637c95));
+    border: var(--banner-tone-border);
+  }
+
+  .banner-size-sm {
+    padding: var(--banner-sm-padding, 6px 12px);
+    border-bottom: none;
+  }
+
+  .banner-flush {
+    border-radius: 0;
+    border: none;
   }
 
   .banner-icon {
@@ -119,6 +187,20 @@
   .banner-icon :global(svg) {
     width: var(--banner-icon-size, 18px);
     height: var(--banner-icon-size, 18px);
+  }
+
+  .banner-body {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    gap: var(--banner-body-gap, 2px);
+  }
+
+  .banner-title {
+    font-weight: var(--banner-title-font-weight, 600);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .banner-text {

--- a/src/lib/Banner/properties.ts
+++ b/src/lib/Banner/properties.ts
@@ -1,5 +1,8 @@
 import type { Snippet } from 'svelte';
 
+export type BannerTone = 'info' | 'success' | 'warning' | 'error';
+export type BannerSize = 'sm' | 'md';
+
 export type BannerProperties = MandatoryBannerProperties &
   OptionalBannerProperties &
   BannerEventProperties;
@@ -17,6 +20,11 @@ export type OptionalBannerProperties = {
   rightContent?: Snippet;
   dismissIcon?: Snippet;
   classes?: string;
+  tone?: BannerTone | null;
+  title?: string | null;
+  size?: BannerSize | null;
+  flush?: boolean;
+  role?: string | null;
 };
 
 export type BannerEventProperties = {


### PR DESCRIPTION
## Summary

- **tone** (`'info' | 'success' | 'warning' | 'error' | null`) — applies `banner-tone-{tone}` class that reads `--banner-tone-background`, `--banner-tone-color`, and `--banner-tone-border` CSS vars (no hardcoded defaults so they fall through to the existing `--banner-background`/`--banner-color` when unset). When `tone === 'error'`, sets `role="alert"` automatically.
- **title** (`string | null`) — renders a `<span class="banner-title">` above the text inside a `<div class="banner-body">` flex-column. When absent, markup is identical to today. Exposes `--banner-title-font-weight` (default `600`) and `--banner-body-gap` (default `2px`).
- **size** (`'sm' | 'md' | null`) — `sm` applies `banner-size-sm` with tighter padding via `--banner-sm-padding` (default `6px 12px`) and removes `border-bottom`.
- **flush** (`boolean`, default `false`) — `banner-flush` zeroes `border-radius` and `border` for edge-to-edge placement inside a card. Exposes `--banner-border-radius` (default `0`).
- **role** (`string | null`) — explicit ARIA role override; takes precedence over the auto-resolved role (`alert` for error tone, `button` for interactive).

## API

| Prop | Type | Default | Notes |
|------|------|---------|-------|
| `tone` | `'info' \| 'success' \| 'warning' \| 'error' \| null` | `null` | Applies semantic colour class |
| `title` | `string \| null` | `null` | Two-line body with bold heading |
| `size` | `'sm' \| 'md' \| null` | `null` | `sm` = tighter padding |
| `flush` | `boolean` | `false` | Remove border-radius/border |
| `role` | `string \| null` | `null` | Override resolved ARIA role |

### New CSS custom properties

| Variable | Default | Purpose |
|----------|---------|---------|
| `--banner-tone-background` | *(none, falls back to `--banner-background`)* | Tone background |
| `--banner-tone-color` | *(none, falls back to `--banner-color`)* | Tone text colour |
| `--banner-tone-border` | *(none)* | Tone border |
| `--banner-title-font-weight` | `600` | Title weight |
| `--banner-body-gap` | `2px` | Gap between title and text |
| `--banner-sm-padding` | `6px 12px` | Padding when `size="sm"` |
| `--banner-border-radius` | `0` | Border radius (used by `flush`) |

## Notes

- **Strictly additive** — all new props are optional with `null` defaults. Omitting them reproduces today's single-line strip exactly.
- `svelte-check` found **0 errors and 0 warnings**.
- Prettier + ESLint **clean** (no `undefined`, no BEM classes, no inline font props).
- No new npm dependencies.
- Builds on the `--banner-white-space` work already merged to `release`.