### PR TITLE
feat: add testId, onclick (interactive-div), and focus CSS vars to Card

### DIFF
--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -1,10 +1,32 @@
 <script lang="ts">
   import type { CardProperties } from './properties';
 
-  let { children, title, description, classes }: CardProperties = $props();
+  let { children, title, description, classes, testId, onclick }: CardProperties = $props();
+
+  const isInteractive = $derived(typeof onclick === 'function');
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      if (event.key === ' ') {
+        event.preventDefault();
+      }
+      if (event.currentTarget instanceof HTMLElement) {
+        event.currentTarget.click();
+      }
+    }
+  }
 </script>
 
-<div class="card {classes ?? ''}">
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+  class="card {classes ?? ''}"
+  class:card-interactive={isInteractive}
+  data-pw={typeof testId === 'string' ? testId : null}
+  role={isInteractive ? 'button' : null}
+  tabindex={isInteractive ? 0 : null}
+  onclick={isInteractive ? onclick : null}
+  onkeydown={isInteractive ? handleKeydown : null}
+>
   {#if typeof title === 'string' && title.length > 0}
     <div class="card-header">
       <div class="card-title">{title}</div>
@@ -25,6 +47,16 @@
     border-radius: var(--card-border-radius, 8px);
     overflow: var(--card-overflow, hidden);
     color: inherit;
+    cursor: var(--card-cursor, inherit);
+  }
+
+  .card-interactive {
+    cursor: var(--card-cursor, pointer);
+  }
+
+  .card-interactive:focus-visible {
+    outline: var(--card-focus-outline, 2px solid currentColor);
+    outline-offset: var(--card-focus-outline-offset, 2px);
   }
 
   .card-header {

--- a/src/lib/Card/properties.ts
+++ b/src/lib/Card/properties.ts
@@ -10,4 +10,13 @@ export type OptionalCardProperties = {
   title?: string;
   description?: string;
   classes?: string;
+  /** Renders as `data-pw` on the root element for Playwright test selection. */
+  testId?: string;
+  /**
+   * When provided the root element becomes interactive:
+   * `role="button"`, `tabindex=0`, and keydown (Enter/Space) triggers the handler.
+   * When omitted the root is a plain `<div>` with no interactive attributes,
+   * so existing consumers see zero behaviour change.
+   */
+  onclick?: (event: MouseEvent) => void;
 };


### PR DESCRIPTION
Slim follow-up to #210 per @sinha-sahil's review — contains only the keepers. Variants/layout stay in consumer CSS (classes + CSS vars) per GUIDELINES §9. Supersedes #210.

## What's in this PR

Exactly three additive changes, nothing else:

- **`testId` prop** — renders as `data-pw` on the root element for Playwright test selection.
- **`onclick` prop** — full interactive-div pattern: `role="button"`, `tabindex={0}`, Enter+Space keydown calling `.click()` with `preventDefault()` on Space. Every interactive attribute is conditionally `null` when `onclick` is omitted — **zero behaviour change for existing consumers**.
- **Three CSS variables** — `--card-cursor`, `--card-focus-outline`, `--card-focus-outline-offset` with sensible defaults. `.card-interactive` class gates the cursor switch.

## What was intentionally dropped

Header layout props (`headerLeading`, `headerAction`, `headerSubtext`) and all associated flex CSS (`card-header-row`, `card-header-leading`, `--card-header-gap`, `--card-header-subtext-*`) are excluded. Per the BLOCK review in #210 and GUIDELINES §9, variants and layout belong in consumer CSS via the `classes` prop and CSS variables — not baked-in presets. The eventual PR-B for a generic `header` snippet will be preceded by a design-issue discussion as requested.

## Validation

- `pnpm run check` → `svelte-check found 0 errors and 0 warnings`
- `pnpm exec prettier --check src/lib/Card/Card.svelte src/lib/Card/properties.ts src/lib/index.ts` → exit 0
- `pnpm exec eslint src/lib/Card/` → exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Card component now supports interactive behavior when an onclick handler is provided, allowing cards to function as clickable elements
- Interactive cards include full keyboard accessibility with Enter and Space key support
- Visual feedback added with pointer cursor and focus outline styling to indicate interactive states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/svelte-ui-components/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->