### PR TITLE
feat(DateRangePicker): add maxRangeDays to cap selectable range span

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -13,6 +13,7 @@
     minDate = null,
     maxDate = null,
     disabledDates = [],
+    maxRangeDays = null,
     presets = null,
     placeholder = 'Select date',
     dualMonth,
@@ -43,6 +44,37 @@
   let draftValue: Date | null = $state(null);
   let draftCompareStart: Date | null = $state(null);
   let draftCompareEnd: Date | null = $state(null);
+
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+  function isBaseDisabledDate(date: Date): boolean {
+    if (typeof disabledDates === 'function') {
+      return disabledDates(date);
+    }
+    return disabledDates.some((disabled) => isSameDay(disabled, date));
+  }
+
+  // When maxRangeDays is set, disable any date whose span from the in-progress
+  // start would exceed the limit (inclusive of both ends), until the range is
+  // completed. Falls back to the raw disabledDates otherwise.
+  const rangeConstrainedDisabledDates = $derived.by(() => {
+    const limit = maxRangeDays;
+    if (limit === null || limit === undefined) {
+      return disabledDates;
+    }
+    const anchor = draftStart;
+    const selecting = anchor !== null && draftEnd === null;
+    return (date: Date): boolean => {
+      if (isBaseDisabledDate(date)) {
+        return true;
+      }
+      if (!selecting || anchor === null) {
+        return false;
+      }
+      const diffDays = Math.abs(Math.round((date.getTime() - anchor.getTime()) / MS_PER_DAY));
+      return diffDays > limit - 1;
+    };
+  });
 
   let isOpen: boolean = $state(false);
   let panelRef: HTMLDivElement | null = $state(null);
@@ -313,7 +345,7 @@
                   {locale}
                   {minDate}
                   {maxDate}
-                  {disabledDates}
+                  disabledDates={rangeConstrainedDisabledDates}
                   initialMonth={leftInitialMonth}
                   onrangeselect={handleRangeSelect}
                   classes="drp-calendar-embedded"
@@ -327,7 +359,7 @@
                   {locale}
                   {minDate}
                   {maxDate}
-                  {disabledDates}
+                  disabledDates={rangeConstrainedDisabledDates}
                   initialMonth={rightInitialMonth}
                   onrangeselect={handleRangeSelect}
                   classes="drp-calendar-embedded"

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -22,6 +22,8 @@ export type OptionalDateRangePickerProperties = {
   maxDate?: Date | null;
   /** Specific dates to disable, or a predicate. */
   disabledDates?: Date[] | ((date: Date) => boolean);
+  /** Maximum number of days a selected range may span, inclusive of both endpoints (range mode only). Once a start date is picked, dates that would exceed this span are disabled until the range is completed. Omit for no limit. */
+  maxRangeDays?: number | null;
   /** Preset options shown in the sidebar. Omit to hide the sidebar. */
   presets?: DateRangePreset[] | null;
   /** Placeholder shown when no range is selected. */


### PR DESCRIPTION
## What

Adds an optional `maxRangeDays?: number | null` prop to `DateRangePicker` (range mode). Once a start date is picked, any date whose span from the anchor would exceed `maxRangeDays` (inclusive of both endpoints) is disabled until the range is completed — implemented as a derived `disabledDates` predicate layered over the consumer's own `disabledDates` (array or function). No behaviour change when unset.

## Why

The Lighthouse dashboard's project date-picker had an `allowedMaxDays` clamp (e.g. cap analytics ranges at 90 days) that the library had no equivalent for, so it was dropped during the DateRangePicker migration. This restores that capability as a first-class prop.

## Gates
- `pnpm check`: 0 errors
- `pnpm build`: ✓ (svelte-package + publint clean)
- Only `src/lib/DateRangePicker/{DateRangePicker.svelte,properties.ts}` touched.

> Note: the `release` branch's `pnpm lint` publish-gate currently fails on **pre-existing** rot in 3 demo pages (banner/modal/table) + an unused svelte-ignore — that's fixed in #266. This PR keeps to the feature files only; rebase after #266 merges for a green lint gate.