### PR TITLE
docs(recipes): add GradientBlur + ComposingARangePicker recipes (follow-up to #199, #209)

### DIFF
--- a/docs/recipes/ComposingARangePicker.md
+++ b/docs/recipes/ComposingARangePicker.md
@@ -1,0 +1,132 @@
+# Composing a range picker
+
+Recipe for a "value range" or "filter range" picker — a trigger button that opens a popover with two number inputs (min/max) and Apply/Cancel actions.
+
+This is a composition of primitives the library already ships. PR [#209](https://github.com/juspay/svelte-ui-components/pull/209) proposed a `RangeSelect` component that wrapped these same four primitives with baked-in Apply/Cancel labels and a fixed blue palette — same bucket as `InfoBlock` ([#200](https://github.com/juspay/svelte-ui-components/pull/200)), `ActionBar` ([#201](https://github.com/juspay/svelte-ui-components/pull/201)), `DescriptiveTile` ([#225](https://github.com/juspay/svelte-ui-components/pull/225)). The library's preferred shape is consumer-composed.
+
+## Primitives used
+
+| Primitive | Role |
+|---|---|
+| `Button` | Trigger that opens the popover and displays the current range |
+| `Popover` | The floating panel that contains the inputs and actions |
+| `NumberInput` (×2) | The min and max value editors |
+| `Button` (×2) | Apply / Cancel inside the popover footer |
+
+## Component
+
+```svelte
+<script lang="ts">
+  import { Button, Popover, NumberInput } from '@juspay/svelte-ui-components';
+
+  type RangePickerProps = {
+    min: number | null;
+    max: number | null;
+    label?: string;
+    onapply: (range: { min: number | null; max: number | null }) => void;
+  };
+
+  let { min, max, label = 'Range', onapply }: RangePickerProps = $props();
+
+  let open = $state(false);
+  let draftMin: number | null = $state(min);
+  let draftMax: number | null = $state(max);
+
+  function openPicker() {
+    draftMin = min;
+    draftMax = max;
+    open = true;
+  }
+
+  function apply() {
+    onapply({ min: draftMin, max: draftMax });
+    open = false;
+  }
+
+  function cancel() {
+    open = false;
+  }
+
+  function formatRange() {
+    if (min === null && max === null) {
+      return label;
+    }
+    if (min !== null && max !== null) {
+      return `${min} – ${max}`;
+    }
+    if (min !== null) {
+      return `≥ ${min}`;
+    }
+    return `≤ ${max}`;
+  }
+</script>
+
+<Popover bind:open>
+  {#snippet trigger()}
+    <Button onclick={openPicker}>{formatRange()}</Button>
+  {/snippet}
+
+  <div class="range-picker-body">
+    <div class="range-picker-inputs">
+      <NumberInput bind:value={draftMin} placeholder="Min" />
+      <span class="range-picker-separator">–</span>
+      <NumberInput bind:value={draftMax} placeholder="Max" />
+    </div>
+    <div class="range-picker-actions">
+      <Button onclick={cancel}>Cancel</Button>
+      <Button onclick={apply}>Apply</Button>
+    </div>
+  </div>
+</Popover>
+
+<style>
+  .range-picker-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+    min-width: 240px;
+  }
+
+  .range-picker-inputs {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .range-picker-separator {
+    color: var(--range-picker-separator-color, #888);
+  }
+
+  .range-picker-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>
+```
+
+## Why no component?
+
+A `RangeSelect` primitive would have to bake in:
+
+- Apply / Cancel button labels (English only, no i18n hook)
+- A particular layout (inline vs stacked)
+- A palette (the original PR used a blue `#2563eb` default — see PR #199's lesson on hardcoded palette)
+- The decision of whether the picker is required to have both bounds or accepts open ranges
+
+Every consumer would then fight those defaults via `classes` / CSS-var overrides — which is the symptom GUIDELINES §9 flags as evidence the surface belongs in user space. The 50 lines above are the entire "component" and they live in the consumer's repo, fully owned, fully customisable.
+
+## Variations
+
+**Slider instead of NumberInput** — if you want drag-to-set, replace the two `<NumberInput>` with a true dual-thumb range slider (a real primitive worth adding if it does not exist yet). The composition pattern stays the same.
+
+**Currency / unit suffix** — wrap each `<NumberInput>` in a flex row with a `<span>` for the unit. The Library does not need a `RangeSelectWithUnit` variant.
+
+**Validation** — derive `isValid = draftMin === null || draftMax === null || draftMin <= draftMax` and disable the Apply button when false. Surface inline error text from a `<p>` in the body.
+
+## Accessibility
+
+- The `Popover` handles focus trap and Escape-to-close.
+- Give the trigger `<Button>` an `aria-label` if `formatRange()` returns a non-descriptive value (e.g., just numbers).
+- Both `<NumberInput>` instances should carry a label via the `label` prop (omitted above for brevity).

--- a/docs/recipes/GradientBlur.md
+++ b/docs/recipes/GradientBlur.md
@@ -1,0 +1,89 @@
+# GradientBlur recipe
+
+Recipe for a layered radial-gradient blur backdrop — typical use is the hero / feature area of a marketing or onboarding surface where text needs to sit on top of a soft chromatic background without an actual image.
+
+This is a pure CSS pattern, not a component. The library philosophy (GUIDELINES §3) is that static decorative pieces with no reactivity and no slots belong in consumer CSS, not in a Svelte component. PR [#199](https://github.com/juspay/svelte-ui-components/pull/199) was closed in favour of this recipe.
+
+## Markup
+
+```svelte
+<div class="gradient-blur">
+  <span class="blob blob-a" aria-hidden="true"></span>
+  <span class="blob blob-b" aria-hidden="true"></span>
+  <span class="blob blob-c" aria-hidden="true"></span>
+
+  <!-- your content -->
+</div>
+```
+
+Three blobs is enough for most surfaces. Add or remove as needed; the recipe scales linearly.
+
+## Styles
+
+```css
+.gradient-blur {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background: var(--gradient-blur-bg, #0b0b14);
+}
+
+.gradient-blur .blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(var(--gradient-blur-radius, 80px));
+  opacity: var(--gradient-blur-opacity, 0.55);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.gradient-blur .blob-a {
+  top: -10%;
+  left: -10%;
+  width: var(--gradient-blur-size-a, 360px);
+  height: var(--gradient-blur-size-a, 360px);
+  background: var(--gradient-blur-color-a, #ff5fa2);
+}
+
+.gradient-blur .blob-b {
+  top: 30%;
+  right: -8%;
+  width: var(--gradient-blur-size-b, 280px);
+  height: var(--gradient-blur-size-b, 280px);
+  background: var(--gradient-blur-color-b, #5fa2ff);
+}
+
+.gradient-blur .blob-c {
+  bottom: -15%;
+  left: 30%;
+  width: var(--gradient-blur-size-c, 320px);
+  height: var(--gradient-blur-size-c, 320px);
+  background: var(--gradient-blur-color-c, #b45fff);
+}
+```
+
+## Why no component?
+
+A `GradientBlur` component would expose props that map 1:1 to the CSS variables above. The component itself would have no state, no slots, and no callbacks — it would just be a verbose wrapper around a CSS class. Inverting it, anything a `GradientBlur` component could do is one class away in user space:
+
+```svelte
+<div class="gradient-blur hero-blur">…</div>
+
+<style>
+  .hero-blur {
+    --gradient-blur-color-a: #f59e0b;
+    --gradient-blur-color-b: #ef4444;
+    --gradient-blur-color-c: #a855f7;
+  }
+</style>
+```
+
+If you need a different blob count, add or remove `<span>`s. If you need a different position, override the per-blob class. The pattern stays additive.
+
+## Accessibility
+
+The blobs are `aria-hidden="true"` because they convey no information. The container's contrast and focus visibility are the responsibility of the content placed inside it — verify against WCAG AA for any text rendered on top.
+
+## Performance
+
+`filter: blur()` is GPU-accelerated in modern engines but expensive on low-end devices. Three blobs is a safe budget; if you push past five, profile on a mid-range Android device before shipping.


### PR DESCRIPTION
## Summary

Adds two consumer-facing recipes promised in the close comments on PRs #199 (GradientBlur) and #209 (RangeSelect).

| File | Source PR | What it shows |
|------|-----------|---------------|
| `docs/recipes/GradientBlur.md` | #199 | Pure-CSS pattern for layered radial-gradient blur backdrops — markup + styles + per-blob CSS-var override surface |
| `docs/recipes/ComposingARangePicker.md` | #209 | ~50-line composition of existing `Button + Popover + NumberInput` primitives without baking in Apply/Cancel labels or a fixed palette |

## Why

Both closed PRs were ruled out as primitives per GUIDELINES §3 (static decorative components belong in CSS) and §9 (composite wrappers bundling already-shipped primitives belong in consumer code). These recipes give the next contributor reaching for that pattern a starting point that lives in the right place — `docs/` rather than `src/lib/`.

The introductory section of each recipe explains the "why no component?" reasoning so the docs themselves reinforce the philosophy.

## Verification

- `pnpm run lint` — clean (lint scope is `src/`, docs untouched)
- New `docs/recipes/` directory follows the existing flat `docs/*.md` layout — no `_index.json` entry needed since they're standalone reference files
