### PR TITLE
feat: add MasonryGrid component

### DIFF
--- a/src/lib/MasonryGrid/MasonryGrid.svelte
+++ b/src/lib/MasonryGrid/MasonryGrid.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { MasonryGridProperties } from './properties';
+
+  let { columns = 3, gap = '16px', testId, classes, children }: MasonryGridProperties = $props();
+</script>
+
+<div
+  class="masonry-grid {classes ?? ''}"
+  data-pw={testId}
+  style="--masonry-columns:{columns}; --masonry-gap:{gap};"
+>
+  {@render children?.()}
+</div>
+
+<style>
+  .masonry-grid {
+    column-count: var(--masonry-columns);
+    column-gap: var(--masonry-gap);
+  }
+
+  .masonry-grid > :global(*) {
+    break-inside: avoid;
+    margin-bottom: var(--masonry-gap);
+  }
+</style>

--- a/src/lib/MasonryGrid/properties.ts
+++ b/src/lib/MasonryGrid/properties.ts
@@ -1,0 +1,9 @@
+import type { Snippet } from 'svelte';
+
+export type MasonryGridProperties = {
+  columns?: number;
+  gap?: string;
+  testId?: string;
+  classes?: string;
+  children?: Snippet;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as MasonryGrid } from './MasonryGrid/MasonryGrid.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './MasonryGrid/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- New `MasonryGrid` layout primitive that arranges slotted children into balanced columns using CSS `column-count` / `column-gap`
- Pure CSS implementation — SSR-safe, no JS measuring, no `ResizeObserver`, no new dependencies
- Children get `break-inside: avoid` + `margin-bottom: var(--masonry-gap)` automatically via a `:global(*)` child rule

## API

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `columns` | `number` | `3` | Number of masonry columns (`column-count`) |
| `gap` | `string` | `'16px'` | Gap between columns and rows (`column-gap` + child margin-bottom) |
| `testId` | `string` | — | Renders as `data-pw` on the root element |
| `classes` | `string` | — | Extra CSS classes appended to the root `div` |
| `children` | `Snippet` | — | Default snippet — any slotted child elements |

**CSS custom properties exposed:** `--masonry-columns`, `--masonry-gap`

**Responsive tip:** Override `--masonry-columns` in a media query on the parent to change column count at different breakpoints.

## Notes

- `svelte-check` found **0 errors and 0 warnings**
- `prettier --check` passed on all new files and `index.ts`
- `eslint` exited 0 on `src/lib/MasonryGrid/`
- Backward-compatible: new named export added after existing `SplitInput` export; no existing APIs changed