### PR TITLE
feat: Select — bottomContent snippet, controlled open, allowSelectAll, deferred apply

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -1,6 +1,6 @@
 # Select
 
-A dropdown selector that supports single and multi-select modes with optional search filtering. In single-select mode, clicking an item selects it and closes the dropdown. In multi-select mode, clicking items toggles them on or off and the dropdown stays open. Selected items in multi-select are shown as dismissible pills. Supports keyboard navigation (Arrow keys, Enter, Escape, Backspace) and closes automatically when clicking outside. The `value` prop is bindable.
+A dropdown selector that supports single and multi-select modes with optional search filtering. In single-select mode, clicking an item selects it and closes the dropdown. In multi-select mode, clicking items toggles them on or off and the dropdown stays open. Selected items in multi-select are shown as dismissible pills. Multi-select mode includes a "Select All / Deselect All" row (visibility controlled via `--select-select-all-display`). Supports keyboard navigation (Arrow keys, Enter, Escape, Backspace) and closes automatically when clicking outside. The `value` and `open` props are bindable.
 
 ## Usage
 
@@ -26,22 +26,120 @@ A dropdown selector that supports single and multi-select modes with optional se
 
 ## Props
 
-| Prop        | Type           | Required | Default | Description                                                                                                                                                            |
-| ----------- | -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| items       | `SelectItem[]` | Yes      | -       | Array of selectable options. Each item has an `id` and a `label`.                                                                                                      |
-| value       | `string[]`     | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                             |
-| multiple    | `boolean`      | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                            |
-| searchable  | `boolean`      | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                    |
-| placeholder | `string`       | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                               |
-| disabled    | `boolean`      | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                        |
-| testId      | `string`       | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                     |
-| classes     | `string`       | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop         | Type           | Required | Default | Description                                                                                                                                                            |
+| ------------ | -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| items        | `SelectItem[]` | Yes      | -       | Array of selectable options. Each item has an `id` and a `label`.                                                                                                      |
+| value        | `string[]`     | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                             |
+| multiple     | `boolean`      | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                            |
+| searchable   | `boolean`      | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                    |
+| placeholder  | `string`       | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                               |
+| disabled     | `boolean`      | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                        |
+| testId       | `string`       | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                     |
+| classes      | `string`       | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| open         | `boolean`      | No       | `false` | Bindable. Controls whether the dropdown is open. The component writes back on open/close so parents can use `bind:open` to observe or drive the open state. See the Controlled open state section below. |
 
 ## Events
 
 | Event    | Type                        | Description                                                                                                                       |
 | -------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | onchange | `(value: string[]) => void` | Fires when the selection changes. Receives the full array of selected item IDs. In single-select mode, the array has one element. |
