### PR TITLE
fix: resolve lint failures blocking the release publish pipeline (unblocks 2.29.0)

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -236,7 +236,7 @@
 
 <div
   class="select {classes ?? ''}"
-  class:open={open}
+  class:open
   class:disabled
   bind:this={containerEl}
   {...typeof testId === 'string' ? { 'data-pw': testId } : {}}

--- a/src/routes/components/banner/+page.svelte
+++ b/src/routes/components/banner/+page.svelte
@@ -56,10 +56,7 @@
   <div
     style="--banner-background: #fff0f0; --banner-color: #c0392b; --banner-border: 1px solid #e74c3c; --banner-border-radius: 6px; --banner-position: static; width: 100%;"
   >
-    <Banner
-      text="Payment failed. Please check your card details and try again."
-      role="alert"
-    />
+    <Banner text="Payment failed. Please check your card details and try again." role="alert" />
   </div>
 
   <div

--- a/src/routes/components/modal/+page.svelte
+++ b/src/routes/components/modal/+page.svelte
@@ -53,7 +53,10 @@
       >
         {#snippet content()}
           <div style="padding: 16px;">
-            <p>The header uses <code>--modal-header-align-items: flex-start</code> so multi-line header content aligns to the top instead of the default center.</p>
+            <p>
+              The header uses <code>--modal-header-align-items: flex-start</code> so multi-line header
+              content aligns to the top instead of the default center.
+            </p>
           </div>
         {/snippet}
       </Modal>

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -168,16 +168,26 @@
     {#snippet paginatorSlot()}
       <div style="display: flex; align-items: center; gap: 8px; justify-content: flex-end;">
         <button
-          onclick={() => { if (currentPage > 1) currentPage -= 1; }}
+          onclick={() => {
+            if (currentPage > 1) {
+              currentPage -= 1;
+            }
+          }}
           disabled={currentPage === 1}
           style="padding: 4px 10px; border: 1px solid #e5e7eb; border-radius: 4px; cursor: pointer; background: white;"
-        >‹ Prev</button>
+          >‹ Prev</button
+        >
         <span style="color: #6b7280;">Page {currentPage} of {totalPages}</span>
         <button
-          onclick={() => { if (currentPage < totalPages) currentPage += 1; }}
+          onclick={() => {
+            if (currentPage < totalPages) {
+              currentPage += 1;
+            }
+          }}
           disabled={currentPage === totalPages}
           style="padding: 4px 10px; border: 1px solid #e5e7eb; border-radius: 4px; cursor: pointer; background: white;"
-        >Next ›</button>
+          >Next ›</button
+        >
       </div>
     {/snippet}
   </Table>


### PR DESCRIPTION
## Why

The `Release and Publish` workflow (`.github/workflows/release.yml`) runs `pnpm lint` (`prettier --check src && eslint src`) **before** the version-bump/publish step. That lint step has been **failing on every push since the `feat(banner)` commit**, so no version has been cut and **13 merged feature PRs sit unpublished on `release`** (Breadcrumb #193, FileInput #212, DateRangePicker #251, Select, Tabs, Pagination, EmptyState, …). npm `latest` is still `2.28.2`.

Two distinct lint failures (CI only ever showed the first, because `&&` short-circuits):
1. **prettier --check** — 4 files committed unformatted: `src/lib/Select/Select.svelte`, `src/routes/components/{banner,modal,table}/+page.svelte`
2. **eslint** — `src/routes/components/table/+page.svelte` had 2 `curly` violations (braces-less `if`)

## What

- `prettier --write` on the 4 unformatted files
- `eslint --fix` (curly) on the table demo page

Formatting/lint-only — no logic changes. `pnpm lint` now passes fully (prettier + eslint).

## Effect

Once merged, the next push to `release` passes lint → the pipeline auto-bumps to **2.29.0** (the pending commits are `feat:` → minor) and publishes to npm, unblocking the entire downstream Lighthouse consumer backlog (datePicker→DateRangePicker, mediaInput→FileInput, LinearBreadcrumb→Breadcrumb, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved component event handler logic for better code structure and maintainability.

* **Style**
  * Updated component documentation examples with improved code formatting and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->