### PR TITLE
feat(Select): add CSS variables for dropdown horizontal sizing

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -58,26 +58,26 @@ Replace the default ☐/☑ glyphs with a custom indicator:
 
 ## Props
 
-| Prop        | Type                        | Required | Default | Description                                                                                                                                                            |
-| ----------- | --------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| items       | `SelectItem[] \| string[]`  | Yes      | -       | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.       |
-| value       | `string[]`                  | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                             |
-| open        | `boolean`                   | No       | `false` | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state. |
-| multiple    | `boolean`                   | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                            |
-| searchable  | `boolean`                   | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                    |
-| placeholder | `string`                    | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                               |
-| disabled    | `boolean`                   | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                        |
-| testId      | `string`                    | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                     |
-| classes     | `string`                    | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop        | Type                       | Required | Default | Description                                                                                                                                                                  |
+| ----------- | -------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| items       | `SelectItem[] \| string[]` | Yes      | -       | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.             |
+| value       | `string[]`                 | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                                   |
+| open        | `boolean`                  | No       | `false` | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state. |
+| multiple    | `boolean`                  | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                                  |
+| searchable  | `boolean`                  | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                          |
+| placeholder | `string`                   | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                                     |
+| disabled    | `boolean`                  | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                              |
+| testId      | `string`                   | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                           |
+| classes     | `string`                   | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.       |
 
 ## Snippets
 
 Svelte 5 Snippet props — pass content blocks to the component.
 
-| Snippet          | Type                              | Description                                                                                                                                          |
-| ---------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| bottomContent    | `Snippet`                         | Arbitrary content rendered at the bottom of the open dropdown, separated by a border. Use for "Manage options" links or bulk actions.                |
-| optionIndicator  | `Snippet<[{ checked: boolean }]>` | Custom indicator rendered before each option label in multi-select mode. Receives `{ checked }` and replaces the default ☐/☑ glyphs when provided.  |
+| Snippet         | Type                              | Description                                                                                                                                        |
+| --------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bottomContent   | `Snippet`                         | Arbitrary content rendered at the bottom of the open dropdown, separated by a border. Use for "Manage options" links or bulk actions.              |
+| optionIndicator | `Snippet<[{ checked: boolean }]>` | Custom indicator rendered before each option label in multi-select mode. Receives `{ checked }` and replaces the default ☐/☑ glyphs when provided. |
 
 ## Events
 
@@ -135,37 +135,42 @@ Override these custom properties to theme the component.
 
 ### Dropdown
 
-| Variable                          | Default                         | CSS Property  | Description                                      |
-| --------------------------------- | ------------------------------- | ------------- | ------------------------------------------------ |
-| `--select-dropdown-gap`           | `4px`                           | margin-top    | Gap between the trigger and the dropdown panel.  |
-| `--select-dropdown-background`    | `#ffffff`                       | background    | Background color of the dropdown panel.          |
-| `--select-dropdown-border`        | `1px solid #cccccc`             | border        | Border of the dropdown panel.                    |
-| `--select-dropdown-border-radius` | `6px`                           | border-radius | Corner rounding of the dropdown panel.           |
-| `--select-dropdown-shadow`        | `0 4px 12px rgba(0, 0, 0, 0.1)` | box-shadow    | Box shadow of the dropdown panel.                |
-| `--select-dropdown-max-height`    | `200px`                         | max-height    | Maximum height of the dropdown (scrolls beyond). |
-| `--select-dropdown-z-index`       | `10`                            | z-index       | Stack order of the dropdown panel.               |
+| Variable                          | Default                         | CSS Property  | Description                                                                                                           |
+| --------------------------------- | ------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `--select-dropdown-gap`           | `4px`                           | margin-top    | Gap between the trigger and the dropdown panel.                                                                       |
+| `--select-dropdown-background`    | `#ffffff`                       | background    | Background color of the dropdown panel.                                                                               |
+| `--select-dropdown-border`        | `1px solid #cccccc`             | border        | Border of the dropdown panel.                                                                                         |
+| `--select-dropdown-border-radius` | `6px`                           | border-radius | Corner rounding of the dropdown panel.                                                                                |
+| `--select-dropdown-shadow`        | `0 4px 12px rgba(0, 0, 0, 0.1)` | box-shadow    | Box shadow of the dropdown panel.                                                                                     |
+| `--select-dropdown-max-height`    | `200px`                         | max-height    | Maximum height of the dropdown (scrolls beyond).                                                                      |
+| `--select-dropdown-z-index`       | `10`                            | z-index       | Stack order of the dropdown panel.                                                                                    |
+| `--select-dropdown-left`          | `0`                             | left          | Left edge of the dropdown relative to the trigger. Set to `auto` to anchor by the right edge instead.                 |
+| `--select-dropdown-right`         | `0`                             | right         | Right edge of the dropdown relative to the trigger. Set to `auto` to let the panel grow rightward from the left edge. |
+| `--select-dropdown-min-width`     | `auto`                          | min-width     | Minimum width of the dropdown panel. Set to `100%` to keep it at least as wide as the trigger.                        |
+| `--select-dropdown-max-width`     | `none`                          | max-width     | Maximum width of the dropdown panel (e.g. `70vw` to cap growth on wide content).                                      |
+| `--select-dropdown-width`         | `auto`                          | width         | Width of the dropdown panel. Set to `max-content` to size to the longest option instead of the trigger width.         |
 
 ### Options
 
