### PR TITLE
feat: add segmented variant to Tabs

### DIFF
--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -13,6 +13,7 @@
     scrollRightIcon,
     tab,
     classes,
+    variant = 'underline',
     onchange,
     onkeychange
   }: TabsProperties = $props();
@@ -111,7 +112,13 @@
   }
 </script>
 
-<div class="tabs-wrapper {classes ?? ''}" class:disabled data-pw={testId}>
+<div
+  class="tabs-wrapper {classes ?? ''}"
+  class:disabled
+  class:tabs-segmented={variant === 'segmented'}
+  data-variant={variant}
+  data-pw={testId}
+>
   {#if canScrollLeft}
     <button
       class="tabs-arrow tabs-arrow-left"
@@ -153,7 +160,7 @@
         {:else}
           {label}
         {/if}
-        {#if isActiveItem(index)}
+        {#if isActiveItem(index) && variant !== 'segmented'}
           <span class="tabs-indicator"></span>
         {/if}
       </div>
@@ -299,5 +306,59 @@
     height: var(--tabs-indicator-height, 2px);
     background-color: var(--tabs-indicator-color, #1a73e8);
     border-radius: var(--tabs-indicator-border-radius, 2px 2px 0 0);
+  }
+
+  /* ─── Segmented variant ─── */
+
+  .tabs-wrapper.tabs-segmented {
+    background: var(--tabs-segmented-track-background, #f1f3f4);
+    border-bottom: none;
+    border-radius: var(--tabs-segmented-track-radius, 10px);
+    padding: var(--tabs-segmented-track-padding, 3px);
+  }
+
+  .tabs-wrapper.tabs-segmented .tabs-bar {
+    gap: var(--tabs-segmented-gap, 2px);
+    padding: 0;
+  }
+
+  .tabs-wrapper.tabs-segmented .tabs-item {
+    flex: 1;
+    justify-content: center;
+    border-radius: var(--tabs-segmented-item-radius, 8px);
+    padding: var(--tabs-segmented-item-padding, 6px 14px);
+    color: var(--tabs-segmented-item-color, #5f6368);
+    background: transparent;
+    font-weight: var(--tabs-segmented-item-font-weight, 400);
+    transition: var(
+      --tabs-transition,
+      color 0.15s ease,
+      background 0.15s ease,
+      box-shadow 0.15s ease
+    );
+  }
+
+  .tabs-wrapper.tabs-segmented .tabs-item:hover:not(.active):not([aria-disabled]) {
+    color: var(--tabs-segmented-hover-color, #1a1a1a);
+    background: var(--tabs-segmented-hover-background, rgba(0, 0, 0, 0.05));
+  }
+
+  .tabs-wrapper.tabs-segmented .tabs-item.active {
+    color: var(--tabs-segmented-active-color, #1a1a1a);
+    font-weight: var(--tabs-segmented-active-font-weight, 500);
+    background: var(--tabs-segmented-active-background, #ffffff);
+    box-shadow: var(
+      --tabs-segmented-active-shadow,
+      0 1px 3px rgba(0, 0, 0, 0.12),
+      0 1px 2px rgba(0, 0, 0, 0.08)
+    );
+  }
+
+  .tabs-wrapper.tabs-segmented .tabs-arrow {
+    background: var(--tabs-segmented-track-background, #f1f3f4);
+  }
+
+  .tabs-wrapper.tabs-segmented .tabs-arrow:hover {
+    background: var(--tabs-segmented-track-background, #f1f3f4);
   }
 </style>

--- a/src/lib/Tabs/properties.ts
+++ b/src/lib/Tabs/properties.ts
@@ -7,6 +7,8 @@ export type TabItem = {
   subtitle?: string;
 };
 
+export type TabVariant = 'underline' | 'segmented';
+
 export type TabsProperties = MandatoryTabsProperties & OptionalTabsProperties & TabsEventProperties;
 
 export type MandatoryTabsProperties = {
@@ -22,6 +24,11 @@ export type OptionalTabsProperties = {
   scrollRightIcon?: Snippet;
   tab?: Snippet<[{ label: string; index: number; active: boolean; subtitle?: string }]>;
   classes?: string;
+  /** Visual style of the tab strip.
+   * - `"underline"` (default) — bottom-border indicator per active tab.
+   * - `"segmented"` — pill group with a track background; active tab rendered as an elevated chip.
+   */
+  variant?: TabVariant;
 };
 
 export type TabsEventProperties = {

--- a/src/routes/components/tabs/+page.svelte
+++ b/src/routes/components/tabs/+page.svelte
@@ -4,6 +4,8 @@
   let activeTab = $state(0);
   let activeOverflow = $state(0);
   let activeWorkspace = $state(0);
+  let activeSegmented = $state(0);
+  let activeSegmentedKey = $state('month');
 
   const manyTabs = Array.from({ length: 20 }, (_, i) => `Tab ${i + 1}`);
 
@@ -89,4 +91,34 @@
     onchange={(index) => (activeOverflow = index)}
   />
   <p class="state-display">Active tab: {activeOverflow}</p>
+</div>
+
+<h3 style="margin: 24px 0 12px; font-size: 1.1rem; color: #374151;">
+  Segmented variant (pill group)
+</h3>
+<div class="demo-row" style="flex-direction: column; max-width: 420px;">
+  <Tabs
+    items={['Day', 'Week', 'Month', 'Year']}
+    variant="segmented"
+    activeIndex={activeSegmented}
+    onchange={(index) => (activeSegmented = index)}
+  />
+  <p class="state-display">Active index: {activeSegmented}</p>
+</div>
+
+<h3 style="margin: 24px 0 12px; font-size: 1.1rem; color: #374151;">
+  Segmented variant — key-based items
+</h3>
+<div class="demo-row" style="flex-direction: column; max-width: 420px;">
+  <Tabs
+    items={[
+      { key: 'day', label: 'Today' },
+      { key: 'week', label: 'This Week' },
+      { key: 'month', label: 'This Month' }
+    ]}
+    variant="segmented"
+    activeKey={activeSegmentedKey}
+    onkeychange={(key) => (activeSegmentedKey = key)}
+  />
+  <p class="state-display">Active key: {activeSegmentedKey}</p>
 </div>

--- a/src/wc/components/Tabs.wc.svelte
+++ b/src/wc/components/Tabs.wc.svelte
@@ -10,6 +10,7 @@
       scrollLeftIcon: { type: 'Object' },
       scrollRightIcon: { type: 'Object' },
       classes: { type: 'String' },
+      variant: { type: 'String', reflect: true },
       onchange: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
## What

Adds `variant="segmented"` as a first-class prop to the library `Tabs` component. When set, the tab strip renders as a pill group — a rounded track with a light grey background, no bottom border, and the active tab lifted onto an elevated white chip — instead of the default underline indicator.

## Why

Lighthouse (and other consumers) currently recreate this segmented/pill look by piling on ~11 CSS-variable overrides via a consumer recipe class (`.global-tabs-segmented`). The legacy project `Tab` component already had `variant: 'underline' | 'segmented'` as a first-class prop. Promoting it to the library lets every consumer drop the override pile and get the look with a single prop.

## Changes

| File | What |
|------|------|
| `src/lib/Tabs/properties.ts` | New `TabVariant = 'underline' \| 'segmented'` type; optional `variant` prop added to `OptionalTabsProperties` |
| `src/lib/Tabs/Tabs.svelte` | Reads `variant` prop (default `'underline'`); adds `.tabs-segmented` class + `data-variant` attribute on the wrapper; suppresses the underline indicator span in segmented mode; scoped CSS for the track, item, active-item states using `--tabs-segmented-*` CSS vars with sensible hex fallbacks |
| `src/wc/components/Tabs.wc.svelte` | Exposes `variant` as a reflected string attribute on `<sui-tabs>` |
| `src/routes/components/tabs/+page.svelte` | Two new demo sections: index-based segmented tabs and key-based segmented tabs |

## Backward compatibility

Default value of `variant` is `'underline'` — all existing consumers with no `variant` prop render identically to before. Zero breaking changes.

## CSS variables exposed for segmented variant

| Variable | Default | Purpose |
|----------|---------|---------|
| `--tabs-segmented-track-background` | `#f1f3f4` | Track/container background |
| `--tabs-segmented-track-radius` | `10px` | Track corner radius |
| `--tabs-segmented-track-padding` | `3px` | Inset padding around pill row |
| `--tabs-segmented-gap` | `2px` | Gap between pill items |
| `--tabs-segmented-item-radius` | `8px` | Per-pill corner radius |
| `--tabs-segmented-item-padding` | `6px 14px` | Per-pill padding |
| `--tabs-segmented-item-color` | `#5f6368` | Inactive tab text colour |
| `--tabs-segmented-hover-color` | `#1a1a1a` | Hover text colour |
| `--tabs-segmented-hover-background` | `rgba(0,0,0,0.05)` | Hover background |
| `--tabs-segmented-active-color` | `#1a1a1a` | Active tab text colour |
| `--tabs-segmented-active-font-weight` | `500` | Active tab weight |
| `--tabs-segmented-active-background` | `#ffffff` | Active pill background |
| `--tabs-segmented-active-shadow` | subtle drop shadow | Active pill elevation |

## Gates

- `pnpm run check` — 0 errors
- `pnpm run lint` — all files pass Prettier + ESLint
- `pnpm run build` — clean build + package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs component now supports configurable `variant` prop with two options: `underline` (default) and `segmented` for pill-button style tabs.
  * Expanded documentation with interactive examples demonstrating both variant styles and their interactive behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->