### PR TITLE
feat(ThemeSwitcher): add link mode — inline cycle button, no chrome

### DIFF
--- a/docs/ThemeSwitcher.md
+++ b/docs/ThemeSwitcher.md
@@ -1,6 +1,6 @@
 # ThemeSwitcher
 
-A theme preference switcher that renders as either a single toggle button or a segmented control. Cycles through configurable options (default: light, dark, system) with animated icon transitions. Persists the user preference to localStorage. Built-in icons are provided for `light`, `dark`, and `system` values; custom options get a generic palette icon, or you can supply your own via the `icon` snippet on each option. This component does NOT apply the theme to the page — it only provides the toggle UI and preference management. The consumer is responsible for applying CSS classes or variables based on the selected value.
+A theme preference switcher that renders as a single toggle button, a segmented control, or a bare inline link-style button. Cycles through configurable options (default: light, dark, system) with animated icon transitions. Persists the user preference to localStorage. Built-in icons are provided for `light`, `dark`, and `system` values; custom options get a generic palette icon, or you can supply your own via the `icon` snippet on each option. This component does NOT apply the theme to the page — it only provides the toggle UI and preference management. The consumer is responsible for applying CSS classes or variables based on the selected value.
 
 ## Usage
 
@@ -17,6 +17,12 @@ A theme preference switcher that renders as either a single toggle button or a s
 
 <!-- Segmented control with light/dark/system (default options) -->
 <ThemeSwitcher mode="segment" />
+
+<!-- Inline link-style cycle button (no background/border/fixed size) -->
+<ThemeSwitcher mode="link" />
+
+<!-- Link mode with active option label shown beside the icon -->
+<ThemeSwitcher mode="link" showLabel={true} />
 ```
 
 ### With Custom Options
@@ -33,16 +39,39 @@ A theme preference switcher that renders as either a single toggle button or a s
 />
 ```
 
+### Link Mode — Consumer Recipe
+
+`mode="link"` renders a chromeless inline button. All visual styling is delegated to CSS custom properties so the consumer can match any design context:
+
+```svelte
+<!-- Styled link that matches the surrounding text -->
+<ThemeSwitcher
+  mode="link"
+  showLabel={true}
+  classes="my-theme-link"
+/>
+
+<style>
+  .my-theme-link {
+    --theme-switcher-link-color: currentColor;
+    --theme-switcher-link-color-hover: #4f46e5;
+    --theme-switcher-link-underline: underline;
+    --theme-switcher-link-font-size: inherit;
+  }
+</style>
+```
+
 ## Props
 
