### PR TITLE
feat: add CopyButton component

### DIFF
--- a/docs/CopyButton.md
+++ b/docs/CopyButton.md
@@ -1,0 +1,71 @@
+# CopyButton
+
+An icon button that copies a string to the clipboard and shows a transient confirmation. On click it writes `textToCopy` to the clipboard (using the async Clipboard API, falling back to `document.execCommand('copy')` in insecure contexts), swaps its icon to a checkmark for `feedbackDuration` ms, announces the result via an `aria-live` region, and fires `onCopy`. The default copy and checkmark icons inherit the current text color (`currentColor`) and can be overridden via the `icon` and `copiedIcon` snippets. Theme it with the `--copy-button-*` CSS variables.
+
+## Usage
+
+```svelte
+<script>
+  import { CopyButton } from '@juspay/svelte-ui-components';
+</script>
+
+<!-- Minimal: copy a value -->
+<CopyButton textToCopy="order_12345" />
+
+<!-- With a callback and custom labels -->
+<CopyButton
+  textToCopy={order.id}
+  copiedLabel="Order ID copied"
+  testId="copy-order-id"
+  onCopy={(text, success) => console.log(success ? 'copied' : 'failed', text)}
+/>
+```
+
+### Custom icon
+
+```svelte
+<CopyButton textToCopy={value}>
+  {#snippet icon()}
+    <MyCopyGlyph />
+  {/snippet}
+</CopyButton>
+```
+
+## Props
+
+| Prop             | Type      | Required | Default               | Description                                                                                    |
+| ---------------- | --------- | -------- | --------------------- | ---------------------------------------------------------------------------------------------- |
+| textToCopy       | `string`  | No       | `''`                  | The text written to the clipboard when the button is clicked.                                  |
+| copiedLabel      | `string`  | No       | `'Copied'`            | Announced (and available to a `copiedIcon`) after a successful copy.                           |
+| failedLabel      | `string`  | No       | `'Copy failed'`       | Announced after a failed copy.                                                                 |
+| ariaLabel        | `string`  | No       | `'Copy to clipboard'` | `aria-label` for the button in its idle state.                                                 |
+| feedbackDuration | `number`  | No       | `2000`                | How long (ms) the copied/failed state is shown before reverting to idle.                       |
+| disabled         | `boolean` | No       | `false`               | Disables the button.                                                                           |
+| icon             | `Snippet` | No       | built-in copy icon    | Overrides the default copy icon.                                                               |
+| copiedIcon       | `Snippet` | No       | built-in checkmark    | Overrides the default success (checkmark) icon.                                                |
+| testId           | `string`  | No       | -                     | Value for the `data-pw` attribute on the button, used for end-to-end testing selectors.        |
+| classes          | `string`  | No       | -                     | CSS class string appended to the button. Useful for theming via CSS-variable-defining classes. |
+
+## Events
+
+| Event  | Type                                       | Description                                                                |
+| ------ | ------------------------------------------ | -------------------------------------------------------------------------- |
+| onCopy | `(text: string, success: boolean) => void` | Fires after every copy attempt with the copied text and whether it worked. |
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                          | Default               | CSS Property       | Description                           |
+| --------------------------------- | --------------------- | ------------------ | ------------------------------------- |
+| --copy-button-padding             | `4px`                 | padding            | Padding around the icon.              |
+| --copy-button-border              | `none`                | border             | Button border.                        |
+| --copy-button-border-radius       | `6px`                 | border-radius      | Corner radius.                        |
+| --copy-button-background          | `transparent`         | background         | Idle background.                      |
+| --copy-button-hover-background    | `rgba(0, 0, 0, 0.06)` | background (hover) | Hover background (non-disabled).      |
+| --copy-button-color               | `currentColor`        | color              | Idle icon color.                      |
+| --copy-button-copied-color        | `currentColor`        | color (copied)     | Icon color in the copied state.       |
+| --copy-button-failed-color        | `currentColor`        | color (failed)     | Icon color in the failed state.       |
+| --copy-button-icon-size           | `16px`                | width / height     | Icon box size.                        |
+| --copy-button-disabled-opacity    | `0.5`                 | opacity (disabled) | Opacity when disabled.                |
+| --copy-button-transition-duration | `0.15s`               | transition         | Background/color transition duration. |

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -32,6 +32,10 @@
     "description": "An action button that supports two loader modes (circular spinner or progress bar), HTML text content, icon and children snippets, aria-expanded for dropdown triggers, and a disabled state. The progress bar mode prevents clicks during animation."
   },
   {
+    "name": "CopyButton",
+    "description": "An icon button that copies a string to the clipboard and shows a transient confirmation. Writes textToCopy via the async Clipboard API with an execCommand fallback, swaps the icon to a checkmark for a configurable duration, announces the result via an aria-live region, and fires onCopy(text, success). Default copy/checkmark icons use currentColor and are overridable via the icon/copiedIcon snippets; theme via --copy-button-* CSS variables."
+  },
+  {
     "name": "Calendar",
     "description": "A date picker with single-date and date-range selection modes. Supports month/year navigation, locale-aware day and month names, min/max date constraints, disabled dates, and keyboard navigation. Range mode shows visual start/end pills with highlighted in-between days."
   },

