### PR TITLE
feat(DateRangePicker): clearable + initialPresetLabel + preset groups

### DIFF
--- a/docs/DateRangePicker.md
+++ b/docs/DateRangePicker.md
@@ -1,6 +1,6 @@
 # DateRangePicker
 
-A compound date-range picker built on top of Calendar. Provides a trigger button shell, an optional preset sidebar, dual-month or single-month calendar display, snippet-based time-picker and compare-range slots, and an apply/cancel footer with draft-state isolation. Supports range and single-date modes, min/max constraints, disabled dates, locale-aware formatting, and full CSS theming via custom properties.
+A compound date-range picker built on top of Calendar. Provides a trigger button shell, an optional preset sidebar, dual-month or single-month calendar display, snippet-based time-picker and compare-range slots, and an apply/cancel footer with draft-state isolation. Supports range and single-date modes, min/max constraints, disabled dates, locale-aware formatting, and full CSS theming via custom properties. Opt-in features include a Clear button for single mode (`clearable`), an initial active-preset display seed (`initialPresetLabel`), and grouped preset sidebars with dividers via the `group` field on `DateRangePreset`.
 
 ## Usage
 
@@ -118,28 +118,118 @@ Pass a `compareCalendar` snippet to render a comparison period section inside th
 </DateRangePicker>
 ```
 
+### Single-mode with Clear button
+
+Pass `clearable` to show a Clear button in the footer whenever a date is committed. Clicking it resets `value` to `null` and fires `onclear`.
+
+```svelte
+<script>
+  import { DateRangePicker } from '@juspay/svelte-ui-components';
+
+  let selectedDate = $state(null);
+</script>
+
+<DateRangePicker
+  mode="single"
+  clearable
+  bind:value={selectedDate}
+  onapplysingle={(e) => {
+    selectedDate = e.date;
+  }}
+  onclear={() => {
+    selectedDate = null;
+  }}
+/>
+```
+
+### Initial active preset (display only, no onapply fired)
+
+Use `initialPresetLabel` to seed a preset as visually active on mount — the trigger shows the preset's label and the sidebar highlights it — without firing `onapply`. When the user opens the picker and clicks Apply, the real `onapply` fires normally.
+
+```svelte
+<script>
+  import { DateRangePicker } from '@juspay/svelte-ui-components';
+
+  const presets = [
+    {
+      label: 'All time',
+      getValue: () => {
+        const s = new Date(2020, 0, 1);
+        return { start: s, end: new Date() };
+      }
+    },
+    {
+      label: 'Last 7 days',
+      getValue: () => {
+        const e = new Date();
+        const s = new Date();
+        s.setDate(s.getDate() - 6);
+        return { start: s, end: e };
+      }
+    }
+  ];
+</script>
+
+<DateRangePicker
+  mode="range"
+  {presets}
+  initialPresetLabel="All time"
+  placeholder="Select range"
+  onapply={(e) => console.log(e.rangeStart, e.rangeEnd)}
+/>
+```
+
+### Preset groups with dividers
+
+Add a `group` key to any `DateRangePreset`. A thin divider (with an optional group label) is rendered between consecutive presets that have different `group` values. Presets without a `group` field render exactly as before.
+
+```svelte
+<script>
+  import { DateRangePicker } from '@juspay/svelte-ui-components';
+
+  const makeRange = (daysBack) => {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(start.getDate() - (daysBack - 1));
+    return { start, end };
+  };
+
+  const presets = [
+    { label: 'Today', group: 'Days', getValue: () => makeRange(1) },
+    { label: 'Yesterday', group: 'Days', getValue: () => makeRange(2) },
+    { label: 'Last 7 days', group: 'Weeks', getValue: () => makeRange(7) },
+    { label: 'Last 30 days', group: 'Months', getValue: () => makeRange(30) },
+    { label: 'Last 90 days', group: 'Months', getValue: () => makeRange(90) }
+  ];
+</script>
+
+<DateRangePicker mode="range" {presets} placeholder="Select range" />
+```
+
 ## Props
 
-| Prop            | Type                                  | Required | Default         | Description                                                                                                                  |
-| --------------- | ------------------------------------- | -------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| rangeStart      | `Date \| null`                        | No       | `null`          | Bindable. Start of the selected range. Only used in range mode.                                                              |
-| rangeEnd        | `Date \| null`                        | No       | `null`          | Bindable. End of the selected range. Only used in range mode.                                                                |
-| value           | `Date \| null`                        | No       | `null`          | Bindable. Selected date in single mode.                                                                                      |
-| mode            | `'range' \| 'single'`                 | No       | `'range'`       | Selection mode.                                                                                                              |
-| minDate         | `Date \| null`                        | No       | `null`          | Earliest selectable date.                                                                                                    |
-| maxDate         | `Date \| null`                        | No       | `null`          | Latest selectable date.                                                                                                      |
-| disabledDates   | `Date[] \| ((date: Date) => boolean)` | No       | `[]`            | Dates that cannot be selected. Pass an array or a predicate function.                                                        |
-| presets         | `DateRangePreset[] \| null`           | No       | `null`          | Preset options shown in the sidebar. Omit or pass null to hide the sidebar.                                                  |
-| placeholder     | `string`                              | No       | `'Select date'` | Text shown on the trigger when no date is selected.                                                                          |
-| dualMonth       | `boolean`                             | No       | `undefined`     | Show two months side by side. Defaults to true for range mode, false for single. Pass an explicit boolean to override.       |
-| timePicker      | `Snippet`                             | No       | —               | Snippet rendered inside a `.drp-time-row` wrapper below the calendars. Consumer owns all time state and input elements.      |
-| compareStart    | `Date \| null`                        | No       | `null`          | Bindable. Start of the compare range. Meaningful when `compareCalendar` snippet is provided and `onapplycompare` commits it. |
-| compareEnd      | `Date \| null`                        | No       | `null`          | Bindable. End of the compare range.                                                                                          |
-| compareCalendar | `Snippet`                             | No       | —               | Snippet rendered inside a `.drp-compare-section` wrapper below the calendars. Consumer owns all compare state and calendar.  |
-| weekStartsOn    | `0 \| 1`                              | No       | `0`             | Which day starts the week. 0 = Sunday, 1 = Monday.                                                                           |
-| locale          | `string`                              | No       | `undefined`     | BCP-47 locale string for date formatting on the trigger label (e.g., `'en-US'`, `'de-DE'`).                                  |
-| testId          | `string`                              | No       | `undefined`     | Value for the `data-pw` attribute on the root wrapper element, used for end-to-end testing selectors.                        |
-| classes         | `string`                              | No       | —               | Extra CSS class string applied to the root wrapper. Use to pass CSS variable overrides.                                      |
+| Prop               | Type                                  | Required | Default         | Description                                                                                                                                                                                                             |
+| ------------------ | ------------------------------------- | -------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rangeStart         | `Date \| null`                        | No       | `null`          | Bindable. Start of the selected range. Only used in range mode.                                                                                                                                                         |
+| rangeEnd           | `Date \| null`                        | No       | `null`          | Bindable. End of the selected range. Only used in range mode.                                                                                                                                                           |
+| value              | `Date \| null`                        | No       | `null`          | Bindable. Selected date in single mode.                                                                                                                                                                                 |
+| mode               | `'range' \| 'single'`                 | No       | `'range'`       | Selection mode.                                                                                                                                                                                                         |
+| minDate            | `Date \| null`                        | No       | `null`          | Earliest selectable date.                                                                                                                                                                                               |
+| maxDate            | `Date \| null`                        | No       | `null`          | Latest selectable date.                                                                                                                                                                                                 |
+| disabledDates      | `Date[] \| ((date: Date) => boolean)` | No       | `[]`            | Dates that cannot be selected. Pass an array or a predicate function.                                                                                                                                                   |
+| presets            | `DateRangePreset[] \| null`           | No       | `null`          | Preset options shown in the sidebar. Omit or pass null to hide the sidebar.                                                                                                                                             |
+| placeholder        | `string`                              | No       | `'Select date'` | Text shown on the trigger when no date is selected.                                                                                                                                                                     |
+| dualMonth          | `boolean`                             | No       | `undefined`     | Show two months side by side. Defaults to true for range mode, false for single. Pass an explicit boolean to override.                                                                                                  |
+| timePicker         | `Snippet`                             | No       | —               | Snippet rendered inside a `.drp-time-row` wrapper below the calendars. Consumer owns all time state and input elements.                                                                                                 |
+| compareStart       | `Date \| null`                        | No       | `null`          | Bindable. Start of the compare range. Meaningful when `compareCalendar` snippet is provided and `onapplycompare` commits it.                                                                                            |
+| compareEnd         | `Date \| null`                        | No       | `null`          | Bindable. End of the compare range.                                                                                                                                                                                     |
+| compareCalendar    | `Snippet`                             | No       | —               | Snippet rendered inside a `.drp-compare-section` wrapper below the calendars. Consumer owns all compare state and calendar.                                                                                             |
+| weekStartsOn       | `0 \| 1`                              | No       | `0`             | Which day starts the week. 0 = Sunday, 1 = Monday.                                                                                                                                                                      |
+| locale             | `string`                              | No       | `undefined`     | BCP-47 locale string for date formatting on the trigger label (e.g., `'en-US'`, `'de-DE'`).                                                                                                                             |
+| testId             | `string`                              | No       | `undefined`     | Value for the `data-pw` attribute on the root wrapper element, used for end-to-end testing selectors.                                                                                                                   |
+| classes            | `string`                              | No       | —               | Extra CSS class string applied to the root wrapper. Use to pass CSS variable overrides.                                                                                                                                 |
+| clearable          | `boolean`                             | No       | `false`         | When `true` and `mode='single'`, shows a Clear button in the footer whenever a date is committed. Clicking it resets `value` to `null` and fires `onclear`. Has no effect in range mode.                                |
+| initialPresetLabel | `string`                              | No       | `undefined`     | Label of the preset to show as active on mount, without firing `onapply`. The trigger displays the preset label and the sidebar highlights it. Only evaluated once at mount; if no preset matches, the prop is ignored. |
 
 ## Snippets
 
@@ -152,13 +242,14 @@ Pass a `compareCalendar` snippet to render a comparison period section inside th
 
 ## Events
 
-| Event          | Type                                                        | Description                                                               |
-| -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------- |
-| onapply        | `(event: { rangeStart: Date; rangeEnd: Date }) => void`     | Fired when Apply is clicked in range mode and both dates are set.         |
-| onapplysingle  | `(event: { date: Date }) => void`                           | Fired when Apply is clicked in single mode and a date is set.             |
-| onapplycompare | `(event: { compareStart: Date; compareEnd: Date }) => void` | Fired when Apply is clicked and the `compareCalendar` snippet is present. |
-| oncancel       | `() => void`                                                | Fired when the user dismisses the picker without applying.                |
-| onopentoggle   | `(event: { open: boolean }) => void`                        | Fired whenever the panel opens or closes.                                 |
+| Event          | Type                                                        | Description                                                                                                                     |
+| -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| onapply        | `(event: { rangeStart: Date; rangeEnd: Date }) => void`     | Fired when Apply is clicked in range mode and both dates are set.                                                               |
+| onapplysingle  | `(event: { date: Date }) => void`                           | Fired when Apply is clicked in single mode and a date is set.                                                                   |
+| onapplycompare | `(event: { compareStart: Date; compareEnd: Date }) => void` | Fired when Apply is clicked and the `compareCalendar` snippet is present.                                                       |
+| oncancel       | `() => void`                                                | Fired when the user dismisses the picker without applying.                                                                      |
+| onopentoggle   | `(event: { open: boolean }) => void`                        | Fired whenever the panel opens or closes.                                                                                       |
+| onclear        | `() => void`                                                | Fired when the Clear button is clicked in single mode (`clearable=true`). `value` is already reset to `null` before this fires. |
 
 ## CSS Variables
 
@@ -221,6 +312,14 @@ Override these custom properties to theme the component.
 | `--drp-apply-hover-background`         | `#333333`                     | Apply button background on hover.                                     |
 | `--drp-apply-disabled-background`      | `#cccccc`                     | Apply button background when disabled.                                |
 | `--drp-apply-disabled-color`           | `#888888`                     | Apply button text color when disabled.                                |
