### PR TITLE
feat: add right-drawer align, showDivider, header description, and dialogue body to Modal

### DIFF
--- a/src/lib/Animations/ModalAnimation.svelte
+++ b/src/lib/Animations/ModalAnimation.svelte
@@ -21,6 +21,8 @@
         return { ...base, y: -30 };
       case 'bottom':
         return { ...base, y: 300 };
+      case 'right':
+        return { ...base, x: 300 };
       default:
         return base;
     }
@@ -28,7 +30,7 @@
 
   let fadeAnimationProperties = { duration: 300 };
 
-  let useFlyAnimation = $derived(align === 'top' || align === 'bottom');
+  let useFlyAnimation = $derived(align === 'top' || align === 'bottom' || align === 'right');
   let useOutTransition = $derived(transitionType === 'ALL');
 </script>
 

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -18,6 +18,8 @@
     transitionType = 'ALL',
     header = {},
     footer,
+    showDivider = false,
+    dialogueConfig,
     debounceTime = 700,
     leftImageTestId,
     testId,
@@ -35,42 +37,53 @@
 
   const debounce = createDebouncer(debounceTime);
 
-  function handlePopstate() {
+  const handlePopstate = () => {
     backPressed = true;
     onclose?.();
-  }
+  };
 
-  function handleRightImageClick(event: MouseEvent): void {
+  const handleRightImageClick = (event: MouseEvent): void => {
     onheaderRightImageClick?.(event);
-  }
+  };
 
-  function handleLeftImageClick(event: MouseEvent): void {
+  const handleLeftImageClick = (event: MouseEvent): void => {
     onheaderLeftImageClick?.(event);
-  }
+  };
 
-  function handlePrimaryButtonClick(event: MouseEvent): void {
+  const handlePrimaryButtonClick = (event: MouseEvent): void => {
     onprimaryButtonClick?.(event);
-  }
+  };
 
-  function handleSecondaryButtonClick(event: MouseEvent): void {
+  const handleSecondaryButtonClick = (event: MouseEvent): void => {
     onsecondaryButtonClick?.(event);
-  }
+  };
 
-  function handleOverlayClick(event: MouseEvent) {
+  const handleOverlayClick = (event: MouseEvent) => {
     if (event.target && event.target === overlayDiv) {
       debounce(() => {
         onoverlayClick?.();
       });
     }
-  }
+  };
 
