### PR TITLE
feat(Select): resting trigger box-shadow + value/placeholder font CSS vars

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -73,16 +73,21 @@ Override these custom properties to theme the component.
 | `--select-trigger-background`         | `#ffffff`                              | background    | Background color of the trigger area.                       |
 | `--select-trigger-border`             | `1px solid #cccccc`                    | border        | Border of the trigger area.                                 |
 | `--select-trigger-border-radius`      | `6px`                                  | border-radius | Corner rounding of the trigger area.                        |
+| `--select-trigger-box-shadow`         | `none`                                 | box-shadow    | Resting box shadow of the trigger area.                     |
 | `--select-trigger-transition`         | `border-color 0.15s, box-shadow 0.15s` | transition    | Transition for trigger hover/focus effects.                 |
 | `--select-trigger-hover-border-color` | `#999999`                              | border-color  | Border color of the trigger on hover.                       |
 | `--select-trigger-focus-border-color` | `#2563eb`                              | border-color  | Border color of the trigger when focused or open.           |
 | `--select-trigger-focus-shadow`       | `0 0 0 2px rgba(37, 99, 235, 0.2)`     | box-shadow    | Box shadow of the trigger when focused or open.             |
 
-### Placeholder
+### Value & Placeholder
 
-| Variable                     | Default   | CSS Property | Description                                                 |
-| ---------------------------- | --------- | ------------ | ----------------------------------------------------------- |
-| `--select-placeholder-color` | `#999999` | color        | Text color of the placeholder and search input placeholder. |
+| Variable                           | Default   | CSS Property | Description                                                 |
+| ---------------------------------- | --------- | ------------ | ----------------------------------------------------------- |
+| `--select-value-font-size`         | `inherit` | font-size    | Font size of the selected-value text.                       |
+| `--select-value-font-weight`       | `inherit` | font-weight  | Font weight of the selected-value text.                     |
+| `--select-placeholder-color`       | `#999999` | color        | Text color of the placeholder and search input placeholder. |
+| `--select-placeholder-font-size`   | `inherit` | font-size    | Font size of the placeholder text.                          |
+| `--select-placeholder-font-weight` | `inherit` | font-weight  | Font weight of the placeholder text.                        |
 
 ### Arrow
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -345,6 +345,7 @@
     background: var(--select-trigger-background, #ffffff);
     border: var(--select-trigger-border, 1px solid #cccccc);
     border-radius: var(--select-trigger-border-radius, 6px);
+    box-shadow: var(--select-trigger-box-shadow, none);
     cursor: pointer;
     outline: none;
     -webkit-tap-highlight-color: transparent;
@@ -363,6 +364,8 @@
 
   .select-value {
     flex: 1;
+    font-size: var(--select-value-font-size, inherit);
+    font-weight: var(--select-value-font-weight, inherit);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -371,6 +374,8 @@
   .select-placeholder {
     flex: 1;
     color: var(--select-placeholder-color, #999999);
+    font-size: var(--select-placeholder-font-size, inherit);
+    font-weight: var(--select-placeholder-font-weight, inherit);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## What

Five new CSS variables on Select, all defaulting to current behavior (`none` / `inherit`) — zero visual change for existing consumers:

| Variable | Applies to | Default |
|---|---|---|
| `--select-trigger-box-shadow` | `.select-trigger` resting state | `none` |
| `--select-value-font-size` | `.select-value` | `inherit` |
| `--select-value-font-weight` | `.select-value` | `inherit` |
| `--select-placeholder-font-size` | `.select-placeholder` | `inherit` |
| `--select-placeholder-font-weight` | `.select-placeholder` | `inherit` |

`docs/Select.md` updated (trigger table + a Value & Placeholder section).

## Why

- The trigger has a focus shadow var but no **resting** shadow hook — design systems with elevated inputs currently need a consumer rule on `.select-trigger` to add one.
- `.select-value` / `.select-placeholder` have no typography hooks, so host apps whose global stylesheets size bare text differently (e.g. a global `span` rule) can't align the trigger text with their own controls via variables. Lighthouse currently carries exactly these rules as documented interim overrides on the library's DOM classes, with these same variable names — once this publishes, those host-side rules delete wholesale.

## Verification

`pnpm run check` 0 errors · `pnpm run lint` clean · `pnpm run build` clean. Var-only change; no markup, props, or JS touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CSS Variables documentation for Select component with expanded styling options.

* **Style**
  * Added configurable box-shadow styling for Select trigger element.
  * Introduced CSS variables for value and placeholder typography (font-size and font-weight).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->