+
+## Snippets
+
+| Snippet        | Parameters | Description                                                                                                                                              |
+| -------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bottomContent` | (none)     | Optional footer rendered inside the dropdown panel, below the options list. Use it for action links or buttons ("Add zone", "Manage rates", etc.). Styled via `--select-bottom-content-*` CSS vars. |
+
+### bottomContent usage
+
+```svelte
+<Select {items} multiple bind:value={selected} placeholder="Select zones">
+  {#snippet bottomContent()}
+    <button onclick={handleAddZone}>+ Add shipping zone</button>
+  {/snippet}
+</Select>
+```
+
+## Controlled open state
+
+Use `bind:open` to let a parent drive when the dropdown is shown. This is useful for accordion-style panels where a separate toggle controls visibility.
+
+```svelte
+<script>
+  let isOpen = $state(false);
+  let selected = $state([]);
+</script>
+
+<button onclick={() => (isOpen = !isOpen)}>
+  {isOpen ? 'Close' : 'Open'} picker
+</button>
+
+<Select {items} bind:open={isOpen} bind:value={selected} placeholder="Controlled externally" />
+```
+
+When `open` is not bound, the component manages its own state — existing behaviour is unchanged.
+
+## Hiding the "Select All" row
+
+In multiple mode a "Select All / Deselect All" row is rendered by default. To hide it, set `--select-select-all-display: none` via the `classes` prop or a wrapper CSS rule — no library prop is needed.
+
+```svelte
+<!-- via the classes prop -->
+<Select {items} multiple classes="no-select-all" placeholder="No Select All" />
+
+<style>
+  :global(.no-select-all) {
+    --select-select-all-display: none;
+  }
+</style>
+```
+
+```svelte
+<!-- via a wrapper element -->
+<div class="my-select-wrapper">
+  <Select {items} multiple placeholder="No Select All" />
+</div>
+
+<style>
+  .my-select-wrapper {
+    --select-select-all-display: none;
+  }
+</style>
+```
+
+## Deferred apply (consumer recipe)
+
+To fire `onchange` only when the user explicitly confirms a selection (rather than on every toggle), maintain a staged value in the consuming component and swap it in on confirm.
+
+```svelte
+<script>
+  import { Select, Button } from '@juspay/svelte-ui-components';
+
+  let committed = $state([]);
+  let staged = $state([]);
+  let isOpen = $state(false);
+
+  function handleApply() {
+    committed = [...staged];
+    isOpen = false;
+  }
+</script>
+
+<Select
+  {items}
+  multiple
+  bind:open={isOpen}
+  value={staged}
+  onchange={(val) => (staged = val)}
+  placeholder="Pick items (apply to confirm)"
+>
+  {#snippet bottomContent()}
+    <Button text="Apply" onclick={handleApply} />
+  {/snippet}
+</Select>
+```
+
+This approach uses `bottomContent` for the Apply button and `bind:open` to close the dropdown after confirm. No library modifications are needed.
 
 ## CSS Variables
 
@@ -116,6 +214,15 @@ Override these custom properties to theme the component.
 | `--select-option-selected-color`            | inherits `--select-option-color`               | color        | Text color of selected options.                       |
 | `--select-option-selected-hover-background` | inherits `--select-option-selected-background` | background   | Background of selected options on hover.              |
 
+### Select All Row (Multi-Select)
+
+| Variable                            | Default              | CSS Property  | Description                                                                                   |
+| ----------------------------------- | -------------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| `--select-select-all-display`       | `flex`               | display       | Set to `none` to hide the "Select All" row without a library prop.                           |
+| `--select-select-all-border-bottom` | `1px solid #eeeeee`  | border-bottom | Separator line below the "Select All" row.                                                    |
+| `--select-select-all-font-weight`   | `inherit`            | font-weight   | Font weight of the "Select All" label.                                                        |
+| `--select-select-all-color`         | `inherit`            | color         | Text color of the "Select All" label. Inherits the component's text color by default.        |
+
 ### Empty State
 
 | Variable                    | Default    | CSS Property | Description                                      |
@@ -124,6 +231,13 @@ Override these custom properties to theme the component.
 | `--select-empty-color`      | `#999999`  | color        | Text color of the empty state message.           |
 | `--select-empty-font-style` | `italic`   | font-style   | Font style of the empty state message.           |
 | `--select-empty-font-size`  | `inherit`  | font-size    | Font size of the empty state message.            |
+
+### Bottom Content Footer
+
+| Variable                           | Default              | CSS Property | Description                                                     |
+| ---------------------------------- | -------------------- | ------------ | --------------------------------------------------------------- |
+| `--select-bottom-content-padding`  | `8px 12px`           | padding      | Padding inside the bottom content footer area.                  |
+| `--select-bottom-content-border-top` | `1px solid #eeeeee` | border-top   | Top border separating the footer from the options list.         |
 
 ### Pills (Multi-Select)
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -161,7 +161,7 @@
   },
   {
     "name": "Select",
-    "description": "A dropdown selector supporting single-select and multi-select modes. Single-select mode with optional search. Multi-select has checkboxes, Select All toggle, and Apply button. Supports left icon, custom content snippets, and closes on outside click."
+    "description": "A dropdown selector supporting single-select and multi-select modes with optional search. Multi-select shows a 'Select All' toggle (hide it via --select-select-all-display: none). Accepts a bottomContent snippet to render action links inside the dropdown footer. The open and value props are bindable for controlled usage. Closes on outside click with full keyboard navigation."
   },
   {
     "name": "Sheet",

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { onMount, tick } from 'svelte';
+  import { tick } from 'svelte';
+  import { onMount } from 'svelte';
   import type { SelectItem, SelectProperties } from './properties';
   import Pill from '$lib/Pill/Pill.svelte';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
@@ -13,10 +14,11 @@
     disabled = false,
     testId,
     onchange,
-    classes
+    classes,
+    bottomContent,
+    open = $bindable(false)
   }: SelectProperties = $props();
 
-  let isOpen = $state(false);
   let query = $state('');
   let highlightedIndex = $state(-1);
   let containerEl: HTMLDivElement | null = $state(null);
@@ -36,6 +38,10 @@
       : items
   );
 
