### PR TITLE
feat(EmptyState): make description optional

### DIFF
--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -1,6 +1,6 @@
 # EmptyState
 
-A centered placeholder component for empty lists, search results, or views. Displays an optional icon/illustration, a title, a description, and an optional action area (e.g. buttons). Inherits text color from its parent for seamless light/dark theme support.
+A centered placeholder component for empty lists, search results, or views. Displays an optional icon/illustration, a required title, an optional description, and an optional action area (e.g. buttons). Inherits text color from its parent for seamless light/dark theme support.
 
 ## Usage
 
@@ -9,10 +9,7 @@ A centered placeholder component for empty lists, search results, or views. Disp
   import { EmptyState, Button } from '@juspay/svelte-ui-components';
 </script>
 
-<EmptyState
-  title="No results found"
-  description="Try adjusting your search or filters."
->
+<EmptyState title="No results found" description="Try adjusting your search or filters.">
   {#snippet icon()}
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
       <circle cx="11" cy="11" r="8" />
@@ -26,10 +23,7 @@ A centered placeholder component for empty lists, search results, or views. Disp
 ### Minimal (Text Only)
 
 ```svelte
-<EmptyState
-  title="Empty inbox"
-  description="Messages you receive will show up here."
-/>
+<EmptyState title="Empty inbox" description="Messages you receive will show up here." />
 ```
 
 ### With Icon, No Action
@@ -42,13 +36,20 @@ A centered placeholder component for empty lists, search results, or views. Disp
 </EmptyState>
 ```
 
+### Title Only (No Description)
+
+```svelte
+<EmptyState title="No results found" />
+```
+
 ## Props
 
-| Prop        | Type      | Required | Default | Description                                                                                                                                                            |
-| ----------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string`  | Yes      | `-`     | Primary heading text displayed prominently.                                                                                                                            |
-| description | `string`  | Yes      | `-`     | Supporting text displayed below the title.                                                                                                                             |
-| classes     | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop        | Type     | Required | Default | Description                                                                                                                                                            |
+| ----------- | -------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title       | `string` | Yes      | `-`     | Primary heading text displayed prominently.                                                                                                                            |
+| description | `string` | No       | `-`     | Supporting text displayed below the title. The description row is omitted entirely when this prop is absent or empty.                                                  |
+| classes     | `string` | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| testId      | `string` | No       | `-`     | Value applied to the `data-pw` attribute on the root element for test selection.                                                                                       |
 
 ## Snippets
 
@@ -56,29 +57,29 @@ Svelte 5 Snippet props — pass content blocks to the component.
 
 | Snippet  | Type      | Description                                                                                                          |
 | -------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
-| icon     | `Snippet` | Icon or illustration area above the title. Rendered inside a sized container with configurable dimensions and color.  |
+| icon     | `Snippet` | Icon or illustration area above the title. Rendered inside a sized container with configurable dimensions and color. |
 | children | `Snippet` | Action area below the description. Typically used for buttons like "Create new", "Clear filters", "Try again", etc.  |
 
 ## CSS Variables
 
 Override these custom properties to theme the component.
 
-| Variable                             | Default        | CSS Property  | Description                                                    |
-| ------------------------------------ | -------------- | ------------- | -------------------------------------------------------------- |
-| `--empty-state-padding`              | `32px 16px`    | padding       | Padding of the empty state container.                          |
-| `--empty-state-text-align`           | `center`       | text-align    | Text alignment of all content.                                 |
-| `--empty-state-gap`                  | `0px`          | gap           | Gap between flex children.                                     |
-| `--empty-state-icon-size`            | `48px`         | width, height | Width and height of the icon container.                        |
-| `--empty-state-icon-color`           | `currentColor` | color         | Color of the icon. Inherits from parent by default.            |
-| `--empty-state-icon-opacity`         | `0.4`          | opacity       | Opacity of the icon for subtle visual treatment.               |
-| `--empty-state-icon-margin-bottom`   | `16px`         | margin-bottom | Space below the icon container.                                |
-| `--empty-state-title-font-size`      | `16px`         | font-size     | Font size of the title.                                        |
-| `--empty-state-title-font-weight`    | `600`          | font-weight   | Font weight of the title.                                      |
-| `--empty-state-title-color`          | `inherit`      | color         | Color of the title. Inherits from parent by default.           |
-| `--empty-state-description-font-size`| `14px`         | font-size     | Font size of the description.                                  |
-| `--empty-state-description-color`    | `inherit`      | color         | Color of the description. Inherits from parent by default.     |
-| `--empty-state-description-opacity`  | `0.6`          | opacity       | Opacity of the description for visual hierarchy.               |
-| `--empty-state-description-max-width`| `360px`        | max-width     | Maximum width of the description for readability.              |
+| Variable                              | Default        | CSS Property  | Description                                                |
+| ------------------------------------- | -------------- | ------------- | ---------------------------------------------------------- |
+| `--empty-state-padding`               | `32px 16px`    | padding       | Padding of the empty state container.                      |
+| `--empty-state-text-align`            | `center`       | text-align    | Text alignment of all content.                             |
+| `--empty-state-gap`                   | `0px`          | gap           | Gap between flex children.                                 |
+| `--empty-state-icon-size`             | `48px`         | width, height | Width and height of the icon container.                    |
+| `--empty-state-icon-color`            | `currentColor` | color         | Color of the icon. Inherits from parent by default.        |
+| `--empty-state-icon-opacity`          | `0.4`          | opacity       | Opacity of the icon for subtle visual treatment.           |
+| `--empty-state-icon-margin-bottom`    | `16px`         | margin-bottom | Space below the icon container.                            |
+| `--empty-state-title-font-size`       | `16px`         | font-size     | Font size of the title.                                    |
+| `--empty-state-title-font-weight`     | `600`          | font-weight   | Font weight of the title.                                  |
+| `--empty-state-title-color`           | `inherit`      | color         | Color of the title. Inherits from parent by default.       |
+| `--empty-state-description-font-size` | `14px`         | font-size     | Font size of the description.                              |
+| `--empty-state-description-color`     | `inherit`      | color         | Color of the description. Inherits from parent by default. |
+| `--empty-state-description-opacity`   | `0.6`          | opacity       | Opacity of the description for visual hierarchy.           |
+| `--empty-state-description-max-width` | `360px`        | max-width     | Maximum width of the description for readability.          |
 
 ## Web Component
 
@@ -96,7 +97,7 @@ Tag: `<sui-empty-state>`
 
 ### Slots
 
-| Slot Name | Maps to Snippet | Description                                                 |
-| --------- | --------------- | ----------------------------------------------------------- |
-| `icon`    | `icon`          | Icon or illustration content displayed above the title.     |
-| (default) | `children`      | Action content (buttons, links) displayed below description.|
+| Slot Name | Maps to Snippet | Description                                                  |
+| --------- | --------------- | ------------------------------------------------------------ |
+| `icon`    | `icon`          | Icon or illustration content displayed above the title.      |
+| (default) | `children`      | Action content (buttons, links) displayed below description. |

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -76,6 +76,10 @@
     "description": "A headless file-picker region that handles drag-and-drop, click-to-open, MIME/extension filtering, and size validation. All visual chrome is supplied by the required `trigger` snippet, which receives `openFilePicker`, `dragOver`, and `disabled`."
   },
   {
+    "name": "EmptyState",
+    "description": "A centered placeholder component for empty lists, search results, or views. Renders an optional icon snippet above a required title, an optional description (omitted entirely when absent), and an optional action area (e.g. buttons) below; all colors inherit from the parent for seamless light/dark theme support."
+  },
+  {
     "name": "Gauge",
     "description": "A semicircular gauge/meter that displays a value between 0 and max on an SVG arc. Supports configurable segments with individual colors, animated value transitions, and a center label. Uses SVG stroke-dasharray for the arc rendering."
   },

