### PR TITLE
feat(Sheet): add onafteropen + onafterclose lifecycle callbacks

### DIFF
--- a/docs/Sheet.md
+++ b/docs/Sheet.md
@@ -47,9 +47,11 @@ Svelte 5 Snippet props — pass content blocks to the component.
 
 ## Events
 
-| Event   | Type         | Description                                                                                                                                                                                            |
-| ------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| onclose | `() => void` | Fires when the sheet is dismissed by clicking the overlay backdrop, pressing the Escape key, or clicking the close button. The `open` prop is automatically set to `false` before this callback fires. |
+| Event        | Type         | Description                                                                                                                                                                                            |
+| ------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| onclose      | `() => void` | Fires when the sheet is dismissed by clicking the overlay backdrop, pressing the Escape key, or clicking the close button. The `open` prop is automatically set to `false` before this callback fires. |
+| onafteropen  | `() => void` | Fires once after the open (intro) transition has fully completed. Useful for triggering animations or focusing elements that should only activate once the sheet is fully visible.                      |
+| onafterclose | `() => void` | Fires once after the close (outro) transition has fully completed. Useful for cleanup tasks that should only run after the sheet has fully left the screen.                                             |
 
 ## CSS Variables
 

--- a/src/lib/Sheet/Sheet.svelte
+++ b/src/lib/Sheet/Sheet.svelte
@@ -14,6 +14,8 @@
     content,
     footer,
     onclose,
+    onafteropen,
+    onafterclose,
     classes
   }: SheetProperties = $props();
 
@@ -90,6 +92,18 @@
       }
     };
   }
+
+  function handleIntroEnd() {
+    if (typeof onafteropen === 'function') {
+      onafteropen();
+    }
+  }
+
+  function handleOutroEnd() {
+    if (typeof onafterclose === 'function') {
+      onafterclose();
+    }
+  }
 </script>
 
 {#if open}
@@ -112,6 +126,8 @@
       aria-label={title ?? 'Sheet'}
       tabindex="-1"
       transition:fly|global={flyParams}
+      onintroend={handleIntroEnd}
+      onoutroend={handleOutroEnd}
     >
       {#if typeof title === 'string' || showCloseButton}
         <div class="sheet-header">

--- a/src/lib/Sheet/properties.ts
+++ b/src/lib/Sheet/properties.ts
@@ -23,4 +23,8 @@ export type OptionalSheetProperties = {
 
 export type SheetEventProperties = {
   onclose?: () => void;
+  /** Called once after the open transition has fully completed. */
+  onafteropen?: () => void;
+  /** Called once after the close transition has fully completed. */
+  onafterclose?: () => void;
 };

--- a/src/routes/components/sheet/+page.svelte
+++ b/src/routes/components/sheet/+page.svelte
@@ -8,6 +8,8 @@
   let showBottom = $state(false);
   let showRaw = $state(false);
   let showFooter = $state(false);
+  let showLifecycle = $state(false);
+  let lifecycleLog = $state<string[]>([]);
 </script>
 
 <div class="page-header">
@@ -83,3 +85,28 @@
     {/snippet}
   </Sheet>
 </div>
+
+<h3>Lifecycle callbacks (onafteropen / onafterclose)</h3>
+<div class="demo-row">
+  <Button
+    text="Open with lifecycle"
+    onclick={() => {
+      lifecycleLog = [];
+      showLifecycle = true;
+    }}
+  />
+  <Sheet
+    bind:open={showLifecycle}
+    side="right"
+    title="Lifecycle demo"
+    onafteropen={() => (lifecycleLog = [...lifecycleLog, 'onafteropen fired'])}
+    onafterclose={() => (lifecycleLog = [...lifecycleLog, 'onafterclose fired'])}
+  >
+    {#snippet content()}
+      <p>Open and close this sheet to observe the transition-end callbacks in the log below.</p>
+    {/snippet}
+  </Sheet>
+</div>
+{#if lifecycleLog.length > 0}
+  <p class="state-display">{lifecycleLog.join(' → ')}</p>
+{/if}

--- a/src/wc/components/Sheet.wc.svelte
+++ b/src/wc/components/Sheet.wc.svelte
@@ -10,7 +10,9 @@
       showCloseButton: { type: 'Boolean', reflect: true, attribute: 'show-close-button' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onclose: { type: 'Object' }
+      onclose: { type: 'Object' },
+      onafteropen: { type: 'Object' },
+      onafterclose: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
Slim follow-up to #206 per @sinha-sahil's review — contains **only** the two lifecycle callbacks, no animation changes, no arrow-const churn.

## What's in this PR

- `onafteropen?: () => void` — fired via `onintroend` once the fly transition completes
- `onafterclose?: () => void` — fired via `onoutroend` once the fly transition completes

Both props follow the lowercase event-prop naming convention consistent with `onclose`. Handlers use `function` declarations matching the existing codebase style. No template duplication, no variant enum, no embedded keyframes.

## What's NOT in this PR

- No `animationType` / `SheetAnimationType` enum (blocked in #206)
- No CSS animation changes (stays in #206 for the CSS-variable rework)
- No conversion of existing `function` declarations to arrow expressions

## Validation

- `pnpm run check` → `svelte-check found 0 errors and 0 warnings`
- `pnpm exec prettier --check` → all files pass
- `pnpm exec eslint src/lib/Sheet/` → exit 0

Variants/layout stay in consumer CSS (`classes` prop + CSS vars) per GUIDELINES §9. Supersedes the lifecycle-callback portion of #206.