### PR TITLE
feat(DateRangePicker): report selected preset label in apply events

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -45,6 +45,10 @@
   let draftCompareStart: Date | null = $state(null);
   let draftCompareEnd: Date | null = $state(null);
 
+  // Tracks the label of the currently active preset, or null when the user
+  // made a custom calendar selection (or before any selection is made).
+  let selectedPresetLabel: string | null = $state(null);
+
   const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
   function isBaseDisabledDate(date: Date): boolean {
@@ -59,7 +63,7 @@
   // completed. Falls back to the raw disabledDates otherwise.
   const rangeConstrainedDisabledDates = $derived.by(() => {
     const limit = maxRangeDays;
-    if (limit === null || limit === undefined) {
+    if (limit === null) {
       return disabledDates;
     }
     const anchor = draftStart;
@@ -125,6 +129,9 @@
     draftCompareStart = compareStart !== null ? compareStart : null;
     draftCompareEnd = compareEnd !== null ? compareEnd : null;
 
+    // Reset preset tracking so each picker session starts clean.
+    selectedPresetLabel = null;
+
     // Navigate left calendar so it shows the committed start month (or today)
     const anchor = rangeStart !== null ? rangeStart : value !== null ? value : now;
     leftYear = anchor.getFullYear();
@@ -152,7 +159,7 @@
       if (draftStart !== null && draftEnd !== null) {
         rangeStart = draftStart;
         rangeEnd = draftEnd;
-        onapply?.({ rangeStart: draftStart, rangeEnd: draftEnd });
+        onapply?.({ rangeStart: draftStart, rangeEnd: draftEnd, presetLabel: selectedPresetLabel });
       }
       if (
         typeof compareCalendar === 'function' &&
@@ -161,12 +168,16 @@
       ) {
         compareStart = draftCompareStart;
         compareEnd = draftCompareEnd;
-        onapplycompare?.({ compareStart: draftCompareStart, compareEnd: draftCompareEnd });
+        onapplycompare?.({
+          compareStart: draftCompareStart,
+          compareEnd: draftCompareEnd,
+          presetLabel: selectedPresetLabel
+        });
       }
     } else {
       if (draftValue !== null) {
         value = draftValue;
-        onapplysingle?.({ date: draftValue });
+        onapplysingle?.({ date: draftValue, presetLabel: selectedPresetLabel });
       }
     }
     closePicker();
@@ -179,6 +190,7 @@
 
   function handlePreset(preset: DateRangePreset): void {
     const { start, end } = preset.getValue();
+    selectedPresetLabel = preset.label;
     if (mode === 'range') {
       draftStart = start;
       draftEnd = end;
@@ -194,10 +206,14 @@
   function handleRangeSelect(event: { rangeStart: Date; rangeEnd: Date }): void {
     draftStart = event.rangeStart;
     draftEnd = event.rangeEnd;
+    // A direct calendar click is not a preset selection.
+    selectedPresetLabel = null;
   }
 
   function handleSingleSelect(event: { date: Date }): void {
     draftValue = event.date;
+    // A direct calendar click is not a preset selection.
+    selectedPresetLabel = null;
   }
 
   // Close on outside-click

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -53,12 +53,16 @@ export type OptionalDateRangePickerProperties = {
 };
 
 export type DateRangePickerEventProperties = {
-  /** Fired when the user clicks Apply in range mode. */
-  onapply?: (event: { rangeStart: Date; rangeEnd: Date }) => void;
-  /** Fired when the user clicks Apply in single mode. */
-  onapplysingle?: (event: { date: Date }) => void;
-  /** Fired when the compare range is applied. */
-  onapplycompare?: (event: { compareStart: Date; compareEnd: Date }) => void;
+  /** Fired when the user clicks Apply in range mode. presetLabel is the sidebar preset name if one was active, or null for a custom calendar selection. */
+  onapply?: (event: { rangeStart: Date; rangeEnd: Date; presetLabel: string | null }) => void;
+  /** Fired when the user clicks Apply in single mode. presetLabel is the sidebar preset name if one was active, or null for a custom calendar selection. */
+  onapplysingle?: (event: { date: Date; presetLabel: string | null }) => void;
+  /** Fired when the compare range is applied. presetLabel is the sidebar preset name if one was active, or null for a custom calendar selection. */
+  onapplycompare?: (event: {
+    compareStart: Date;
+    compareEnd: Date;
+    presetLabel: string | null;
+  }) => void;
   /** Fired when the user dismisses without applying. */
   oncancel?: () => void;
   /** Fired whenever the picker opens or closes. */

--- a/src/routes/components/date-range-picker/+page.svelte
+++ b/src/routes/components/date-range-picker/+page.svelte
@@ -7,6 +7,7 @@
   // --- Range mode state ---
   let rangeStart = $state<Date | null>(null);
   let rangeEnd = $state<Date | null>(null);
+  let lastAppliedPreset = $state<string | null>(null);
 
   // --- Single mode state ---
   let singleDate = $state<Date | null>(null);
@@ -176,10 +177,12 @@
       onapply={(e) => {
         rangeStart = e.rangeStart;
         rangeEnd = e.rangeEnd;
+        lastAppliedPreset = e.presetLabel;
       }}
     />
   </div>
   <p class="result-label">Applied range: <strong>{rangeLabel}</strong></p>
+  <p class="result-label">Preset: <strong>{lastAppliedPreset ?? 'custom'}</strong></p>
 </section>
 
 <!-- ── 2. Single-month range (dualMonth=false) ── -->


### PR DESCRIPTION
## Summary

- Adds an additive `presetLabel: string | null` field to all three apply event payloads: `onapply`, `onapplysingle`, and `onapplycompare`.
- `presetLabel` is the sidebar preset's `label` string when the user clicked a preset and then hit Apply; `null` when the user made a direct calendar selection or opened a fresh picker session without touching a preset.
- Fully backward-compatible: existing consumers that only destructure `{ rangeStart, rangeEnd }`, `{ date }`, or `{ compareStart, compareEnd }` are unaffected.

## Motivation

Unblocks Lighthouse analytics compare pickers (`analytics/+page.svelte`, `order/+page.svelte`) which need preset identity to correctly preserve "No Comparison" vs custom-range logic when the user re-opens the picker.

## Implementation

- `selectedPresetLabel` ($state, `string | null`) is reset to `null` on `openPicker()`.
- `handlePreset(preset)` sets it to `preset.label`.
- `handleRangeSelect` / `handleSingleSelect` (direct calendar interactions) reset it to `null`.
- `handleApply` threads it into each event object.
- Demo page (`date-range-picker/+page.svelte`) updated to show the last applied preset.

## Gate results

- `pnpm run check`: 0 errors, 4 pre-existing warnings (ThemeSwitcher/Modal lint-rot, tsconfig deprecation — none introduced by this PR)
- `pnpm run build`: succeeded, only pre-existing publint repository URL suggestion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Date range picker now tracks and reports which preset was applied when dates are selected.
  * Preset information is included in all apply event callbacks (range, single, and compare modes).
  * Demo displays the applied preset name or "custom" for manual calendar selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->