### PR TITLE
feat(Toggle): disabled prop

### DIFF
--- a/docs/Toggle.md
+++ b/docs/Toggle.md
@@ -14,11 +14,13 @@ A labeled on/off switch with sliding ball animation. The `checked` prop controls
 
 ## Props
 
-| Prop    | Type      | Required | Default | Description                                                                                                                                                            |
-| ------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| checked | `boolean` | No       | `false` | The current on/off state of the toggle switch.                                                                                                                         |
-| text    | `string`  | No       | `''`    | Label text displayed next to the toggle switch.                                                                                                                        |
-| classes | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop     | Type      | Required | Default | Description                                                                                                                                                            |
+| -------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| checked  | `boolean` | No       | `false` | The current on/off state of the toggle switch.                                                                                                                         |
+| text     | `string`  | No       | `''`    | Label text displayed next to the toggle switch.                                                                                                                        |
+| disabled | `boolean` | No       | `false` | When true, prevents interaction and applies reduced opacity to indicate the disabled state.                                                                            |
+| testId   | `string`  | No       | `-`     | Value for the `data-pw` attribute on the container element, used for Playwright test targeting.                                                                        |
+| classes  | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
 
 ## Events
 
@@ -35,6 +37,7 @@ Override these custom properties to theme the component.
 | `--toggle-container-display`              | `flex`            | display            | Display mode of the toggle container.                        |
 | `--toggle-container-align-items`          | `center`          | align-items        | Vertical alignment of switch and label.                      |
 | `--toggle-container-gap`                  | `8px`             | gap                | Gap between the switch and label text.                       |
+| `--toggle-disabled-opacity`               | `0.4`             | opacity            | Opacity of the toggle when in the disabled state.            |
 | `--toggle-text-font-size`                 | `14px`            | font-size          | Font size of the label text.                                 |
 | `--toggle-text-font-weight`               | `400`             | font-weight        | Font weight of the label text.                               |
 | `--toggle-text-color`                     | `#4a4a4a`         | color              | Color of the label text.                                     |

--- a/src/lib/Toggle/Toggle.svelte
+++ b/src/lib/Toggle/Toggle.svelte
@@ -1,20 +1,33 @@
 <script lang="ts">
   import type { ToggleProperties } from './properties';
 
-  let { checked = false, text = '', classes, onclick }: ToggleProperties = $props();
+  let {
+    checked = false,
+    text = '',
+    disabled = false,
+    testId,
+    classes,
+    onclick
+  }: ToggleProperties = $props();
 
-  function handleCheckboxClick(e: MouseEvent): void {
+  const handleCheckboxClick = (e: MouseEvent): void => {
     if (e.target instanceof HTMLInputElement && typeof e.target.checked === 'boolean') {
       checked = e.target.checked;
     }
     onclick?.(checked);
-  }
+  };
 </script>
 
-<div class="container {classes ?? ''}">
+<div class="container {classes ?? ''}" class:disabled aria-disabled={disabled} data-pw={testId}>
   <div class="text" hidden={text.length === 0}>{text}</div>
   <label class="switch">
-    <input class="input-checkbox" type="checkbox" {checked} onclick={handleCheckboxClick} />
+    <input
+      class="input-checkbox"
+      type="checkbox"
+      {checked}
+      {disabled}
+      onclick={handleCheckboxClick}
+    />
     <span class="slider round"></span>
   </label>
 </div>
@@ -24,6 +37,12 @@
     display: var(--toggle-container-display, flex);
     align-items: var(--toggle-container-align-items, center);
     gap: var(--toggle-container-gap, 8px);
+  }
+
+  .container.disabled {
+    opacity: var(--toggle-disabled-opacity, 0.4);
+    cursor: not-allowed;
+    pointer-events: none;
   }
 
   .text {

--- a/src/lib/Toggle/properties.ts
+++ b/src/lib/Toggle/properties.ts
@@ -1,6 +1,10 @@
-export type ToggleProperties = ToggleEventProperties & {
+export type ToggleProperties = OptionalToggleProperties & ToggleEventProperties;
+
+export type OptionalToggleProperties = {
+  text?: string;
   checked?: boolean;
-  text: string;
+  disabled?: boolean;
+  testId?: string;
   classes?: string;
 };
 

--- a/src/wc/components/Toggle.wc.svelte
+++ b/src/wc/components/Toggle.wc.svelte
@@ -5,6 +5,7 @@
     props: {
       checked: { type: 'Boolean', reflect: true },
       text: { type: 'String', reflect: true },
+      disabled: { type: 'Boolean', reflect: true },
       classes: { type: 'String' },
       onclick: { type: 'Object' }
     }


### PR DESCRIPTION
Adds an optional disabled prop to Toggle (dim styling, cursor not-allowed, pointer-events none, guarded onclick) via --toggle-disabled-opacity. Backward-compatible. svelte-check + lint clean. hold-and-fold.