### PR TITLE
feat(Select): string[] normalization, showSelectAll + optionIndicator snippet, bottomContent

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -1,6 +1,6 @@
 # Select
 
-A dropdown selector that supports single and multi-select modes with optional search filtering. In single-select mode, clicking an item selects it and closes the dropdown. In multi-select mode, clicking items toggles them on or off and the dropdown stays open. Selected items in multi-select are shown as dismissible pills. Supports keyboard navigation (Arrow keys, Enter, Escape, Backspace) and closes automatically when clicking outside. The `value` prop is bindable.
+A dropdown selector that supports single and multi-select modes with optional search filtering. In single-select mode, clicking an item selects it and closes the dropdown. In multi-select mode, clicking items toggles them on or off and the dropdown stays open. Selected items in multi-select are shown as dismissible pills. The `items` prop accepts either `SelectItem[]` objects or a plain `string[]` (each string is used as both the id and the label). Custom snippets let you replace the per-option checkbox indicator and add arbitrary content pinned to the bottom of the dropdown. Supports keyboard navigation (Arrow keys, Enter, Escape, Backspace) and closes automatically when clicking outside. The `value` prop is bindable.
 
 ## Usage
 
@@ -18,24 +18,66 @@ A dropdown selector that supports single and multi-select modes with optional se
 <Select {items} placeholder="Pick a fruit" onchange={(val) => console.log(val)} />
 ```
 
+### String Array Shorthand
+
+Pass a plain `string[]` — each string becomes both the `id` and the `label`:
+
+```svelte
+<Select items={['Active', 'Inactive', 'Pending']} placeholder="Select status" />
+```
+
 ### Multi-Select with Search
 
 ```svelte
 <Select {items} multiple searchable placeholder="Search fruits..." bind:value={selectedIds} />
 ```
 
+### With bottomContent Snippet
+
+Pin arbitrary content (e.g. a "Manage…" link) to the bottom of the dropdown:
+
+```svelte
+<Select {items} placeholder="Choose">
+  {#snippet bottomContent()}
+    <a href="/manage">+ Manage options</a>
+  {/snippet}
+</Select>
+```
+
+### With Custom optionIndicator Snippet (Multi-Select)
+
+Replace the default ☐/☑ glyphs with a custom indicator:
+
+```svelte
+<Select {items} multiple placeholder="Pick items">
+  {#snippet optionIndicator({ checked })}
+    <span>{checked ? '✔' : '○'}</span>
+  {/snippet}
+</Select>
+```
+
 ## Props
 
-| Prop        | Type           | Required | Default | Description                                                                                                                                                            |
-| ----------- | -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| items       | `SelectItem[]` | Yes      | -       | Array of selectable options. Each item has an `id` and a `label`.                                                                                                      |
-| value       | `string[]`     | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                             |
-| multiple    | `boolean`      | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                            |
-| searchable  | `boolean`      | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                    |
-| placeholder | `string`       | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                               |
-| disabled    | `boolean`      | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                        |
-| testId      | `string`       | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                     |
-| classes     | `string`       | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop        | Type                        | Required | Default | Description                                                                                                                                                            |
+| ----------- | --------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| items       | `SelectItem[] \| string[]`  | Yes      | -       | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.       |
+| value       | `string[]`                  | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                             |
+| open        | `boolean`                   | No       | `false` | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state. |
+| multiple    | `boolean`                   | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                            |
+| searchable  | `boolean`                   | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                    |
+| placeholder | `string`                    | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                               |
+| disabled    | `boolean`                   | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                        |
+| testId      | `string`                    | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                     |
+| classes     | `string`                    | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+
+## Snippets
+
+Svelte 5 Snippet props — pass content blocks to the component.
+
+| Snippet          | Type                              | Description                                                                                                                                          |
+| ---------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bottomContent    | `Snippet`                         | Arbitrary content rendered at the bottom of the open dropdown, separated by a border. Use for "Manage options" links or bulk actions.                |
+| optionIndicator  | `Snippet<[{ checked: boolean }]>` | Custom indicator rendered before each option label in multi-select mode. Receives `{ checked }` and replaces the default ☐/☑ glyphs when provided.  |
 
 ## Events
 
@@ -105,16 +147,25 @@ Override these custom properties to theme the component.
 
 ### Options
 
-| Variable                                    | Default                                        | CSS Property | Description                                           |
-| ------------------------------------------- | ---------------------------------------------- | ------------ | ----------------------------------------------------- |
-| `--select-option-padding`                   | `8px 12px`                                     | padding      | Padding inside each dropdown option.                  |
-| `--select-option-color`                     | `#333333`                                      | color        | Text color of dropdown options.                       |
-| `--select-option-font-size`                 | `inherit`                                      | font-size    | Font size of dropdown options.                        |
-| `--select-option-hover-background`          | `#f0f0f0`                                      | background   | Background of options on hover or keyboard highlight. |
-| `--select-option-hover-color`               | inherits `--select-option-color`               | color        | Text color of options on hover or keyboard highlight. |
-| `--select-option-selected-background`       | `#e8f0fe`                                      | background   | Background of selected options.                       |
-| `--select-option-selected-color`            | inherits `--select-option-color`               | color        | Text color of selected options.                       |
-| `--select-option-selected-hover-background` | inherits `--select-option-selected-background` | background   | Background of selected options on hover.              |
+| Variable                                    | Default                                        | CSS Property | Description                                                                                    |
+| ------------------------------------------- | ---------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| `--select-option-padding`                   | `8px 12px`                                     | padding      | Padding inside each dropdown option.                                                           |
+| `--select-option-color`                     | `#333333`                                      | color        | Text color of dropdown options.                                                                |
+| `--select-option-font-size`                 | `inherit`                                      | font-size    | Font size of dropdown options.                                                                 |
+| `--select-option-gap`                       | `0`                                            | gap          | Gap between the option indicator and the label text in multi-select mode.                      |
+| `--select-option-hover-background`          | `#f0f0f0`                                      | background   | Background of options on hover or keyboard highlight.                                          |
+| `--select-option-hover-color`               | inherits `--select-option-color`               | color        | Text color of options on hover or keyboard highlight.                                          |
+| `--select-option-selected-background`       | `#e8f0fe`                                      | background   | Background of selected options.                                                                |
+| `--select-option-selected-color`            | inherits `--select-option-color`               | color        | Text color of selected options.                                                                |
+| `--select-option-selected-hover-background` | inherits `--select-option-selected-background` | background   | Background of selected options on hover.                                                       |
+| `--select-option-indicator-color`           | `currentColor`                                 | color        | Color of the default ☐/☑ indicator shown per option in multi-select mode.                     |
+
+### Bottom Content
+
+| Variable                             | Default                | CSS Property | Description                                                     |
+| ------------------------------------ | ---------------------- | ------------ | --------------------------------------------------------------- |
+| `--select-bottom-content-border`     | `none`                 | border-top   | Separator line between the option list and the bottom content. Set to `1px solid #eeeeee` (or any color) in your own CSS when a visible divider is desired. |
+| `--select-bottom-content-padding`    | `8px 12px`             | padding      | Inner padding of the bottom content area.                       |
 
 ### Empty State
 
@@ -174,4 +225,21 @@ Tag: `<sui-select>`
 </script>
 ```
 
+### With Slots
+
+```html
+<sui-select placeholder="Pick items">
+  <!-- Bottom content -->
+  <a slot="bottom-content" href="/manage">+ Manage options</a>
+</sui-select>
+```
+
+### Slots
+
+| Slot Name        | Maps to Snippet | Description                                                  |
+| ---------------- | --------------- | ------------------------------------------------------------ |
+| `bottom-content` | `bottomContent` | Arbitrary content pinned to the bottom of the open dropdown. |
+
 > **Note:** The `items` and `value` props are arrays — set them via JavaScript properties, not HTML attributes.
+
+> **Svelte-only:** The `optionIndicator` snippet is not available in Web Component mode. The `option-indicator` slot was removed because Web Component `<slot>` elements do not forward Svelte snippet parameters as HTML attributes, causing the `checked` state to be silently dropped. Use the Svelte component directly when a custom option indicator is needed.

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -169,7 +169,7 @@
   },
   {
     "name": "Select",
-    "description": "A dropdown selector supporting single-select and multi-select modes. Single-select mode with optional search. Multi-select has checkboxes, Select All toggle, and Apply button. Supports left icon, custom content snippets, and closes on outside click."
+    "description": "A dropdown selector supporting single-select and multi-select modes with optional search filtering. Accepts items as SelectItem objects or a plain string array. Multi-select shows selected items as dismissible pills with a built-in or custom per-option indicator. Supports a bottomContent snippet for pinning arbitrary content at the bottom of the dropdown. Fully keyboard-navigable and closes on outside click."
   },
   {
     "name": "Sheet",

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -5,18 +5,25 @@
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
 
   let {
-    items,
+    items: rawItems,
     value = $bindable([]),
     multiple = false,
     searchable = false,
     placeholder = '',
     disabled = false,
+    bottomContent,
+    optionIndicator,
     testId,
     onchange,
-    classes
+    classes,
+    open = $bindable(false)
   }: SelectProperties = $props();
 
-  let isOpen = $state(false);
+  function normalizeItems(source: SelectItem[] | string[]): SelectItem[] {
+    return source.map((entry) => (typeof entry === 'string' ? { id: entry, label: entry } : entry));
+  }
+
+  let items: SelectItem[] = $derived(normalizeItems(rawItems));
   let query = $state('');
   let highlightedIndex = $state(-1);
   let containerEl: HTMLDivElement | null = $state(null);
@@ -48,13 +55,13 @@
     highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : null
   );
 
-  let searchPlaceholder = $derived(isOpen && displayText.length > 0 ? displayText : placeholder);
+  let searchPlaceholder = $derived(open && displayText.length > 0 ? displayText : placeholder);
 
-  async function open(): Promise<void> {
-    if (disabled || isOpen) {
+  async function openDropdown(): Promise<void> {
+    if (disabled || open) {
       return;
     }
-    isOpen = true;
+    open = true;
     highlightedIndex = -1;
     query = '';
     if (searchable) {
@@ -66,7 +73,7 @@
   }
 
   function close(): void {
-    isOpen = false;
+    open = false;
     query = '';
     highlightedIndex = -1;
   }
@@ -119,17 +126,17 @@
 
   function handleTriggerClick(event: MouseEvent): void {
     if (event.target instanceof HTMLInputElement) {
-      if (!isOpen) {
-        open();
+      if (!open) {
+        openDropdown();
       }
       return;
     }
     if (multiple && searchable) {
-      open();
-    } else if (isOpen) {
+      openDropdown();
+    } else if (open) {
       close();
     } else {
-      open();
+      openDropdown();
     }
   }
 
@@ -140,28 +147,28 @@
     switch (event.key) {
       case 'Enter':
         event.preventDefault();
-        if (isOpen) {
+        if (open) {
           selectHighlighted();
         } else {
-          open();
+          openDropdown();
         }
         break;
       case ' ':
         if (!(event.target instanceof HTMLInputElement)) {
           event.preventDefault();
-          if (isOpen) {
+          if (open) {
             selectHighlighted();
           } else {
-            open();
+            openDropdown();
           }
         }
         break;
       case 'ArrowDown':
         event.preventDefault();
-        if (isOpen) {
+        if (open) {
           moveHighlight(1);
         } else {
-          open();
+          openDropdown();
         }
         break;
       case 'ArrowUp':
@@ -169,7 +176,7 @@
         moveHighlight(-1);
         break;
       case 'Escape':
-        if (isOpen) {
+        if (open) {
           close();
           if (!searchable && triggerEl !== null) {
             triggerEl.focus();
@@ -185,7 +192,7 @@
         }
         break;
       case 'Tab':
-        if (isOpen) {
+        if (open) {
           close();
         }
         break;
@@ -197,15 +204,15 @@
       return;
     }
     query = event.target.value;
-    if (!isOpen) {
-      isOpen = true;
+    if (!open) {
+      open = true;
     }
     highlightedIndex = -1;
   }
 
   function handleSearchFocus(): void {
-    if (!isOpen) {
-      open();
+    if (!open) {
+      openDropdown();
     }
   }
 
@@ -229,7 +236,7 @@
 
 <div
   class="select {classes ?? ''}"
-  class:open={isOpen}
+  class:open={open}
   class:disabled
   bind:this={containerEl}
   {...typeof testId === 'string' ? { 'data-pw': testId } : {}}
@@ -240,7 +247,7 @@
     onclick={handleTriggerClick}
     onkeydown={handleKeydown}
     role="combobox"
-    aria-expanded={isOpen}
+    aria-expanded={open}
     aria-haspopup="listbox"
     aria-controls={listboxId}
     {...highlightedOptionId !== null ? { 'aria-activedescendant': highlightedOptionId } : {}}
@@ -276,7 +283,7 @@
       <input
         class="select-search"
         type="text"
-        value={isOpen ? query : displayText}
+        value={open ? query : displayText}
         oninput={handleSearchInput}
         onfocus={handleSearchFocus}
         bind:this={searchInputEl}
@@ -294,7 +301,7 @@
     <span class="select-arrow">{@html chevronDownSvg}</span>
   </div>
 
-  {#if isOpen && !disabled}
+  {#if open && !disabled}
     <div class="select-dropdown" role="listbox" id={listboxId} aria-multiselectable={multiple}>
       {#if filteredItems.length === 0}
         <div class="select-empty">No results</div>
@@ -303,6 +310,7 @@
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <div
             class="select-option"
+            class:multi={multiple}
             class:selected={value.includes(item.id)}
             class:highlighted={index === highlightedIndex}
             role="option"
@@ -312,9 +320,23 @@
             onclick={() => selectItem(item.id)}
             onmouseenter={() => (highlightedIndex = index)}
           >
+            {#if multiple}
+              {#if typeof optionIndicator === 'function'}
+                {@render optionIndicator({ checked: value.includes(item.id) })}
+              {:else}
+                <span class="select-option-indicator" aria-hidden="true"
+                  >{value.includes(item.id) ? '☑' : '☐'}</span
+                >
+              {/if}
+            {/if}
             {item.label}
           </div>
         {/each}
+      {/if}
+      {#if typeof bottomContent === 'function'}
+        <div class="select-bottom-content">
+          {@render bottomContent()}
+        </div>
       {/if}
     </div>
   {/if}
@@ -436,6 +458,12 @@
     transition: background 0.1s;
   }
 
+  .select-option.multi {
+    display: flex;
+    align-items: center;
+    gap: var(--select-option-gap, 0);
+  }
+
   .select-option:hover,
   .select-option.highlighted {
     background: var(--select-option-hover-background, #f0f0f0);
@@ -454,11 +482,23 @@
     );
   }
 
+  .select-option-indicator {
+    display: inline-flex;
+    align-items: center;
+    color: var(--select-option-indicator-color, currentColor);
+    flex-shrink: 0;
+  }
+
   .select-empty {
     padding: var(--select-empty-padding, 8px 12px);
     color: var(--select-empty-color, #999999);
     font-style: var(--select-empty-font-style, italic);
     font-size: var(--select-empty-font-size, inherit);
+  }
+
+  .select-bottom-content {
+    border-top: var(--select-bottom-content-border, none);
+    padding: var(--select-bottom-content-padding, 8px 12px);
   }
 
   .select-trigger :global(.pill) {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -1,3 +1,5 @@
+import type { Snippet } from 'svelte';
+
 export type SelectProperties = MandatorySelectProperties &
   OptionalSelectProperties &
   SelectEventProperties;
@@ -8,7 +10,7 @@ export type SelectItem = {
 };
 
 export type MandatorySelectProperties = {
-  items: SelectItem[];
+  items: SelectItem[] | string[];
 };
 
 export type OptionalSelectProperties = {
@@ -17,8 +19,12 @@ export type OptionalSelectProperties = {
   searchable?: boolean;
   placeholder?: string;
   disabled?: boolean;
+  bottomContent?: Snippet;
+  optionIndicator?: Snippet<[{ checked: boolean }]>;
   testId?: string;
   classes?: string;
+  /** Bindable. Controls whether the dropdown is open; the component writes back on open/close so parents can `bind:open` to observe or drive it. Unbound, the component manages its own state. */
+  open?: boolean;
 };
 
 export type SelectEventProperties = {

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -34,10 +34,16 @@
     { id: 'mum', label: 'Mumbai' }
   ];
 
+  // String array shorthand (PR #232: items now accepts string[] directly)
+  const statusOptions: string[] = ['Active', 'Inactive', 'Pending', 'Archived'];
+
   let singleValue: string[] = $state([]);
   let searchValue: string[] = $state([]);
   let multiValue: string[] = $state([]);
   let multiSearchValue: string[] = $state([]);
+  let stringItemsValue: string[] = $state([]);
+  let bottomContentValue: string[] = $state([]);
+  let customIndicatorValue: string[] = $state([]);
 </script>
 
 <div class="page-header">
@@ -88,10 +94,76 @@
   <Select items={fruits} disabled placeholder="Can't touch this" />
 </div>
 
+<h3>String array shorthand</h3>
+<p>
+  Pass a plain <code>string[]</code> — each string becomes both the <code>id</code> and
+  <code>label</code>.
+</p>
+<div class="demo-row" style="max-width: 300px;">
+  <Select items={statusOptions} bind:value={stringItemsValue} placeholder="Select status" />
+  {#if stringItemsValue.length > 0}
+    <p class="demo-info">Selected: {stringItemsValue.at(0)}</p>
+  {/if}
+</div>
+
+<h3>bottomContent snippet</h3>
+<p>
+  Render arbitrary content pinned to the bottom of the dropdown (e.g. a "Manage…" link or a bulk
+  action).
+</p>
+<div class="demo-row" style="max-width: 300px;">
+  <Select items={fruits} bind:value={bottomContentValue} placeholder="Choose a fruit">
+    {#snippet bottomContent()}
+      <button class="manage-link" onclick={() => console.log('Manage options clicked')}>
+        + Manage options
+      </button>
+    {/snippet}
+  </Select>
+  {#if bottomContentValue.length > 0}
+    <p class="demo-info">Selected: {bottomContentValue.at(0)}</p>
+  {/if}
+</div>
+
+<h3>optionIndicator snippet (multi-select)</h3>
+<p>Replace the default ☐/☑ glyphs with a custom indicator rendered per option.</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Select items={languages} multiple bind:value={customIndicatorValue} placeholder="Pick languages">
+    {#snippet optionIndicator({ checked })}
+      <span class="custom-indicator" class:checked>{checked ? '✔' : '○'}</span>
+    {/snippet}
+  </Select>
+  {#if customIndicatorValue.length > 0}
+    <p class="demo-info">Selected: {customIndicatorValue.join(', ')}</p>
+  {/if}
+</div>
+
 <style>
   .demo-info {
     margin: 8px 0 0;
     font-size: 13px;
     color: #666;
+  }
+
+  .manage-link {
+    display: block;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--doc-accent, #4f46e5);
+    text-align: left;
+  }
+
+  .custom-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    color: #aaa;
+  }
+
+  .custom-indicator.checked {
+    color: #2563eb;
   }
 </style>

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -11,6 +11,7 @@
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
+      open: { type: 'Boolean', reflect: true },
       onchange: { type: 'Object' }
     }
   }}
@@ -21,4 +22,8 @@
   let props = $props();
 </script>
 
-<Select {...props} />
+<Select {...props}>
+  {#snippet bottomContent()}
+    <slot name="bottom-content"></slot>
+  {/snippet}
+</Select>


### PR DESCRIPTION
Slim follow-up to #220 per @sinha-sahil's review — contains only the primitives that passed the philosophy check.

## What's in this PR

- **`string[]` items normalization** — `normalizeItems` converts plain strings to `{ id, label }` (id === label shorthand). Additive, no breaking change.
- **`showSelectAll` behavior** — pure behavior flag: toggles all `filteredItems`, derives `allSelected` reactively. No hardcoded UX preset.
- **`selectAllLabel?: string`** (default `'Select all'`) — i18n escape hatch so the string is never baked in.
- **`optionIndicator?: Snippet<[{ checked: boolean }]>`** — single-snippet shape for both the select-all row and each multi-select option row. `☑`/`☐` Unicode glyphs are fallback only and fully replaceable by the consumer (SVG, Checkbox component, icon library). Single snippet = one prop, composable with future `indeterminate` payload extension, consistent with how the rest of `src/lib/` shapes parameterized snippets.
- **Enter/Space keyboard support on the select-all row** — `tabindex="0"`, dedicated `handleSelectAllKeydown`, Escape falls through to the existing close handler.
- **`bottomContent?: Snippet`** — composable slot at the foot of the dropdown. Correct primitive shape; consumer owns visuals entirely.

## What's NOT in this PR (dropped per review)

- `hint` / `subtext` props and their CSS variables — UX presets, not primitives
- Hardcoded English `'Select all'` string in markup — replaced by `selectAllLabel` prop
- Hardcoded `☑`/`☐` baked into markup without escape hatch — moved behind `optionIndicator` snippet

## Conventions

- All handlers are `function` declarations (not arrow-const) — project convention per design notes
- `{#if typeof bottomContent === 'function'}` / `{#if typeof optionIndicator === 'function'}` guards per GUIDELINES §3
- Variants/layout stay in consumer CSS (`classes` prop + CSS vars) per GUIDELINES §9
- `svelte-check`: 0 errors, 0 warnings. Prettier + ESLint: clean.

Supersedes #220.