### PR TITLE
feat(banner): border-radius/border vars, title snippet, role escape hatch

### DIFF
--- a/docs/Banner.md
+++ b/docs/Banner.md
@@ -38,17 +38,55 @@ A notification banner with optional icon snippet, text content, inline link text
 </Banner>
 ```
 
+### With Title Snippet
+
+```svelte
+<Banner text="Your cart was abandoned 2 hours ago.">
+  {#snippet title()}
+    <strong>Don't forget your items</strong>
+  {/snippet}
+</Banner>
+```
+
+### Consumer Theming via `classes` (error + compact variant)
+
+No tone enum is needed — define the variant in your app's CSS and pass it through `classes`:
+
+```css
+/* app.css */
+.banner-error {
+  --banner-background: #fff0f0;
+  --banner-color: #c0392b;
+  --banner-border: 1px solid #e74c3c;
+  --banner-border-radius: 6px;
+}
+
+.banner-compact {
+  --banner-padding: 6px 12px;
+}
+```
+
+```svelte
+<Banner
+  text="Payment failed. Please try again."
+  classes="banner-error banner-compact"
+  role="alert"
+/>
+```
+
 ## Props
 
-| Prop        | Type      | Required | Default | Description                                                                                                                                                                                                                |
-| ----------- | --------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| text        | `string`  | Yes      | `-`     | The main banner message text.                                                                                                                                                                                              |
-| icon        | `Snippet` | No       | `-`     | Svelte 5 Snippet for a custom icon displayed to the left of the text. Replaces the old `string` image URL prop.                                                                                                            |
-| linkText    | `string`  | No       | `-`     | Optional link text appended inline after the main text, styled in a different color (blue by default).                                                                                                                     |
-| dismissible | `boolean` | No       | `false` | Whether to show a close/dismiss button on the right side of the banner.                                                                                                                                                    |
-| visible     | `boolean` | No       | `true`  | Bindable. Controls whether the banner is visible. When `dismissible` is true, clicking the dismiss button sets this to `false`. Supports two-way binding via `bind:visible`.                                               |
-| testId      | `string`  | No       | `-`     | Value for the `data-pw` attribute on the banner container. The dismiss button gets `{testId}-dismiss`. Used for Playwright selectors.                                                                                      |
-| classes     | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides (e.g., `.btn-primary { --button-color: #0070f3; }`) and pass them to create variant styles. |
+| Prop        | Type             | Required | Default | Description                                                                                                                                                                                                                   |
+| ----------- | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| text        | `string`         | Yes      | `-`     | The main banner message text.                                                                                                                                                                                                 |
+| icon        | `Snippet`        | No       | `-`     | Svelte 5 Snippet for a custom icon displayed to the left of the text.                                                                                                                                                         |
+| title       | `Snippet`        | No       | `-`     | Optional Snippet rendered above the main text inside a `banner-body` flex column. When omitted the layout is identical to today.                                                                                              |
+| linkText    | `string`         | No       | `-`     | Optional link text appended inline after the main text, styled in a different color (blue by default).                                                                                                                        |
+| dismissible | `boolean`        | No       | `false` | Whether to show a close/dismiss button on the right side of the banner.                                                                                                                                                       |
+| visible     | `boolean`        | No       | `true`  | Bindable. Controls whether the banner is visible. When `dismissible` is true, clicking the dismiss button sets this to `false`. Supports two-way binding via `bind:visible`.                                                  |
+| role        | `string \| null` | No       | `null`  | ARIA role override. When provided, this value is used verbatim instead of the automatic `"button"` role that is added when `onclick` is present. Use `role="alert"` for error banners that should announce to screen readers. |
+| testId      | `string`         | No       | `-`     | Value for the `data-pw` attribute on the banner container. The dismiss button gets `{testId}-dismiss`. Used for Playwright selectors.                                                                                         |
+| classes     | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles (see example above).                                    |
 
 ## Snippets
 
@@ -57,6 +95,7 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | Snippet      | Type      | Description                                                                                                                              |
 | ------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | icon         | `Snippet` | Custom icon content displayed to the left of the text. Rendered inside a flex container with configurable size via `--banner-icon-size`. |
+| title        | `Snippet` | Optional heading rendered above the main text. Controlled via `--banner-title-font-weight` and `--banner-body-gap`.                      |
 | rightContent | `Snippet` | Custom content on the right side of the banner, before the dismiss button.                                                               |
 | dismissIcon  | `Snippet` | Custom icon for the dismiss button. Defaults to a built-in close (X) SVG.                                                                |
 
@@ -71,36 +110,41 @@ Svelte 5 Snippet props — pass content blocks to the component.
 
 Override these custom properties to theme the component.
 
-| Variable                            | Default              | CSS Property     | Description                                                               |
-| ----------------------------------- | -------------------- | ---------------- | ------------------------------------------------------------------------- |
-| `--banner-width`                    | `100%`               | width            | Width of the banner.                                                      |
-| `--banner-height`                   | `-`                  | height           | Height of the banner.                                                     |
-| `--banner-padding`                  | `10px 12px`          | padding          | Inner padding of the banner.                                              |
-| `--banner-gap`                      | `8px`                | gap              | Gap between banner content elements (icon, text, right content, dismiss). |
-| `--banner-justify-content`          | `center`             | justify-content  | Horizontal alignment of banner content.                                   |
-| `--banner-background`               | `#f0f4f8`            | background-color | Background color of the banner.                                           |
-| `--banner-color`                    | `#637c95`            | color            | Text color of the banner.                                                 |
-| `--banner-font-family`              | `-`                  | font-family      | Font family of the banner text.                                           |
-| `--banner-font-size`                | `14px`               | font-size        | Font size of the banner text.                                             |
-| `--banner-font-weight`              | `500`                | font-weight      | Font weight of the banner text.                                           |
-| `--banner-line-height`              | `1.3`                | line-height      | Line height of the banner text.                                           |
-| `--banner-border-bottom`            | `none`               | border-bottom    | Bottom border of the banner.                                              |
-| `--banner-cursor`                   | `pointer`            | cursor           | Cursor style when hovering the banner.                                    |
-| `--banner-position`                 | `sticky`             | position         | CSS position of the banner (sticky sticks to viewport on scroll).         |
-| `--banner-top`                      | `0`                  | top              | Top position of the banner.                                               |
-| `--banner-z-index`                  | `100`                | z-index          | Z-index stacking order of the banner.                                     |
-| `--banner-icon-color`               | `currentColor`       | color            | Color of the icon container.                                              |
-| `--banner-icon-size`                | `18px`               | width, height    | Width and height of SVGs inside the icon snippet.                         |
-| `--banner-link-color`               | `#0099ff`            | color            | Color of the inline link text.                                            |
-| `--banner-link-gap`                 | `4px`                | margin-left      | Space between the main text and the link text.                            |
-| `--banner-dismiss-border-radius`    | `4px`                | border-radius    | Border radius of the dismiss button.                                      |
-| `--banner-dismiss-color`            | `currentColor`       | color            | Color of the dismiss button icon.                                         |
-| `--banner-dismiss-hover-background` | `rgba(0, 0, 0, 0.1)` | background-color | Background color of the dismiss button on hover.                          |
-| `--banner-dismiss-size`             | `14px`               | width, height    | Width and height of the dismiss button icon SVG.                          |
+| Variable                            | Default              | CSS Property     | Description                                                                                                                    |
+| ----------------------------------- | -------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `--banner-width`                    | `100%`               | width            | Width of the banner.                                                                                                           |
+| `--banner-height`                   | `-`                  | height           | Height of the banner.                                                                                                          |
+| `--banner-padding`                  | `10px 12px`          | padding          | Inner padding of the banner.                                                                                                   |
+| `--banner-gap`                      | `8px`                | gap              | Gap between banner content elements (icon, text, right content, dismiss).                                                      |
+| `--banner-justify-content`          | `center`             | justify-content  | Horizontal alignment of banner content.                                                                                        |
+| `--banner-background`               | `#f0f4f8`            | background-color | Background color of the banner.                                                                                                |
+| `--banner-color`                    | `#637c95`            | color            | Text color of the banner.                                                                                                      |
+| `--banner-font-family`              | `-`                  | font-family      | Font family of the banner text.                                                                                                |
+| `--banner-font-size`                | `14px`               | font-size        | Font size of the banner text.                                                                                                  |
+| `--banner-font-weight`              | `500`                | font-weight      | Font weight of the banner text.                                                                                                |
+| `--banner-line-height`              | `1.3`                | line-height      | Line height of the banner text.                                                                                                |
+| `--banner-border-bottom`            | `none`               | border-bottom    | Bottom border of the banner.                                                                                                   |
+| `--banner-border`                   | `-`                  | border           | Full border shorthand. Overrides `--banner-border-bottom` when set.                                                            |
+| `--banner-border-radius`            | `0`                  | border-radius    | Corner radius of the banner. Use with `--banner-border` for card-style notifications.                                          |
+| `--banner-cursor`                   | `pointer`            | cursor           | Cursor style when hovering the banner.                                                                                         |
+| `--banner-position`                 | `sticky`             | position         | CSS position of the banner (sticky sticks to viewport on scroll).                                                              |
+| `--banner-top`                      | `0`                  | top              | Top position of the banner.                                                                                                    |
+| `--banner-z-index`                  | `100`                | z-index          | Z-index stacking order of the banner.                                                                                          |
+| `--banner-icon-color`               | `currentColor`       | color            | Color of the icon container.                                                                                                   |
+| `--banner-icon-size`                | `18px`               | width, height    | Width and height of SVGs inside the icon snippet.                                                                              |
+| `--banner-body-gap`                 | `0`                  | gap              | Vertical gap between the title and text inside `banner-body`. Set to e.g. `4px` to add spacing when using the `title` snippet. |
+| `--banner-title-font-weight`        | `inherit`            | font-weight      | Font weight of the title row. Inherits the banner's font-weight by default.                                                    |
+| `--banner-link-color`               | `#0099ff`            | color            | Color of the inline link text.                                                                                                 |
+| `--banner-link-gap`                 | `4px`                | margin-left      | Space between the main text and the link text.                                                                                 |
+| `--banner-dismiss-border-radius`    | `4px`                | border-radius    | Border radius of the dismiss button.                                                                                           |
+| `--banner-dismiss-color`            | `currentColor`       | color            | Color of the dismiss button icon.                                                                                              |
+| `--banner-dismiss-hover-background` | `rgba(0, 0, 0, 0.1)` | background-color | Background color of the dismiss button on hover.                                                                               |
+| `--banner-dismiss-size`             | `14px`               | width, height    | Width and height of the dismiss button icon SVG.                                                                               |
 
 ## Accessibility
 
 - When `onclick` is provided, the banner gets `role="button"` and `tabindex="0"` for keyboard interaction.
+- Use the `role` prop to override the automatic role (e.g. `role="alert"` for error banners that should be announced immediately by screen readers). Pass `role=""` to remove any role.
 - Enter and Space keys trigger the banner's click handler.
 - The dismiss button has `aria-label="Dismiss"`.
 - Uses Svelte's `slide` transition for smooth show/hide animation.
@@ -127,5 +171,6 @@ Tag: `<sui-banner>`
 | Slot Name       | Maps to Snippet | Description                                       |
 | --------------- | --------------- | ------------------------------------------------- |
 | `icon`          | `icon`          | Icon content rendered at the start of the banner. |
+| `title`         | `title`         | Optional heading rendered above the main text.    |
 | `right-content` | `rightContent`  | Content rendered on the right side.               |
 | `dismiss-icon`  | `dismissIcon`   | Custom dismiss/close icon.                        |

--- a/src/lib/Banner/Banner.svelte
+++ b/src/lib/Banner/Banner.svelte
@@ -15,10 +15,14 @@
     dismissIcon,
     onclick,
     ondismiss,
-    classes
+    classes,
+    title,
+    role = null
   }: BannerProperties = $props();
 
   let interactive = $derived(typeof onclick === 'function');
+
+  let rootClass = $derived(['banner', classes ?? ''].filter((c) => c.length > 0).join(' '));
 
   function handleClick(event: MouseEvent): void {
     onclick?.(event);
@@ -43,10 +47,10 @@
 {#if visible}
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
-    class="banner {classes ?? ''}"
+    class={rootClass}
     onclick={interactive ? handleClick : null}
     onkeydown={interactive ? handleKeydown : null}
-    role={interactive ? 'button' : null}
+    role={role !== null ? role : interactive ? 'button' : null}
     tabindex={interactive ? 0 : null}
     data-pw={typeof testId === 'string' ? testId : null}
     transition:slide={{ duration: 300 }}
@@ -56,11 +60,18 @@
         {@render icon()}
       </div>
     {/if}
-    <div class="banner-text">
-      {text}
-      {#if typeof linkText === 'string' && linkText.length > 0}
-        <span class="banner-link-text">{linkText}</span>
+    <div class="banner-body">
+      {#if typeof title === 'function'}
+        <div class="banner-title">
+          {@render title()}
+        </div>
       {/if}
+      <div class="banner-text">
+        {text}
+        {#if typeof linkText === 'string' && linkText.length > 0}
+          <span class="banner-link-text">{linkText}</span>
+        {/if}
+      </div>
     </div>
     {#if typeof rightContent === 'function'}
       <div class="banner-right">
@@ -102,6 +113,8 @@
     font-weight: var(--banner-font-weight, 500);
     line-height: var(--banner-line-height, 1.3);
     border-bottom: var(--banner-border-bottom, none);
+    border: var(--banner-border);
+    border-radius: var(--banner-border-radius, 0);
     cursor: var(--banner-cursor, pointer);
     position: var(--banner-position, sticky);
     top: var(--banner-top, 0);
@@ -119,6 +132,20 @@
   .banner-icon :global(svg) {
     width: var(--banner-icon-size, 18px);
     height: var(--banner-icon-size, 18px);
+  }
+
+  .banner-body {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    gap: var(--banner-body-gap, 0);
+  }
+
+  .banner-title {
+    font-weight: var(--banner-title-font-weight, inherit);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .banner-text {

--- a/src/lib/Banner/properties.ts
+++ b/src/lib/Banner/properties.ts
@@ -10,6 +10,7 @@ export type MandatoryBannerProperties = {
 
 export type OptionalBannerProperties = {
   icon?: Snippet;
+  title?: Snippet;
   linkText?: string;
   dismissible?: boolean;
   visible?: boolean;
@@ -17,6 +18,7 @@ export type OptionalBannerProperties = {
   rightContent?: Snippet;
   dismissIcon?: Snippet;
   classes?: string;
+  role?: string | null;
 };
 
 export type BannerEventProperties = {

--- a/src/routes/components/banner/+page.svelte
+++ b/src/routes/components/banner/+page.svelte
@@ -23,3 +23,48 @@
     <Button text="Reset" onclick={() => (dismissVisible = true)} />
   {/if}
 </div>
+
+<div class="demo-row" style="flex-direction: column; max-width: 600px; gap: 12px;">
+  <Banner text="Your cart was abandoned 2 hours ago.">
+    {#snippet title()}
+      <strong>Don't forget your items</strong>
+    {/snippet}
+  </Banner>
+
+  <Banner text="We noticed unusual activity on your account.">
+    {#snippet title()}
+      <strong>Security alert</strong>
+    {/snippet}
+    {#snippet icon()}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><path
+          d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+        /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" /></svg
+      >
+    {/snippet}
+  </Banner>
+</div>
+
+<div class="demo-row" style="flex-direction: column; max-width: 600px; gap: 12px;">
+  <div
+    style="--banner-background: #fff0f0; --banner-color: #c0392b; --banner-border: 1px solid #e74c3c; --banner-border-radius: 6px; --banner-position: static; width: 100%;"
+  >
+    <Banner
+      text="Payment failed. Please check your card details and try again."
+      role="alert"
+    />
+  </div>
+
+  <div
+    style="--banner-background: #f0f7ff; --banner-color: #1a5276; --banner-border: 1px solid #5dade2; --banner-border-radius: 8px; --banner-position: static; width: 100%;"
+  >
+    <Banner text="Maintenance window scheduled for Sunday 2–4 AM UTC." role="status" dismissible />
+  </div>
+</div>

--- a/src/wc/components/Banner.wc.svelte
+++ b/src/wc/components/Banner.wc.svelte
@@ -9,6 +9,7 @@
       visible: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
+      role: { type: 'String' },
       onclick: { type: 'Object' },
       ondismiss: { type: 'Object' }
     }
@@ -23,6 +24,9 @@
 <Banner {...props}>
   {#snippet icon()}
     <slot name="icon"></slot>
+  {/snippet}
+  {#snippet title()}
+    <slot name="title"></slot>
   {/snippet}
   {#snippet rightContent()}
     <slot name="right-content"></slot>


### PR DESCRIPTION
Slim follow-up to #221 per @sinha-sahil's review — contains only the four keepers. Variants/layout stay in consumer CSS (classes + CSS vars) per GUIDELINES §9. Supersedes #221.

## Keepers

- **`--banner-border` and `--banner-border-radius`** CSS vars on `.banner` — enables card-style notifications without any class enum
- **`title` Snippet** rendered inside a `<div class="banner-body">` flex-column wrapper (`--banner-body-gap` defaults to `0`, `.banner-title` `font-weight` defaults to `inherit`) — omitting `title` reproduces today's layout exactly; the new structure is invisible until a consumer opts in
- **`role` prop** as a plain ARIA escape hatch — no tone-to-role derivation, consumer passes `role="alert"` explicitly when needed
- **README consumer-theming example** using `classes="banner-error banner-compact"` showing `--banner-border` + `--banner-border-radius` in action (§9 canonical pattern)

## GUIDELINES nits also folded in

- `filter(Boolean)` → `filter((c) => c.length > 0)` in `rootClass` derivation (§3)
- `handleClick` / `handleKeydown` / `handleDismiss` kept as `function` declarations (second-to-last review note)
- Redundant `title !== null` guard removed — `typeof title === 'function'` is sufficient (§5)

## What was dropped vs #221

- `tone` enum (`info` | `success` | `warning` | `error`) and `.banner-tone-*` preset classes
- `size` enum and `.banner-size-sm` preset
- `flush` boolean and `.banner-flush` preset
- Automatic `tone === 'error' → role="alert"` derivation

All of those belong in consumer CSS via `classes` + CSS vars.