-| Prop       | Type                    | Required | Default                                                                                                                          | Description                                                                                                                                                                                                                                                                   |
-| ---------- | ----------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| options    | `ThemeSwitcherOption[]` | No       | `[{ value: 'light', label: 'Light theme' }, { value: 'dark', label: 'Dark theme' }, { value: 'system', label: 'System theme' }]` | Array of theme options to display. Each option has a `value`, optional `label`, and optional `icon` snippet. Built-in icons are provided for `'light'`, `'dark'`, and `'system'` values.                                                                                      |
-| value      | `string`                | No       | `'system'`                                                                                                                       | The initially selected theme value. If not provided, defaults to `'system'`. On mount, a stored preference (if any) takes priority, and an explicit `value` prop overrides the stored preference.                                                                             |
-| mode       | `'toggle' \| 'segment'` | No       | (derived)                                                                                                                        | Controls the switcher variant. `'toggle'` renders a single icon button that cycles through options on click. `'segment'` renders a segmented control with one button per option. If not set, defaults to `'toggle'` when options has 2 or fewer items, `'segment'` otherwise. |
-| storageKey | `string`                | No       | `'theme-preference'`                                                                                                             | The localStorage key used to persist the theme preference. Set to an empty string `''` to disable persistence entirely.                                                                                                                                                       |
-| testId     | `string`                | No       | -                                                                                                                                | Value for the `data-pw` attribute on the root element, used for end-to-end testing selectors.                                                                                                                                                                                 |
-| classes    | `string`                | No       | -                                                                                                                                | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                                                                        |
+| Prop       | Type                             | Required | Default                                                                                                                          | Description                                                                                                                                                                                                                                                                                                      |
+| ---------- | -------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| options    | `ThemeSwitcherOption[]`          | No       | `[{ value: 'light', label: 'Light theme' }, { value: 'dark', label: 'Dark theme' }, { value: 'system', label: 'System theme' }]` | Array of theme options to display. Each option has a `value`, optional `label`, and optional `icon` snippet. Built-in icons are provided for `'light'`, `'dark'`, and `'system'` values.                                                                                                                         |
+| value      | `string`                         | No       | `'system'`                                                                                                                       | The initially selected theme value. If not provided, defaults to `'system'`. On mount, a stored preference (if any) takes priority, and an explicit `value` prop overrides the stored preference.                                                                                                                |
+| mode       | `'toggle' \| 'segment' \| 'link'` | No       | (derived)                                                                                                                        | Controls the switcher rendering. `'toggle'` renders a single icon button that cycles through options on click. `'segment'` renders a segmented control with one button per option. `'link'` renders a single inline chromeless button showing the active option's icon (and optionally its label). If not set, defaults to `'toggle'` when options has 2 or fewer items, `'segment'` otherwise. |
+| storageKey | `string`                         | No       | `'theme-preference'`                                                                                                             | The localStorage key used to persist the theme preference. Set to an empty string `''` to disable persistence entirely.                                                                                                                                                                                          |
+| showLabel  | `boolean`                        | No       | `false`                                                                                                                          | When `true` and `mode="link"`, renders the active option's label beside the icon. Has no effect in `toggle` or `segment` mode.                                                                                                                                                                                   |
+| testId     | `string`                         | No       | -                                                                                                                                | Value for the `data-pw` attribute on the root element, used for end-to-end testing selectors.                                                                                                                                                                                                                    |
+| classes    | `string`                         | No       | -                                                                                                                                | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                                                                                                           |
 
 ## Events
 
@@ -84,6 +113,17 @@ Override these custom properties to theme the component.
 | `--theme-switcher-segment-shadow`         | `0 1px 2px rgba(0, 0, 0, 0.1)` | box-shadow       | Shadow on the active segment indicator.                                            |
 | `--theme-switcher-segment-button-padding` | `6px 10px`                     | padding          | Padding inside each segment button.                                                |
 
+### Link Mode
+
+| Variable                             | Default   | CSS Property    | Description                                                                                                    |
+| ------------------------------------ | --------- | --------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--theme-switcher-link-color`        | `inherit` | color           | Idle text/icon color. Defaults to `inherit` so the link blends into surrounding text without imposing a color. |
+| `--theme-switcher-link-color-hover`  | `inherit` | color           | Color on hover. Set to a brand color to indicate interactivity.                                                |
+| `--theme-switcher-link-gap`          | `4px`     | gap             | Gap between the icon and the label when `showLabel` is true.                                                   |
+| `--theme-switcher-link-padding`      | `0`       | padding         | Padding on the root button. Default `0` keeps the element truly chromeless.                                    |
+| `--theme-switcher-link-underline`    | `none`    | text-decoration | Set to `underline` for a classic hyperlink appearance.                                                         |
+| `--theme-switcher-link-font-size`    | `inherit` | font-size       | Font size for the label. Inherits from the parent by default; the component never sets a hard-coded size.      |
+
 ## Type Reference
 
 Custom types used by this component's props and events:
@@ -101,7 +141,7 @@ type ThemeSwitcherOption = {
 ### ThemeSwitcherMode
 
 ```typescript
