### PR TITLE
feat(Pagination): stamp {testId}-prev / {testId}-next on the arrow buttons

### DIFF
--- a/docs/Pagination.md
+++ b/docs/Pagination.md
@@ -20,7 +20,7 @@ Page-level navigation with numbered page buttons, prev/next controls, and ellips
 | currentPage  | `number`  | No       | `1`     | Bindable. The currently active page number. Controls which page button is highlighted and determines prev/next button disabled states.                                          |
 | siblingCount | `number`  | No       | `1`     | Number of page buttons to show on each side of the current page. For example, siblingCount=1 with currentPage=5 shows pages 4, 5, 6. Higher values show more surrounding pages. |
 | disabled     | `boolean` | No       | `false` | Whether the entire pagination is disabled. When true, all buttons become non-interactive, the container dims (opacity 0.5), and the cursor changes to not-allowed.              |
-| testId       | `string`  | No       | `-`     | Value for the data-pw attribute on the nav container, used for end-to-end testing selectors.                                                                                    |
+| testId       | `string`  | No       | `-`     | Value for the data-pw attribute on the nav container; the arrow buttons also get `{testId}-prev` / `{testId}-next` so tests can target them directly.                           |
 | classes      | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.          |
 
 ## Events

--- a/src/lib/Pagination/Pagination.svelte
+++ b/src/lib/Pagination/Pagination.svelte
@@ -58,6 +58,7 @@
     disabled={disabled || currentPage <= 1}
     onclick={() => goToPage(currentPage - 1)}
     aria-label="Previous page"
+    data-pw={typeof testId === 'string' ? `${testId}-prev` : null}
   >
     &#8249;
   </button>
@@ -84,6 +85,7 @@
     disabled={disabled || currentPage >= totalPages}
     onclick={() => goToPage(currentPage + 1)}
     aria-label="Next page"
+    data-pw={typeof testId === 'string' ? `${testId}-next` : null}
   >
     &#8250;
   </button>


### PR DESCRIPTION
## What

When `testId` is set, the previous/next arrow buttons now carry `data-pw="{testId}-prev"` / `data-pw="{testId}-next"` in addition to the existing `data-pw` on the nav container. No new props; `null` (attribute omitted) when `testId` is unset — zero change for consumers that don't pass one.

`docs/Pagination.md` testId row updated.

## Why

E2E suites can currently target the whole pagination but not the arrows — page-flip tests end up with brittle `nth(...)`/class selectors on `.prev-button`/`.next-button`. Same per-element pattern Select already uses for its pills (`{testId}-pill-{id}`).

## Verification

`pnpm run check` 0 errors · `pnpm run lint` clean · `pnpm run build` clean.