### PR TITLE
feat(Card): headerRight, footer, stretch, scrollable

### DIFF
--- a/docs/Card.md
+++ b/docs/Card.md
@@ -145,6 +145,38 @@ The Card component intentionally omits named layout slots to keep its API minima
 
 This pattern gives full layout control to the consumer (any number of zones, any flex/grid arrangement) without baking structural presets into the library.
 
+### Card with Header Right Slot
+
+```svelte
+<script>
+  import { Card, Button } from '@juspay/svelte-ui-components';
+</script>
+
+<Card title="Recent Orders" description="Last 7 days">
+  {#snippet headerRight()}
+    <Button text="View All" />
+  {/snippet}
+  <p>12 orders placed</p>
+</Card>
+```
+
+### Stretch and Scrollable Card
+
+```svelte
+<div style="height: 300px; display: flex;">
+  <Card title="Activity Log" stretch scrollable>
+    {#snippet children()}
+      {#each events as event}
+        <p>{event.message}</p>
+      {/each}
+    {/snippet}
+    {#snippet footer()}
+      <span>End of log</span>
+    {/snippet}
+  </Card>
+</div>
+```
+
 ## Props
 
 | Prop        | Type                          | Required | Default | Description                                                                                                                                                                  |
@@ -155,6 +187,10 @@ This pattern gives full layout control to the consumer (any number of zones, any
 | classes     | `string`                      | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.       |
 | testId      | `string`                      | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                                                                                   |
 | onclick     | `(event: MouseEvent) => void` | No       | `-`     | Click handler. When provided, the card root becomes interactive: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler. Omit to keep a plain `<div>`. |
+| headerRight | `Snippet`                     | No       | `-`     | Snippet rendered at the top-right of the header row alongside the title/description. When omitted the header row is unchanged (title block takes full width).                |
+| footer      | `Snippet`                     | No       | `-`     | Snippet rendered in a `<footer>` element below the content area. When omitted no footer element is rendered.                                                                 |
+| stretch     | `boolean`                     | No       | `false` | When true, the card root gets `height: 100%` and becomes a flex column so the content area grows to fill remaining space. Useful in equal-height grid/flex layouts.         |
+| scrollable  | `boolean`                     | No       | `false` | When true, the content area becomes vertically scrollable (max-height via `--card-content-max-height`, default 400px). The region also gains `role="region"` and `tabindex="0"` for keyboard accessibility. |
 
 ## Events
 
@@ -191,13 +227,30 @@ Override these custom properties to theme the component.
 | `--card-description-color`     | `inherit`                | color         | Color of the description text. Inherits from parent by default.                                |
 | `--card-description-opacity`   | `0.6`                    | opacity       | Opacity of the description text for visual hierarchy.                                          |
 | `--card-content-padding`       | `16px`                   | padding       | Padding of the content body.                                                                   |
+| `--card-stretch-height`        | `100%`                   | height        | Height of the card root when `stretch=true`. Set to a fixed value or `100%` for full-height layouts. |
+| `--card-content-flex`          | `1`                      | flex          | Flex grow/shrink/basis shorthand for the content area when `stretch=true`, allowing it to fill remaining height. |
+| `--card-header-align-items`    | `flex-start`             | align-items   | Vertical alignment of the header row when `headerRight` is provided (`.card-header-split` flex container). |
+| `--card-header-gap`            | `8px`                    | gap           | Gap between the header main section and the `headerRight` slot when both are present.         |
+| `--card-header-right-align-items` | `center`              | align-items   | Vertical alignment of the `headerRight` slot container.                                        |
+| `--card-content-max-height`    | `400px`                  | max-height    | Maximum height of the scrollable content area when `scrollable=true`.                         |
+| `--card-footer-padding`        | `12px 16px`              | padding       | Padding of the footer element.                                                                 |
+| `--card-footer-border-top`     | `none`                   | border-top    | Optional top border for the footer. Set to a border value (e.g. `1px solid #e5e7eb`) to visually separate the footer. |
+| `--card-footer-background`     | `inherit`                | background    | Background color of the footer element. Inherits from the card by default.                    |
 
 ## Web Component
 
 Tag: `<sui-card>`
 
+Reflected boolean attributes: `stretch`, `scrollable`.
+
 ```html
 <sui-card title="Order Summary" description="Review your items">
   <p>3 items in your cart</p>
+</sui-card>
+
+<!-- stretch + scrollable -->
+<sui-card title="Activity Log" stretch scrollable>
+  <p>Event 1</p>
+  <p>Event 2</p>
 </sui-card>
 ```

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
   import type { CardProperties } from './properties';
 
-  let { children, title, description, classes, testId, onclick }: CardProperties = $props();
+  let {
+    children,
+    title,
+    description,
+    classes,
+    testId,
+    onclick,
+    headerRight,
+    footer,
+    stretch = false,
+    scrollable = false
+  }: CardProperties = $props();
 
   const isInteractive = $derived(typeof onclick === 'function');
 
-  function handleKeydown(event: KeyboardEvent): void {
+  const handleKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Enter' || event.key === ' ') {
       if (event.key === ' ') {
         event.preventDefault();
@@ -14,31 +25,54 @@
         event.currentTarget.click();
       }
     }
-  }
+  };
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   class="card {classes ?? ''}"
   class:card-interactive={isInteractive}
+  class:card-stretch={stretch}
+  class:card-has-scroll={scrollable}
   data-pw={typeof testId === 'string' ? testId : null}
   role={isInteractive ? 'button' : null}
   tabindex={isInteractive ? 0 : null}
   onclick={isInteractive ? onclick : null}
   onkeydown={isInteractive ? handleKeydown : null}
 >
