### PR TITLE
feat(Toolbar): add testId + headingTestId

### DIFF
--- a/docs/Toolbar.md
+++ b/docs/Toolbar.md
@@ -20,6 +20,8 @@ A fixed-position header bar with a back button (left), center title text, and cu
 | text           | `string \| null` | No       | `-`                                              | Title text displayed in the center of the toolbar. Only shown when centerContent snippet is not provided.                                                              |
 | backIcon       | `string \| null` | No       | `'https://sdk.breeze.in/gallery/icons/back.svg'` | URL for the back button icon image. Defaults to a back-arrow SVG from sdk.breeze.in.                                                                                   |
 | classes        | `string`         | No       | `-`                                              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| testId         | `string`         | No       | `-`                                              | `data-pw` attribute on the toolbar's root element for Playwright selectors.                                                                                            |
+| headingTestId  | `string`         | No       | `-`                                              | `data-pw` attribute on the heading text element for Playwright selectors.                                                                                              |
 
 ## Snippets
 
@@ -75,12 +77,30 @@ Override these custom properties to theme the component.
 Tag: `<sui-toolbar>`
 
 ```html
-<sui-toolbar text="Page Title" show-back-button>
-  <button slot="left-content">Menu</button>
-  <span slot="center-content">Title</span>
+<sui-toolbar
+  text="Page Title"
+  show-back-button
+  test-id="toolbar-root"
+  heading-test-id="toolbar-heading"
+>
   <button slot="right-content">Settings</button>
   <div slot="additional-content">Breadcrumbs</div>
 </sui-toolbar>
+```
+
+### Subheading (consumer recipe)
+
+The library Toolbar intentionally does not offer a `subheading` prop — string props that carry presentational structure are rejected in favour of Snippets. To render a secondary line beneath the heading, use `centerContent`:
+
+```svelte
+<Toolbar testId="my-toolbar">
+  {#snippet centerContent()}
+    <div style="display: flex; flex-direction: column; flex: 1;">
+      <span data-pw="toolbar-heading">Order Details</span>
+      <span data-pw="toolbar-subheading">Placed on 5 Jun 2026</span>
+    </div>
+  {/snippet}
+</Toolbar>
 ```
 
 ### Slots

--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -11,11 +11,13 @@
     additionalContent,
     classes,
     onbackClick,
-    onkeydown
+    onkeydown,
+    testId,
+    headingTestId
   }: ToolbarProperties = $props();
 </script>
 
-<div class="toolbar {classes ?? ''}">
+<div class="toolbar {classes ?? ''}" data-pw={testId}>
   <div class="content">
     {#if typeof leftContent === 'function'}
       {@render leftContent()}
@@ -29,7 +31,7 @@
         {@render centerContent()}
       </div>
     {:else if typeof text === 'string' && text.length > 0}
-      <div class="text">
+      <div class="text" data-pw={headingTestId}>
         {text}
       </div>
     {/if}

--- a/src/lib/Toolbar/properties.ts
+++ b/src/lib/Toolbar/properties.ts
@@ -9,6 +9,8 @@ export type ToolbarProperties = ToolbarEventProperties & {
   rightContent?: Snippet;
   additionalContent?: Snippet;
   classes?: string;
+  testId?: string;
+  headingTestId?: string;
 };
 
 export type ToolbarEventProperties = {

--- a/src/routes/components/toolbar/+page.svelte
+++ b/src/routes/components/toolbar/+page.svelte
@@ -7,6 +7,14 @@
   <h1>Toolbar</h1>
 </div>
 
-<div class="demo-row" style="max-width: 500px;">
+<div class="demo-row" style="max-width: 500px; flex-direction: column; gap: 24px;">
   <Toolbar text="Page Title" showBackButton onbackClick={() => alert('Back clicked')} />
+
+  <Toolbar
+    text="Order Details"
+    testId="toolbar-root"
+    headingTestId="toolbar-heading"
+    showBackButton
+    onbackClick={() => alert('Back clicked')}
+  />
 </div>

--- a/src/wc/components/Toolbar.wc.svelte
+++ b/src/wc/components/Toolbar.wc.svelte
@@ -7,6 +7,8 @@
       text: { type: 'String', reflect: true },
       backIcon: { type: 'String', attribute: 'back-icon' },
       classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' },
+      headingTestId: { type: 'String', attribute: 'heading-test-id' },
       onbackClick: { type: 'Object' },
       onkeydown: { type: 'Object' }
     }


### PR DESCRIPTION
## Summary

Slim split of PR #203 per maintainer review feedback — adds only the two test-selector props that have no clean Snippet-based consumer recipe.

- **properties.ts** — `testId?: string` and `headingTestId?: string` added to `ToolbarProperties`; no `subheading` or `subheadingTestId`
- **Toolbar.svelte** — `data-pw={testId}` on root `<div>`; `data-pw={headingTestId}` on existing `.text` div; DOM structure identical to `origin/release` (single `.text` div with `flex: var(--toolbar-text-flex, 1)`, no `.text-block` wrapper, no `.subheading` rule)
- **Toolbar.wc.svelte** — exposes `test-id` and `heading-test-id` attributes; no `subheading` or `subheading-test-id`
- **docs/Toolbar.md** — `testId` + `headingTestId` prop rows added; web component example updated to minimal `test-id` snippet; consumer recipe for subheading via `{#snippet centerContent()}` added (per maintainer doctrine: string props carrying markup structure belong in consumer code, not the library API)
- **Demo route** — one `<Toolbar>` instance exercising both new props; original single-instance demo preserved

## Gates

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean
- `npm run build` — clean

## Addresses review feedback from #203

The `subheading` + `subheadingTestId` props from #203 are intentionally excluded. The maintainer confirmed these are a consumer-side responsibility best handled via `{#snippet centerContent()}`. The consumer recipe is documented in `docs/Toolbar.md`.