### PR TITLE
feat(Select): add triggerSummary snippet for compact multi-select trigger

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -13,6 +13,7 @@
     disabled = false,
     bottomContent,
     optionIndicator,
+    triggerSummary,
     testId,
     itemTestId,
     onchange,
@@ -256,30 +257,48 @@
     tabindex={disabled ? -1 : searchable ? -1 : 0}
   >
     {#if multiple}
-      {#each value as id (id)}
-        <Pill
-          text={getLabel(id)}
-          dismissible
-          {disabled}
-          ondismiss={() => removeItem(id)}
-          {...typeof testId === 'string' ? { testId: `${testId}-pill-${id}` } : {}}
-        />
-      {/each}
-      {#if searchable}
-        <input
-          class="select-search"
-          type="text"
-          value={query}
-          oninput={handleSearchInput}
-          onfocus={handleSearchFocus}
-          bind:this={searchInputEl}
-          placeholder={value.length === 0 ? placeholder : ''}
-          {disabled}
-          autocomplete="off"
-          tabindex={disabled ? -1 : 0}
-        />
-      {:else if value.length === 0}
-        <span class="select-placeholder">{placeholder}</span>
+      {#if typeof triggerSummary === 'function'}
+        {@render triggerSummary({ value, items })}
+        {#if searchable}
+          <input
+            class="select-search"
+            type="text"
+            value={query}
+            oninput={handleSearchInput}
+            onfocus={handleSearchFocus}
+            bind:this={searchInputEl}
+            placeholder={value.length === 0 ? placeholder : ''}
+            {disabled}
+            autocomplete="off"
+            tabindex={disabled ? -1 : 0}
+          />
+        {/if}
+      {:else}
+        {#each value as id (id)}
+          <Pill
+            text={getLabel(id)}
+            dismissible
+            {disabled}
+            ondismiss={() => removeItem(id)}
+            {...typeof testId === 'string' ? { testId: `${testId}-pill-${id}` } : {}}
+          />
+        {/each}
+        {#if searchable}
+          <input
+            class="select-search"
+            type="text"
+            value={query}
+            oninput={handleSearchInput}
+            onfocus={handleSearchFocus}
+            bind:this={searchInputEl}
+            placeholder={value.length === 0 ? placeholder : ''}
+            {disabled}
+            autocomplete="off"
+            tabindex={disabled ? -1 : 0}
+          />
+        {:else if value.length === 0}
+          <span class="select-placeholder">{placeholder}</span>
+        {/if}
       {/if}
     {:else if searchable}
       <input

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -31,6 +31,8 @@ export type OptionalSelectProperties = {
   open?: boolean;
   /** Horizontal anchor of the dropdown panel. `'left'` (default) anchors to the trigger's left edge; `'right'` anchors to the right edge so a content-wider panel hangs leftward instead of overflowing. */
   dropdownAlign?: 'left' | 'right';
+  /** Snippet for rendering a compact trigger summary in multiple mode instead of one Pill per selected value. Receives `{ value, items }` so the consumer can compute e.g. "All" / "3 selected". When not provided the default Pill-per-value behaviour is used. */
+  triggerSummary?: import('svelte').Snippet<[{ value: string[]; items: SelectItem[] }]>;
 };
 
 export type SelectEventProperties = {

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -45,6 +45,7 @@
   let bottomContentValue: string[] = $state([]);
   let customIndicatorValue: string[] = $state([]);
   let alignValue: string[] = $state([]);
+  let summaryValue: string[] = $state([]);
 </script>
 
 <div class="page-header">
@@ -138,6 +139,28 @@
   {/if}
 </div>
 
+<h3>triggerSummary snippet (compact multi-select trigger)</h3>
+<p>
+  Pass a <code>triggerSummary</code> snippet to replace the per-value Pill loop with a compact summary
+  label — useful for fixed-width filter triggers where pills would overflow.
+</p>
+<div class="demo-row" style="max-width: 220px;">
+  <Select items={fruits} multiple bind:value={summaryValue} placeholder="Filter fruits">
+    {#snippet triggerSummary({ value: selected, items: allItems })}
+      <span class="trigger-summary">
+        {selected.length === 0
+          ? 'All'
+          : selected.length === allItems.length
+            ? 'All'
+            : `${selected.length} selected`}
+      </span>
+    {/snippet}
+  </Select>
+  {#if summaryValue.length > 0}
+    <p class="demo-info">Selected IDs: {summaryValue.join(', ')}</p>
+  {/if}
+</div>
+
 <h3>Right-aligned dropdown</h3>
 <p>
   Anchor the dropdown panel to the trigger's right edge (so a content-wider panel hangs leftward
@@ -180,5 +203,12 @@
 
   .custom-indicator.checked {
     color: #2563eb;
+  }
+
+  .trigger-summary {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>


### PR DESCRIPTION
Optional `triggerSummary` snippet renders compact trigger content (e.g. "All" / "3 selected") for multiple mode instead of one Pill per selected value; unblocks Lighthouse offers filters + PaymentMethodField; backward compatible — pills remain the default when `triggerSummary` is not provided. check+build green.