### PR TITLE
feat(Pill): add leadingIcon snippet slot

### DIFF
--- a/docs/Pill.md
+++ b/docs/Pill.md
@@ -64,9 +64,10 @@ Define variant classes in your app's CSS that set Pill CSS variables, then pass 
 
 Svelte 5 Snippet props — pass content blocks to the component.
 
-| Snippet     | Type      | Description                               |
-| ----------- | --------- | ----------------------------------------- |
-| dismissIcon | `Snippet` | Custom icon for the dismiss/close button. |
+| Snippet     | Type      | Description                                                                                                                                                                                                                                                             |
+| ----------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| leadingIcon | `Snippet` | Content rendered immediately before the text label inside a `<span class="pill-leading-icon">` wrapper. Compose with an icon or small image. Leave accessibility attributes (e.g. `aria-hidden`, `aria-label`) on the icon itself — the wrapper is presentational only. |
+| dismissIcon | `Snippet` | Custom icon for the dismiss/close button.                                                                                                                                                                                                                               |
 
 ## Events
 
@@ -117,6 +118,7 @@ Tag: `<sui-pill>`
 
 ### Slots
 
-| Slot Name      | Maps to Snippet | Description                               |
-| -------------- | --------------- | ----------------------------------------- |
-| `dismiss-icon` | `dismissIcon`   | Custom icon for the dismiss/close button. |
+| Slot Name      | Maps to Snippet | Description                                                              |
+| -------------- | --------------- | ------------------------------------------------------------------------ |
+| `leading-icon` | `leadingIcon`   | Content rendered before the text label (icon, image, or inline element). |
+| `dismiss-icon` | `dismissIcon`   | Custom icon for the dismiss/close button.                                |

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -141,7 +141,7 @@
   },
   {
     "name": "Pill",
-    "description": "A compact label/tag element for displaying status, categories, or metadata. Supports an optional icon snippet and click interaction with keyboard accessibility (role=button, Enter/Space). Optionally clickable when onclick is provided."
+    "description": "A compact label/tag element for displaying status, categories, or metadata. Supports a leadingIcon snippet (rendered before the label) and a dismissIcon snippet, click interaction with keyboard accessibility (role=button, Enter/Space), and an optional dismiss button. Optionally clickable when onclick is provided."
   },
   {
     "name": "Progress",

--- a/src/lib/Pill/Pill.svelte
+++ b/src/lib/Pill/Pill.svelte
@@ -9,6 +9,7 @@
     disabled = false,
     testId,
     dismissIcon,
+    leadingIcon,
     onclick,
     ondismiss,
     classes
@@ -52,6 +53,9 @@
   aria-disabled={interactive && disabled ? true : null}
   data-pw={typeof testId === 'string' ? testId : null}
 >
+  {#if typeof leadingIcon === 'function'}
+    <span class="pill-leading-icon">{@render leadingIcon()}</span>
+  {/if}
   <span class="pill-text">{text}</span>
   {#if dismissible}
     <div class="pill-dismiss">
@@ -104,6 +108,12 @@
     overflow: hidden;
     text-overflow: var(--pill-text-overflow, ellipsis);
     white-space: nowrap;
+  }
+
+  .pill-leading-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 
   .pill-dismiss {

--- a/src/lib/Pill/properties.ts
+++ b/src/lib/Pill/properties.ts
@@ -11,6 +11,13 @@ export type OptionalPillProperties = {
   disabled?: boolean;
   testId?: string;
   dismissIcon?: Snippet;
+  /**
+   * A Svelte snippet rendered immediately before the text label inside a
+   * `<span class="pill-leading-icon">` wrapper. Use for icons, logos, or any
+   * inline decoration. The wrapper does not receive `aria-hidden` — leave
+   * accessibility attributes on the icon itself.
+   */
+  leadingIcon?: Snippet;
   classes?: string;
 };
 

--- a/src/routes/components/pill/+page.svelte
+++ b/src/routes/components/pill/+page.svelte
@@ -25,3 +25,75 @@
     />
   {/if}
 </div>
+
+<div class="demo-row">
+  <Pill text="Verified">
+    {#snippet leadingIcon()}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"><polyline points="20 6 9 17 4 12" /></svg
+      >
+    {/snippet}
+  </Pill>
+
+  <Pill text="TypeScript" classes="pill-info">
+    {#snippet leadingIcon()}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        ><path
+          d="M3 3h18v18H3V3zm10.71 14.29c.18.18.43.3.71.3a1 1 0 0 0 .71-1.71l-1-1H16a3 3 0 0 0 0-6h-1V8h-2v1h-1a3 3 0 0 0 0 6h.29l-1 1a1 1 0 0 0 1.42 1.42l1.71-1.72L13.7 17.3zM15 10a1 1 0 0 1 0 2h-2v-2h2zm-4 2a1 1 0 0 1 0-2h.17L10 11.17V12H11z"
+        /></svg
+      >
+    {/snippet}
+  </Pill>
+
+  <Pill text="Error" classes="pill-error" dismissible>
+    {#snippet leadingIcon()}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+        ><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line
+          x1="12"
+          y1="16"
+          x2="12.01"
+          y2="16"
+        /></svg
+      >
+    {/snippet}
+  </Pill>
+</div>
+
+<style>
+  :global(.pill-info) {
+    --pill-background: #d1ecf1;
+    --pill-color: #0c5460;
+    --pill-hover-background: #bee5eb;
+  }
+
+  :global(.pill-error) {
+    --pill-background: #f8d7da;
+    --pill-color: #721c24;
+    --pill-hover-background: #f1b0b7;
+  }
+</style>

--- a/src/wc/components/Pill.wc.svelte
+++ b/src/wc/components/Pill.wc.svelte
@@ -7,6 +7,7 @@
       dismissible: { type: 'Boolean', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
+      leadingIcon: { type: 'Object' },
       dismissIcon: { type: 'Object' },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
@@ -21,6 +22,9 @@
 </script>
 
 <Pill {...props}>
+  {#snippet leadingIcon()}
+    <slot name="leading-icon"></slot>
+  {/snippet}
   {#snippet dismissIcon()}
     <slot name="dismiss-icon"></slot>
   {/snippet}


### PR DESCRIPTION
Slim follow-up to #211 per @sinha-sahil's review — contains only `leadingIcon`. Variants/layout stay in consumer CSS (classes + CSS vars) per GUIDELINES §9. Supersedes #211.

## What changed

- `OptionalPillProperties` gains `leadingIcon?: Snippet` — mirrors the existing `dismissIcon` declaration verbatim for naming/JSDoc consistency.
- `Pill.svelte` renders the slot inside the existing flex row, immediately before the `text` span, inside `<span class="pill-leading-icon">`.
- No new CSS variables — the existing `--pill-gap` already controls spacing. Consumers can target `.pill-leading-icon` in their own CSS for additional control.
- No `aria-hidden` on the wrapper — accessibility attributes belong on the consumer's icon.
- `docs/Pill.md` updated with `leadingIcon` in the Snippets table and the Web Component slots table.

## What was dropped from #211

- `variant` prop + `pill-variant-*` class application
- `size` prop + `pill-size-*` class application + baked `padding: 3px 8px` preset
- `showDot` prop + `.pill-dot` markup and CSS
- The `function` → `const arrow` rewrites for `handleClick`, `handleKeydown`, `handleDismiss` — kept as `function` declarations per library convention

## Validation

- `pnpm run check` → `svelte-check found 0 errors and 0 warnings`
- `pnpm exec prettier --check` → exit 0
- `pnpm exec eslint src/lib/Pill/` → exit 0