### PR TITLE
feat: add DescriptiveTile component

### DIFF
--- a/src/lib/DescriptiveTile/DescriptiveTile.svelte
+++ b/src/lib/DescriptiveTile/DescriptiveTile.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import type { DescriptiveTileProperties } from './properties';
+
+  let {
+    image,
+    alt,
+    label,
+    selected = false,
+    disabled = false,
+    testId,
+    classes,
+    bottom,
+    onclick
+  }: DescriptiveTileProperties = $props();
+
+  const isInteractive = $derived(!!onclick);
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (disabled || !onclick) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onclick(new MouseEvent('click'));
+    }
+  };
+
+  const handleClick = (event: MouseEvent) => {
+    if (disabled || !onclick) {
+      return;
+    }
+    onclick(event);
+  };
+</script>
+
+{#if isInteractive}
+  <div
+    class="descriptive-tile {classes ?? ''}"
+    class:descriptive-tile-selected={selected}
+    class:descriptive-tile-disabled={disabled}
+    role="button"
+    tabindex={disabled ? -1 : 0}
+    data-pw={testId}
+    onclick={handleClick}
+    onkeydown={handleKeydown}
+  >
+    <div class="descriptive-tile-preview">
+      {#if image}
+        <img src={image} alt={alt ?? ''} />
+      {/if}
+    </div>
+    <div class="descriptive-tile-label">{label ?? ''}</div>
+    {#if bottom}
+      <div class="descriptive-tile-bottom">
+        {@render bottom()}
+      </div>
+    {/if}
+  </div>
+{:else}
+  <div
+    class="descriptive-tile {classes ?? ''}"
+    class:descriptive-tile-selected={selected}
+    class:descriptive-tile-disabled={disabled}
+    data-pw={testId}
+  >
+    <div class="descriptive-tile-preview">
+      {#if image}
+        <img src={image} alt={alt ?? ''} />
+      {/if}
+    </div>
+    <div class="descriptive-tile-label">{label ?? ''}</div>
+    {#if bottom}
+      <div class="descriptive-tile-bottom">
+        {@render bottom()}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .descriptive-tile {
+    display: flex;
+    flex-direction: column;
+    gap: var(--descriptive-tile-gap, 8px);
+    padding: var(--descriptive-tile-padding, 12px);
+    border-radius: var(--descriptive-tile-radius, 8px);
+    border: var(--descriptive-tile-border, 1px solid transparent);
+    cursor: default;
+    box-sizing: border-box;
+  }
+
+  .descriptive-tile[role='button'] {
+    cursor: pointer;
+  }
+
+  .descriptive-tile[role='button']:focus-visible {
+    outline: 2px solid var(--descriptive-tile-selected-border, #0070f3);
+    outline-offset: 2px;
+  }
+
+  .descriptive-tile-selected {
+    border: var(--descriptive-tile-selected-border, 1px solid #0070f3);
+  }
+
+  .descriptive-tile-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .descriptive-tile-preview {
+    border-radius: var(--descriptive-tile-preview-radius, 6px);
+    aspect-ratio: var(--descriptive-tile-preview-aspect, 16 / 9);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .descriptive-tile-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .descriptive-tile-label {
+    color: var(--descriptive-tile-label-color, inherit);
+    font-weight: var(--descriptive-tile-label-font-weight, inherit);
+  }
+
+  .descriptive-tile-bottom {
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/src/lib/DescriptiveTile/properties.ts
+++ b/src/lib/DescriptiveTile/properties.ts
@@ -1,0 +1,13 @@
+import type { Snippet } from 'svelte';
+
+export type DescriptiveTileProperties = {
+  image?: string;
+  alt?: string;
+  label?: string;
+  selected?: boolean;
+  disabled?: boolean;
+  testId?: string;
+  classes?: string;
+  bottom?: Snippet;
+  onclick?: (event: MouseEvent) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,7 @@ export { default as EmptyState } from './EmptyState/EmptyState.svelte';
 export { default as Combobox } from './Combobox/Combobox.svelte';
 export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
+export { default as DescriptiveTile } from './DescriptiveTile/DescriptiveTile.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -109,5 +110,6 @@ export type * from './EmptyState/properties';
 export type * from './Combobox/properties';
 export type * from './ColorPicker/properties';
 export type * from './SplitInput/properties';
+export type * from './DescriptiveTile/properties';
 
 export { validateInput } from './utils';


### PR DESCRIPTION
## Summary

- Adds a new `DescriptiveTile` primitive component for gallery/selection UI patterns
- Tile has an image/preview region at the top, a label row, and an optional `bottom` snippet slot for extra content
- Supports `selected`, `disabled`, `classes`, `testId`, and `onclick` interaction with full keyboard support (Enter/Space)

## API

```ts
type DescriptiveTileProperties = {
  image?: string;
  alt?: string;
  label?: string;
  selected?: boolean;      // default false
  disabled?: boolean;      // default false
  testId?: string;
  classes?: string;
  bottom?: Snippet;
  onclick?: (event: MouseEvent) => void;
};
```

**CSS custom properties exposed:**
`--descriptive-tile-padding`, `--descriptive-tile-radius`, `--descriptive-tile-border`, `--descriptive-tile-selected-border`, `--descriptive-tile-preview-radius`, `--descriptive-tile-preview-aspect`, `--descriptive-tile-label-color`, `--descriptive-tile-label-font-weight`, `--descriptive-tile-gap`

## Notes

- svelte-check: **0 errors, 0 warnings**
- prettier: clean
- eslint: clean
- Backward-compatible — purely additive export to `src/lib/index.ts`
- No new npm dependencies
- Svelte 5 runes syntax throughout
- `role="button"` and `tabindex` are only applied when `onclick` is provided, avoiding a11y warnings on non-interactive tiles