### PR TITLE
feat(Select): add dropdownAlign prop to right-anchor the dropdown panel

### DIFF
--- a/docs/_index.json
+++ b/docs/_index.json
@@ -177,7 +177,7 @@
   },
   {
     "name": "Select",
-    "description": "A dropdown selector supporting single-select and multi-select modes with optional search filtering. Accepts items as SelectItem objects or a plain string array. Multi-select shows selected items as dismissible pills with a built-in or custom per-option indicator. Supports a bottomContent snippet for pinning arbitrary content at the bottom of the dropdown. Fully keyboard-navigable and closes on outside click."
+    "description": "A dropdown selector supporting single-select and multi-select modes with optional search filtering. Accepts items as SelectItem objects or a plain string array. Multi-select shows selected items as dismissible pills with a built-in or custom per-option indicator. Supports a bottomContent snippet for pinning arbitrary content at the bottom of the dropdown, and a dropdownAlign prop ('left' | 'right') to anchor the panel to either edge of the trigger. Fully keyboard-navigable and closes on outside click."
   },
   {
     "name": "Sheet",

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -17,7 +17,8 @@
     itemTestId,
     onchange,
     classes,
-    open = $bindable(false)
+    open = $bindable(false),
+    dropdownAlign = 'left'
   }: SelectProperties = $props();
 
   function normalizeItems(source: SelectItem[] | string[]): SelectItem[] {
@@ -303,7 +304,13 @@
   </div>
 
   {#if open && !disabled}
-    <div class="select-dropdown" role="listbox" id={listboxId} aria-multiselectable={multiple}>
+    <div
+      class="select-dropdown"
+      class:select-dropdown-right={dropdownAlign === 'right'}
+      role="listbox"
+      id={listboxId}
+      aria-multiselectable={multiple}
+    >
       {#if filteredItems.length === 0}
         <div class="select-empty">No results</div>
       {:else}
@@ -455,6 +462,13 @@
     max-height: var(--select-dropdown-max-height, 200px);
     overflow-y: auto;
     z-index: var(--select-dropdown-z-index, 10);
+  }
+
+  .select-dropdown-right {
+    left: auto;
+    right: 0;
+    min-width: 100%;
+    width: max-content;
   }
 
   .select-option {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -29,6 +29,8 @@ export type OptionalSelectProperties = {
   classes?: string;
   /** Bindable. Controls whether the dropdown is open; the component writes back on open/close so parents can `bind:open` to observe or drive it. Unbound, the component manages its own state. */
   open?: boolean;
+  /** Horizontal anchor of the dropdown panel. `'left'` (default) anchors to the trigger's left edge; `'right'` anchors to the right edge so a content-wider panel hangs leftward instead of overflowing. */
+  dropdownAlign?: 'left' | 'right';
 };
 
 export type SelectEventProperties = {

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -44,6 +44,7 @@
   let stringItemsValue: string[] = $state([]);
   let bottomContentValue: string[] = $state([]);
   let customIndicatorValue: string[] = $state([]);
+  let alignValue: string[] = $state([]);
 </script>
 
 <div class="page-header">
@@ -135,6 +136,20 @@
   {#if customIndicatorValue.length > 0}
     <p class="demo-info">Selected: {customIndicatorValue.join(', ')}</p>
   {/if}
+</div>
+
+<h3>Right-aligned dropdown</h3>
+<p>
+  Anchor the dropdown panel to the trigger's right edge (so a content-wider panel hangs leftward
+  instead of overflowing).
+</p>
+<div class="demo-row" style="max-width: 200px; margin-left: 220px;">
+  <Select
+    items={cities}
+    bind:value={alignValue}
+    placeholder="Right aligned"
+    dropdownAlign="right"
+  />
 </div>
 
 <style>

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -12,6 +12,7 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       open: { type: 'Boolean', reflect: true },
+      dropdownAlign: { type: 'String', attribute: 'dropdown-align' },
       onchange: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
## What

Adds an optional `dropdownAlign?: 'left' | 'right'` prop to **Select**. Default `'left'` keeps today's behavior (panel anchored to the trigger's left edge, full trigger width). `'right'` anchors the panel to the trigger's right edge and sizes it to content (`min-width: 100%; width: max-content`) so a content-wider dropdown hangs leftward instead of overflowing the viewport.

## Why

Consumer parity: project-owned dropdowns used a right-aligned body (`--dropdown-body-right: auto; right: 0`) for selectors near the right edge of their container (e.g. payment/offer config rows, order page). Library Select had no alignment control, blocking those migrations.

## Changes

- `src/lib/Select/properties.ts` — `dropdownAlign?: 'left' | 'right'` on `OptionalSelectProperties` (JSDoc'd).
- `src/lib/Select/Select.svelte` — destructure with default `'left'`; `class:select-dropdown-right={dropdownAlign === 'right'}` on `.select-dropdown`; `.select-dropdown-right { left: auto; right: 0; min-width: 100%; width: max-content; }`.
- `src/wc/components/Select.wc.svelte` — exposed as the `dropdown-align` attribute.
- `src/routes/components/select/+page.svelte` — 'Right-aligned dropdown' demo.
- `docs/_index.json` — description updated.

## Testing

- `pnpm check` — 0 errors.
- `pnpm lint` — changed files pass prettier (pre-existing unrelated formatting in other demo routes left untouched).
- `pnpm build` — svelte-package + publint OK.

Purely additive; default behavior unchanged. (Sibling PR #263 `leftIcon` touches different regions of Select.svelte — low conflict risk; whichever merges first, the other rebases trivially.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `dropdownAlign` prop to the Select component, enabling flexible control over dropdown panel positioning. Users can now anchor the dropdown panel to either the left or right edge of the trigger element, with left alignment as the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->