### PR TITLE
feat: add InputField composite component

### DIFF
--- a/src/lib/InputField/InputField.svelte
+++ b/src/lib/InputField/InputField.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import Input from '../Input/Input.svelte';
+  import Button from '../Button/Button.svelte';
+  import type { InputFieldProperties } from './properties';
+
+  let {
+    label,
+    mandatory = false,
+    value = $bindable(''),
+    placeholder = '',
+    hintText,
+    errorText,
+    disabled = false,
+    type = 'text',
+    testId,
+    classes,
+    trailingIcon,
+    ontrailingClick,
+    oninput
+  }: InputFieldProperties = $props();
+
+  const inputId = testId ? `${testId}-input` : '';
+
+  const handleInput = (inputValue: string) => {
+    value = inputValue;
+    oninput?.(inputValue);
+  };
+</script>
+
+<div class="input-field {classes ?? ''}" data-pw={testId}>
+  {#if label}
+    <label class="input-field-label" for={inputId || null}>
+      {label}{#if mandatory}<span class="input-field-asterisk">*</span>{/if}
+    </label>
+  {/if}
+
+  <div class="input-field-row">
+    <Input
+      value={value ?? ''}
+      {placeholder}
+      disable={disabled}
+      dataType={type}
+      name={inputId}
+      testId={inputId}
+      onInput={handleInput}
+      classes="input-field-inner"
+    />
+    {#if trailingIcon}
+      <Button
+        testId={testId ? `${testId}-trailing` : ''}
+        onclick={ontrailingClick}
+        icon={trailingIcon}
+        classes="input-field-trailing"
+        ariaLabel="trailing action"
+      />
+    {/if}
+  </div>
+
+  {#if hintText}
+    <p class="input-field-hint">{hintText}</p>
+  {/if}
+
+  {#if errorText}
+    <p class="input-field-error" data-pw={testId ? `${testId}-error` : null} role="alert">
+      {errorText}
+    </p>
+  {/if}
+</div>
+
+<style>
+  .input-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--input-field-gap, 4px);
+    width: var(--input-field-width, fit-content);
+  }
+
+  .input-field-label {
+    color: var(--input-field-label-color, #637c95);
+    font-size: var(--input-field-label-font-size, 12px);
+    font-weight: var(--input-field-label-font-weight, 400);
+  }
+
+  .input-field-asterisk {
+    color: var(--input-field-asterisk-color, #e53e3e);
+    margin-inline-start: 2px;
+  }
+
+  .input-field-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+  }
+
+  .input-field-hint {
+    color: var(--input-field-hint-color, #637c95);
+  }
+
+  .input-field-error {
+    color: var(--input-field-error-color, #e53e3e);
+  }
+</style>

--- a/src/lib/InputField/properties.ts
+++ b/src/lib/InputField/properties.ts
@@ -1,0 +1,18 @@
+import type { Snippet } from 'svelte';
+import type { InputDataType } from '$lib/types';
+
+export type InputFieldProperties = {
+  label?: string;
+  mandatory?: boolean;
+  value?: string;
+  placeholder?: string;
+  hintText?: string;
+  errorText?: string;
+  disabled?: boolean;
+  type?: InputDataType;
+  testId?: string;
+  classes?: string;
+  trailingIcon?: Snippet;
+  ontrailingClick?: (event: MouseEvent) => void;
+  oninput?: (value: string) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as InputField } from './InputField/InputField.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './InputField/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- Adds `InputField` — a new composite form-field primitive that wraps the library `Input` with an outer `<label>`, required asterisk, hint text, error message, and optional trailing icon-button (using the library `Button`).
- Exports `InputField` from `src/lib/index.ts` and exposes `InputFieldProperties` as a public type.

## API

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `label` | `string` | — | Label text rendered above the input |
| `mandatory` | `boolean` | `false` | Shows a red `*` after the label |
| `value` | `string` (bindable) | `''` | Input value, two-way bindable |
| `placeholder` | `string` | `''` | Input placeholder text |
| `hintText` | `string` | — | Helper text shown below the input |
| `errorText` | `string` | — | Error message shown with `role="alert"` |
| `disabled` | `boolean` | `false` | Disables the input |
| `type` | `InputDataType` | `'text'` | Input type (`text`, `tel`, `password`, `email`, `number`) |
| `testId` | `string` | — | Sets `data-pw` on root; derives `{testId}-input`, `{testId}-error`, `{testId}-trailing` |
| `classes` | `string` | — | Extra CSS classes on the root wrapper |
| `trailingIcon` | `Snippet` | — | Svelte snippet rendered inside the trailing `Button` icon slot |
| `ontrailingClick` | `(event: MouseEvent) => void` | — | Click handler for the trailing button |
| `oninput` | `(value: string) => void` | — | Called on every input change with the current value |

**CSS custom properties**: `--input-field-gap`, `--input-field-label-color`, `--input-field-label-font-size`, `--input-field-label-font-weight`, `--input-field-asterisk-color`, `--input-field-hint-color`, `--input-field-error-color`, `--input-field-width`.

## Notes

- `svelte-check` found **0 errors and 0 warnings**
- `prettier --check` exits **0** on all new files
- `eslint` exits **0** on all new files
- No new npm dependencies added
- Fully backward-compatible — existing exports are unchanged
- Uses Svelte 5 runes (`$props`, `$bindable`), kebab-case CSS selectors, no hardcoded font properties (all exposed as CSS vars)