### PR TITLE
feat: add hasMore + prevButtonTestId + nextButtonTestId to Pagination

### DIFF
--- a/docs/Pagination.md
+++ b/docs/Pagination.md
@@ -1,6 +1,6 @@
 # Pagination
 
-Page-level navigation with numbered page buttons, prev/next controls, and ellipsis for large page ranges. The `currentPage` prop is bindable and `siblingCount` controls how many pages are shown around the active page. Ellipsis indicators appear automatically when pages are truncated.
+Page-level navigation with numbered page buttons, prev/next controls, and ellipsis for large page ranges. The `currentPage` prop is bindable and `siblingCount` controls how many pages are shown around the active page. Ellipsis indicators appear automatically when pages are truncated. The `hasMore` prop supports cursor-based APIs where the total page count is unknown — when true, the next button stays enabled even when `currentPage` reaches `totalPages`. Individual prev/next buttons can be targeted in tests via `prevButtonTestId` and `nextButtonTestId`.
 
 ## Usage
 
@@ -14,14 +14,17 @@ Page-level navigation with numbered page buttons, prev/next controls, and ellips
 
 ## Props
 
-| Prop         | Type      | Required | Default | Description                                                                                                                                                                     |
-| ------------ | --------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| totalPages   | `number`  | Yes      | `-`     | The total number of pages available. Determines the range of page buttons rendered.                                                                                             |
-| currentPage  | `number`  | No       | `1`     | Bindable. The currently active page number. Controls which page button is highlighted and determines prev/next button disabled states.                                          |
-| siblingCount | `number`  | No       | `1`     | Number of page buttons to show on each side of the current page. For example, siblingCount=1 with currentPage=5 shows pages 4, 5, 6. Higher values show more surrounding pages. |
-| disabled     | `boolean` | No       | `false` | Whether the entire pagination is disabled. When true, all buttons become non-interactive, the container dims (opacity 0.5), and the cursor changes to not-allowed.              |
-| testId       | `string`  | No       | `-`     | Value for the data-pw attribute on the nav container, used for end-to-end testing selectors.                                                                                    |
-| classes      | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.          |
+| Prop             | Type      | Required | Default | Description                                                                                                                                                                                                                                                                                                            |
+| ---------------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| totalPages       | `number`  | Yes      | `-`     | The total number of pages available. Determines the range of page buttons rendered.                                                                                                                                                                                                                                    |
+| currentPage      | `number`  | No       | `1`     | Bindable. The currently active page number. Controls which page button is highlighted and determines prev/next button disabled states.                                                                                                                                                                                 |
+| siblingCount     | `number`  | No       | `1`     | Number of page buttons to show on each side of the current page. For example, siblingCount=1 with currentPage=5 shows pages 4, 5, 6. Higher values show more surrounding pages.                                                                                                                                        |
+| disabled         | `boolean` | No       | `false` | Whether the entire pagination is disabled. When true, all buttons become non-interactive, the container dims (opacity 0.5), and the cursor changes to not-allowed.                                                                                                                                                     |
+| testId           | `string`  | No       | `-`     | Value for the `data-pw` attribute on the nav container, used for end-to-end testing selectors.                                                                                                                                                                                                                         |
+| classes          | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                                                                                                                 |
+| hasMore          | `boolean` | No       | `false` | Cursor-pagination hint. When `true`, the next button stays enabled even when `currentPage >= totalPages`. Use this when the total page count is not known ahead of time (e.g. cursor-based APIs). `totalPages` takes precedence: the next button is enabled only if `hasMore` is `true` OR `currentPage < totalPages`. |
+| prevButtonTestId | `string`  | No       | `-`     | Value for the `data-pw` attribute on the previous-page button, used for end-to-end testing selectors.                                                                                                                                                                                                                  |
+| nextButtonTestId | `string`  | No       | `-`     | Value for the `data-pw` attribute on the next-page button, used for end-to-end testing selectors.                                                                                                                                                                                                                      |
 
 ## Events
 
