### PR TITLE
feat: Card — add layout CSS vars (box-shadow/width/margin/max-*), clickable support, and docs

### DIFF
--- a/docs/Card.md
+++ b/docs/Card.md
@@ -1,6 +1,6 @@
 # Card
 
-A generic container component with an optional title/description header and a content body. Designed as a building block for dashboards, settings panels, product listings, and any grouped content. All visual properties are controlled via CSS custom properties, making it fully theme-agnostic — it inherits text color and background from its parent by default.
+A generic container component with an optional title/description header and a content body. Designed as a building block for dashboards, settings panels, product listings, and any grouped content. All visual properties are controlled via CSS custom properties — it looks correct with zero consumer overrides and is fully theme-agnostic. When `onclick` is provided the root element becomes an accessible button (`role="button"`, `tabindex="0"`, Enter/Space keyboard support) without any API change for existing consumers that omit the prop.
 
 ## Usage
 
@@ -41,34 +41,97 @@ A generic container component with an optional title/description header and a co
 </style>
 ```
 
+### Sized Card
+
+```svelte
+<div class="gateway-card">
+  <Card title="Payment Gateway">
+    <p>Configure your payment settings.</p>
+  </Card>
+</div>
+
+<style>
+  .gateway-card {
+    --card-width: 600px;
+    --card-min-width: 600px;
+    --card-max-width: 600px;
+    --card-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  }
+</style>
+```
+
+### Clickable Card
+
+```svelte
+<script>
+  import { Card } from '@juspay/svelte-ui-components';
+
+  const handleCardClick = (event: MouseEvent) => {
+    console.log('card clicked', event);
+  };
+</script>
+
+<div class="clickable-card">
+  <Card onclick={handleCardClick} testId="platform-card">
+    <p>Click anywhere on this card.</p>
+  </Card>
+</div>
+
+<style>
+  .clickable-card {
+    --card-background: #f9fafb;
+    --card-border: 1px solid #e5e7eb;
+    --card-border-radius: 12px;
+    --card-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+</style>
+```
+
 ## Props
 
-| Prop        | Type      | Required | Default | Description                                                                                                                                                            |
-| ----------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| children    | `Snippet` | Yes      | `-`     | Main content body of the card. Rendered inside the `.card-content` container.                                                                                          |
-| title       | `string`  | No       | `-`     | Header title text. When provided, renders the `.card-header` section.                                                                                                  |
-| description | `string`  | No       | `-`     | Header subtitle/description text displayed below the title. Only rendered if `title` is also provided.                                                                 |
-| classes     | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop        | Type                          | Required | Default | Description                                                                                                                                                                  |
+| ----------- | ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| children    | `Snippet`                     | Yes      | `-`     | Main content body of the card. Rendered inside the `.card-content` container.                                                                                                |
+| title       | `string`                      | No       | `-`     | Header title text. When provided, renders the `.card-header` section.                                                                                                        |
+| description | `string`                      | No       | `-`     | Header subtitle/description text displayed below the title. Only rendered if `title` is also provided.                                                                       |
+| classes     | `string`                      | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.       |
+| testId      | `string`                      | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                                                                                   |
+| onclick     | `(event: MouseEvent) => void` | No       | `-`     | Click handler. When provided, the card root becomes interactive: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler. Omit to keep a plain `<div>`. |
+
+## Events
+
+| Event   | Type                          | Description                                                                                                                                        |
+| ------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| onclick | `(event: MouseEvent) => void` | Fires when the card is clicked. When provided, the card gains `role="button"`, `tabindex="0"`, and keyboard support (Enter/Space). No-op if omitted. |
 
 ## CSS Variables
 
 Override these custom properties to theme the component.
 
-| Variable                       | Default          | CSS Property  | Description                                                          |
-| ------------------------------ | ---------------- | ------------- | -------------------------------------------------------------------- |
-| `--card-background`            | `inherit`        | background    | Background color of the card.                                        |
-| `--card-border`                | `1px solid currentColor` | border | Border of the card. Inherits text color by default.                  |
-| `--card-border-radius`         | `8px`            | border-radius | Corner radius of the card.                                           |
-| `--card-overflow`              | `hidden`         | overflow      | Overflow behavior of the card content.                               |
-| `--card-header-padding`        | `16px 16px 0`    | padding       | Padding of the header section.                                       |
-| `--card-header-border-bottom`  | `none`           | border-bottom | Optional border below the header.                                    |
-| `--card-title-font-size`       | `16px`           | font-size     | Font size of the title text.                                         |
-| `--card-title-font-weight`     | `600`            | font-weight   | Font weight of the title text.                                       |
-| `--card-title-color`           | `inherit`        | color         | Color of the title text. Inherits from parent by default.            |
-| `--card-description-font-size` | `14px`           | font-size     | Font size of the description text.                                   |
-| `--card-description-color`     | `inherit`        | color         | Color of the description text. Inherits from parent by default.      |
-| `--card-description-opacity`   | `0.6`            | opacity       | Opacity of the description text for visual hierarchy.                |
-| `--card-content-padding`       | `16px`           | padding       | Padding of the content body.                                         |
+| Variable                       | Default                  | CSS Property  | Description                                                                                    |
+| ------------------------------ | ------------------------ | ------------- | ---------------------------------------------------------------------------------------------- |
+| `--card-background`            | `inherit`                | background    | Background color of the card.                                                                  |
+| `--card-border`                | `1px solid currentColor` | border        | Border of the card. Inherits text color by default.                                            |
+| `--card-border-radius`         | `8px`                    | border-radius | Corner radius of the card.                                                                     |
+| `--card-overflow`              | `hidden`                 | overflow      | Overflow behavior of the card content.                                                         |
+| `--card-box-shadow`            | `none`                   | box-shadow    | Box shadow of the card. Set to a shadow value (e.g. `0 2px 8px rgba(0,0,0,0.1)`) or `none`.  |
+| `--card-width`                 | `auto`                   | width         | Width of the card. Set to a fixed value (e.g. `600px`) or leave as `auto` for natural sizing. |
+| `--card-min-width`             | `0`                      | min-width     | Minimum width constraint.                                                                      |
+| `--card-max-width`             | `none`                   | max-width     | Maximum width constraint.                                                                      |
+| `--card-max-height`            | `none`                   | max-height    | Maximum height constraint. Use with `overflow: auto` for scrollable card bodies.               |
+| `--card-margin`                | `0`                      | margin        | Outer margin of the card. Useful for stacked card layouts.                                     |
+| `--card-cursor`                | `inherit`                | cursor        | Cursor on the card root. Defaults to `pointer` when `onclick` is provided.                     |
+| `--card-focus-outline`         | `2px solid currentColor` | outline       | Focus ring shown on the card when interactive and focused via keyboard.                        |
+| `--card-focus-outline-offset`  | `2px`                    | outline-offset| Offset of the focus ring from the card edge.                                                   |
+| `--card-header-padding`        | `16px 16px 0`            | padding       | Padding of the header section.                                                                 |
+| `--card-header-border-bottom`  | `none`                   | border-bottom | Optional border below the header.                                                              |
+| `--card-title-font-size`       | `16px`                   | font-size     | Font size of the title text.                                                                   |
+| `--card-title-font-weight`     | `600`                    | font-weight   | Font weight of the title text.                                                                 |
+| `--card-title-color`           | `inherit`                | color         | Color of the title text. Inherits from parent by default.                                      |
+| `--card-description-font-size` | `14px`                   | font-size     | Font size of the description text.                                                             |
+| `--card-description-color`     | `inherit`                | color         | Color of the description text. Inherits from parent by default.                                |
+| `--card-description-opacity`   | `0.6`                    | opacity       | Opacity of the description text for visual hierarchy.                                          |
+| `--card-content-padding`       | `16px`                   | padding       | Padding of the content body.                                                                   |
 
 ## Web Component
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -36,6 +36,10 @@
     "description": "A date picker with single-date and date-range selection modes. Supports month/year navigation, locale-aware day and month names, min/max date constraints, disabled dates, and keyboard navigation. Range mode shows visual start/end pills with highlighted in-between days."
   },
   {
+    "name": "Card",
+    "description": "A generic layout container with an optional title/description header and a content body. Supports box-shadow, width/min-width/max-width/max-height/margin CSS vars for sizing, and an onclick prop that makes the card an accessible interactive button (role=button, tabindex=0, Enter/Space keyboard support) when provided. All visual properties are CSS-var driven with sensible defaults — no consumer overrides required for basic usage."
+  },
+  {
     "name": "Carousel",
     "description": "An auto-playing slideshow that renders Svelte components as slides. Supports touch swipe and mouse drag for navigation. Shows optional dot indicators below the slides for direct navigation."
   },

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -48,6 +48,12 @@
     overflow: var(--card-overflow, hidden);
     color: inherit;
     cursor: var(--card-cursor, inherit);
+    box-shadow: var(--card-box-shadow, none);
+    width: var(--card-width, auto);
+    min-width: var(--card-min-width, 0);
+    max-width: var(--card-max-width, none);
+    max-height: var(--card-max-height, none);
+    margin: var(--card-margin, 0);
   }
 
   .card-interactive {

--- a/src/routes/components/card/+page.svelte
+++ b/src/routes/components/card/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import Card from '$lib/Card/Card.svelte';
   import Button from '$lib/Button/Button.svelte';
+
+  let lastClicked = $state('');
+
+  const handleCardClick = (label: string) => (_event: MouseEvent) => {
+    lastClicked = label;
+  };
 </script>
 
 <div class="page-header">
@@ -8,40 +14,117 @@
   <h1>Card</h1>
 </div>
 
-<div class="demo-row" style="flex-direction: column; max-width: 420px; gap: 16px;">
-  <div class="card-theme">
-    <Card title="Order Summary" description="Review your items before checkout.">
-      <p style="margin: 0;">3 items in your cart totalling $49.99</p>
-    </Card>
-  </div>
+<div class="demo-section">
+  <h2 class="demo-section-title">Basic Cards</h2>
+  <div class="demo-row" style="flex-direction: column; max-width: 420px; gap: 16px;">
+    <div class="card-theme">
+      <Card title="Order Summary" description="Review your items before checkout.">
+        <p style="margin: 0;">3 items in your cart totalling $49.99</p>
+      </Card>
+    </div>
 
-  <div class="card-theme">
-    <Card>
-      <p style="margin: 0;">A card with no header — just content.</p>
-    </Card>
-  </div>
+    <div class="card-theme">
+      <Card>
+        <p style="margin: 0;">A card with no header — just content.</p>
+      </Card>
+    </div>
 
-  <div class="card-theme">
-    <Card title="Quick Actions" description="Common tasks at a glance.">
-      <div style="display: flex; gap: 8px;">
-        <Button text="Create" />
-        <Button text="Import" />
-      </div>
-    </Card>
-  </div>
+    <div class="card-theme">
+      <Card title="Quick Actions" description="Common tasks at a glance.">
+        <div style="display: flex; gap: 8px;">
+          <Button text="Create" />
+          <Button text="Import" />
+        </div>
+      </Card>
+    </div>
 
-  <div class="card-theme card-accent">
-    <Card title="Pro Plan" description="Unlock all features.">
-      <div style="display: flex; gap: 8px; flex-wrap: wrap;">
-        <span class="tag">Unlimited</span>
-        <span class="tag">Priority Support</span>
-        <span class="tag">Analytics</span>
-      </div>
-    </Card>
+    <div class="card-theme card-accent">
+      <Card title="Pro Plan" description="Unlock all features.">
+        <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+          <span class="tag">Unlimited</span>
+          <span class="tag">Priority Support</span>
+          <span class="tag">Analytics</span>
+        </div>
+      </Card>
+    </div>
   </div>
 </div>
 
+<div class="demo-section">
+  <h2 class="demo-section-title">Sized Cards (--card-width / --card-box-shadow / --card-margin)</h2>
+  <div class="demo-row" style="flex-direction: column; gap: 16px;">
+    <div class="card-sized">
+      <Card title="Fixed Width + Shadow" description="600px wide, box-shadow applied.">
+        <p style="margin: 0;">
+          Useful for onboarding flows, gateway config forms, and step panels.
+        </p>
+      </Card>
+    </div>
+
+    <div class="card-theme card-with-margin">
+      <Card title="Card with Margin">
+        <p style="margin: 0;">Outer margin via --card-margin — useful in stacked list layouts.</p>
+      </Card>
+    </div>
+
+    <div class="card-theme card-constrained">
+      <Card title="Max/Min Width Constrained">
+        <p style="margin: 0;">Stays between 200px and 400px regardless of container size.</p>
+      </Card>
+    </div>
+  </div>
+</div>
+
+<div class="demo-section">
+  <h2 class="demo-section-title">Clickable Cards (onclick + keyboard a11y)</h2>
+  {#if lastClicked}
+    <p class="click-status">Last clicked: <strong>{lastClicked}</strong></p>
+  {/if}
+  <div class="demo-row" style="gap: 16px; flex-wrap: wrap;">
+    <div class="card-clickable">
+      <Card onclick={handleCardClick('Platform A')} testId="platform-a-card">
+        <div class="platform-tile">
+          <span class="platform-icon">🛒</span>
+          <span class="platform-name">Platform A</span>
+        </div>
+      </Card>
+    </div>
+
+    <div class="card-clickable">
+      <Card onclick={handleCardClick('Platform B')} testId="platform-b-card">
+        <div class="platform-tile">
+          <span class="platform-icon">📦</span>
+          <span class="platform-name">Platform B</span>
+        </div>
+      </Card>
+    </div>
+
+    <div class="card-clickable card-clickable-disabled">
+      <Card classes="card-coming-soon">
+        <div class="platform-tile">
+          <span class="platform-icon">🔒</span>
+          <span class="platform-name">Coming Soon</span>
+        </div>
+      </Card>
+    </div>
+  </div>
+  <p class="demo-hint">Tab to the interactive cards and press Enter or Space to activate.</p>
+</div>
+
 <style>
+  .demo-section {
+    margin-bottom: 40px;
+  }
+
+  .demo-section-title {
+    margin: 0 0 16px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--doc-text-secondary, #6b7280);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
   .card-theme {
     --card-background: var(--doc-demo-bg);
     --card-border: 1px solid var(--doc-border);
@@ -52,6 +135,55 @@
     --card-background: var(--doc-accent-bg);
   }
 
+  .card-sized {
+    --card-background: var(--doc-demo-bg);
+    --card-border: 1px solid var(--doc-border);
+    --card-width: 600px;
+    --card-min-width: 600px;
+    --card-max-width: 600px;
+    --card-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  }
+
+  .card-with-margin {
+    --card-margin: 0 0 0 24px;
+  }
+
+  .card-constrained {
+    --card-min-width: 200px;
+    --card-max-width: 400px;
+  }
+
+  .card-clickable {
+    --card-background: var(--doc-demo-bg);
+    --card-border: 1px solid var(--doc-border);
+    --card-border-radius: 12px;
+    --card-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    --card-content-padding: 20px;
+    --card-width: 160px;
+  }
+
+  .card-clickable-disabled {
+    opacity: 0.45;
+  }
+
+  .platform-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .platform-icon {
+    font-size: 28px;
+    line-height: 1;
+  }
+
+  .platform-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--doc-text, #111827);
+  }
+
   .tag {
     padding: 4px 10px;
     background: var(--doc-accent-subtle-bg);
@@ -59,5 +191,17 @@
     font-size: 13px;
     color: var(--doc-accent-text);
     font-weight: 600;
+  }
+
+  .click-status {
+    margin: 0 0 12px;
+    font-size: 13px;
+    color: var(--doc-text-secondary, #6b7280);
+  }
+
+  .demo-hint {
+    margin: 12px 0 0;
+    font-size: 12px;
+    color: var(--doc-text-secondary, #9ca3af);
   }
 </style>


### PR DESCRIPTION
## What

Three backward-compatible additions to the `Card` component:

### 1. Six new layout/decoration CSS vars

| Variable | Fallback | Why needed |
|---|---|---|
| `--card-box-shadow` | `none` | Lighthouse callsites set per-card shadow; library Card had no hook |
| `--card-width` | `auto` | Fixed-width gateway/onboarding panels (e.g. 600px) |
| `--card-min-width` | `0` | Min-width constraint for responsive grids |
| `--card-max-width` | `none` | Max-width cap for wide containers |
| `--card-max-height` | `none` | Scrollable card bodies |
| `--card-margin` | `0` | Outer margin for stacked list layouts |

All six have sensible fallbacks → the card looks identical to pre-PR with zero consumer overrides.

### 2. `onclick` + keyboard a11y (already in the component, now surfaced in docs)

The component already had `onclick` wired with `role="button"`, `tabindex="0"`, and Enter/Space keydown support (conditional on prop presence). This PR documents it fully in `Card.md` and exercises it in the demo.

### 3. Card added to the MCP registry (`docs/_index.json`)

`list_components` was returning 51 components with no Card entry despite Card being exported in `dist/index.js`. Added the Card entry to `_index.json` so `get_component_docs("Card")` now works.

## Why (Lighthouse migration context)

Unblocks the `BZ-3383` CUSTOM-mode Card migration in Lighthouse. 27 of 44 Card callsites use the library-compatible CUSTOM layout mode, but were blocked by:
1. Library Card absent from MCP docs (no SLA)
2. Missing `--card-box-shadow`, `--card-width`, `--card-min-width`, `--card-max-width`, `--card-max-height`, `--card-margin` CSS vars

This PR resolves both blockers without touching any existing behavior.

## Demo route

`/components/card` — three sections: basic cards, sized cards (new CSS var showcase), clickable cards (onclick + tab/keyboard a11y demo).

## Gates

- `pnpm run check` — 0 errors, 4 pre-existing warnings (Modal/ThemeSwitcher, unrelated)
- `pnpm run lint` — clean
- `pnpm run build` — clean (SSR + client + package)

## Files changed

- `src/lib/Card/Card.svelte` — add 6 CSS vars to `.card` rule
- `docs/Card.md` — complete prop/event/CSS-var table, four usage examples
- `docs/_index.json` — add Card entry (fixes MCP registry gap)
- `src/routes/components/card/+page.svelte` — expanded demo with sized + clickable sections