--- a/src/lib/CopyButton/CopyButton.svelte
+++ b/src/lib/CopyButton/CopyButton.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import type { CopyButtonProperties, CopyButtonStatus } from './properties';
+  import copySvg from '$lib/assets/copy.svg?raw';
+  import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
+
+  let {
+    textToCopy = '',
+    copiedLabel = 'Copied',
+    failedLabel = 'Copy failed',
+    ariaLabel = 'Copy to clipboard',
+    feedbackDuration = 2000,
+    disabled = false,
+    icon,
+    copiedIcon,
+    testId,
+    classes,
+    onCopy
+  }: CopyButtonProperties = $props();
+
+  let status: CopyButtonStatus = $state('idle');
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const writeToClipboard = async (text: string): Promise<boolean> => {
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
+    } catch {
+      // Clipboard API can reject in insecure contexts or when permission is denied;
+      // fall through to the legacy execCommand path below.
+    }
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const succeeded = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return succeeded;
+    } catch {
+      return false;
+    }
+  };
+
+  const handleClick = async (): Promise<void> => {
+    const success = await writeToClipboard(textToCopy);
+    status = success ? 'copied' : 'failed';
+    onCopy?.(textToCopy, success);
+    if (resetTimer) {
+      clearTimeout(resetTimer);
+    }
+    resetTimer = setTimeout(() => {
+      status = 'idle';
+    }, feedbackDuration);
+  };
+</script>
+
+<button
+  type="button"
+  class="copy-button {classes ?? ''}"
+  class:copied={status === 'copied'}
+  class:failed={status === 'failed'}
+  aria-label={ariaLabel}
+  {disabled}
+  data-pw={typeof testId === 'string' ? testId : null}
+  onclick={handleClick}
+>
+  <span class="copy-button-icon">
+    {#if status === 'copied'}
+      {#if copiedIcon}
+        {@render copiedIcon()}
+      {:else}
+        <!-- eslint-disable svelte/no-at-html-tags -->
+        {@html checkmarkSvg}
+      {/if}
+    {:else if icon}
+      {@render icon()}
+    {:else}
+      <!-- eslint-disable svelte/no-at-html-tags -->
+      {@html copySvg}
+    {/if}
+  </span>
+</button>
+<span class="copy-button-status" aria-live="polite">
+  {status === 'copied' ? copiedLabel : status === 'failed' ? failedLabel : ''}
+</span>
+
+<style>
+  .copy-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--copy-button-padding, 4px);
+    border: var(--copy-button-border, none);
+    border-radius: var(--copy-button-border-radius, 6px);
+    background: var(--copy-button-background, transparent);
+    color: var(--copy-button-color, currentColor);
+    cursor: pointer;
+    transition:
+      background-color var(--copy-button-transition-duration, 0.15s) ease,
+      color var(--copy-button-transition-duration, 0.15s) ease;
+    font-family: inherit;
+  }
+
+  .copy-button:hover:not(:disabled) {
+    background: var(--copy-button-hover-background, rgba(0, 0, 0, 0.06));
+  }
+
+  .copy-button:disabled {
+    cursor: not-allowed;
+    opacity: var(--copy-button-disabled-opacity, 0.5);
+  }
+
+  .copy-button.copied {
+    color: var(--copy-button-copied-color, currentColor);
+  }
+
+  .copy-button.failed {
+    color: var(--copy-button-failed-color, currentColor);
+  }
+
+  .copy-button-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--copy-button-icon-size, 16px);
+    height: var(--copy-button-icon-size, 16px);
+  }
+
+  .copy-button-icon :global(svg) {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  /* Visually hidden live region announcing the copy result to screen readers. */
+  .copy-button-status {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/lib/CopyButton/properties.ts
+++ b/src/lib/CopyButton/properties.ts
@@ -1,0 +1,33 @@
+import type { Snippet } from 'svelte';
+
+export type CopyButtonStatus = 'idle' | 'copied' | 'failed';
+
+export type CopyButtonProperties = OptionalCopyButtonProperties & CopyButtonEventProperties;
+
+export type OptionalCopyButtonProperties = {
+  /** Text written to the clipboard when the button is clicked. */
+  textToCopy?: string;
+  /** Accessible/announced label shown after a successful copy. Default: 'Copied'. */
+  copiedLabel?: string;
+  /** Accessible/announced label shown after a failed copy. Default: 'Copy failed'. */
+  failedLabel?: string;
+  /** aria-label for the button in its idle state. Default: 'Copy to clipboard'. */
+  ariaLabel?: string;
+  /** How long (ms) the copied/failed state is shown before reverting to idle. Default: 2000. */
+  feedbackDuration?: number;
+  /** Disables the button. */
+  disabled?: boolean;
+  /** Override the default copy icon. */
+  icon?: Snippet;
+  /** Override the default success (checkmark) icon. */
+  copiedIcon?: Snippet;
+  /** Rendered as the `data-pw` test id on the button element. */
+  testId?: string;
+  /** Extra class names appended to the button for consumer theming. */
+  classes?: string;
+};
+
+export type CopyButtonEventProperties = {
+  /** Fired after every copy attempt with the text and whether it succeeded. */
+  onCopy?: (text: string, success: boolean) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 export { default as Modal } from './Modal/Modal.svelte';
 export { default as BrandLoader } from './BrandLoader/BrandLoader.svelte';
 export { default as Button } from './Button/Button.svelte';
+export { default as CopyButton } from './CopyButton/CopyButton.svelte';
 export { default as Input } from './Input/Input.svelte';
 export { default as InputButton } from './InputButton/InputButton.svelte';
 export { default as ListItem } from './ListItem/ListItem.svelte';
@@ -58,6 +59,7 @@ export { default as ColorPicker } from './ColorPicker/ColorPicker.svelte';
 export { default as SplitInput } from './SplitInput/SplitInput.svelte';
 
 export type * from './Button/properties';
+export type * from './CopyButton/properties';
 export type * from './Modal/properties';
 export type * from './Input/properties';
 export type * from './InputButton/properties';


### PR DESCRIPTION
## Summary

Adds a **`CopyButton`** component — an icon button that copies a string to the clipboard and shows a transient confirmation.

This is a commonly re-implemented pattern in consumer apps (e.g. Lighthouse maintained its own copy-button wrapper). Moving it into the library removes that duplication and gives a themable, accessible primitive.

## Behavior

- Writes `textToCopy` via the async **Clipboard API**, with a **`document.execCommand('copy')` fallback** for insecure contexts / permission denials.
- On click, the copy icon swaps to a **checkmark** for `feedbackDuration` ms (default 2000), then reverts.
- Announces the result through a visually-hidden **`aria-live`** region (`copiedLabel` / `failedLabel`).
- Fires **`onCopy(text, success)`** after every attempt.

## API

| Prop | Type | Default | |
|---|---|---|---|
| `textToCopy` | `string` | `''` | text written to the clipboard |
| `copiedLabel` / `failedLabel` | `string` | `'Copied'` / `'Copy failed'` | announced result |
| `ariaLabel` | `string` | `'Copy to clipboard'` | idle aria-label |
| `feedbackDuration` | `number` | `2000` | ms before reverting to idle |
| `disabled` | `boolean` | `false` | |
| `icon` / `copiedIcon` | `Snippet` | built-in copy / checkmark | override icons |
| `testId` | `string` | – | rendered as `data-pw` |
| `classes` | `string` | – | consumer theming hook |
| `onCopy` | `(text, success) => void` | – | result callback |

Themable via `--copy-button-*` CSS variables (padding, border, radius, background, hover-background, color, copied/failed color, icon-size, disabled-opacity, transition-duration). Default copy/checkmark icons use `currentColor`.

## Conventions followed

- Self-contained component (like `ThemeSwitcher`), bundling the existing `copy.svg` / `checkmark.svg` assets via `?raw`.
- Registered in `src/lib/index.ts` (component + `properties` types).
- Documented in `docs/CopyButton.md` and `docs/_index.json` (feeds the component MCP).

## Gates

- `pnpm run check` — **0 errors / 0 warnings**
- `pnpm run lint` — clean (prettier + eslint)
- `pnpm run build` — packages; `dist/index.js` exports `CopyButton`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `CopyButton` component with clipboard copy functionality (using modern API with fallback support).
  * Displays transient feedback icons (checkmark for success, error for failure).
  * Provides accessible announcements and customizable labels.
  * Supports custom icons and CSS variable theming.
  * Includes `onCopy` callback for copy events.

* **Documentation**
  * Added comprehensive component documentation with usage examples and API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->