### PR TITLE
feat: Img — opt-in SVG inlining + transform hook (inlineSvg, transformSvg)

### DIFF
--- a/docs/Img.md
+++ b/docs/Img.md
@@ -1,6 +1,6 @@
 # Img
 
-An image component with automatic fallback. If the primary `src` fails to load (onerror), it switches to the `fallback` URL. The fallback only triggers once (won't loop if fallback also fails). Supports hover styling for interactive image use cases.
+An image component with automatic fallback. If the primary `src` fails to load (onerror), it switches to the `fallback` URL. The fallback only triggers once (won't loop if fallback also fails). Supports hover styling for interactive image use cases, and opt-in SVG inlining (`inlineSvg` / `transformSvg`) so icons can be recoloured by page CSS or a transform hook.
 
 ## Usage
 
@@ -20,6 +20,31 @@ An image component with automatic fallback. If the primary `src` fails to load (
 | alt      | `string`         | Yes      | `-`     | Alt text for the image.                                                                                                                                                |
 | fallback | `string \| null` | No       | `-`     | Fallback image URL. If the primary src fails to load (onerror), the component switches to this URL.                                                                    |
 | classes  | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| inlineSvg | `boolean`       | No       | `false` | Fetch `.svg` / `data:image/svg+xml` sources and inline their markup into an `<svg>` host so page CSS (`currentColor`, fill/stroke overrides) applies. Non-SVG sources always render the plain `<img>`. If fetching or parsing fails, the component falls back to the plain `<img>` (and from there to the regular `fallback`/`onerror` chain). |
+| transformSvg | `(svg: string) => string` | No | `-` | Hook to rewrite the fetched SVG markup before it is inlined (e.g. recolour hardcoded fills). Providing a transform implies `inlineSvg`. The inlining effect re-runs when the prop identity changes, so a closure over reactive state (e.g. a theme colour) re-renders live. JS-only prop (not exposed as a web-component attribute). |
+
+## SVG inlining
+
+With `inlineSvg` (or any `transformSvg`), SVG sources are fetched and their markup is inlined into an `<svg>` host element instead of an `<img>`. This makes the icon stylable by page CSS — `fill: currentColor`, theme variables, and selector-based recolouring all work, which an external `<img>` cannot do.
+
+```svelte
+<!-- Inline so the icon picks up currentColor from its parent -->
+<Img src={'/icons/refresh.svg'} alt="" inlineSvg />
+
+<!-- Recolour hardcoded fills, live-reactive to a theme store -->
+<Img
+  src={'/icons/wallet.svg'}
+  alt="Wallet"
+  transformSvg={(svg) => svg.replaceAll('#2b2b2b', themeColor)}
+/>
+```
+
+Behaviour notes:
+
+- Non-SVG sources ignore both props and always render the plain `<img>`.
+- A failed fetch/parse for a given URL falls back to the plain `<img>` for that URL (which then drives the normal `fallback`/`onerror` chain); a changed `src` gets a fresh inlining attempt.
+- Accessibility: the `<svg>` host gets `role="img"` + `aria-label` when `alt` is non-empty, and `aria-hidden="true"` when `alt` is empty (decorative).
+- All CSS variables below apply to the inlined `<svg>` host exactly as they do to the `<img>`.
 
 ## CSS Variables
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -89,7 +89,7 @@
   },
   {
     "name": "Img",
-    "description": "An image component with automatic fallback. If the primary `src` fails to load (onerror), it switches to the `fallback` URL. The fallback only triggers once (won't loop if fallback also fails). Supports hover styling."
+    "description": "An image component with automatic fallback. If the primary `src` fails to load (onerror), it switches to the `fallback` URL. The fallback only triggers once (won't loop if fallback also fails). Supports hover styling, and opt-in SVG inlining (`inlineSvg` / `transformSvg`) that injects SVG sources into an `<svg>` host so page CSS or a transform hook can recolour the icon."
   },
   {
     "name": "Input",

--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -1,9 +1,27 @@
 <script lang="ts">
   import type { ImgProperties } from './properties';
 
-  let { src, alt, fallback, onerror, classes }: ImgProperties = $props();
+  let { src, alt, fallback, onerror, classes, inlineSvg, transformSvg }: ImgProperties = $props();
 
   let currentSrc = $derived(src);
+  // Per-source failure marker: when inlining a given URL fails we fall back to
+  // the plain <img> for that URL (which drives the regular fallback/onerror
+  // chain), while a new src still gets a fresh inlining attempt.
+  let failedInlineSrc: string | null = $state(null);
+
+  function isSvgSource(source: string): boolean {
+    if (source.startsWith('data:image/svg+xml')) {
+      return true;
+    }
+    const path = source.split('?')[0] ?? '';
+    return path.endsWith('.svg');
+  }
+
+  let shouldInline = $derived(
+    (inlineSvg === true || typeof transformSvg === 'function') &&
+      isSvgSource(currentSrc) &&
+      failedInlineSrc !== currentSrc
+  );
 
   function handleFallback(): void {
     if (typeof fallback === 'string' && fallback.length > 0 && currentSrc !== fallback) {
@@ -12,12 +30,98 @@
       onerror?.();
     }
   }
+
+  type InlineParams = {
+    url: string;
+    transform: ((svg: string) => string) | null;
+  };
+
+  async function loadInlineSvg(
+    host: SVGSVGElement,
+    url: string,
+    transform: ((svg: string) => string) | null,
+    signal: AbortSignal
+  ): Promise<void> {
+    try {
+      const response = await fetch(url, { signal });
+      if (!response.ok) {
+        failedInlineSrc = url;
+        return;
+      }
+      const rawSvg = await response.text();
+      const markup = typeof transform === 'function' ? transform(rawSvg) : rawSvg;
+      const parsed = new DOMParser().parseFromString(markup, 'image/svg+xml');
+      if (parsed.querySelector('parsererror') !== null) {
+        failedInlineSrc = url;
+        return;
+      }
+      const sourceSvg = parsed.querySelector('svg');
+      if (sourceSvg === null) {
+        failedInlineSrc = url;
+        return;
+      }
+      // The action may have been torn down (or re-run) while awaiting the
+      // body — bail before mutating so a stale fetch never paints over the
+      // latest one.
+      if (signal.aborted) {
+        return;
+      }
+      while (host.firstChild !== null) {
+        host.removeChild(host.firstChild);
+      }
+      for (const attribute of Array.from(sourceSvg.attributes)) {
+        if (attribute.name === 'class') {
+          continue;
+        }
+        host.setAttribute(attribute.name, attribute.value);
+      }
+      while (sourceSvg.firstChild !== null) {
+        host.appendChild(sourceSvg.firstChild);
+      }
+    } catch {
+      if (!signal.aborted) {
+        failedInlineSrc = url;
+      }
+    }
+  }
+
+  function inlineSvgInto(host: SVGSVGElement, params: InlineParams) {
+    let controller = new AbortController();
+
+    function load(current: InlineParams): void {
+      controller.abort();
+      controller = new AbortController();
+      void loadInlineSvg(host, current.url, current.transform, controller.signal);
+    }
+
+    load(params);
+
+    return {
+      update(next: InlineParams): void {
+        load(next);
+      },
+      destroy(): void {
+        controller.abort();
+      }
+    };
+  }
 </script>
 
-<img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} />
+{#if shouldInline}
+  <svg
+    use:inlineSvgInto={{ url: currentSrc, transform: transformSvg ?? null }}
+    class={classes ?? ''}
+    role={alt.length > 0 ? 'img' : null}
+    aria-label={alt.length > 0 ? alt : null}
+    aria-hidden={alt.length === 0 ? 'true' : null}
+  ></svg>
+{:else}
+  <img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} />
+{/if}
 
 <style>
-  img {
+  img,
+  svg {
     object-fit: var(--image-object-fit);
     height: var(--image-height, 24px);
     width: var(--image-width, 24px);
@@ -30,7 +134,8 @@
     transition: var(--image-transition);
   }
 
-  img:hover {
+  img:hover,
+  svg:hover {
     background: var(--image-hover-background, var(--image-background));
     border: var(--image-hover-border, var(--image-border));
   }

--- a/src/lib/Img/properties.ts
+++ b/src/lib/Img/properties.ts
@@ -8,6 +8,22 @@ export type MandatoryImgProperties = {
 export type OptionalImgProperties = {
   fallback?: string | null;
   classes?: string;
+  /**
+   * Fetch `.svg` / `data:image/svg+xml` sources and inline their markup into an
+   * `<svg>` host element so page CSS (currentColor, fill/stroke overrides) applies
+   * to the icon. Non-SVG sources always render the plain `<img>`. If fetching or
+   * parsing fails, the component falls back to the plain `<img>` (and from there
+   * to the regular `fallback`/`onerror` chain).
+   */
+  inlineSvg?: boolean;
+  /**
+   * Hook to rewrite the fetched SVG markup before it is inlined (e.g. recolor
+   * hardcoded fills). Receives the raw SVG text and returns the transformed text.
+   * Providing a transform implies `inlineSvg`. The inlining effect re-runs when
+   * the prop identity changes, so consumers can pass a closure over reactive
+   * state (e.g. a theme colour) to get live re-renders on theme change.
+   */
+  transformSvg?: (svg: string) => string;
 };
 
 export type ImgEventProperties = {


### PR DESCRIPTION
## What

Two opt-in, non-breaking props on `Img`:

- **`inlineSvg?: boolean`** — fetch `.svg` / `data:image/svg+xml` sources and inline their markup into an `<svg>` host element, so page CSS applies to the icon (`fill: currentColor`, theme variables, selector-based recolouring — none of which reach an external `<img>`).
- **`transformSvg?: (svg: string) => string`** — hook to rewrite the fetched SVG markup before inlining (e.g. recolour hardcoded fills). Providing a transform implies `inlineSvg`. The inlining re-runs when the prop identity changes, so a closure over reactive state (a theme colour store) recolours live on theme switch.

Default behaviour (neither prop) is byte-identical to today: plain `<img>` with the existing fallback/onerror chain.

## Why

Consumers migrating icon rendering to `Img` hit a wall wherever icons must be recoloured: an external `<img>` can't see `currentColor` or CSS variables. Lighthouse has 8 such call sites (UnifiedProgressReportCard ×3, settings ×3, wallet, Platform) currently stuck on a project-local `Image` copy purely for its SVG-inlining + recolour transform. This PR brings that capability into the library so the project copy can be deleted and the call sites folded onto `Img`.

## Design notes

- **No `$effect`, no `undefined`** — implemented as a Svelte action (`use:` — same pattern as Tabs/Carousel/Sheet) with abortable fetch and `null`-only types, per the repo's lint rules.
- **Failure degrades gracefully**: a failed fetch/parse for a given URL marks that URL and falls back to the plain `<img>` (which then drives the regular `fallback`/`onerror` chain). A changed `src` gets a fresh inlining attempt.
- **Stale-fetch safety**: re-runs abort the in-flight fetch; an aborted load never paints over a newer one.
- **A11y**: the `<svg>` host gets `role="img"` + `aria-label` when `alt` is non-empty, `aria-hidden="true"` when `alt` is empty (decorative) — slightly better than the `<img>` path for decorative icons.
- **CSS variable parity**: the existing `--image-*` variables (and hover variants) apply to the inlined `<svg>` host exactly as to the `<img>` (the component stylesheet now targets both).
- **Web component**: `inlineSvg` works as an attribute; `transformSvg` is a function prop, JS-only (documented).

## Docs

`docs/Img.md` — new props rows + an "SVG inlining" section (usage, recolour example, behaviour/a11y notes); `docs/_index.json` description updated.

## Gates

`npm run check` ✅ · `npm run lint` ✅ · `npm run check:wc` ✅ · `npm run build` ✅

## Consumer fold plan (Lighthouse)

After merge + publish + version bump: the 8 `customTransform` call sites move to `Img inlineSvg/transformSvg`, and the project-local `Image` component is deleted (completes BZ-3362).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SVG inlining support to the Img component, allowing fetched SVG files to be embedded into the page for CSS-based customization
  * Added optional SVG transformation hook for markup rewriting before inlining
  * Automatic fallback to standard image rendering if SVG inlining fails

* **Documentation**
  * Updated component documentation with new SVG inlining options, behavior, and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->