### PR TITLE
feat(modal): §3 falsy-guard fixes, §5 redundant-guard removal, expose --modal-header-align-items

### DIFF
--- a/docs/Modal.md
+++ b/docs/Modal.md
@@ -85,6 +85,7 @@ Override these custom properties to theme the component.
 | `--modal-header-padding`                                 | `18px 20px`        | padding                         | Padding inside the header bar.                                     |
 | `--modal-header-border-radius`                           | `0px`              | border-radius                   | Corner rounding of the header bar.                                 |
 | `--modal-header-border-bottom`                           | `none`             | border-bottom                   | Bottom border of the header bar.                                   |
+| `--modal-header-align-items`                             | `center`           | align-items                     | Vertical alignment of items inside the header bar.                 |
 | `--modal-footer-background-color`                        | `#f6f7f9`          | background-color                | Background color of the footer area.                               |
 | `--modal-footer-padding`                                 | `18px 20px`        | padding                         | Padding inside the footer area.                                    |
 | `--modal-footer-border-radius`                           | `0px`              | border-radius                   | Corner rounding of the footer area.                                |

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -57,7 +57,7 @@
   }
 
   function handleOverlayClick(event: MouseEvent) {
-    if (event.target && event.target === overlayDiv) {
+    if (event.target === overlayDiv) {
       debounce(() => {
         onoverlayClick?.();
       });
@@ -110,7 +110,7 @@
         <div class="modal-content {size}">
           {#if (typeof header?.leftImage === 'string' && header.leftImage.length > 0) || (typeof header?.text === 'string' && header.text.length > 0) || (typeof header?.rightImage === 'string' && header.rightImage.length > 0)}
             <div class="header">
-              {#if header.leftImage}
+              {#if typeof header.leftImage === 'string' && header.leftImage.length > 0}
                 <div
                   onclick={handleLeftImageClick}
                   {onkeydown}
@@ -121,12 +121,12 @@
                   <img class="header-left-img" src={header.leftImage} alt="" />
                 </div>
               {/if}
-              {#if header.text}
+              {#if typeof header.text === 'string' && header.text.length > 0}
                 <div class="header-text" data-pw={header.testId}>
                   {header.text}
                 </div>
               {/if}
-              {#if header.rightImage}
+              {#if typeof header.rightImage === 'string' && header.rightImage.length > 0}
                 <div
                   role="button"
                   tabindex="0"
@@ -255,6 +255,7 @@
     padding: var(--modal-header-padding, 18px 20px);
     border-radius: var(--modal-header-border-radius, 0px);
     border-bottom: var(--modal-header-border-bottom, none);
+    align-items: var(--modal-header-align-items, center);
   }
 
   .footer-content {

--- a/src/routes/components/modal/+page.svelte
+++ b/src/routes/components/modal/+page.svelte
@@ -3,6 +3,7 @@
   import Modal from '$lib/Modal/Modal.svelte';
 
   let showModal = $state(false);
+  let showModalTop = $state(false);
 </script>
 
 <div class="page-header">
@@ -38,3 +39,30 @@
     </Modal>
   {/if}
 </div>
+
+<div class="demo-row">
+  <Button text="Open Modal (header align: flex-start)" onclick={() => (showModalTop = true)} />
+  {#if showModalTop}
+    <div class="modal-top-aligned">
+      <Modal
+        size="fit-content"
+        align="center"
+        showOverlay
+        header={{ text: 'Top-Aligned Header Items' }}
+        onoverlayClick={() => (showModalTop = false)}
+      >
+        {#snippet content()}
+          <div style="padding: 16px;">
+            <p>The header uses <code>--modal-header-align-items: flex-start</code> so multi-line header content aligns to the top instead of the default center.</p>
+          </div>
+        {/snippet}
+      </Modal>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .modal-top-aligned {
+    --modal-header-align-items: flex-start;
+  }
+</style>


### PR DESCRIPTION
Slim follow-up to #226 per @sinha-sahil's review — contains only the salvageable, non-composite keepers. Variants/layout presets stay in consumer CSS (`classes` + CSS vars) per GUIDELINES §9. Supersedes #226.

## What changed

**`src/lib/Modal/Modal.svelte` only — no properties.ts changes, no new props.**

### §5 — Redundant guard removal (`handleOverlayClick`)
`event.target &&` before `event.target === overlayDiv` was a redundant null guard: strict equality (`===`) already returns `false` for `null`, so the `&&` check was dead code. Removed per GUIDELINES §5.

### §3 — Falsy-check fixes (inner header renders)
The three inner header conditionals used implicit truthy coercion on `string | undefined` props:
- \`{#if header.leftImage}\`
- \`{#if header.text}\`  
- \`{#if header.rightImage}\`

Replaced with explicit \`typeof … === 'string' && ….length > 0\` guards per GUIDELINES §3.

### CSS — expose \`--modal-header-align-items\`
Added \`align-items: var(--modal-header-align-items, center)\` to the \`.header\` rule. Consumers can now override the header's cross-axis alignment (e.g. \`flex-start\` for a multi-line title) via a CSS variable without a wrapper element. Default is \`center\` (preserving existing behavior).

## What was dropped (from #226)
All five blocked composite/preset props and their associated markup and CSS:
- \`align = 'right'\` drawer literal + \`.modal-align-right\` / \`.right\` CSS classes + \`ModalAnimation\` \`'right'\` case
- \`showDivider\` prop + \`.modal-divider\` CSS
- \`header.description\` + \`.header-description\` / \`.header-title-group\` CSS
- \`header.showCloseButton\` derived
- \`dialogueConfig\` prop + \`.dialogue-body\` / \`.dialogue-body-text\` CSS
- Arrow-function conversions reverted (function declarations kept, per @sinha-sahil's separate note)

## Validation
- \`pnpm run check\` → \`svelte-check found 0 errors and 0 warnings\`
- \`pnpm exec prettier --check src/lib/Modal/Modal.svelte src/lib/index.ts\` → exit 0
- \`pnpm exec eslint src/lib/Modal/\` → exit 0