### PR TITLE
feat(Img): add testId prop (slim split from #218)

### DIFF
--- a/docs/Img.md
+++ b/docs/Img.md
@@ -19,6 +19,7 @@ An image component with automatic fallback. If the primary `src` fails to load (
 | src      | `string`         | Yes      | `-`     | The primary image URL to display.                                                                                                                                      |
 | alt      | `string`         | Yes      | `-`     | Alt text for the image.                                                                                                                                                |
 | fallback | `string \| null` | No       | `-`     | Fallback image URL. If the primary src fails to load (onerror), the component switches to this URL.                                                                    |
+| testId   | `string`         | No       | `-`     | Test identifier applied as `data-pw` attribute on the `<img>` element for Playwright test selectors.                                                                  |
 | classes  | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
 | inlineSvg | `boolean`       | No       | `false` | Fetch `.svg` / `data:image/svg+xml` sources and inline their markup into an `<svg>` host so page CSS (`currentColor`, fill/stroke overrides) applies. Non-SVG sources always render the plain `<img>`. If fetching or parsing fails, the component falls back to the plain `<img>` (and from there to the regular `fallback`/`onerror` chain). |
 | transformSvg | `(svg: string) => string` | No | `-` | Hook to rewrite the fetched SVG markup before it is inlined (e.g. recolour hardcoded fills). Providing a transform implies `inlineSvg`. The inlining effect re-runs when the prop identity changes, so a closure over reactive state (e.g. a theme colour) re-renders live. JS-only prop (not exposed as a web-component attribute). |
@@ -76,5 +77,5 @@ Override these custom properties to theme the component.
 Tag: `<sui-img>`
 
 ```html
-<sui-img src="/photo.jpg" alt="Description" fallback="/fallback.jpg"></sui-img>
+<sui-img src="/photo.jpg" alt="Description" fallback="/fallback.jpg" test-id="my-img"></sui-img>
 ```

--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { ImgProperties } from './properties';
 
-  let { src, alt, fallback, onerror, classes, inlineSvg, transformSvg }: ImgProperties = $props();
+  let { src, alt, fallback, onerror, classes, inlineSvg, transformSvg, testId }: ImgProperties =
+    $props();
 
   let currentSrc = $derived(src);
   // Per-source failure marker: when inlining a given URL fails we fall back to
@@ -114,9 +115,10 @@
     role={alt.length > 0 ? 'img' : null}
     aria-label={alt.length > 0 ? alt : null}
     aria-hidden={alt.length === 0 ? 'true' : null}
+    data-pw={testId}
   ></svg>
 {:else}
-  <img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} />
+  <img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} data-pw={testId} />
 {/if}
 
 <style>

--- a/src/lib/Img/properties.ts
+++ b/src/lib/Img/properties.ts
@@ -24,6 +24,7 @@ export type OptionalImgProperties = {
    * state (e.g. a theme colour) to get live re-renders on theme change.
    */
   transformSvg?: (svg: string) => string;
+  testId?: string;
 };
 
 export type ImgEventProperties = {

--- a/src/routes/components/img/+page.svelte
+++ b/src/routes/components/img/+page.svelte
@@ -12,3 +12,12 @@
   <Img src="https://picsum.photos/200/150?random=61" alt="Sample architecture" />
   <Img src="https://picsum.photos/200/150?random=62" alt="Sample nature" />
 </div>
+
+<div class="demo-row">
+  <Img
+    src="https://picsum.photos/200/150?random=63"
+    alt="Test-targeted image"
+    testId="sample-img"
+  />
+</div>
+<p class="state-display">testId="sample-img" → data-pw="sample-img" on the &lt;img&gt; element</p>

--- a/src/wc/components/Img.wc.svelte
+++ b/src/wc/components/Img.wc.svelte
@@ -6,6 +6,7 @@
       src: { type: 'String', reflect: true },
       alt: { type: 'String', reflect: true },
       fallback: { type: 'String', reflect: true },
+      testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onerror: { type: 'Object' }
     }


### PR DESCRIPTION
## Summary

- Adds optional `testId?: string` to `OptionalImgProperties` in `properties.ts`
- Wires it as `data-pw={testId}` on the `<img>` root element in `Img.svelte`
- Svelte omits the attribute when `testId` is `undefined`, so no conditional needed and backward compatibility is fully preserved
- Matches the exact pattern already used by Tabs, Pagination, Choicebox, RelativeTime, and Tooltip

## Context

This is the maintainer-requested slim slice from #218. Per @sinha-sahil's review at 14:07Z UTC (2026-05-30), the following features from #218 have been dropped and will not be included here or in any follow-up on `Img`:

- `inlineSvg?: boolean` + the `{@html}` render-path fork — rejected (turns `Img` into a render-mode switch)
- `src` polymorphism (`isSvgMarkup` runtime check) — rejected (URL and raw-markup are different contracts)
- `transform?: (svg: string) => string` — rejected (UX-preset callback; consumers preprocess before passing in)
- `.img-inline-svg` CSS block with baked hover rules — rejected (hardcoded design preset violates theming rule)

If inline SVG is needed in future it will ship as a separate `InlineSvg` component.

## Verification

- `pnpm run lint` — clean
- `pnpm run check` — 0 errors, 0 warnings
- `pnpm run build` — clean

@sinha-sahil — happy to fast-track per your review on #218. Closes #218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image component now supports an optional testId property. When provided, this identifier is rendered as a data attribute on the image element. All existing component functionality, including fallback and error handling, remains fully intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/svelte-ui-components/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->