-  function handleKeyDown(event: KeyboardEvent): void {
+  const handleKeyDown = (event: KeyboardEvent): void => {
     onkeydown?.(event);
-    let key = event?.key;
+    const key = event?.key;
     if (key === 'Escape') {
       onoverlayClick?.();
     }
-  }
+  };
+
+  const hasHeader = $derived(
+    (typeof header?.leftImage === 'string' && header.leftImage.length > 0) ||
+      (typeof header?.text === 'string' && header.text.length > 0) ||
+      (typeof header?.rightImage === 'string' && header.rightImage.length > 0) ||
+      (typeof header?.description === 'string' && header.description.length > 0)
+  );
+
+  const showCloseButton = $derived(header?.showCloseButton !== false);
+
+  const dialogueFooter = $derived(dialogueConfig?.footerConfig);
 
   onMount(() => {
     document.body.style.overflow = 'hidden';
@@ -95,7 +108,7 @@
 
 <svelte:window onkeydown={handleKeyDown} />
 
-{#if typeof content === 'function'}
+{#if typeof content === 'function' || dialogueConfig}
   <OverlayAnimation>
     <div
       bind:this={overlayDiv}
@@ -107,8 +120,8 @@
       data-pw={testId}
     >
       <ModalAnimation enable={enableTransition} {align} {transitionType}>
-        <div class="modal-content {size}">
-          {#if (typeof header?.leftImage === 'string' && header.leftImage.length > 0) || (typeof header?.text === 'string' && header.text.length > 0) || (typeof header?.rightImage === 'string' && header.rightImage.length > 0)}
+        <div class="modal-content {size} {align === 'right' ? 'modal-align-right' : ''}">
+          {#if hasHeader}
             <div class="header">
               {#if header.leftImage}
                 <div
@@ -121,12 +134,19 @@
                   <img class="header-left-img" src={header.leftImage} alt="" />
                 </div>
               {/if}
-              {#if header.text}
-                <div class="header-text" data-pw={header.testId}>
-                  {header.text}
-                </div>
-              {/if}
-              {#if header.rightImage}
+              <div class="header-title-group">
+                {#if header.text}
+                  <div class="header-text" data-pw={header.testId}>
+                    {header.text}
+                  </div>
+                {/if}
+                {#if typeof header.description === 'string' && header.description.length > 0}
+                  <div class="header-description">
+                    {header.description}
+                  </div>
+                {/if}
+              </div>
+              {#if header.rightImage && showCloseButton}
                 <div
                   role="button"
                   tabindex="0"
@@ -138,15 +158,58 @@
                 </div>
               {/if}
             </div>
+            {#if showDivider}
+              <div class="modal-divider" role="separator" aria-hidden="true"></div>
+            {/if}
           {/if}
-          <div class="slot-content">
-            {@render content?.()}
-          </div>
-          {#if typeof footerSnippet === 'function'}
+
+          {#if dialogueConfig}
+            <div class="slot-content dialogue-body">
+              <p class="dialogue-body-text">{dialogueConfig.bodyText}</p>
+            </div>
+          {:else}
+            <div class="slot-content">
+              {@render content?.()}
+            </div>
+          {/if}
+
+          {#if dialogueConfig}
+            {#if typeof dialogueFooter?.primaryButton === 'object' || typeof dialogueFooter?.secondaryButton === 'object'}
+              {#if showDivider}
+                <div class="modal-divider" role="separator" aria-hidden="true"></div>
+              {/if}
+              <div class="footer-content">
+                <div class="footer-action-buttons">
+                  {#if dialogueFooter.secondaryButton}
+                    <div class="footer-secondary-button">
+                      <Button
+                        {...dialogueFooter.secondaryButton}
+                        onclick={handleSecondaryButtonClick}
+                      />
+                    </div>
+                  {/if}
+                  {#if dialogueFooter.primaryButton}
+                    <div class="footer-primary-button">
+                      <Button
+                        {...dialogueFooter.primaryButton}
+                        onclick={handlePrimaryButtonClick}
+                      />
+                    </div>
+                  {/if}
+                </div>
+              </div>
+            {/if}
+          {:else if typeof footerSnippet === 'function'}
+            {#if showDivider}
+              <div class="modal-divider" role="separator" aria-hidden="true"></div>
+            {/if}
             <div class="footer-content">
               {@render footerSnippet?.()}
             </div>
           {:else if typeof footer?.primaryButton === 'object' || typeof footer?.secondaryButton === 'object'}
+            {#if showDivider}
+              <div class="modal-divider" role="separator" aria-hidden="true"></div>
+            {/if}
             <div class="footer-content">
               <div class="footer-action-buttons">
                 {#if footer.secondaryButton}
@@ -204,6 +267,19 @@
     border-top: var(--modal-content-border-top);
   }
 
+  .modal-align-right {
+    height: 100%;
+    width: var(--modal-drawer-width, 420px);
+    max-width: 100%;
+    border-radius: var(--modal-drawer-border-radius, 0px);
+  }
+
+  .right {
+    justify-content: var(--modal-right-justify-content, flex-start);
+    align-items: var(--modal-right-align-items, flex-end);
+    flex-direction: row;
+  }
+
   .slot-content {
     display: var(--modal-display, flex);
     overflow-y: var(--modal-overflow-y, scroll);
@@ -212,6 +288,16 @@
 
   .slot-content::-webkit-scrollbar {
     display: none;
+  }
+
+  .dialogue-body {
+    padding: var(--modal-dialogue-body-padding, 20px);
+    overflow-y: auto;
+  }
+
+  .dialogue-body-text {
+    margin: 0;
+    color: var(--modal-dialogue-body-text-color, inherit);
   }
 
   .center {
@@ -255,6 +341,23 @@
     padding: var(--modal-header-padding, 18px 20px);
     border-radius: var(--modal-header-border-radius, 0px);
     border-bottom: var(--modal-header-border-bottom, none);
+    align-items: var(--modal-header-align-items, center);
+  }
+
+  .header-title-group {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .header-description {
+    color: var(--modal-header-description-color, #6b7280);
+  }
+
+  .modal-divider {
+    height: 0;
+    border-top: 1px solid var(--modal-divider-color, #e5e7eb);
+    flex-shrink: 0;
   }
 
   .footer-content {

--- a/src/lib/Modal/properties.ts
+++ b/src/lib/Modal/properties.ts
@@ -3,7 +3,7 @@ import type { ModalTransition } from '$lib/types';
 import type { Snippet } from 'svelte';
 
 export type ModalSize = 'large' | 'medium' | 'small' | 'fit-content';
-export type ModalAlign = 'top' | 'center' | 'bottom';
+export type ModalAlign = 'top' | 'center' | 'bottom' | 'right';
 
 export type ModalProperties = ModalEventProperties & {
   size?: ModalSize;
@@ -18,10 +18,27 @@ export type ModalProperties = ModalEventProperties & {
     text?: string;
     testId?: string;
     buttonTestId?: string;
+    /** Secondary line rendered beneath the header title. Rendered only when non-empty. */
+    description?: string;
+    /** When false the close button (rightImage) is hidden. Defaults to true (current behaviour). */
+    showCloseButton?: boolean;
   };
   footer?: {
     primaryButton?: ButtonProperties;
     secondaryButton?: ButtonProperties;
+  };
+  /** When true renders a divider line between the header/footer and the content area. Default false. */
+  showDivider?: boolean;
+  /**
+   * When provided, renders a compact confirmation dialogue (bodyText + optional footer buttons)
+   * instead of the content snippet. When omitted the content snippet is rendered as today.
+   */
+  dialogueConfig?: {
+    bodyText: string;
+    footerConfig?: {
+      primaryButton?: ButtonProperties;
+      secondaryButton?: ButtonProperties;
+    };
   };
   debounceTime?: number;
   leftImageTestId?: string;


### PR DESCRIPTION
## Summary

- **`align: 'right'`** — adds a right-edge drawer variant to `ModalAlign`. The modal-content slides in from the right (`fly x:300`), stretches full-height, and takes its width from `--modal-drawer-width` (default `420px`). Implemented as a new `.modal-align-right` CSS class + `.right` overlay class; the top/center/bottom branches are completely untouched.
- **`showDivider?: boolean`** (default `false`) — when `true`, renders a `1px solid` separator between the header and content area, and between the content area and the footer. Color is controlled by `--modal-divider-color` (default `#e5e7eb`). When omitted or `false`, no divider is rendered — identical to today.
- **`header.description?: string`** — optional secondary text line rendered beneath the header title. Only rendered when the string is non-empty. Color exposed as `--modal-header-description-color` (default `#6b7280`).
- **`header.showCloseButton?: boolean`** — gates rendering of `header.rightImage`. Defaults to `true`, preserving existing behavior exactly.
- **`dialogueConfig?: { bodyText: string; footerConfig?: ... }`** — when provided, renders a compact confirmation body (`<p>` with `bodyText`) instead of the `content` snippet, plus an optional footer using the same button shape as `footer`. When absent, the component renders the `content` snippet exactly as before.

## API

| New prop | Type | Default | Effect |
|---|---|---|---|
| `align` | `'top'\|'center'\|'bottom'\|'right'` | `'center'` | `'right'` produces a full-height right-edge drawer |
| `showDivider` | `boolean` | `false` | Divider line between header↔content and content↔footer |
| `header.description` | `string` | — | Secondary line below header title |
| `header.showCloseButton` | `boolean` | `true` | Show/hide the close (rightImage) button |
| `dialogueConfig` | `{ bodyText: string; footerConfig?: FooterConfig }` | — | Compact confirmation body; replaces content snippet when set |

New CSS custom properties: `--modal-drawer-width`, `--modal-drawer-border-radius`, `--modal-divider-color`, `--modal-header-description-color`, `--modal-dialogue-body-padding`, `--modal-dialogue-body-text-color`.

## Notes

- `svelte-check` reports **0 errors, 0 warnings**
- `prettier --check` exits **0** on all Modal files
- `eslint src/lib/Modal/` exits **0**
- All new props are optional with defaults that reproduce today's behavior exactly — no existing callsites require changes
- `ModalAnimation.svelte` gains a `case 'right': return { ...base, x: 300 }` branch; the `useFlyAnimation` derived also includes `align === 'right'`; all other align branches are untouched