### PR TITLE
feat(Select): onOpen/onClose callbacks + ghost variant

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -58,17 +58,18 @@ Replace the default ☐/☑ glyphs with a custom indicator:
 
 ## Props
 
-| Prop        | Type                       | Required | Default | Description                                                                                                                                                                  |
-| ----------- | -------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| items       | `SelectItem[] \| string[]` | Yes      | -       | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.             |
-| value       | `string[]`                 | No       | `[]`    | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                                   |
-| open        | `boolean`                  | No       | `false` | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state. |
-| multiple    | `boolean`                  | No       | `false` | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                                  |
-| searchable  | `boolean`                  | No       | `false` | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                          |
-| placeholder | `string`                   | No       | `''`    | Text shown when no item is selected (or in the search input when empty).                                                                                                     |
-| disabled    | `boolean`                  | No       | `false` | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                              |
-| testId      | `string`                   | No       | -       | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                           |
-| classes     | `string`                   | No       | -       | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.       |
+| Prop        | Type                       | Required | Default     | Description                                                                                                                                                                                           |
+| ----------- | -------------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| items       | `SelectItem[] \| string[]` | Yes      | -           | Array of selectable options. Pass `SelectItem[]` objects (each with `id` and `label`) or a plain `string[]` where each string becomes both the id and the label.                                      |
+| value       | `string[]`                 | No       | `[]`        | Bindable. Array of selected item IDs. In single-select mode, contains at most one element.                                                                                                            |
+| open        | `boolean`                  | No       | `false`     | Bindable. Controls whether the dropdown is open; writes back on open/close so a parent can `bind:open` to observe or drive it. Unbound, the component manages its own state.                          |
+| multiple    | `boolean`                  | No       | `false`     | Enables multi-select mode. Items are toggled on/off and displayed as dismissible pills in the trigger area.                                                                                           |
+| searchable  | `boolean`                  | No       | `false`     | Enables a text input in the trigger area for filtering items by label. Works in both single and multi-select modes.                                                                                   |
+| placeholder | `string`                   | No       | `''`        | Text shown when no item is selected (or in the search input when empty).                                                                                                                              |
+| disabled    | `boolean`                  | No       | `false`     | When true, the select is non-interactive, has reduced opacity, and pointer events are disabled.                                                                                                       |
+| testId      | `string`                   | No       | -           | Value for the `data-pw` attribute on the container element, used for end-to-end testing selectors.                                                                                                    |
+| classes     | `string`                   | No       | -           | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                |
+| hierarchy   | `SelectHierarchy`          | No       | `'default'` | Visual hierarchy of the trigger. `'ghost'` renders a transparent, borderless trigger — useful when the Select is embedded in a toolbar or header where a full bordered input would be visually heavy. |
 
 ## Snippets
 
@@ -84,6 +85,8 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | Event    | Type                        | Description                                                                                                                       |
 | -------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | onchange | `(value: string[]) => void` | Fires when the selection changes. Receives the full array of selected item IDs. In single-select mode, the array has one element. |
+| onopen   | `() => void`                | Fires when the dropdown opens.                                                                                                    |
+| onclose  | `() => void`                | Fires when the dropdown closes.                                                                                                   |
 
 ## CSS Variables
 
@@ -171,6 +174,19 @@ Override these custom properties to theme the component.
 | --------------------------------- | ---------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--select-bottom-content-border`  | `none`     | border-top   | Separator line between the option list and the bottom content. Set to `1px solid #eeeeee` (or any color) in your own CSS when a visible divider is desired. |
 | `--select-bottom-content-padding` | `8px 12px` | padding      | Inner padding of the bottom content area.                                                                                                                   |
+
+### Ghost Trigger
+
+These variables apply when `hierarchy="ghost"`. The trigger starts fully transparent and reveals a subtle background on hover and when open.
+
+| Variable                                    | Default            | CSS Property | Description                                                  |
+| ------------------------------------------- | ------------------ | ------------ | ------------------------------------------------------------ |
+| `--select-ghost-trigger-background`         | `transparent`      | background   | Background of the ghost trigger at rest.                     |
+| `--select-ghost-trigger-border-color`       | `transparent`      | border-color | Border color of the ghost trigger at rest.                   |
+| `--select-ghost-trigger-hover-background`   | `rgba(0,0,0,0.04)` | background   | Background of the ghost trigger on hover.                    |
+| `--select-ghost-trigger-hover-border-color` | `transparent`      | border-color | Border color of the ghost trigger on hover.                  |
+| `--select-ghost-trigger-open-background`    | `rgba(0,0,0,0.06)` | background   | Background of the ghost trigger when the dropdown is open.   |
+| `--select-ghost-trigger-open-border-color`  | `transparent`      | border-color | Border color of the ghost trigger when the dropdown is open. |
 
 ### Empty State
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -17,9 +17,12 @@
     testId,
     itemTestId,
     onchange,
+    onopen,
+    onclose,
     classes,
     open = $bindable(false),
-    dropdownAlign = 'left'
+    dropdownAlign = 'left',
+    hierarchy = 'default'
   }: SelectProperties = $props();
 
   function normalizeItems(source: SelectItem[] | string[]): SelectItem[] {
@@ -65,6 +68,7 @@
       return;
     }
     open = true;