-  {#if typeof title === 'string' && title.length > 0}
-    <div class="card-header">
-      <div class="card-title">{title}</div>
-      {#if typeof description === 'string' && description.length > 0}
-        <div class="card-description">{description}</div>
+  {#if (typeof title === 'string' && title.length > 0) || typeof headerRight === 'function'}
+    <div class="card-header" class:card-header-split={typeof headerRight === 'function'}>
+      <div class="card-header-main">
+        {#if typeof title === 'string' && title.length > 0}
+          <div class="card-title">{title}</div>
+        {/if}
+        {#if typeof description === 'string' && description.length > 0}
+          <div class="card-description">{description}</div>
+        {/if}
+      </div>
+      {#if typeof headerRight === 'function'}
+        <div class="card-header-right">
+          {@render headerRight()}
+        </div>
       {/if}
     </div>
   {/if}
   {#if typeof children === 'function'}
-    <div class="card-content">
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <div
+      class="card-content"
+      class:card-content-scrollable={scrollable}
+      role={scrollable ? 'region' : null}
+      aria-label={scrollable ? 'Scrollable card content' : null}
+      tabindex={scrollable ? 0 : null}
+    >
       {@render children()}
     </div>
+  {/if}
+  {#if typeof footer === 'function'}
+    <footer class="card-footer">
+      {@render footer()}
+    </footer>
   {/if}
 </div>
 
@@ -68,9 +102,48 @@
     outline-offset: var(--card-focus-outline-offset, 2px);
   }
 
+  /* stretch: fill parent height */
+  .card-stretch {
+    height: var(--card-stretch-height, 100%);
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* when stretch is on, content area should grow to fill remaining space */
+  .card-stretch .card-content {
+    flex: var(--card-content-flex, 1);
+  }
+
+  /* when scrollable=true the child sets overflow-y:auto, so the card must not clip it */
+  .card-has-scroll {
+    overflow: visible;
+  }
+
+  /* header row layout — base block flow; flex only applied when headerRight is present */
   .card-header {
     padding: var(--card-header-padding, 16px 16px 0);
     border-bottom: var(--card-header-border-bottom, none);
+  }
+
+  /* flex layout activated only when headerRight snippet is provided */
+  .card-header-split {
+    display: flex;
+    align-items: var(--card-header-align-items, flex-start);
+    justify-content: space-between;
+    gap: var(--card-header-gap, 8px);
+  }
+
+  .card-header-main {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .card-header-right {
+    display: flex;
+    align-items: var(--card-header-right-align-items, center);
+    flex-shrink: 0;
   }
 
   .card-title {
@@ -88,5 +161,19 @@
 
   .card-content {
     padding: var(--card-content-padding, 16px);
+  }
+
+  /* scrollable content area */
+  .card-content-scrollable {
+    overflow-y: auto;
+    max-height: var(--card-content-max-height, 400px);
+    scrollbar-width: thin;
+  }
+
+  /* footer */
+  .card-footer {
+    padding: var(--card-footer-padding, 12px 16px);
+    border-top: var(--card-footer-border-top, none);
+    background: var(--card-footer-background, inherit);
   }
 </style>

--- a/src/lib/Card/properties.ts
+++ b/src/lib/Card/properties.ts
@@ -21,4 +21,27 @@ export type OptionalCardProperties = {
    * so existing consumers see zero behaviour change.
    */
   onclick?: (event: MouseEvent) => void;
+  /**
+   * Snippet rendered at the top-right of the header row, alongside title/description.
+   * When omitted the header row is unchanged (title block takes full width).
+   */
+  headerRight?: Snippet;
+  /**
+   * Snippet rendered in a `<footer class="card-footer">` element below the content area.
+   * When omitted no footer element is rendered.
+   */
+  footer?: Snippet;
+  /**
+   * When true, the root `.card` element gets `height: 100%` and becomes a flex column
+   * so the content area grows to fill the remaining space. Defaults to false.
+   */
+  stretch?: boolean;
+  /**
+   * When true, the `.card-content` area becomes vertically scrollable with a
+   * configurable `max-height` (default 400px via `--card-content-max-height`).
+   * The content div receives `role="region"`, `aria-label="Scrollable card content"`,
+   * and `tabindex="0"` so keyboard users can focus and scroll the overflowing region.
+   * Defaults to false.
+   */
+  scrollable?: boolean;
 };

--- a/src/wc/components/Card.wc.svelte
+++ b/src/wc/components/Card.wc.svelte
@@ -5,7 +5,9 @@
     props: {
       title: { type: 'String', reflect: true },
       description: { type: 'String', reflect: true },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      stretch: { type: 'Boolean', reflect: true },
+      scrollable: { type: 'Boolean', reflect: true }
     }
   }}
 />


### PR DESCRIPTION
Adds backward-compatible props to **Card**: `headerRight?: Snippet` (top-right of header row), `footer?: Snippet` (.card-footer below content), `stretch?: boolean` (fill parent height), `scrollable?: boolean` (scrollable content area), with matching `--card-*` CSS vars. All optional — zero behaviour change for existing consumers.

Unblocks the project Section→Card and StepCard→Card folds (hold-and-fold). svelte-check + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `headerRight` snippet slot for card headers
  * Added `footer` snippet slot for cards
  * Added `stretch` boolean prop for full-height card layouts
  * Added `scrollable` boolean prop for card content
  * Extended CSS custom properties for card styling

* **Documentation**
  * Updated Card documentation with new props, examples, and configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->