-| Variable                                    | Default                                        | CSS Property | Description                                                                                    |
-| ------------------------------------------- | ---------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
-| `--select-option-padding`                   | `8px 12px`                                     | padding      | Padding inside each dropdown option.                                                           |
-| `--select-option-color`                     | `#333333`                                      | color        | Text color of dropdown options.                                                                |
-| `--select-option-font-size`                 | `inherit`                                      | font-size    | Font size of dropdown options.                                                                 |
-| `--select-option-gap`                       | `0`                                            | gap          | Gap between the option indicator and the label text in multi-select mode.                      |
-| `--select-option-hover-background`          | `#f0f0f0`                                      | background   | Background of options on hover or keyboard highlight.                                          |
-| `--select-option-hover-color`               | inherits `--select-option-color`               | color        | Text color of options on hover or keyboard highlight.                                          |
-| `--select-option-selected-background`       | `#e8f0fe`                                      | background   | Background of selected options.                                                                |
-| `--select-option-selected-color`            | inherits `--select-option-color`               | color        | Text color of selected options.                                                                |
-| `--select-option-selected-hover-background` | inherits `--select-option-selected-background` | background   | Background of selected options on hover.                                                       |
-| `--select-option-indicator-color`           | `currentColor`                                 | color        | Color of the default ☐/☑ indicator shown per option in multi-select mode.                     |
+| Variable                                    | Default                                        | CSS Property | Description                                                               |
+| ------------------------------------------- | ---------------------------------------------- | ------------ | ------------------------------------------------------------------------- |
+| `--select-option-padding`                   | `8px 12px`                                     | padding      | Padding inside each dropdown option.                                      |
+| `--select-option-color`                     | `#333333`                                      | color        | Text color of dropdown options.                                           |
+| `--select-option-font-size`                 | `inherit`                                      | font-size    | Font size of dropdown options.                                            |
+| `--select-option-gap`                       | `0`                                            | gap          | Gap between the option indicator and the label text in multi-select mode. |
+| `--select-option-hover-background`          | `#f0f0f0`                                      | background   | Background of options on hover or keyboard highlight.                     |
+| `--select-option-hover-color`               | inherits `--select-option-color`               | color        | Text color of options on hover or keyboard highlight.                     |
+| `--select-option-selected-background`       | `#e8f0fe`                                      | background   | Background of selected options.                                           |
+| `--select-option-selected-color`            | inherits `--select-option-color`               | color        | Text color of selected options.                                           |
+| `--select-option-selected-hover-background` | inherits `--select-option-selected-background` | background   | Background of selected options on hover.                                  |
+| `--select-option-indicator-color`           | `currentColor`                                 | color        | Color of the default ☐/☑ indicator shown per option in multi-select mode. |
 
 ### Bottom Content
 