+    onopen?.();
     highlightedIndex = -1;
     query = '';
     if (searchable) {
@@ -77,6 +81,7 @@
 
   function close(): void {
     open = false;
+    onclose?.();
     query = '';
     highlightedIndex = -1;
   }
@@ -208,7 +213,7 @@
     }
     query = event.target.value;
     if (!open) {
-      open = true;
+      openDropdown();
     }
     highlightedIndex = -1;
   }
@@ -233,6 +238,9 @@
     document.addEventListener('click', handleClickOutside);
     return () => {
       document.removeEventListener('click', handleClickOutside);
+      if (open) {
+        onclose?.();
+      }
     };
   });
 </script>
@@ -241,6 +249,7 @@
   class="select {classes ?? ''}"
   class:open
   class:disabled
+  class:ghost={hierarchy === 'ghost'}
   bind:this={containerEl}
   {...typeof testId === 'string' ? { 'data-pw': testId } : {}}
 >
@@ -551,5 +560,23 @@
     --pill-border-radius: var(--select-pill-border-radius, 999px);
     --pill-padding: var(--select-pill-padding, 2px 8px);
     --pill-font-size: var(--select-pill-font-size, 13px);
+  }
+
+  /* Ghost hierarchy: transparent, borderless trigger */
+  .select.ghost .select-trigger {
+    background: var(--select-ghost-trigger-background, transparent);
+    border-color: var(--select-ghost-trigger-border-color, transparent);
+    box-shadow: none;
+  }
+
+  .select.ghost .select-trigger:hover:not(.disabled .select-trigger) {
+    border-color: var(--select-ghost-trigger-hover-border-color, transparent);
+    background: var(--select-ghost-trigger-hover-background, rgba(0, 0, 0, 0.04));
+  }
+
+  .select.ghost.open .select-trigger {
+    border-color: var(--select-ghost-trigger-open-border-color, transparent);
+    background: var(--select-ghost-trigger-open-background, rgba(0, 0, 0, 0.06));
+    box-shadow: none;
   }
 </style>

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -15,6 +15,8 @@ export type MandatorySelectProperties = {
   items: SelectItem[] | string[];
 };
 
+export type SelectHierarchy = 'default' | 'ghost';
+
 export type OptionalSelectProperties = {
   value?: string[];
   multiple?: boolean;
@@ -33,8 +35,12 @@ export type OptionalSelectProperties = {
   dropdownAlign?: 'left' | 'right';
   /** Snippet for rendering a compact trigger summary in multiple mode instead of one Pill per selected value. Receives `{ value, items }` so the consumer can compute e.g. "All" / "3 selected". When not provided the default Pill-per-value behaviour is used. */
   triggerSummary?: import('svelte').Snippet<[{ value: string[]; items: SelectItem[] }]>;
+  /** Visual hierarchy of the trigger. `'ghost'` renders a transparent, borderless trigger — useful when the Select is embedded in a toolbar or header where a full bordered input would be visually heavy. Defaults to `'default'`. */
+  hierarchy?: SelectHierarchy;
 };
 
 export type SelectEventProperties = {
   onchange?: (value: string[]) => void;
+  onopen?: () => void;
+  onclose?: () => void;
 };

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -46,6 +46,8 @@
   let customIndicatorValue: string[] = $state([]);
   let alignValue: string[] = $state([]);
   let summaryValue: string[] = $state([]);
+  let ghostValue: string[] = $state([]);
+  let openEventLog: string[] = $state([]);
 </script>
 
 <div class="page-header">
@@ -158,6 +160,34 @@
   </Select>
   {#if summaryValue.length > 0}
     <p class="demo-info">Selected IDs: {summaryValue.join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Ghost hierarchy</h3>
+<p>
+  Use <code>hierarchy="ghost"</code> for a transparent, borderless trigger — ideal for toolbar or header
+  selects where a full bordered input would be visually heavy.
+</p>
+<div class="demo-row" style="max-width: 300px;">
+  <Select items={fruits} bind:value={ghostValue} placeholder="Ghost trigger" hierarchy="ghost" />
+  {#if ghostValue.length > 0}
+    <p class="demo-info">Selected: {ghostValue.at(0)}</p>
+  {/if}
+</div>
+
+<h3>onopen / onclose callbacks</h3>
+<p>
+  Use <code>onopen</code> and <code>onclose</code> to react to dropdown open/close events.
+</p>
+<div class="demo-row" style="max-width: 300px;">
+  <Select
+    items={fruits}
+    placeholder="Watch the log"
+    onopen={() => (openEventLog = [...openEventLog, 'opened'])}
+    onclose={() => (openEventLog = [...openEventLog, 'closed'])}
+  />
+  {#if openEventLog.length > 0}
+    <p class="demo-info">Event log: {openEventLog.slice(-4).join(' → ')}</p>
   {/if}
 </div>
 


### PR DESCRIPTION
Adds optional onOpen/onClose callbacks (fired on dropdown open/close) and a ghost (transparent/borderless) trigger variant to Select. Backward-compatible. Unblocks the project Dropdown→Select migration. svelte-check + lint clean. hold-and-fold.