### PR TITLE
fix: use effect for Validation State

### DIFF
--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -84,13 +84,12 @@
     return valueValidation;
   });
 
-  const validationStateForCallback = $derived.by(() => {
-    const state = validationState;
-    onStateChange(state);
-    return state;
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    onStateChange(validationState);
   });
 
-  const showErrorMessage = $derived(validationStateForCallback === 'Invalid');
+  const showErrorMessage = $derived(validationState === 'Invalid');
 
   function handleOnInput(event: Event) {
     if (inputElement === null) {


### PR DESCRIPTION
- use `$effect` rather that `$derived` in the validation state of `Input.svelte`

### What is the problem

`Input.svelte` calls `onStateChange(state)` inside a `$derived.by()`. `InputButton.svelte` passes `handleStateChange` as `onStateChange`, and `handleStateChange` mutates `[validationState = state]`— a `$state` variable. Svelte 5 throws `state_unsafe_mutation` because you can't mutate state inside a derived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Input component's internal state management to improve efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->