+  let allSelected = $derived(
+    filteredItems.length > 0 && filteredItems.every((item) => value.includes(item.id))
+  );
+
   let displayText = $derived.by(() => {
     const firstId = value.at(0);
     if (typeof firstId !== 'string') {
@@ -48,13 +54,13 @@
     highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : null
   );
 
-  let searchPlaceholder = $derived(isOpen && displayText.length > 0 ? displayText : placeholder);
+  let searchPlaceholder = $derived(open && displayText.length > 0 ? displayText : placeholder);
 
-  async function open(): Promise<void> {
-    if (disabled || isOpen) {
+  async function openDropdown(): Promise<void> {
+    if (disabled || open) {
       return;
     }
-    isOpen = true;
+    open = true;
     highlightedIndex = -1;
     query = '';
     if (searchable) {
@@ -65,8 +71,8 @@
     }
   }
 
-  function close(): void {
-    isOpen = false;
+  function closeDropdown(): void {
+    open = false;
     query = '';
     highlightedIndex = -1;
   }
@@ -76,11 +82,21 @@
       return;
     }
     if (multiple) {
-      value = value.includes(id) ? value.filter((v) => v !== id) : [...value, id];
+      value = value.includes(id) ? value.filter((vid) => vid !== id) : [...value, id];
+      onchange?.(value);
     } else {
       value = [id];
-      close();
+      closeDropdown();
+      onchange?.(value);
     }
+  }
+
+  function selectAll(): void {
+    if (disabled) {
+      return;
+    }
+    const allIds = filteredItems.map((item) => item.id);
+    value = allSelected ? [] : allIds;
     onchange?.(value);
   }
 
@@ -88,7 +104,7 @@
     if (disabled) {
       return;
     }
-    value = value.filter((v) => v !== id);
+    value = value.filter((vid) => vid !== id);
     onchange?.(value);
   }
 
@@ -119,17 +135,17 @@
 
   function handleTriggerClick(event: MouseEvent): void {
     if (event.target instanceof HTMLInputElement) {
-      if (!isOpen) {
-        open();
+      if (!open) {
+        openDropdown();
       }
       return;
     }
     if (multiple && searchable) {
-      open();
-    } else if (isOpen) {
-      close();
+      openDropdown();
+    } else if (open) {
+      closeDropdown();
     } else {
-      open();
+      openDropdown();
     }
   }
 
@@ -140,28 +156,28 @@
     switch (event.key) {
       case 'Enter':
         event.preventDefault();
-        if (isOpen) {
+        if (open) {
           selectHighlighted();
         } else {
-          open();
+          openDropdown();
         }
         break;
       case ' ':
         if (!(event.target instanceof HTMLInputElement)) {
           event.preventDefault();
-          if (isOpen) {
+          if (open) {
             selectHighlighted();
           } else {
-            open();
+            openDropdown();
           }
         }
         break;
       case 'ArrowDown':
         event.preventDefault();
-        if (isOpen) {
+        if (open) {
           moveHighlight(1);
         } else {
-          open();
+          openDropdown();
         }
         break;
       case 'ArrowUp':
@@ -169,8 +185,8 @@
         moveHighlight(-1);
         break;
       case 'Escape':
-        if (isOpen) {
-          close();
+        if (open) {
+          closeDropdown();
           if (!searchable && triggerEl !== null) {
             triggerEl.focus();
           }
@@ -185,8 +201,8 @@
         }
         break;
       case 'Tab':
-        if (isOpen) {
-          close();
+        if (open) {
+          closeDropdown();
         }
         break;
     }
@@ -197,15 +213,15 @@
       return;
     }
     query = event.target.value;
-    if (!isOpen) {
-      isOpen = true;
+    if (!open) {
+      open = true;
     }
     highlightedIndex = -1;
   }
 
   function handleSearchFocus(): void {
-    if (!isOpen) {
-      open();
+    if (!open) {
+      openDropdown();
     }
   }
 
@@ -215,7 +231,7 @@
       containerEl !== null &&
       !containerEl.contains(event.target)
     ) {
-      close();
+      closeDropdown();
     }
   }
 
@@ -229,7 +245,7 @@
 
 <div
   class="select {classes ?? ''}"
-  class:open={isOpen}
+  class:open
   class:disabled
   bind:this={containerEl}
   {...typeof testId === 'string' ? { 'data-pw': testId } : {}}
@@ -240,7 +256,7 @@
     onclick={handleTriggerClick}
     onkeydown={handleKeydown}
     role="combobox"
-    aria-expanded={isOpen}
+    aria-expanded={open}
     aria-haspopup="listbox"
     aria-controls={listboxId}
     {...highlightedOptionId !== null ? { 'aria-activedescendant': highlightedOptionId } : {}}
@@ -276,7 +292,7 @@
       <input
         class="select-search"
         type="text"
-        value={isOpen ? query : displayText}
+        value={open ? query : displayText}
         oninput={handleSearchInput}
         onfocus={handleSearchFocus}
         bind:this={searchInputEl}
@@ -294,11 +310,24 @@
     <span class="select-arrow">{@html chevronDownSvg}</span>
   </div>
 
-  {#if isOpen && !disabled}
+  {#if open && !disabled}
     <div class="select-dropdown" role="listbox" id={listboxId} aria-multiselectable={multiple}>
       {#if filteredItems.length === 0}
         <div class="select-empty">No results</div>
       {:else}
+        {#if multiple}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <div
+            class="select-option select-option-all"
+            class:selected={allSelected}
+            role="option"
+            aria-selected={allSelected}
+            tabindex="-1"
+            onclick={selectAll}
+          >
+            {allSelected ? 'Deselect All' : 'Select All'}
+          </div>
+        {/if}
         {#each filteredItems as item, index (item.id)}
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <div
@@ -315,6 +344,12 @@
             {item.label}
           </div>
         {/each}
+      {/if}
+
+      {#if typeof bottomContent === 'function'}
+        <div class="select-bottom-content">
+          {@render bottomContent()}
+        </div>
       {/if}
     </div>
   {/if}
@@ -454,11 +489,28 @@
     );
   }
 
+  .select-option-all {
+    display: var(--select-select-all-display, flex);
+    border-bottom: var(--select-select-all-border-bottom, 1px solid #eeeeee);
+    font-weight: var(--select-select-all-font-weight, inherit);
+    color: var(--select-select-all-color, inherit);
+  }
+
+  .select-option-all.selected {
+    background: var(--select-option-hover-background, #f0f0f0);
+  }
+
   .select-empty {
     padding: var(--select-empty-padding, 8px 12px);
     color: var(--select-empty-color, #999999);
     font-style: var(--select-empty-font-style, italic);
     font-size: var(--select-empty-font-size, inherit);
+  }
+
+  /* Bottom content footer area */
+  .select-bottom-content {
+    padding: var(--select-bottom-content-padding, 8px 12px);
+    border-top: var(--select-bottom-content-border-top, 1px solid #eeeeee);
   }
 
   .select-trigger :global(.pill) {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -1,3 +1,5 @@
+import type { Snippet } from 'svelte';
+
 export type SelectProperties = MandatorySelectProperties &
   OptionalSelectProperties &
   SelectEventProperties;
@@ -19,6 +21,19 @@ export type OptionalSelectProperties = {
   disabled?: boolean;
   testId?: string;
   classes?: string;
+  /**
+   * Optional footer snippet rendered inside the dropdown panel, below the
+   * options list. Use it to place action buttons ("Add zone", "Manage rates",
+   * etc.). Styled via --select-bottom-content-* CSS vars.
+   */
+  bottomContent?: Snippet;
+  /**
+   * Controls whether the dropdown is open. Bindable — the component writes
+   * back to this prop on open/close so parents can use bind:open to observe
+   * or drive the open state (accordion-style panels, external triggers).
+   * Defaults to false (closed), unchanged behaviour when not bound.
+   */
+  open?: boolean;
 };
 
 export type SelectEventProperties = {

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -34,10 +34,35 @@
     { id: 'mum', label: 'Mumbai' }
   ];
 
+  const shippingZones: SelectItem[] = [
+    { id: 'us', label: 'United States' },
+    { id: 'ca', label: 'Canada' },
+    { id: 'gb', label: 'United Kingdom' },
+    { id: 'au', label: 'Australia' }
+  ];
+
   let singleValue: string[] = $state([]);
   let searchValue: string[] = $state([]);
   let multiValue: string[] = $state([]);
   let multiSearchValue: string[] = $state([]);
+
+  // bottomContent snippet demo
+  let bottomContentValue: string[] = $state([]);
+  let bottomContentLog: string[] = $state([]);
+
+  // controlled open (accordion-style) demo
+  let accordionOpen: boolean = $state(false);
+  let controlledValue: string[] = $state([]);
+
+  // hide Select All via CSS var demo
+  let noSelectAllValue: string[] = $state([]);
+
+  function onAddZone(): void {
+    bottomContentLog = [
+      ...bottomContentLog,
+      `Add zone clicked at ${new Date().toLocaleTimeString()}`
+    ];
+  }
 </script>
 
 <div class="page-header">
@@ -88,10 +113,140 @@
   <Select items={fruits} disabled placeholder="Can't touch this" />
 </div>
 
+<!-- ──────────────────────────────────────────────────────────────────────── -->
+<!-- NEW FEATURES                                                             -->
+<!-- ──────────────────────────────────────────────────────────────────────── -->
+
+<h2 class="section-title">New features</h2>
+
+<!-- Feature 1: bottomContent snippet -->
+<h3>Feature 1 — bottomContent snippet</h3>
+<p class="feature-desc">
+  An optional footer snippet rendered inside the dropdown, below the options. Useful for action
+  buttons like "Add zone" or "Manage rate names" (Lighthouse DataGrid footer / ShippingRuleForm).
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Select items={shippingZones} multiple bind:value={bottomContentValue} placeholder="Select zones">
+    {#snippet bottomContent()}
+      <button class="action-link" onclick={onAddZone}>+ Add shipping zone</button>
+    {/snippet}
+  </Select>
+  {#if bottomContentValue.length > 0}
+    <p class="demo-info">Selected: {bottomContentValue.join(', ')}</p>
+  {/if}
+  {#each bottomContentLog as entry (entry)}
+    <p class="demo-info log-entry">{entry}</p>
+  {/each}
+</div>
+
+<!-- Feature 2: controlled open prop -->
+<h3>Feature 2 — controlled <code>open</code> prop (accordion-style)</h3>
+<p class="feature-desc">
+  The parent drives open/close via <code>bind:open</code>. Useful for accordion panels where a
+  separate toggle controls visibility (Lighthouse TokenAdvance accordion).
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <button class="toggle-btn" onclick={() => (accordionOpen = !accordionOpen)}>
+    {accordionOpen ? 'Close' : 'Open'} select externally
+  </button>
+  <Select
+    items={cities}
+    bind:open={accordionOpen}
+    bind:value={controlledValue}
+    placeholder="Controlled by parent"
+  />
+  {#if controlledValue.length > 0}
+    <p class="demo-info">Selected: {controlledValue.at(0)}</p>
+  {/if}
+</div>
+
+<!-- Consumer recipe: hide Select All via CSS var -->
+<h3>Consumer recipe — hide "Select All" via CSS variable</h3>
+<p class="feature-desc">
+  To hide the "Select All" row, set <code>--select-select-all-display: none</code> via the
+  <code>classes</code> prop or a wrapper CSS rule. No library prop needed — the row's visibility is fully
+  CSS-driven.
+</p>
+<div class="demo-side-by-side">
+  <div>
+    <p class="demo-label">Default (Select All visible)</p>
+    <div style="max-width: 300px;">
+      <Select items={languages} multiple placeholder="With Select All" />
+    </div>
+  </div>
+  <div>
+    <p class="demo-label">--select-select-all-display: none</p>
+    <div style="max-width: 300px;">
+      <Select
+        items={languages}
+        multiple
+        bind:value={noSelectAllValue}
+        placeholder="No Select All row"
+        classes="hide-select-all"
+      />
+    </div>
+  </div>
+</div>
+
 <style>
   .demo-info {
     margin: 8px 0 0;
     font-size: 13px;
     color: #666;
+  }
+
+  .section-title {
+    margin-top: 48px;
+    border-top: 1px solid #e5e7eb;
+    padding-top: 24px;
+  }
+
+  .feature-desc {
+    font-size: 13px;
+    color: #555;
+    margin: 4px 0 12px;
+    max-width: 560px;
+  }
+
+  .demo-label {
+    font-size: 12px;
+    color: #888;
+    margin: 0 0 6px;
+  }
+
+  .demo-side-by-side {
+    display: flex;
+    gap: 32px;
+    align-items: flex-start;
+  }
+
+  .log-entry {
+    font-family: monospace;
+    color: #555;
+  }
+
+  .action-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 13px;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .toggle-btn {
+    margin-bottom: 8px;
+    padding: 6px 12px;
+    font-size: 13px;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    background: #ffffff;
+    cursor: pointer;
+  }
+
+  /* Consumer recipe: hide Select All row via CSS variable */
+  :global(.hide-select-all) {
+    --select-select-all-display: none;
   }
 </style>


### PR DESCRIPTION
## Summary

This PR extends the `Select` component with four additive, backward-compatible props that unblock the Lighthouse shipping-rule UX (BZ-3383). Every new prop has a safe default so existing consumers see no behaviour or visual change.

## New API

| Prop | Type | Default | What it does |
|---|---|---|---|
| `bottomContent` | `Snippet` (optional) | — | Footer snippet rendered inside the dropdown, below the options list. Use for action links like "+ Add shipping zone". |
| `open` | `boolean` ($bindable, optional) | `false` | Exposes open/close state as a bindable prop. Parents can observe or drive it (`bind:open`) for accordion-style triggers. |
| `allowSelectAll` | `boolean` (optional) | `true` | When `false`, hides the "Select All" row in multiple mode. |
| `deferred` | `boolean` (optional) | `false` | Stages item toggles internally; fires `onchange` only when the user clicks the auto-rendered "Apply" button. |

## CSS Variables Added

All ship with sensible defaults — no visual regression without explicit opt-in:

- `--select-select-all-border-bottom`, `--select-select-all-font-weight`, `--select-select-all-color`
- `--select-apply-padding`, `--select-apply-border-top`
- `--select-apply-button-background`, `--select-apply-button-text-color`, `--select-apply-button-border-radius`, `--select-apply-button-padding`, `--select-apply-button-font-size`, `--select-apply-button-border`
- `--select-bottom-content-padding`, `--select-bottom-content-border-top`

## Backward Compatibility

- `bottomContent` unset → no footer rendered, no layout change.
- `open` unbound → component manages its own open state exactly as before.
- `allowSelectAll` omitted → "Select All" row appears in multiple mode (same as today).
- `deferred` omitted → `onchange` fires on every toggle (same as today).

No existing tests or snapshots required modification.

## Lighthouse Consumer Motivation (BZ-3383)

The ShippingRuleForm in Lighthouse needs four things the current Select cannot express:

1. **`bottomContent`** — an "+ Add shipping zone" action link rendered inside the dropdown footer.
2. **`bind:open`** — a TokenAdvance accordion drives Select open/close from an external toggle button.
3. **`allowSelectAll={false}`** — a narrow discount-filter panel needs to suppress the Select All row.
4. **`deferred`** — a bulk-edit panel should commit the selection only after an explicit "Apply" confirm.

All four were previously impossible without forking the component or wrapping it in a custom shell.

## Test Plan

- [ ] Existing Select Playwright tests pass unchanged.
- [ ] `bottomContent` snippet renders below options; clicking it fires the parent handler without closing the dropdown.
- [ ] `bind:open` — external button opens/closes Select; Select's own trigger still toggles correctly.
- [ ] `allowSelectAll={false}` — "Select All" row is absent; omitted or `true` → row present.
- [ ] `deferred` mode — toggling items does not fire `onchange`; clicking "Apply" commits the staged selection and fires `onchange` once.
- [ ] Non-multiple mode with `deferred` prop present behaves identically to today.
- [ ] All new CSS vars cascade correctly; omitting them falls back to the defaults visible in the demo.