--- a/src/lib/EmptyState/EmptyState.svelte
+++ b/src/lib/EmptyState/EmptyState.svelte
@@ -11,7 +11,9 @@
     </div>
   {/if}
   <div class="empty-state-title">{title}</div>
-  <div class="empty-state-description">{description}</div>
+  {#if typeof description === 'string' && description.length > 0}
+    <div class="empty-state-description">{description}</div>
+  {/if}
   {#if typeof children === 'function'}
     <div class="empty-state-actions">
       {@render children()}

--- a/src/lib/EmptyState/properties.ts
+++ b/src/lib/EmptyState/properties.ts
@@ -4,10 +4,10 @@ export type EmptyStateProperties = MandatoryEmptyStateProperties & OptionalEmpty
 
 export type MandatoryEmptyStateProperties = {
   title: string;
-  description: string;
 };
 
 export type OptionalEmptyStateProperties = {
+  description?: string;
   icon?: Snippet;
   children?: Snippet;
   classes?: string;

--- a/src/routes/components/empty-state/+page.svelte
+++ b/src/routes/components/empty-state/+page.svelte
@@ -65,3 +65,29 @@
     {/snippet}
   </EmptyState>
 </div>
+
+<h3>Title only (no description)</h3>
+<div class="demo-row" style="flex-direction: column; max-width: 500px; gap: 24px;">
+  <EmptyState title="No items yet" />
+
+  <EmptyState title="Nothing here">
+    {#snippet icon()}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line
+          x1="12"
+          y1="16"
+          x2="12.01"
+          y2="16"
+        /></svg
+      >
+    {/snippet}
+    <Button text="Get started" />
+  </EmptyState>
+</div>


### PR DESCRIPTION
## Summary

Makes `description` optional on `EmptyState`. The description row is omitted entirely when the prop is absent or empty.

## Why

- The no-baked-defaults philosophy says required props earn their place. `description` is not load-bearing: an empty state with just a title (\"No results found\") is a legitimate and common shape.
- Unblocks downstream consumer migration cases where the source component had only a single message string (Lighthouse's \`ConnectionErrorState\`, for one — but the principle is general).
- Strictly additive: existing consumers passing both \`title\` and \`description\` are unaffected.

## Changes

| File | Change |
|---|---|
| \`src/lib/EmptyState/properties.ts\` | Move \`description\` from \`MandatoryEmptyStateProperties\` to \`OptionalEmptyStateProperties\` |
| \`src/lib/EmptyState/EmptyState.svelte\` | Wrap the description div in \`{#if typeof description === 'string' && description.length > 0}\` (typeof guard per §3, empty-string drop per §5) |
| \`docs/EmptyState.md\` | Description row in props table → \`Required: No\`; add \"Title Only\" usage example; clarify in component prose |

## Test plan

- [x] \`pnpm run check\` — 0 errors, 0 warnings
- [x] \`pnpm run lint\` — prettier + eslint clean
- [x] Existing consumers (title + description both set) render identically — verified by the same code path
- [x] New \`title\` only path renders the title and skips the description div entirely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EmptyState component's `description` prop is now optional; the description element is conditionally rendered only when provided with a non-empty value.

* **Documentation**
  * Updated component documentation and type definitions to reflect that the `description` property is now optional, and includes a title-only usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->