### PR TITLE
feat(Select): add itemTestId prop + per-option data-pw test hook

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -14,6 +14,7 @@
     bottomContent,
     optionIndicator,
     testId,
+    itemTestId,
     onchange,
     classes,
     open = $bindable(false)
@@ -307,7 +308,6 @@
         <div class="select-empty">No results</div>
       {:else}
         {#each filteredItems as item, index (item.id)}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
           <div
             class="select-option"
             class:multi={multiple}
@@ -317,6 +317,13 @@
             id={`${listboxId}-option-${index}`}
             aria-selected={value.includes(item.id)}
             tabindex="-1"
+            {...item.testId
+              ? { 'data-pw': item.testId }
+              : typeof itemTestId === 'string'
+                ? { 'data-pw': `${itemTestId}-${item.id}` }
+                : typeof testId === 'string'
+                  ? { 'data-pw': `${testId}-${item.id}` }
+                  : {}}
             onclick={() => selectItem(item.id)}
             onmouseenter={() => (highlightedIndex = index)}
           >

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -7,6 +7,8 @@ export type SelectProperties = MandatorySelectProperties &
 export type SelectItem = {
   id: string;
   label: string;
+  /** Optional per-option test id, emitted as `data-pw` on the option element. */
+  testId?: string;
 };
 
 export type MandatorySelectProperties = {
@@ -22,6 +24,8 @@ export type OptionalSelectProperties = {
   bottomContent?: Snippet;
   optionIndicator?: Snippet<[{ checked: boolean }]>;
   testId?: string;
+  /** Fallback per-option test id prefix. Each option emits `data-pw="{itemTestId}-{id}"` when its own `item.testId` is not set. */
+  itemTestId?: string;
   classes?: string;
   /** Bindable. Controls whether the dropdown is open; the component writes back on open/close so parents can `bind:open` to observe or drive it. Unbound, the component manages its own state. */
   open?: boolean;


### PR DESCRIPTION
## What

Adds a test-id hook to `Select` so consumers can target individual options in e2e tests:

- `SelectItem.testId?: string` — explicit per-option id
- `itemTestId?: string` (component prop) — fallback prefix

Each option now emits `data-pw` as: `item.testId` → else `${itemTestId}-${id}` → else `${testId}-${id}` (no attribute if none set). No behaviour change otherwise.

## Why

The Lighthouse dashboard currently carries a **downstream pnpm patch** of `Select` solely to add this per-option `data-pw` (its Playwright suite locates options by id). Upstreaming it lets Lighthouse drop that patch entirely on the next bump.

## Incidental (lint publish-gate)

`pnpm lint` (`prettier --check src && eslint src`, run before version-bump/publish in release.yml) was **already failing** on `release` due to regressed formatting/curly in 3 demo pages (banner/modal/table) + an unused `svelte-ignore` in Select. Re-applied those fixes so this PR is green and the publish pipeline unblocks (same class of fix as #265).

## Gates
- `pnpm check`: 0 errors
- `pnpm lint`: ✓ (prettier + eslint clean)
- `pnpm build`: ✓ (svelte-package + publint clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Select component now supports additional test identification options for improved testing capabilities.

* **Documentation**
  * Documentation examples refined and clarified for Banner, Modal, and Table components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->