+| `--drp-clear-border-color`             | `#d0d0d0`                     | Clear button border color (single-mode `clearable`).                  |
+| `--drp-clear-color`                    | `inherit`                     | Clear button text color.                                              |
+| `--drp-clear-hover-background`         | `#f5f5f5`                     | Clear button background on hover.                                     |
+| `--drp-preset-divider-border`          | `1px solid #e8e8e8`           | Border style for the preset group divider line.                       |
+| `--drp-preset-divider-gap`             | `6px`                         | Gap between the divider line and the group label.                     |
+| `--drp-preset-divider-margin`          | `4px 0`                       | Vertical margin above and below each preset group divider.            |
+| `--drp-preset-group-label-color`       | `#999999`                     | Text color of the preset group label rendered beside the divider.     |
+| `--drp-preset-divider-leader-width`    | `8px`                         | Width of the leading line segment before the group label.             |
 
 ## Web Component
 
@@ -261,15 +360,17 @@ drp.maxDate = new Date();
 
 String and boolean props map to kebab-case HTML attributes:
 
-| Attribute        | Prop           | Type      |
-| ---------------- | -------------- | --------- |
-| `mode`           | `mode`         | `String`  |
-| `placeholder`    | `placeholder`  | `String`  |
-| `dual-month`     | `dualMonth`    | `Boolean` |
-| `week-starts-on` | `weekStartsOn` | `Number`  |
-| `locale`         | `locale`       | `String`  |
-| `test-id`        | `testId`       | `String`  |
-| `classes`        | `classes`      | `String`  |
+| Attribute              | Prop                 | Type      |
+| ---------------------- | -------------------- | --------- |
+| `mode`                 | `mode`               | `String`  |
+| `placeholder`          | `placeholder`        | `String`  |
+| `dual-month`           | `dualMonth`          | `Boolean` |
+| `week-starts-on`       | `weekStartsOn`       | `Number`  |
+| `locale`               | `locale`             | `String`  |
+| `test-id`              | `testId`             | `String`  |
+| `classes`              | `classes`            | `String`  |
+| `clearable`            | `clearable`          | `Boolean` |
+| `initial-preset-label` | `initialPresetLabel` | `String`  |
 
 Object and function props (`presets`, `minDate`, `maxDate`, `disabledDates`, `rangeStart`, `rangeEnd`, `value`, `compareStart`, `compareEnd`, and all event handlers) must be set via JavaScript property assignment, not HTML attributes.
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -93,7 +93,7 @@
   },
   {
     "name": "DateRangePicker",
-    "description": "A compound date-range picker built on top of Calendar. Provides a trigger button, optional preset sidebar, dual-month or single-month calendar layout, snippet-based time-picker and compare-range slots, and an apply/cancel footer with draft-state isolation. Supports range and single-date modes, min/max constraints, disabled dates, locale-aware formatting, and full CSS theming."
+    "description": "A compound date-range picker built on top of Calendar. Provides a trigger button, optional preset sidebar, dual-month or single-month calendar layout, snippet-based time-picker and compare-range slots, and an apply/cancel footer with draft-state isolation. Supports range and single-date modes, min/max constraints, disabled dates, locale-aware formatting, and full CSS theming. Opt-in: clearable (Clear button in single mode), initialPresetLabel (seed active preset label on mount without firing onapply), and preset groups with dividers via the group field on DateRangePreset."
   },
   {
     "name": "Gauge",

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { DateRangePickerProperties, DateRangePreset } from './properties';
+  import { untrack } from 'svelte';
   import { SvelteDate } from 'svelte/reactivity';
   import Calendar from '../Calendar/Calendar.svelte';
   import Button from '../Button/Button.svelte';
@@ -27,11 +28,14 @@
     classes,
     triggerSnippet,
     triggerIcon,
+    clearable = false,
+    initialPresetLabel,
     onapply,
     onapplysingle,
     onapplycompare,
     oncancel,
-    onopentoggle
+    onopentoggle,
+    onclear
   }: DateRangePickerProperties = $props();
 
   const isDualMonth: boolean = $derived(
@@ -84,6 +88,22 @@
   let panelRef: HTMLDivElement | null = $state(null);
   let triggerRef: HTMLDivElement | null = $state(null);
 
+  // Tracks the active preset label for the trigger display (seeded from initialPresetLabel on mount)
+  const resolvedInitialPresetLabel: string | null = untrack(() => {
+    if (
+      typeof initialPresetLabel === 'string' &&
+      initialPresetLabel !== '' &&
+      presets !== null &&
+      presets.length > 0
+    ) {
+      const matched = presets.find((preset) => preset.label === initialPresetLabel);
+      return matched ? matched.label : null;
+    }
+    return null;
+  });
+
+  let activePresetLabel: string | null = $state(resolvedInitialPresetLabel);
+
   // Dual-month navigation: track the year+month of the left calendar
   let leftYear: number = $state(new SvelteDate().getFullYear());
   let leftMonth: number = $state(new SvelteDate().getMonth());
@@ -109,6 +129,10 @@
   }
 
   const triggerLabel: string = $derived.by(() => {
+    // If an initial preset label is active (seeded on mount, not yet overridden), show it
+    if (activePresetLabel !== null) {
+      return activePresetLabel;
+    }
     if (mode === 'single') {
       return value !== null ? formatDate(value) : placeholder;
     }
@@ -155,6 +179,8 @@
   }
 
   function handleApply(): void {
+    // Once the user explicitly applies, clear the initial-preset display label
+    activePresetLabel = null;
     if (mode === 'range') {
       if (draftStart !== null && draftEnd !== null) {
         rangeStart = draftStart;
@@ -183,12 +209,21 @@
     closePicker();
   }
 
+  function handleClear(): void {
+    value = null;
+    draftValue = null;
+    onclear?.();
+    closePicker();
+  }
+
   function handleCancel(): void {
     oncancel?.();
     closePicker();
   }
 
   function handlePreset(preset: DateRangePreset): void {
+    // User explicitly picked a preset — clear the initial-preset display label
+    activePresetLabel = null;
     const { start, end } = preset.getValue();
     selectedPresetLabel = preset.label;
     if (mode === 'range') {
@@ -246,6 +281,16 @@
   });
 
   function isPresetActive(preset: DateRangePreset): boolean {
+    // When an initial preset label is active and the user hasn't picked anything yet,
+    // highlight the matching preset in the sidebar by label match
+    if (
+      activePresetLabel !== null &&
+      draftStart === null &&
+      draftEnd === null &&
+      draftValue === null
+    ) {
+      return preset.label === activePresetLabel;
+    }
     if (mode === 'single') {
       if (draftValue === null) {
         return false;
@@ -308,7 +353,19 @@
         <!-- Preset sidebar -->
         {#if presets !== null && presets.length > 0}
           <div class="drp-sidebar" role="listbox" aria-label="Date presets">
-            {#each presets as preset (preset.label)}
+            {#each presets as preset, presetIndex (preset.label)}
+              {@const previousPreset = presetIndex > 0 ? presets[presetIndex - 1] : null}
+              {@const groupChanged =
+                presetIndex > 0 &&
+                'group' in preset &&
+                (previousPreset === null || previousPreset.group !== preset.group)}
+              {#if groupChanged}
+                <div class="drp-preset-divider" role="separator" aria-hidden="true">
+                  {#if preset.group !== ''}
+                    <span class="drp-preset-group-label">{preset.group}</span>
+                  {/if}
+                </div>
+              {/if}
               <button
                 type="button"
                 class="drp-preset-item"
@@ -418,6 +475,11 @@
 
       <!-- Footer -->
       <div class="drp-footer">
+        {#if clearable && mode === 'single' && value !== null}
+          <Button onclick={handleClear} ariaLabel="Clear date selection" classes="drp-btn-clear">
+            Clear
+          </Button>
+        {/if}
         <Button onclick={handleCancel} ariaLabel="Cancel date selection" classes="drp-btn-cancel">
           Cancel
         </Button>
@@ -655,12 +717,59 @@
     border-top: var(--drp-footer-border, 1px solid #e8e8e8);
   }
 
+  /* ── Preset group dividers ── */
+  .drp-preset-divider {
+    display: flex;
+    align-items: center;
+    gap: var(--drp-preset-divider-gap, 6px);
+    margin: var(--drp-preset-divider-margin, 4px 0);
+    padding: 0 var(--drp-preset-padding-left, 12px);
+  }
+
+  .drp-preset-divider::before {
+    content: '';
+    flex: 1;
+    height: 0;
+    border-top: var(--drp-preset-divider-border, 1px solid #e8e8e8);
+  }
+
+  .drp-preset-group-label {
+    color: var(--drp-preset-group-label-color, #999999);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .drp-preset-divider:has(.drp-preset-group-label) {
+    padding-right: var(--drp-preset-padding-right, 12px);
+  }
+
+  .drp-preset-divider:has(.drp-preset-group-label)::before {
+    flex: none;
+    width: var(--drp-preset-divider-leader-width, 8px);
+  }
+
+  .drp-preset-divider:has(.drp-preset-group-label)::after {
+    content: '';
+    flex: 1;
+    height: 0;
+    border-top: var(--drp-preset-divider-border, 1px solid #e8e8e8);
+  }
+
   /* Cancel button variant via Button's CSS vars */
   :global(.drp-btn-cancel) {
     --button-color: transparent;
     --button-border: 1px solid var(--drp-cancel-border-color, #d0d0d0);
     --button-text-color: var(--drp-cancel-color, inherit);
     --button-hover-color: var(--drp-cancel-hover-background, #f5f5f5);
+  }
+
+  /* Clear button variant (single-mode reset) */
+  :global(.drp-btn-clear) {
+    --button-color: transparent;
+    --button-border: 1px solid var(--drp-clear-border-color, #d0d0d0);
+    --button-text-color: var(--drp-clear-color, inherit);
+    --button-hover-color: var(--drp-clear-hover-background, #f5f5f5);
+    margin-right: auto;
   }
 
   /* Apply button variant */

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -3,6 +3,13 @@ import type { Snippet } from 'svelte';
 export type DateRangePreset = {
   label: string;
   getValue: () => { start: Date; end: Date };
+  /**
+   * Optional group key. Consecutive presets sharing the same group key are
+   * visually grouped together. A thin divider (and optional group label) is
+   * rendered whenever the group key changes between two consecutive presets.
+   * Presets without a group field render exactly as before.
+   */
+  group?: string;
 };
 
 export type DateRangePickerMode = 'range' | 'single';
@@ -50,6 +57,19 @@ export type OptionalDateRangePickerProperties = {
   triggerSnippet?: Snippet<[string]>;
   /** Custom icon snippet for the trigger button. */
   triggerIcon?: Snippet;
+  /**
+   * When true (and mode='single'), shows a Clear button in the footer whenever a
+   * date is committed. Clicking Clear resets value to null and fires onclear.
+   * Has no effect in range mode. Default: false.
+   */
+  clearable?: boolean;
+  /**
+   * Label of the preset that should appear active on mount, without firing onapply.
+   * The matching preset's date range is seeded into the draft and the trigger shows
+   * the preset label. If no preset matches the string exactly, the prop is ignored.
+   * Only takes effect once on mount; subsequent prop changes are not tracked.
+   */
+  initialPresetLabel?: string;
 };
 
 export type DateRangePickerEventProperties = {
@@ -67,6 +87,11 @@ export type DateRangePickerEventProperties = {
   oncancel?: () => void;
   /** Fired whenever the picker opens or closes. */
   onopentoggle?: (event: { open: boolean }) => void;
+  /**
+   * Fired when the user clicks the Clear button in single mode (requires clearable=true).
+   * value is reset to null before this callback is invoked.
+   */
+  onclear?: () => void;
 };
 
 export type DateRangePickerProperties = OptionalDateRangePickerProperties &

--- a/src/routes/components/date-range-picker/+page.svelte
+++ b/src/routes/components/date-range-picker/+page.svelte
@@ -147,6 +147,116 @@
     }
   ];
 
+  // Grouped preset definitions for the preset-groups demo
+  const groupedPresets: DateRangePreset[] = [
+    {
+      label: 'Today',
+      group: 'Days',
+      getValue: () => {
+        const start = new SvelteDate();
+        start.setHours(0, 0, 0, 0);
+        const end = new SvelteDate(start);
+        end.setHours(23, 59, 59, 999);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Yesterday',
+      group: 'Days',
+      getValue: () => {
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 1);
+        start.setHours(0, 0, 0, 0);
+        const end = new SvelteDate(start);
+        end.setHours(23, 59, 59, 999);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Last 7 days',
+      group: 'Weeks',
+      getValue: () => {
+        const end = new SvelteDate();
+        end.setHours(23, 59, 59, 999);
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 6);
+        start.setHours(0, 0, 0, 0);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Last 14 days',
+      group: 'Weeks',
+      getValue: () => {
+        const end = new SvelteDate();
+        end.setHours(23, 59, 59, 999);
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 13);
+        start.setHours(0, 0, 0, 0);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Last 30 days',
+      group: 'Months',
+      getValue: () => {
+        const end = new SvelteDate();
+        end.setHours(23, 59, 59, 999);
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 29);
+        start.setHours(0, 0, 0, 0);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Last 90 days',
+      group: 'Months',
+      getValue: () => {
+        const end = new SvelteDate();
+        end.setHours(23, 59, 59, 999);
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 89);
+        start.setHours(0, 0, 0, 0);
+        return { start, end };
+      }
+    }
+  ];
+
+  // Preset with initialPresetLabel demo
+  const presetsWithAllTime: DateRangePreset[] = [
+    {
+      label: 'All time',
+      getValue: () => {
+        const start = new SvelteDate(2020, 0, 1);
+        return { start, end: new SvelteDate() };
+      }
+    },
+    {
+      label: 'Last 7 days',
+      getValue: () => {
+        const end = new SvelteDate();
+        end.setHours(23, 59, 59, 999);
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 6);
+        start.setHours(0, 0, 0, 0);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Last 30 days',
+      getValue: () => {
+        const end = new SvelteDate();
+        end.setHours(23, 59, 59, 999);
+        const start = new SvelteDate();
+        start.setDate(start.getDate() - 29);
+        start.setHours(0, 0, 0, 0);
+        return { start, end };
+      }
+    }
+  ];
+
+  let clearableDate = $state<Date | null>(null);
+
   const today = new SvelteDate();
   const maxDate = new SvelteDate(today.getFullYear(), today.getMonth(), today.getDate());
 </script>
@@ -337,6 +447,72 @@
       presets={commonPresets}
       placeholder="Historical range only"
       testId="drp-constrained-demo"
+    />
+  </div>
+</section>
+
+<!-- ── 7. Single mode with Clear button (clearable) ── -->
+<section class="demo-section">
+  <h2>Single mode — with Clear button (clearable)</h2>
+  <p class="section-note">
+    When <code>clearable</code> is true and a date is committed, a Clear button appears in the
+    footer that resets <code>value</code> to <code>null</code> and fires <code>onclear</code>.
+  </p>
+  <div class="demo-row">
+    <DateRangePicker
+      mode="single"
+      clearable
+      bind:value={clearableDate}
+      placeholder="Pick a date (clearable)"
+      testId="drp-clearable-demo"
+      onapplysingle={(e) => {
+        clearableDate = e.date;
+      }}
+      onclear={() => {
+        clearableDate = null;
+      }}
+    />
+  </div>
+  <p class="result-label">Selected: <strong>{formatDate(clearableDate)}</strong></p>
+</section>
+
+<!-- ── 8. Initial preset label (display seed, no onapply) ── -->
+<section class="demo-section">
+  <h2>Range mode — initialPresetLabel (active preset seeded on mount)</h2>
+  <p class="section-note">
+    <code>initialPresetLabel="All time"</code> seeds the trigger label and sidebar highlight on
+    mount without firing <code>onapply</code>. The real <code>onapply</code> fires when the user opens
+    and clicks Apply.
+  </p>
+  <div class="demo-row">
+    <DateRangePicker
+      mode="range"
+      presets={presetsWithAllTime}
+      initialPresetLabel="All time"
+      placeholder="Select range"
+      testId="drp-initial-preset-demo"
+      onapply={(e) => {
+        rangeStart = e.rangeStart;
+        rangeEnd = e.rangeEnd;
+      }}
+    />
+  </div>
+</section>
+
+<!-- ── 9. Preset groups with dividers ── -->
+<section class="demo-section">
+  <h2>Range mode — preset groups with dividers</h2>
+  <p class="section-note">
+    Adding a <code>group</code> key to <code>DateRangePreset</code> renders a thin divider (with
+    group label) between consecutive presets belonging to different groups. Flat arrays without a
+    <code>group</code> field are unaffected.
+  </p>
+  <div class="demo-row">
+    <DateRangePicker
+      mode="range"
+      presets={groupedPresets}
+      placeholder="Select range (grouped)"
+      testId="drp-groups-demo"
     />
   </div>
 </section>

--- a/src/wc/components/DateRangePicker.wc.svelte
+++ b/src/wc/components/DateRangePicker.wc.svelte
@@ -19,11 +19,14 @@
       locale: { type: 'String', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
+      clearable: { type: 'Boolean', reflect: true },
+      initialPresetLabel: { type: 'String', attribute: 'initial-preset-label' },
       onapply: { type: 'Object' },
       onapplysingle: { type: 'Object' },
       onapplycompare: { type: 'Object' },
       oncancel: { type: 'Object' },
-      onopentoggle: { type: 'Object' }
+      onopentoggle: { type: 'Object' },
+      onclear: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
## Three additive DateRangePicker capabilities

All backward-compatible — existing consumers are unaffected when the new props are unset. These unblock deferred date-picker migrations in consuming apps (single-mode clear, preset-label-on-load, grouped preset sidebars).

### 1. Single-mode clear/reset — `clearable` + `onclear`
- `clearable?: boolean` (default `false`). When `clearable && mode === 'single' && value !== null`, a **Clear** button renders in the footer (left of Cancel/Apply).
- `handleClear()` resets `value`/`draftValue` to `null`, fires `onclear?: () => void`, then closes.
- New CSS vars: `--drp-clear-border-color`, `--drp-clear-color`, `--drp-clear-hover-background`.

### 2. Initial preset highlight — `initialPresetLabel`
- `initialPresetLabel?: string`. Resolved **once** at init via `untrack()` (matching `Calendar.svelte`), highlights the matching preset and shows its label in the trigger **without firing `onapply`**.
- Cleared automatically when the user clicks Apply or any preset, handing control back to the date-derived label.

### 3. Preset groups with dividers — `group` on `DateRangePreset`
- Optional `group?: string` field. A `.drp-preset-divider` (with optional `.drp-preset-group-label`) renders between consecutive presets whose `group` changes.
- Flat arrays without `group` render exactly as before.
- New CSS vars: `--drp-preset-divider-border`, `--drp-preset-divider-gap`, `--drp-preset-divider-margin`, `--drp-preset-group-label-color`, `--drp-preset-divider-leader-width`.

### Surface updated
`DateRangePicker.svelte`, `properties.ts`, the WC wrapper (`clearable`, `initial-preset-label`), the demo page, and docs (`DateRangePicker.md`, `_index.json`).

### Gates
`pnpm check` 0 errors · `pnpm build` success · ESLint 0 errors on changed files. (Pre-existing prettier failures in unrelated demo pages / Select.svelte were left untouched.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Clear button for single-date selections to reset the value
  * Added initial preset label support to pre-select a preset on component load
  * Added preset grouping with dividers for better organization
  * Extended CSS customization variables for Clear button and preset groups

* **Documentation**
  * Updated component documentation with new features and Web Component attribute mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->