-| Variable                             | Default                | CSS Property | Description                                                     |
-| ------------------------------------ | ---------------------- | ------------ | --------------------------------------------------------------- |
-| `--select-bottom-content-border`     | `none`                 | border-top   | Separator line between the option list and the bottom content. Set to `1px solid #eeeeee` (or any color) in your own CSS when a visible divider is desired. |
-| `--select-bottom-content-padding`    | `8px 12px`             | padding      | Inner padding of the bottom content area.                       |
+| Variable                          | Default    | CSS Property | Description                                                                                                                                                 |
+| --------------------------------- | ---------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--select-bottom-content-border`  | `none`     | border-top   | Separator line between the option list and the bottom content. Set to `1px solid #eeeeee` (or any color) in your own CSS when a visible divider is desired. |
+| `--select-bottom-content-padding` | `8px 12px` | padding      | Inner padding of the bottom content area.                                                                                                                   |
 
 ### Empty State
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -471,8 +471,11 @@
   .select-dropdown {
     position: absolute;
     top: 100%;
-    left: 0;
-    right: 0;
+    left: var(--select-dropdown-left, 0);
+    right: var(--select-dropdown-right, 0);
+    min-width: var(--select-dropdown-min-width, auto);
+    max-width: var(--select-dropdown-max-width, none);
+    width: var(--select-dropdown-width, auto);
     margin-top: var(--select-dropdown-gap, 4px);
     background: var(--select-dropdown-background, #ffffff);
     border: var(--select-dropdown-border, 1px solid #cccccc);
@@ -485,9 +488,10 @@
 
   .select-dropdown-right {
     left: auto;
-    right: 0;
-    min-width: 100%;
-    width: max-content;
+    right: var(--select-dropdown-right, 0);
+    min-width: var(--select-dropdown-min-width, 100%);
+    max-width: var(--select-dropdown-max-width, none);
+    width: var(--select-dropdown-width, max-content);
   }
 
   .select-option {


### PR DESCRIPTION
## What

Adds five CSS custom properties to the `Select` dropdown panel so its **horizontal placement and width** can be themed via the `classes` prop, consistent with how every other dropdown property is already exposed:

| Variable | Default | CSS Property |
|---|---|---|
| `--select-dropdown-left` | `0` | `left` |
| `--select-dropdown-right` | `0` | `right` |
| `--select-dropdown-min-width` | `auto` | `min-width` |
| `--select-dropdown-max-width` | `none` | `max-width` |
| `--select-dropdown-width` | `auto` | `width` |

## Why

The dropdown panel already exposes a CSS-var hook for **every** other property — `--select-dropdown-gap`, `-background`, `-border`, `-border-radius`, `-shadow`, `-max-height`, `-z-index` — but its horizontal sizing was hardcoded to `left: 0; right: 0`, pinning the panel to the trigger width and **clipping long option labels**.

The only escape hatch was reaching the internal `.select-dropdown` class through a `:global()` override. Real consumers are doing exactly that today, e.g. a left-anchored menu that needs to grow to its content while capping at a viewport fraction:

```css
/* before — reaches a library-internal class via :global() */
.my-select :global(.select-dropdown) {
  right: auto;
  min-width: 100%;
  width: max-content;
  max-width: 70vw;
}
```

```css
/* after — pure CSS-var theming via the documented classes API */
.my-select {
  --select-dropdown-right: auto;
  --select-dropdown-min-width: 100%;
  --select-dropdown-width: max-content;
  --select-dropdown-max-width: 70vw;
}
```

`dropdownAlign="right"` only swaps the anchor edge (it already grows to `max-content` leftward); it can't express a **left-anchored** panel that grows rightward, nor a `max-width` cap — hence the var hooks.

## Backward compatibility

The defaults reproduce the current rendering exactly (`left:0; right:0; min-width:auto; max-width:none; width:auto`), so existing usages are unaffected. The `.select-dropdown-right` preset is unchanged.

## Changes

- `src/lib/Select/Select.svelte` — wrap the five horizontal-sizing declarations in `var()`.
- `docs/Select.md` — document the five new variables in the Dropdown table.

## Verification

- `pnpm run check` → 0 errors.
- `pnpm exec prettier --check` → clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Props, Snippets, and CSS Variables tables in Select component documentation for improved organization.

* **Improvements**
  * Select component dropdown now offers configurable positioning and sizing through CSS variables instead of fixed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->