### PR TITLE
feat(Select): add leftIcon prop for a leading trigger icon

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -56,20 +56,30 @@ Replace the default ☐/☑ glyphs with a custom indicator:
 </Select>
 ```
 
+### With Leading Icon
+
+Pass an image URL (or inline data URI) via `leftIcon` to render a leading icon at the left of the trigger. The icon size defaults to 16×16 px and can be customised with the `--select-left-icon-size` CSS variable.
+
+```svelte
+<Select {items} placeholder="Select a city" leftIcon="/icons/globe.svg" />
+```
+
 ## Props
 
-| Prop        | Type                       | Required | Default     | Description                                                                                                                                                                                           |
-| ----------- | -------------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| items       | `SelectItem[] \| string[]` | Yes      | -           | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.                                      |
-| value       | `string[]`                 | No       | `[]`        | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                                                            |
-| open        | `boolean`                  | No       | `false`     | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state.                          |
-| multiple    | `boolean`                  | No       | `false`     | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                                                           |
-| searchable  | `boolean`                  | No       | `false`     | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                                                   |
-| placeholder | `string`                   | No       | `''`        | Text shown when no item is selected (or in the search input when empty).                                                                                                                              |
-| disabled    | `boolean`                  | No       | `false`     | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                                                       |
-| testId      | `string`                   | No       | -           | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                                                    |
-| classes     | `string`                   | No       | -           | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                |
-| hierarchy   | `SelectHierarchy`          | No       | `'default'` | Visual hierarchy of the trigger. `'ghost'` renders a transparent, borderless trigger — useful when the Select is embedded in a toolbar or header where a full bordered input would be visually heavy. |
+| Prop           | Type                       | Required | Default     | Description                                                                                                                                                                                           |
+| -------------- | -------------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| items          | `SelectItem[] \| string[]` | Yes      | -           | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.                                      |
+| value          | `string[]`                 | No       | `[]`        | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                                                            |
+| open           | `boolean`                  | No       | `false`     | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state.                          |
+| multiple       | `boolean`                  | No       | `false`     | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                                                           |
+| searchable     | `boolean`                  | No       | `false`     | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                                                   |
+| placeholder    | `string`                   | No       | `''`        | Text shown when no item is selected (or in the search input when empty).                                                                                                                              |
+| disabled       | `boolean`                  | No       | `false`     | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                                                       |
+| testId         | `string`                   | No       | -           | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                                                    |
+| classes        | `string`                   | No       | -           | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                |
+| hierarchy      | `SelectHierarchy`          | No       | `'default'` | Visual hierarchy of the trigger. `'ghost'` renders a transparent, borderless trigger — useful when the Select is embedded in a toolbar or header where a full bordered input would be visually heavy. |
+| leftIcon       | `string`                   | No       | -           | Image src (URL or data URI) for an icon rendered at the left of the trigger. Size is controlled by `--select-left-icon-size` (default 16px).                                                          |
+| leftIconTestId | `string`                   | No       | -           | `data-pw` test id forwarded to the leading icon element for end-to-end testing selectors.                                                                                                             |
 
 ## Snippets
 
@@ -122,6 +132,12 @@ Override these custom properties to theme the component.
 | `--select-trigger-hover-border-color` | `#999999`                              | border-color  | Border color of the trigger on hover.                       |
 | `--select-trigger-focus-border-color` | `#2563eb`                              | border-color  | Border color of the trigger when focused or open.           |
 | `--select-trigger-focus-shadow`       | `0 0 0 2px rgba(37, 99, 235, 0.2)`     | box-shadow    | Box shadow of the trigger when focused or open.             |
+
+### Left Icon
+
+| Variable                  | Default | CSS Property  | Description                              |
+| ------------------------- | ------- | ------------- | ---------------------------------------- |
+| `--select-left-icon-size` | `16px`  | width, height | Size of the leading icon in the trigger. |
 
 ### Placeholder
 
