### PR TITLE
fix: Tooltip label color no longer relies on inheritance

### DIFF
--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -164,4 +164,8 @@
     border-color: transparent var(--tooltip-arrow-color, var(--tooltip-background, #333333))
       transparent transparent;
   }
+
+  .tooltip-text {
+    color: var(--tooltip-color, #ffffff);
+  }
 </style>


### PR DESCRIPTION
## What

Add an explicit `color: var(--tooltip-color, #ffffff)` declaration directly on `.tooltip-text` in `Tooltip.svelte`.

## Why

The tooltip label is a `<span class="tooltip-text">` that previously only **inherited** its color from the parent `.tooltip-bubble` rule (`color: var(--tooltip-color, #ffffff)`). A consumer design system with a global `span { color }` rule (specificity 0,0,1) overrides an inherited value, making the label invisible or low-contrast (e.g. a Lighthouse light-theme rendered the label dark-on-dark because `text.css` set a global `span` color that won over the inherited white from the bubble).

By setting `color` directly on `.tooltip-text` (a scoped class selector, specificity 0,1,0), it takes precedence over any global element rule the consumer may have.

## Backward compatibility

- Same CSS custom property `--tooltip-color` with the same `#ffffff` default — consumer override hooks are unchanged.
- The existing `color` on `.tooltip-bubble` is kept for completeness (both now explicitly set the same var).
- No API changes, no prop changes, no visual difference in default usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tooltip text color customization through CSS variable support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->