@@ -99,4 +102,13 @@ Tag: `<sui-pagination>`
 
 ```html
 <sui-pagination total-pages="10" current-page="1"></sui-pagination>
+
+<!-- cursor-based pagination with test IDs -->
+<sui-pagination
+  total-pages="3"
+  current-page="1"
+  has-more="true"
+  prev-button-test-id="prev-btn"
+  next-button-test-id="next-btn"
+></sui-pagination>
 ```

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -133,7 +133,7 @@
   },
   {
     "name": "Pagination",
-    "description": "A page navigation component with previous/next buttons and numbered page links. Supports configurable visible page range with ellipsis for large page counts, disabled states, and custom arrow snippets."
+    "description": "A page navigation component with previous/next buttons and numbered page links. Supports configurable visible page range with ellipsis for large page counts, disabled states, cursor-based pagination via `hasMore`, and per-button test IDs via `prevButtonTestId`/`nextButtonTestId`."
   },
   {
     "name": "Phone",

--- a/src/lib/Pagination/Pagination.svelte
+++ b/src/lib/Pagination/Pagination.svelte
@@ -8,7 +8,10 @@
     disabled = false,
     testId,
     onchange,
-    classes
+    classes,
+    hasMore = false,
+    prevButtonTestId,
+    nextButtonTestId
   }: PaginationProperties = $props();
 
   function generatePages(total: number, current: number, siblings: number): (number | '...')[] {
@@ -40,12 +43,15 @@
   let pages = $derived(generatePages(totalPages, currentPage, siblingCount));
 
   function goToPage(page: number): void {
-    if (disabled || page < 1 || page > totalPages || page === currentPage) {
+    const isForwardAllowed = hasMore || page <= totalPages;
+    if (disabled || page < 1 || !isForwardAllowed || page === currentPage) {
       return;
     }
     currentPage = page;
     onchange?.(page);
   }
+
+  let isNextDisabled = $derived(disabled || (!hasMore && currentPage >= totalPages));
 </script>
 
 <nav
@@ -58,6 +64,7 @@
     disabled={disabled || currentPage <= 1}
     onclick={() => goToPage(currentPage - 1)}
     aria-label="Previous page"
+    data-pw={typeof prevButtonTestId === 'string' ? prevButtonTestId : null}
   >
     &#8249;
   </button>
@@ -81,9 +88,10 @@
 
   <button
     class="page-button next-button"
-    disabled={disabled || currentPage >= totalPages}
+    disabled={isNextDisabled}
     onclick={() => goToPage(currentPage + 1)}
     aria-label="Next page"
+    data-pw={typeof nextButtonTestId === 'string' ? nextButtonTestId : null}
   >
     &#8250;
   </button>

--- a/src/lib/Pagination/properties.ts
+++ b/src/lib/Pagination/properties.ts
@@ -12,6 +12,18 @@ export type OptionalPaginationProperties = {
   disabled?: boolean;
   testId?: string;
   classes?: string;
+  /**
+   * Cursor-pagination hint. When `true`, the next button stays enabled even
+   * when `currentPage >= totalPages` — use this when the total page count is
+   * not known ahead of time (e.g. cursor-based APIs). `totalPages` takes
+   * precedence when both are provided: the next button is enabled only if
+   * `hasMore` is `true` OR `currentPage < totalPages`.
+   */
+  hasMore?: boolean;
+  /** `data-pw` test-id for the previous-page button. */
+  prevButtonTestId?: string;
+  /** `data-pw` test-id for the next-page button. */
+  nextButtonTestId?: string;
 };
 
 export type PaginationEventProperties = {

--- a/src/routes/components/pagination/+page.svelte
+++ b/src/routes/components/pagination/+page.svelte
@@ -2,6 +2,8 @@
   import Pagination from '$lib/Pagination/Pagination.svelte';
 
   let currentPage = $state(1);
+  let cursorPage = $state(1);
+  let hasMore = $state(true);
 </script>
 
 <div class="page-header">
@@ -9,7 +11,32 @@
   <h1>Pagination</h1>
 </div>
 
+<h3>Default</h3>
 <div class="demo-row">
   <Pagination totalPages={10} bind:currentPage siblingCount={1} />
   <span class="state-display">Page: {currentPage}</span>
+</div>
+
+<h3>hasMore — cursor-based pagination</h3>
+<p class="state-display">
+  When <code>hasMore</code> is true the next button stays enabled past <code>totalPages</code>.
+  Toggle it to simulate a cursor API that signals "no more results".
+</p>
+<div class="demo-row">
+  <Pagination
+    totalPages={3}
+    bind:currentPage={cursorPage}
+    {hasMore}
+    prevButtonTestId="cursor-prev"
+    nextButtonTestId="cursor-next"
+  />
+  <span class="state-display">Page: {cursorPage}</span>
+  <button class="toggle-btn" onclick={() => (hasMore = !hasMore)}>
+    hasMore: {hasMore}
+  </button>
+</div>
+
+<h3>Disabled</h3>
+<div class="demo-row">
+  <Pagination totalPages={10} currentPage={5} disabled />
 </div>

--- a/src/wc/components/Pagination.wc.svelte
+++ b/src/wc/components/Pagination.wc.svelte
@@ -9,6 +9,9 @@
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
+      hasMore: { type: 'Boolean', reflect: true, attribute: 'has-more' },
+      prevButtonTestId: { type: 'String', attribute: 'prev-button-test-id' },
+      nextButtonTestId: { type: 'String', attribute: 'next-button-test-id' },
       onchange: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
Slim follow-up to #216 per @sinha-sahil's review — contains only the three keepers.

## Changes

- **`hasMore?: boolean`** — cursor-pagination hint. When `true`, the next button stays enabled even when `currentPage >= totalPages`, for APIs where total page count is not known ahead of time. `totalPages` takes precedence: next is enabled if `hasMore || currentPage < totalPages`.
- **`prevButtonTestId?: string`** — `data-pw` attribute on the previous-page button.
- **`nextButtonTestId?: string`** — `data-pw` attribute on the next-page button.

Both test-id props are typed `string | undefined` (i.e. `?: string`), matching the dominant convention across the library (Button, Input, Select, Table, Tabs, etc.).

## What is explicitly NOT in this PR

- No `totalItems` / `Showing … of … items` summary.
- No `pageSize` / `pageSizes` / page-size `<select>`.
- No `selectedItemLabel` or `onPageSizeChange`.
- No `<div class="pagination-wrapper">` — root stays `<nav class="pagination {classes ?? ''}">` so §9 holds.
- No conversion of `generatePages` / `goToPage` from `function` declarations to arrow consts.

## GUIDELINES compliance

- Variants/layout stay in consumer CSS via the `classes` prop + CSS vars (§9).
- No baked-in enums, presets, or hardcoded typography.
- `function` declarations kept for named functions; inline arrow callbacks used only for event handlers.
- All checks pass: `pnpm run check` → 0 errors 0 warnings; prettier clean; eslint clean.

Supersedes #216.