### PR TITLE
feat: Select — footer/bottomContent snippet, bind:open, allowSelectAll, deferred multi-select apply

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -7,13 +7,20 @@
   let {
     items,
     value = $bindable([]),
+    open = $bindable(false),
+    manageOpenState = true,
     multiple = false,
     searchable = false,
     placeholder = '',
     disabled = false,
     testId,
     onchange,
-    classes
+    onopen,
+    onclose,
+    classes,
+    allowSelectAll = true,
+    showSelectButton = false,
+    bottomContent
   }: SelectProperties = $props();
 
   let isOpen = $state(false);
@@ -23,12 +30,18 @@
   let searchInputEl: HTMLInputElement | null = $state(null);
   let triggerEl: HTMLDivElement | null = $state(null);
 
+  /**
+   * Pending selection used when showSelectButton is true.
+   * We only commit to `value` and fire onchange when Apply is clicked.
+   */
+  let pendingValue: string[] = $state([]);
+
   const listboxId = `select-listbox-${Math.random().toString(36).slice(2, 9)}`;
 
-  function getLabel(id: string): string {
+  const getLabel = (id: string): string => {
     const found = items.find((item) => item.id === id);
     return typeof found === 'object' ? found.label : id;
-  }
+  };
 
   let filteredItems: SelectItem[] = $derived(
     searchable && query.length > 0
@@ -50,118 +63,182 @@
 
   let searchPlaceholder = $derived(isOpen && displayText.length > 0 ? displayText : placeholder);
 
-  async function open(): Promise<void> {
-    if (disabled || isOpen) {
+  /**
+   * The effective selected set shown in the dropdown checkboxes / select-all row.
+   * In deferred mode this is pendingValue so the UI reflects staged choices.
+   */
+  let activeSelection: string[] = $derived(showSelectButton && multiple ? pendingValue : value);
+
+  const allSelected: boolean = $derived(
+    items.length > 0 && items.every((item) => activeSelection.includes(item.id))
+  );
+
+  /** Open the dropdown panel. Respects disabled and manageOpenState. */
+  const openDropdown = async (): Promise<void> => {
+    if (disabled) {
       return;
     }
-    isOpen = true;
+    if (manageOpenState) {
+      isOpen = true;
+    }
+    open = true;
     highlightedIndex = -1;
     query = '';
+    if (multiple && showSelectButton) {
+      pendingValue = [...value];
+    }
+    onopen?.();
     if (searchable) {
       await tick();
       if (searchInputEl !== null) {
         searchInputEl.focus();
       }
     }
-  }
+  };
 
-  function close(): void {
-    isOpen = false;
+  /** Close the dropdown panel. Resets deferred state without committing. */
+  const closeDropdown = (): void => {
+    if (manageOpenState) {
+      isOpen = false;
+    }
+    open = false;
     query = '';
     highlightedIndex = -1;
-  }
+    pendingValue = [];
+    onclose?.();
+  };
 
-  function selectItem(id: string): void {
+  /**
+   * Whether the dropdown panel is currently visible.
+   * When manageOpenState is false the parent's `open` prop drives this.
+   */
+  const panelVisible: boolean = $derived(manageOpenState ? isOpen : open);
+
+  const selectItem = (id: string): void => {
     if (disabled) {
       return;
     }
     if (multiple) {
-      value = value.includes(id) ? value.filter((v) => v !== id) : [...value, id];
+      if (showSelectButton) {
+        pendingValue = pendingValue.includes(id)
+          ? pendingValue.filter((pendingId) => pendingId !== id)
+          : [...pendingValue, id];
+      } else {
+        value = value.includes(id)
+          ? value.filter((existingId) => existingId !== id)
+          : [...value, id];
+        onchange?.(value);
+      }
     } else {
       value = [id];
-      close();
+      onchange?.(value);
+      closeDropdown();
     }
-    onchange?.(value);
-  }
+  };
 
-  function removeItem(id: string): void {
+  const toggleSelectAll = (): void => {
     if (disabled) {
       return;
     }
-    value = value.filter((v) => v !== id);
-    onchange?.(value);
-  }
+    if (showSelectButton) {
+      pendingValue = allSelected ? [] : items.map((item) => item.id);
+    } else {
+      value = allSelected ? [] : items.map((item) => item.id);
+      onchange?.(value);
+    }
+  };
 
-  function selectHighlighted(): void {
-    if (highlightedIndex < 0 || highlightedIndex >= filteredItems.length) {
+  const applySelection = (): void => {
+    value = [...pendingValue];
+    onchange?.(value);
+    closeDropdown();
+  };
+
+  const removeItem = (id: string): void => {
+    if (disabled) {
       return;
     }
-    const item = filteredItems.at(highlightedIndex);
-    if (typeof item === 'object' && item !== null) {
-      selectItem(item.id);
-    }
-  }
+    value = value.filter((existingId) => existingId !== id);
+    onchange?.(value);
+  };
 
-  async function moveHighlight(delta: number): Promise<void> {
+  const selectHighlighted = (): void => {
+    const itemsWithSelectAll =
+      allowSelectAll && multiple ? [null, ...filteredItems] : filteredItems;
+    const highlighted = itemsWithSelectAll.at(highlightedIndex);
+    if (highlighted === null) {
+      toggleSelectAll();
+    } else if (typeof highlighted === 'object' && highlighted !== null) {
+      selectItem(highlighted.id);
+    }
+  };
+
+  const moveHighlight = async (delta: number): Promise<void> => {
+    const rowCount = allowSelectAll && multiple ? filteredItems.length + 1 : filteredItems.length;
     const next = highlightedIndex + delta;
-    if (next < 0 || next >= filteredItems.length) {
+    if (next < 0 || next >= rowCount) {
       return;
     }
     highlightedIndex = next;
     await tick();
     if (containerEl !== null) {
-      const el = containerEl.querySelector('.select-option.highlighted');
-      if (el instanceof HTMLElement) {
-        el.scrollIntoView({ block: 'nearest' });
+      const highlighted = containerEl.querySelector(
+        '.select-option.highlighted, .select-all-option.highlighted'
+      );
+      if (highlighted instanceof HTMLElement) {
+        highlighted.scrollIntoView({ block: 'nearest' });
       }
     }
-  }
+  };
 
-  function handleTriggerClick(event: MouseEvent): void {
+  const handleTriggerClick = (event: MouseEvent): void => {
     if (event.target instanceof HTMLInputElement) {
-      if (!isOpen) {
-        open();
+      if (!panelVisible) {
+        openDropdown();
       }
       return;
     }
-    if (multiple && searchable) {
-      open();
-    } else if (isOpen) {
-      close();
-    } else {
-      open();
+    if (!manageOpenState) {
+      return;
     }
-  }
+    if (multiple && searchable) {
+      openDropdown();
+    } else if (panelVisible) {
+      closeDropdown();
+    } else {
+      openDropdown();
+    }
+  };
 
-  function handleKeydown(event: KeyboardEvent): void {
+  const handleKeydown = (event: KeyboardEvent): void => {
     if (disabled) {
       return;
     }
     switch (event.key) {
       case 'Enter':
         event.preventDefault();
-        if (isOpen) {
+        if (panelVisible) {
           selectHighlighted();
         } else {
-          open();
+          openDropdown();
         }
         break;
       case ' ':
         if (!(event.target instanceof HTMLInputElement)) {
           event.preventDefault();
-          if (isOpen) {
+          if (panelVisible) {
             selectHighlighted();
           } else {
-            open();
+            openDropdown();
           }
         }
         break;
       case 'ArrowDown':
         event.preventDefault();
-        if (isOpen) {
+        if (panelVisible) {
           moveHighlight(1);
         } else {
-          open();
+          openDropdown();
         }
         break;
       case 'ArrowUp':
@@ -169,8 +246,8 @@
         moveHighlight(-1);
         break;
       case 'Escape':
-        if (isOpen) {
-          close();
+        if (panelVisible) {
+          closeDropdown();
           if (!searchable && triggerEl !== null) {
             triggerEl.focus();
           }
@@ -185,39 +262,39 @@
         }
         break;
       case 'Tab':
-        if (isOpen) {
-          close();
+        if (panelVisible) {
+          closeDropdown();
         }
         break;
     }
-  }
+  };
 
-  function handleSearchInput(event: Event): void {
+  const handleSearchInput = (event: Event): void => {
     if (!(event.target instanceof HTMLInputElement)) {
       return;
     }
     query = event.target.value;
-    if (!isOpen) {
+    if (!panelVisible) {
       isOpen = true;
     }
     highlightedIndex = -1;
-  }
+  };
 
-  function handleSearchFocus(): void {
-    if (!isOpen) {
-      open();
+  const handleSearchFocus = (): void => {
+    if (!panelVisible) {
+      openDropdown();
     }
-  }
+  };
 
-  function handleClickOutside(event: Event): void {
+  const handleClickOutside = (event: Event): void => {
     if (
       event.target instanceof Node &&
       containerEl !== null &&
       !containerEl.contains(event.target)
     ) {
-      close();
+      closeDropdown();
     }
-  }
+  };
 
   onMount(() => {
     document.addEventListener('click', handleClickOutside);
@@ -229,7 +306,7 @@
 
 <div
   class="select {classes ?? ''}"
-  class:open={isOpen}
+  class:open={panelVisible}
   class:disabled
   bind:this={containerEl}
   {...typeof testId === 'string' ? { 'data-pw': testId } : {}}
@@ -240,7 +317,7 @@
     onclick={handleTriggerClick}
     onkeydown={handleKeydown}
     role="combobox"
-    aria-expanded={isOpen}
+    aria-expanded={panelVisible}
     aria-haspopup="listbox"
     aria-controls={listboxId}
     {...highlightedOptionId !== null ? { 'aria-activedescendant': highlightedOptionId } : {}}
@@ -276,7 +353,7 @@
       <input
         class="select-search"
         type="text"
-        value={isOpen ? query : displayText}
+        value={panelVisible ? query : displayText}
         oninput={handleSearchInput}
         onfocus={handleSearchFocus}
         bind:this={searchInputEl}
@@ -294,27 +371,65 @@
     <span class="select-arrow">{@html chevronDownSvg}</span>
   </div>
 
-  {#if isOpen && !disabled}
+  {#if panelVisible && !disabled}
     <div class="select-dropdown" role="listbox" id={listboxId} aria-multiselectable={multiple}>
-      {#if filteredItems.length === 0}
-        <div class="select-empty">No results</div>
-      {:else}
-        {#each filteredItems as item, index (item.id)}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <div
-            class="select-option"
-            class:selected={value.includes(item.id)}
-            class:highlighted={index === highlightedIndex}
-            role="option"
-            id={`${listboxId}-option-${index}`}
-            aria-selected={value.includes(item.id)}
-            tabindex="-1"
-            onclick={() => selectItem(item.id)}
-            onmouseenter={() => (highlightedIndex = index)}
+      <div class="select-items">
+        {#if filteredItems.length === 0}
+          <div class="select-empty">No results</div>
+        {:else}
+          {#if multiple && allowSelectAll}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <div
+              class="select-option select-all-option"
+              class:selected={allSelected}
+              class:highlighted={highlightedIndex === 0}
+              role="option"
+              aria-selected={allSelected}
+              tabindex="-1"
+              onclick={toggleSelectAll}
+              onmouseenter={() => (highlightedIndex = 0)}
+            >
+              {allSelected ? 'Deselect All' : 'Select All'}
+            </div>
+          {/if}
+          {#each filteredItems as item, index (item.id)}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <div
+              class="select-option"
+              class:selected={activeSelection.includes(item.id)}
+              class:highlighted={index ===
+                (allowSelectAll && multiple ? highlightedIndex - 1 : highlightedIndex)}
+              role="option"
+              id={`${listboxId}-option-${index}`}
+              aria-selected={activeSelection.includes(item.id)}
+              tabindex="-1"
+              onclick={() => selectItem(item.id)}
+              onmouseenter={() =>
+                (highlightedIndex = allowSelectAll && multiple ? index + 1 : index)}
+            >
+              {item.label}
+            </div>
+          {/each}
+        {/if}
+      </div>
+
+      {#if multiple && showSelectButton}
+        <div class="select-apply-bar">
+          <button
+            class="select-apply-btn"
+            type="button"
+            onclick={applySelection}
+            {...typeof testId === 'string' ? { 'data-pw': `${testId}-apply` } : {}}
           >
-            {item.label}
-          </div>
-        {/each}
+            Apply
+          </button>
+        </div>
+      {/if}
+
+      {#if bottomContent}
+        <div class="select-bottom-content">
+          {@render bottomContent()}
+        </div>
       {/if}
     </div>
   {/if}
@@ -423,9 +538,13 @@
     border: var(--select-dropdown-border, 1px solid #cccccc);
     border-radius: var(--select-dropdown-border-radius, 6px);
     box-shadow: var(--select-dropdown-shadow, 0 4px 12px rgba(0, 0, 0, 0.1));
+    overflow: hidden;
+    z-index: var(--select-dropdown-z-index, 10);
+  }
+
+  .select-items {
     max-height: var(--select-dropdown-max-height, 200px);
     overflow-y: auto;
-    z-index: var(--select-dropdown-z-index, 10);
   }
 
   .select-option {
@@ -454,11 +573,45 @@
     );
   }
 
+  .select-all-option {
+    border-bottom: var(--select-all-option-border, 1px solid #eeeeee);
+    font-size: var(--select-all-option-font-size, inherit);
+  }
+
   .select-empty {
     padding: var(--select-empty-padding, 8px 12px);
     color: var(--select-empty-color, #999999);
     font-style: var(--select-empty-font-style, italic);
     font-size: var(--select-empty-font-size, inherit);
+  }
+
+  .select-apply-bar {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--select-apply-bar-padding, 8px 12px);
+    border-top: var(--select-apply-bar-border, 1px solid #eeeeee);
+    background: var(--select-apply-background, #ffffff);
+  }
+
+  .select-apply-btn {
+    padding: var(--select-apply-btn-padding, 6px 16px);
+    background: var(--select-apply-btn-background, #2563eb);
+    color: var(--select-apply-btn-color, #ffffff);
+    border: none;
+    border-radius: var(--select-apply-btn-border-radius, 4px);
+    font-size: var(--select-apply-btn-font-size, 13px);
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .select-apply-btn:hover {
+    opacity: var(--select-apply-btn-hover-opacity, 0.85);
+  }
+
+  .select-bottom-content {
+    border-top: var(--select-bottom-content-border, 1px solid #eeeeee);
+    background: var(--select-bottom-content-background, #ffffff);
   }
 
   .select-trigger :global(.pill) {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -1,3 +1,5 @@
+import type { Snippet } from 'svelte';
+
 export type SelectProperties = MandatorySelectProperties &
   OptionalSelectProperties &
   SelectEventProperties;
@@ -13,14 +15,41 @@ export type MandatorySelectProperties = {
 
 export type OptionalSelectProperties = {
   value?: string[];
+  /** Bindable. When manageOpenState is false the parent fully controls open/close. */
+  open?: boolean;
+  /**
+   * When true (default) the component manages its own open/close state.
+   * Set to false to drive open state entirely via the `open` prop.
+   */
+  manageOpenState?: boolean;
   multiple?: boolean;
   searchable?: boolean;
   placeholder?: string;
   disabled?: boolean;
   testId?: string;
   classes?: string;
+  /**
+   * When true (default) a "Select All / Deselect All" row is shown at the
+   * top of the dropdown in multiple mode. Set to false to suppress it.
+   */
+  allowSelectAll?: boolean;
+  /**
+   * When true in multiple mode the dropdown stays open and onchange only
+   * fires when the user clicks the Apply button rendered in the footer.
+   * Defaults to false (immediate onchange on every toggle).
+   */
+  showSelectButton?: boolean;
+  /**
+   * Optional Snippet rendered pinned at the bottom of the open dropdown
+   * panel, below the item list. Useful for action buttons or custom footers.
+   */
+  bottomContent?: Snippet;
 };
 
 export type SelectEventProperties = {
   onchange?: (value: string[]) => void;
+  /** Fired when the dropdown opens. */
+  onopen?: () => void;
+  /** Fired when the dropdown closes. */
+  onclose?: () => void;
 };

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -34,10 +34,40 @@
     { id: 'mum', label: 'Mumbai' }
   ];
 
+  const paymentMethods: SelectItem[] = [
+    { id: 'card', label: 'Credit / Debit Card' },
+    { id: 'upi', label: 'UPI' },
+    { id: 'nb', label: 'Net Banking' },
+    { id: 'wallet', label: 'Wallet' },
+    { id: 'emi', label: 'EMI' },
+    { id: 'cod', label: 'Cash on Delivery' }
+  ];
+
   let singleValue: string[] = $state([]);
   let searchValue: string[] = $state([]);
   let multiValue: string[] = $state([]);
   let multiSearchValue: string[] = $state([]);
+
+  // (a) bottomContent — zone picker with an add action in the footer
+  let zoneValue: string[] = $state([]);
+  let addedZoneCount = $state(0);
+  const handleAddZone = (): void => {
+    addedZoneCount += 1;
+  };
+
+  // (b) controlled open — parent drives accordion-style toggle
+  let accordionOpen = $state(false);
+  let controlledValue: string[] = $state([]);
+
+  // (c) allowSelectAll=false — suppress the Select All row
+  let paymentValue: string[] = $state([]);
+
+  // (d) deferred apply — onchange fires only on Apply
+  let deferredValue: string[] = $state([]);
+  let deferredLog: string[] = $state([]);
+  const handleDeferredChange = (vals: string[]): void => {
+    deferredLog = [...deferredLog, `Applied: [${vals.join(', ')}]`];
+  };
 </script>
 
 <div class="page-header">
@@ -88,10 +118,183 @@
   <Select items={fruits} disabled placeholder="Can't touch this" />
 </div>
 
+<hr class="demo-divider" />
+
+<h2>New capabilities</h2>
+
+<h3>(a) bottomContent Snippet — custom footer inside the dropdown panel</h3>
+<p class="demo-caption">
+  Pass a <code>bottomContent</code> snippet to render pinned content below the item list. This unblocks
+  ShippingRuleForm (Add Shipping Zone) and JSONForm (nested form) in Lighthouse.
+</p>
+<div class="demo-row" style="max-width: 360px;">
+  <Select items={cities} bind:value={zoneValue} placeholder="Select shipping zone">
+    {#snippet bottomContent()}
+      <div class="demo-footer-action">
+        <button type="button" class="demo-add-btn" onclick={handleAddZone}> + Add new zone </button>
+        {#if addedZoneCount > 0}
+          <span class="demo-badge">{addedZoneCount} added</span>
+        {/if}
+      </div>
+    {/snippet}
+  </Select>
+  {#if zoneValue.length > 0}
+    <p class="demo-info">Selected: {zoneValue.at(0)}</p>
+  {/if}
+</div>
+
+<h3>(b) Controlled open state (manageOpenState={false} + bind:open)</h3>
+<p class="demo-caption">
+  When <code>manageOpenState=false</code> the parent drives open/close via the bindable
+  <code>open</code> prop. This unblocks RtoSuite/TokenAdvance accordion in Lighthouse.
+</p>
+<div class="demo-row" style="max-width: 360px;">
+  <div class="demo-accordion-header">
+    <span>Choose a language</span>
+    <button type="button" class="demo-toggle-btn" onclick={() => (accordionOpen = !accordionOpen)}>
+      {accordionOpen ? 'Close panel' : 'Open panel'}
+    </button>
+  </div>
+  <Select
+    items={languages}
+    bind:value={controlledValue}
+    bind:open={accordionOpen}
+    manageOpenState={false}
+    placeholder="Panel driven by parent"
+    onopen={() => (accordionOpen = true)}
+    onclose={() => (accordionOpen = false)}
+  />
+  {#if controlledValue.length > 0}
+    <p class="demo-info">Selected: {controlledValue.at(0)}</p>
+  {/if}
+</div>
+
+<h3>(c) allowSelectAll={false} — suppress the Select All row</h3>
+<p class="demo-caption">
+  Set <code>allowSelectAll=false</code> to hide the "Select All / Deselect All" row in multi-select mode.
+  This unblocks offers/PaymentMethodField in Lighthouse.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Select
+    items={paymentMethods}
+    multiple
+    allowSelectAll={false}
+    bind:value={paymentValue}
+    placeholder="Select payment methods"
+  />
+  {#if paymentValue.length > 0}
+    <p class="demo-info">Selected: {paymentValue.join(', ')}</p>
+  {/if}
+</div>
+
+<h3>(d) Deferred multi-select (showSelectButton=true) — Apply fires onchange</h3>
+<p class="demo-caption">
+  With <code>showSelectButton=true</code> the dropdown stays open as the user toggles items.
+  <code>onchange</code> fires only when the Apply button is clicked. This unblocks offers/PaymentMethodField
+  deferred-apply pattern in Lighthouse.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Select
+    items={paymentMethods}
+    multiple
+    allowSelectAll={false}
+    showSelectButton={true}
+    bind:value={deferredValue}
+    placeholder="Pick methods and apply"
+    onchange={handleDeferredChange}
+    testId="deferred-select"
+  />
+  {#if deferredValue.length > 0}
+    <p class="demo-info">Committed: {deferredValue.join(', ')}</p>
+  {/if}
+  {#if deferredLog.length > 0}
+    <ul class="demo-log">
+      {#each deferredLog as entry (entry)}
+        <li>{entry}</li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
 <style>
   .demo-info {
     margin: 8px 0 0;
     font-size: 13px;
     color: #666;
+  }
+
+  .demo-divider {
+    border: none;
+    border-top: 1px solid #e5e7eb;
+    margin: 32px 0;
+  }
+
+  .demo-caption {
+    font-size: 13px;
+    color: #555;
+    margin: 0 0 12px;
+    max-width: 520px;
+  }
+
+  .demo-footer-action {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .demo-add-btn {
+    background: none;
+    border: 1px dashed #2563eb;
+    color: #2563eb;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+
+  .demo-add-btn:hover {
+    background: #eff6ff;
+  }
+
+  .demo-badge {
+    font-size: 12px;
+    background: #dbeafe;
+    color: #1d4ed8;
+    border-radius: 999px;
+    padding: 2px 8px;
+  }
+
+  .demo-accordion-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    font-size: 14px;
+  }
+
+  .demo-toggle-btn {
+    background: none;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .demo-toggle-btn:hover {
+    background: #f9fafb;
+  }
+
+  .demo-log {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    font-size: 12px;
+    color: #555;
+    list-style: disc;
+  }
+
+  .demo-log li {
+    margin-bottom: 2px;
   }
 </style>

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -5,13 +5,19 @@
     props: {
       items: { type: 'Object' },
       value: { type: 'Object' },
+      open: { type: 'Boolean', reflect: true },
+      manageOpenState: { type: 'Boolean', reflect: true, attribute: 'manage-open-state' },
       multiple: { type: 'Boolean', reflect: true },
       searchable: { type: 'Boolean', reflect: true },
       placeholder: { type: 'String', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onchange: { type: 'Object' }
+      allowSelectAll: { type: 'Boolean', reflect: true, attribute: 'allow-select-all' },
+      showSelectButton: { type: 'Boolean', reflect: true, attribute: 'show-select-button' },
+      onchange: { type: 'Object' },
+      onopen: { type: 'Object' },
+      onclose: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
## What

Four backward-compatible optional props added to the `Select` component. All defaults preserve current behavior for existing consumers.

### (a) `bottomContent` — `Snippet` prop

Renders pinned content below the item list inside the open dropdown panel.

```svelte
<Select items={zones} bind:value>
  {#snippet bottomContent()}
    <button onclick={addZone}>+ Add new zone</button>
  {/snippet}
</Select>
```

### (b) `open` (bindable) + `manageOpenState` — controlled open state

When `manageOpenState={false}` the parent drives open/close via `bind:open`; the component does not toggle the panel on trigger clicks.

```svelte
<Select items={languages} bind:open={accordionOpen} manageOpenState={false} />
```

### (c) `allowSelectAll` — suppress the Select All row

`allowSelectAll={false}` hides the "Select All / Deselect All" row in `multiple` mode (default `true`).

### (d) `showSelectButton` — deferred multi-select Apply

`showSelectButton={true}` keeps the dropdown open while the user toggles items. `onchange` fires only when the Apply button in the footer is clicked.

## Why / which Lighthouse migrations this unblocks

| Gap | Blocked callsite | This prop |
|---|---|---|
| footer snippet in dropdown panel | `ShippingRuleForm.svelte` (Add Shipping Zone), `JSONForm.svelte` (nested form), `DataGrid.svelte` (select-action-footer) | `bottomContent` |
| parent-driven accordion open | `RtoSuite/TokenAdvance.svelte` (`manageOpenState:false + isBodyOpen`) | `bind:open` + `manageOpenState` |
| suppress Select All | `offers/PaymentMethodField.svelte` (`showSelectAll:false`) | `allowSelectAll` |
| deferred Apply (not immediate) | `offers/PaymentMethodField.svelte` (`showSelectButton:true`) | `showSelectButton` |

These are the four hard gaps that block the Lighthouse Dropdown → library Select migration (phases 0a–0d from the migration plan).

## Demo

View all four variants at `/components/select` in the dev server:

```
cd /path/to/svelte-ui-components && pnpm run dev
```

Navigate to **Form Controls → Select**.

## Gates

- `pnpm run check` — 0 errors, 4 pre-existing warnings (Modal, ThemeSwitcher — untouched)
- `pnpm run lint` — clean (prettier + eslint)
- `pnpm run build` — clean (SSR + client + package)

## Compatibility

All new props are optional with defaults that preserve existing behavior. No breaking changes to existing consumers.

CSS vars follow library convention: `var(--select-apply-btn-background, #2563eb)` etc. — sensible hex fallbacks, zero consumer overrides required.

No `as` type assertions. No bare `undefined`. Arrow functions throughout.