-type ThemeSwitcherMode = 'toggle' | 'segment';
+type ThemeSwitcherMode = 'toggle' | 'segment' | 'link';
 ```
 
 ## Web Component

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -209,7 +209,7 @@
   },
   {
     "name": "ThemeSwitcher",
-    "description": "A segmented control for switching between light, dark, and system theme modes. Displays icons for each mode with an animated sliding indicator. Fires a callback with the selected theme value."
+    "description": "A theme preference switcher with three rendering modes: toggle (single cycling icon button), segment (animated sliding indicator bar), and link (inline chromeless cycle button with no background or border). Cycles through configurable options (default: light/dark/system) and persists the selection to localStorage. In link mode, all styling is controlled via CSS custom properties with neutral inherit defaults."
   },
   {
     "name": "Toast",

--- a/src/lib/ThemeSwitcher/ThemeSwitcher.svelte
+++ b/src/lib/ThemeSwitcher/ThemeSwitcher.svelte
@@ -30,6 +30,7 @@
     storageKey = 'theme-preference',
     testId,
     classes,
+    showLabel = false,
     onchange
   }: ThemeSwitcherProperties = $props();
 
@@ -39,6 +40,8 @@
   let hasSystemOption = $derived(options.some((o) => o.value === 'system'));
   let effectiveMode = $derived(mode ?? (options.length <= 2 ? 'toggle' : 'segment'));
   let currentIndex = $derived(options.findIndex((o) => o.value === currentValue));
+
+  let currentOption = $derived(options.at(currentIndex));
 
   let segmentButtons: HTMLButtonElement[] = $state([]);
   let indicatorLeft: number = $state(0);
@@ -124,6 +127,25 @@
         {/if}
       </span>
     {/each}
+  </button>
+{:else if effectiveMode === 'link'}
+  <button
+    class="link-button {classes ?? ''}"
+    onclick={handleToggle}
+    aria-label={currentOption?.label ?? currentOption?.value ?? 'Switch theme'}
+    data-pw={typeof testId === 'string' ? testId : null}
+  >
+    <span class="icon">
+      {#if typeof currentOption?.icon === 'function'}
+        {@render currentOption.icon()}
+      {:else}
+        <!-- eslint-disable svelte/no-at-html-tags -->
+        {@html getDefaultIcon(currentOption?.value ?? '')}
+      {/if}
+    </span>
+    {#if showLabel}
+      <span class="link-label">{currentOption?.label ?? currentOption?.value}</span>
+    {/if}
   </button>
 {:else}
   <div class="segment-control {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
@@ -245,5 +267,33 @@
 
   .segment-button.selected {
     color: var(--theme-switcher-icon-color-active, #1f2937);
+  }
+
+  .link-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--theme-switcher-link-gap, 4px);
+    padding: var(--theme-switcher-link-padding, 0);
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--theme-switcher-link-color, inherit);
+    text-decoration: var(--theme-switcher-link-underline, none);
+    font-family: inherit;
+    font-size: var(--theme-switcher-link-font-size, inherit);
+  }
+
+  .link-button:hover {
+    color: var(--theme-switcher-link-color-hover, inherit);
+  }
+
+  .link-button .icon {
+    width: var(--theme-switcher-icon-size, 18px);
+    height: var(--theme-switcher-icon-size, 18px);
+    transition: none;
+  }
+
+  .link-label {
+    display: inline;
   }
 </style>

--- a/src/lib/ThemeSwitcher/properties.ts
+++ b/src/lib/ThemeSwitcher/properties.ts
@@ -6,7 +6,7 @@ export type ThemeSwitcherOption = {
   icon?: Snippet;
 };
 
-export type ThemeSwitcherMode = 'toggle' | 'segment';
+export type ThemeSwitcherMode = 'toggle' | 'segment' | 'link';
 
 export type ThemeSwitcherProperties = OptionalThemeSwitcherProperties &
   ThemeSwitcherEventProperties;
@@ -18,6 +18,7 @@ export type OptionalThemeSwitcherProperties = {
   storageKey?: string;
   testId?: string;
   classes?: string;
+  showLabel?: boolean;
 };
 
 export type ThemeSwitcherEventProperties = {

--- a/src/routes/components/theme-switcher/+page.svelte
+++ b/src/routes/components/theme-switcher/+page.svelte
@@ -52,4 +52,27 @@
       </p>
     {/if}
   </div>
+
+  <div>
+    <p style="margin-bottom: 8px;">Link mode (icon only):</p>
+    <ThemeSwitcher mode="link" />
+  </div>
+
+  <div>
+    <p style="margin-bottom: 8px;">Link mode with label:</p>
+    <ThemeSwitcher mode="link" showLabel={true} />
+  </div>
+
+  <div>
+    <p style="margin-bottom: 8px;">Link mode — custom color via CSS vars:</p>
+    <ThemeSwitcher mode="link" showLabel={true} classes="demo-link-themed" />
+  </div>
 </div>
+
+<style>
+  :global(.demo-link-themed) {
+    --theme-switcher-link-color: #6366f1;
+    --theme-switcher-link-color-hover: #4f46e5;
+    --theme-switcher-link-underline: underline;
+  }
+</style>

--- a/src/wc/components/ThemeSwitcher.wc.svelte
+++ b/src/wc/components/ThemeSwitcher.wc.svelte
@@ -9,6 +9,7 @@
       storageKey: { type: 'String', reflect: true, attribute: 'storage-key' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
+      showLabel: { type: 'Boolean', reflect: true, attribute: 'show-label' },
       onchange: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
## What / Why

Lighthouse needs a bare inline theme toggle that fits inside a navigation bar or header without imposing any visual chrome. The existing `toggle` mode is visually a button (fixed 36×36px, background, border-radius); `segment` mode is a filled track. Neither is suitable as a link-like inline element. This PR adds `mode='link'` — a third identifier in the existing `ThemeSwitcherMode` union — that renders a single inline chromeless button cycling through all options on click.

## Changes

- `properties.ts`: extends `ThemeSwitcherMode` to `'toggle' | 'segment' | 'link'`; adds optional `showLabel?: boolean` (default `false`) to show the active option's label beside the icon in link mode
- `ThemeSwitcher.svelte`: adds a `{:else if effectiveMode === 'link'}` branch using the existing `handleToggle` (identical cycle logic); CSS block for `.link-button` with six CSS vars, all with neutral `inherit`/`0`/`none` defaults; no font-family/size/weight/line-height hard-coded
- `ThemeSwitcher.wc.svelte`: exposes `show-label` attribute
- `docs/ThemeSwitcher.md`: updated mode type, added `showLabel` prop row, added Link Mode CSS Variables table, consumer recipe example, updated type reference
- `docs/_index.json`: updated ThemeSwitcher description
- Demo route: three new demo instances (icon-only, icon+label, styled via CSS vars)

## Doctrine compliance

- Mode identifier only — no visual preset baked in; all styling via CSS vars
- CSS var defaults are neutral (`inherit`, `0`, `none`) — existing consumers see zero visual change
- No typography properties in the style block; `font-size` forwarded via `--theme-switcher-link-font-size: inherit`
- Explicit type guards: `typeof currentOption?.icon === 'function'` before `{@render}`
- Named functions use `function` declarations; arrow only for inline callbacks
- `data-pw` wired identically to the other modes
- Gates: `npm run check` (0 errors) + `npm run lint` (clean) + `npm run build` (clean)

## Lighthouse consumer recipe

Replace `mode='segment'` in `+layout.svelte` with `mode='link'` and set `--theme-switcher-link-color` / `--theme-switcher-link-color-hover` via `.global-theme-toggle-container` in `globalClasses.css`, keeping the existing `--theme-switcher-icon-*` vars in place.