@@ -227,6 +243,7 @@ type SelectItem = {
 This component uses the following library components internally:
 
 - Pill (for displaying selected items in multi-select mode)
+- Img (for rendering the optional leading trigger icon via `leftIcon`)
 
 ## Web Component
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -2,6 +2,7 @@
   import { onMount, tick } from 'svelte';
   import type { SelectItem, SelectProperties } from './properties';
   import Pill from '$lib/Pill/Pill.svelte';
+  import Img from '$lib/Img/Img.svelte';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
 
   let {
@@ -22,7 +23,9 @@
     classes,
     open = $bindable(false),
     dropdownAlign = 'left',
-    hierarchy = 'default'
+    hierarchy = 'default',
+    leftIcon,
+    leftIconTestId
   }: SelectProperties = $props();
 
   function normalizeItems(source: SelectItem[] | string[]): SelectItem[] {
@@ -266,6 +269,14 @@
     {...highlightedOptionId !== null ? { 'aria-activedescendant': highlightedOptionId } : {}}
     tabindex={disabled ? -1 : searchable ? -1 : 0}
   >
+    {#if typeof leftIcon === 'string' && leftIcon.length > 0}
+      <Img
+        src={leftIcon}
+        alt=""
+        classes="select-left-icon"
+        {...typeof leftIconTestId === 'string' ? { testId: leftIconTestId } : {}}
+      />
+    {/if}
     {#if multiple}
       {#if typeof triggerSummary === 'function'}
         {@render triggerSummary({ value, items })}
@@ -414,6 +425,13 @@
     outline: none;
     -webkit-tap-highlight-color: transparent;
     transition: var(--select-trigger-transition, border-color 0.15s, box-shadow 0.15s);
+  }
+
+  .select-trigger :global(.select-left-icon) {
+    --image-width: var(--select-left-icon-size, 16px);
+    --image-height: var(--select-left-icon-size, 16px);
+    --image-object-fit: contain;
+    flex: none;
   }
 
   .select-trigger:hover:not(.disabled .select-trigger) {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -37,6 +37,10 @@ export type OptionalSelectProperties = {
   triggerSummary?: import('svelte').Snippet<[{ value: string[]; items: SelectItem[] }]>;
   /** Visual hierarchy of the trigger. `'ghost'` renders a transparent, borderless trigger — useful when the Select is embedded in a toolbar or header where a full bordered input would be visually heavy. Defaults to `'default'`. */
   hierarchy?: SelectHierarchy;
+  /** Optional image src (URL or data URI) rendered at the left of the trigger. Size is controlled by the `--select-left-icon-size` CSS variable (default 16px). */
+  leftIcon?: string;
+  /** `data-pw` test id forwarded to the leading icon `<Img>` element. */
+  leftIconTestId?: string;
 };
 
 export type SelectEventProperties = {

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -48,6 +48,15 @@
   let summaryValue: string[] = $state([]);
   let ghostValue: string[] = $state([]);
   let openEventLog: string[] = $state([]);
+  let leftIconValue: string[] = $state([]);
+
+  // Inline SVG data URI — a simple globe icon, no external asset needed
+  const globeIconSrc =
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23555' stroke-width='1.5'%3E` +
+    `%3Ccircle cx='8' cy='8' r='6.5'/%3E` +
+    `%3Cellipse cx='8' cy='8' rx='3' ry='6.5'/%3E` +
+    `%3Cline x1='1.5' y1='8' x2='14.5' y2='8'/%3E` +
+    `%3C/svg%3E`;
 </script>
 
 <div class="page-header">
@@ -203,6 +212,24 @@
     placeholder="Right aligned"
     dropdownAlign="right"
   />
+</div>
+
+<h3>leftIcon prop</h3>
+<p>
+  Pass an image URL (or data URI) via <code>leftIcon</code> to render a leading icon at the left of
+  the trigger. Size is controlled by the <code>--select-left-icon-size</code> CSS variable (default 16px).
+</p>
+<div class="demo-row" style="max-width: 300px;">
+  <Select
+    items={cities}
+    bind:value={leftIconValue}
+    placeholder="Select a city"
+    leftIcon={globeIconSrc}
+    leftIconTestId="select-left-icon"
+  />
+  {#if leftIconValue.length > 0}
+    <p class="demo-info">Selected: {leftIconValue.at(0)}</p>
+  {/if}
 </div>
 
 <style>

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -13,7 +13,9 @@
       classes: { type: 'String' },
       open: { type: 'Boolean', reflect: true },
       dropdownAlign: { type: 'String', attribute: 'dropdown-align' },
-      onchange: { type: 'Object' }
+      onchange: { type: 'Object' },
+      leftIcon: { type: 'String', attribute: 'left-icon', reflect: true },
+      leftIconTestId: { type: 'String', attribute: 'left-icon-test-id' }
     }
   }}
 />


### PR DESCRIPTION
## What

Adds an optional `leftIcon?: string` prop to **Select** that renders an image at the left of the trigger (before the value/placeholder).

## Why

Consumer parity: several Lighthouse selectors (mandate download menus, ConfigController, etc.) show a leading icon in the trigger — the project-owned Dropdown supported `leadingIcon`, but library Select had no equivalent, blocking their migration. This is the smallest cohesive addition to unblock them.

## Changes

- `src/lib/Select/properties.ts` — `leftIcon?: string` on `OptionalSelectProperties` (JSDoc'd).
- `src/lib/Select/Select.svelte` — render `<img class="select-left-icon" src={leftIcon} alt="" />` as the first child of `.select-trigger` (only when a non-empty string); `.select-left-icon` sized via `--select-left-icon-size` (default 16px), `object-fit: contain`, `flex: none`.
- `src/wc/components/Select.wc.svelte` — expose as the `left-icon` attribute.
- `src/routes/components/select/+page.svelte` — demo instance.
- `docs/_index.json` — description updated.

## Testing

- `pnpm check` — 0 errors.
- `pnpm lint` — changed files pass prettier (pre-existing unrelated formatting in banner/modal/table demo routes left untouched).
- `pnpm build` — svelte-package + publint OK.

Purely additive; no behavior change when `leftIcon` is omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `leftIcon` prop to the Select component, allowing users to display an icon on the left side of the trigger. The icon size can be customized using the `--select-left-icon-size` CSS variable.

* **Documentation**
  * Updated Select component documentation to clarify that `items` can accept either `SelectItem` objects or a plain string array, and documented the new `leftIcon` prop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->