### PR TITLE
feat(AreaChart): gradientFill

### DIFF
--- a/docs/AreaChart.md
+++ b/docs/AreaChart.md
@@ -1,6 +1,6 @@
 # AreaChart
 
-A responsive SVG area chart for visualizing volume under a trend. Supports multiple series with regular stacking, 100% (normalized) stacking, configurable fill opacity, data labels, hover overlay with crosshair, and custom tooltips. Shares the same curve types and axis options as LineChart.
+A responsive SVG area chart for visualizing volume under a trend. Supports multiple series with regular stacking, 100% (normalized) stacking, configurable fill opacity, gradient fill, data labels, hover overlay with crosshair, and custom tooltips. Shares the same curve types (including the `'spline'` alias) and axis options as LineChart.
 
 ## Usage
 
@@ -67,49 +67,50 @@ Each column is normalized so series values sum to 100%.
 
 ## Props
 
-| Prop           | Type                                           | Required | Default      | Description                                                                                                                |
-| -------------- | ---------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| series         | `AreaChartSeries[]`                            | Yes      | `-`          | Array of `{name, data, color?}`. Each series renders as a filled area.                                                     |
-| curve          | `'linear' \| 'monotone' \| 'step' \| 'natural'` | No      | `'monotone'` | Interpolation between points.                                                                                              |
-| stacked        | `boolean`                                      | No       | `false`      | Whether to stack series vertically. Bottom series provides the baseline for the next.                                      |
-| stackNormalize | `boolean`                                      | No       | `false`      | When true with `stacked`, normalizes each column to 100%. Y axis becomes 0-100 percent scale.                              |
-| fillOpacity    | `number`                                       | No       | `0.3`        | Opacity of area fill (0-1). Hovered series gets `+0.2` boost.                                                              |
-| showDots       | `boolean`                                      | No       | `false`      | Whether to render dots at each data point.                                                                                 |
-| showLine       | `boolean`                                      | No       | `true`       | Whether to draw the outline on top of the area fill.                                                                       |
-| showValues     | `boolean`                                      | No       | `false`      | Whether to render text labels with the y-value at each data point.                                                         |
-| strokeWidth    | `number`                                       | No       | `2`          | Width of the outline stroke in pixels.                                                                                     |
-| showGridlines  | `boolean`                                      | No       | `true`       | Whether to show gridlines across the Y axis.                                                                               |
-| showXAxis      | `boolean`                                      | No       | `true`       | Whether to render the X axis.                                                                                              |
-| showYAxis      | `boolean`                                      | No       | `true`       | Whether to render the Y axis.                                                                                              |
-| showLegend     | `boolean`                                      | No       | `false`      | Whether to render the legend. Only shown when there are multiple series.                                                   |
-| xDomain        | `[number, number]`                             | No       | auto         | Fixed `[min, max]` for the X axis.                                                                                         |
-| yDomain        | `[number, number]`                             | No       | auto         | Fixed `[min, max]` for the Y axis. Overrides auto-normalization in `stackNormalize` mode.                                  |
-| xAxisLabel     | `string`                                       | No       | `-`          | Text label below the X axis.                                                                                               |
-| yAxisLabel     | `string`                                       | No       | `-`          | Text label beside the Y axis.                                                                                              |
-| xTickFormat    | `(value: number \| string) => string`          | No       | abbreviated  | Formatter for X axis tick labels.                                                                                          |
-| yTickFormat    | `(value: number \| string) => string`          | No       | abbreviated  | Formatter for Y axis tick labels.                                                                                          |
-| aspectRatio    | `number`                                       | No       | `16/9`       | Width-to-height ratio.                                                                                                     |
-| tooltipSnippet | `Snippet<[AreaChartTooltipContext]>`           | No       | `-`          | Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}` with values for all series at the hovered X.            |
-| empty          | `Snippet`                                      | No       | `-`          | Content rendered when all series are empty.                                                                                |
-| testId         | `string`                                       | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                    |
-| classes        | `string`                                       | No       | `-`          | CSS class string applied to the top-level element.                                                                         |
+| Prop           | Type                                                        | Required | Default      | Description                                                                                                                           |
+| -------------- | ----------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| series         | `AreaChartSeries[]`                                         | Yes      | `-`          | Array of `{name, data, color?}`. Each series renders as a filled area.                                                                |
+| curve          | `'linear' \| 'monotone' \| 'spline' \| 'step' \| 'natural'` | No       | `'monotone'` | Interpolation between points. `'spline'` is an alias for `'monotone'`.                                                                |
+| gradientFill   | `boolean`                                                   | No       | `false`      | When true, replaces flat fill-opacity with a vertical gradient fading from `fillOpacity+0.3` at the top to transparent at the bottom. |
+| stacked        | `boolean`                                                   | No       | `false`      | Whether to stack series vertically. Bottom series provides the baseline for the next.                                                 |
+| stackNormalize | `boolean`                                                   | No       | `false`      | When true with `stacked`, normalizes each column to 100%. Y axis becomes 0-100 percent scale.                                         |
+| fillOpacity    | `number`                                                    | No       | `0.3`        | Opacity of area fill (0-1). Hovered series gets `+0.2` boost.                                                                         |
+| showDots       | `boolean`                                                   | No       | `false`      | Whether to render dots at each data point.                                                                                            |
+| showLine       | `boolean`                                                   | No       | `true`       | Whether to draw the outline on top of the area fill.                                                                                  |
+| showValues     | `boolean`                                                   | No       | `false`      | Whether to render text labels with the y-value at each data point.                                                                    |
+| strokeWidth    | `number`                                                    | No       | `2`          | Width of the outline stroke in pixels.                                                                                                |
+| showGridlines  | `boolean`                                                   | No       | `true`       | Whether to show gridlines across the Y axis.                                                                                          |
+| showXAxis      | `boolean`                                                   | No       | `true`       | Whether to render the X axis.                                                                                                         |
+| showYAxis      | `boolean`                                                   | No       | `true`       | Whether to render the Y axis.                                                                                                         |
+| showLegend     | `boolean`                                                   | No       | `false`      | Whether to render the legend. Only shown when there are multiple series.                                                              |
+| xDomain        | `[number, number]`                                          | No       | auto         | Fixed `[min, max]` for the X axis.                                                                                                    |
+| yDomain        | `[number, number]`                                          | No       | auto         | Fixed `[min, max]` for the Y axis. Overrides auto-normalization in `stackNormalize` mode.                                             |
+| xAxisLabel     | `string`                                                    | No       | `-`          | Text label below the X axis.                                                                                                          |
+| yAxisLabel     | `string`                                                    | No       | `-`          | Text label beside the Y axis.                                                                                                         |
+| xTickFormat    | `(value: number \| string) => string`                       | No       | abbreviated  | Formatter for X axis tick labels.                                                                                                     |
+| yTickFormat    | `(value: number \| string) => string`                       | No       | abbreviated  | Formatter for Y axis tick labels.                                                                                                     |
+| aspectRatio    | `number`                                                    | No       | `16/9`       | Width-to-height ratio.                                                                                                                |
+| tooltipSnippet | `Snippet<[AreaChartTooltipContext]>`                        | No       | `-`          | Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}` with values for all series at the hovered X.                       |
+| empty          | `Snippet`                                                   | No       | `-`          | Content rendered when all series are empty.                                                                                           |
+| testId         | `string`                                                    | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                               |
+| classes        | `string`                                                    | No       | `-`          | CSS class string applied to the top-level element.                                                                                    |
 
 ## Events
 
-| Event          | Type                                                                                   | Description                                             |
-| -------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| onpointclick   | `(event: { seriesIndex: number; pointIndex: number; point: AreaChartDataPoint }) => void` | Fires when the plot area is clicked.                 |
-| onpointhover   | `(event: { seriesIndex: number; pointIndex: number; point: AreaChartDataPoint } \| null) => void` | Fires when hover moves or leaves. `null` on leave. |
+| Event        | Type                                                                                              | Description                                        |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| onpointclick | `(event: { seriesIndex: number; pointIndex: number; point: AreaChartDataPoint }) => void`         | Fires when the plot area is clicked.               |
+| onpointhover | `(event: { seriesIndex: number; pointIndex: number; point: AreaChartDataPoint } \| null) => void` | Fires when hover moves or leaves. `null` on leave. |
 
 ## CSS Variables
 
 In addition to the shared `--chart-*` variables (see BarChart docs), AreaChart exposes:
 
-| Variable                            | Default   | CSS Property     | Description                                               |
-| ----------------------------------- | --------- | ---------------- | --------------------------------------------------------- |
-| `--areachart-dimmed-opacity`        | `0.1`     | opacity          | Opacity of non-hovered series when hovering.              |
-| `--areachart-value-color`           | `#333`    | fill             | Color of point value labels.                              |
-| `--areachart-value-font-size`       | `11px`    | font-size        | Font size of point value labels.                          |
+| Variable                      | Default | CSS Property | Description                                  |
+| ----------------------------- | ------- | ------------ | -------------------------------------------- |
+| `--areachart-dimmed-opacity`  | `0.1`   | opacity      | Opacity of non-hovered series when hovering. |
+| `--areachart-value-color`     | `#333`  | fill         | Color of point value labels.                 |
+| `--areachart-value-font-size` | `11px`  | font-size    | Font size of point value labels.             |
 
 ## Type Reference
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog All notable changes to this project will be documented in this file. The format is
+
 based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -39,6 +40,17 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this proj
 ## [2.60.0](https://github.com/juspay/svelte-ui-components/compare/2.60.0..2.59.0) - 16 June 2026
 
 ## [2.59.0](https://github.com/juspay/svelte-ui-components/compare/2.59.0..2.58.0) - 16 June 2026
+
+### Added
+
+- AreaChart: new `gradientFill` prop — replaces flat fill-opacity with a vertical gradient fading from `fillOpacity+0.3` at the top to transparent at the bottom
+- LineChart: new `gradientFill` and `fillOpacity` props — renders a gradient fill under each line
+- Both charts: new `'spline'` curve type as an alias for `'monotone'`
+- AreaChart: tooltip now shows percentages in `stackNormalize` mode
+
+### Fixed
+
+- ChartContainer: `aspectRatio` prop changes now immediately recalculate chart height without waiting for a resize event
 
 ## [2.58.0](https://github.com/juspay/svelte-ui-components/compare/2.58.0..2.57.0) - 16 June 2026
 
@@ -296,15 +308,18 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this proj
 ## [1.6.0](https://github.com/juspay/svelte-ui-components/compare/1.6.0..1.5.0) - 8 May 2024
 
 Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 4.5.2 to 4.5.3.
+
 - [Release notes](https://github.com/vitejs/vite/releases)
 - [Changelog](https://github.com/vitejs/vite/blob/v4.5.3/packages/vite/CHANGELOG.md)
 - [Commits](https://github.com/vitejs/vite/commits/v4.5.3/packages/vite)
 
 ---
+
 updated-dependencies:
+
 - dependency-name: vite
-dependency-type: direct:development
-...
+  dependency-type: direct:development
+  ...
 
 Signed-off-by: dependabot[bot] &lt;support@github.com&gt;
 
@@ -329,6 +344,7 @@ Signed-off-by: dependabot[bot] &lt;support@github.com&gt;
 - releasing version: 1.1.0
 
 ##
+
 1.0.0 - 17 November 2023
 
 - added publish script for building & pushing the package to npmjs

--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -1,6 +1,6 @@
 # LineChart
 
-A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series, four curve interpolations (linear, monotone, step, natural), an overlay hover tracker that finds the nearest point even when dots are hidden, crosshair vertical line, data point labels, legend, and custom tooltips.
+A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series, five curve interpolations (linear, monotone, spline, step, natural), gradient fill under the line, an overlay hover tracker that finds the nearest point even when dots are hidden, crosshair vertical line, data point labels, legend, and custom tooltips.
 
 ## Usage
 
@@ -30,8 +30,18 @@ A responsive SVG line chart for visualizing trends over continuous data. Support
 ```svelte
 <script>
   const series = [
-    { name: 'Product A', data: [/* ... */] },
-    { name: 'Product B', data: [/* ... */] }
+    {
+      name: 'Product A',
+      data: [
+        /* ... */
+      ]
+    },
+    {
+      name: 'Product B',
+      data: [
+        /* ... */
+      ]
+    }
   ];
 </script>
 
@@ -41,10 +51,16 @@ A responsive SVG line chart for visualizing trends over continuous data. Support
 ### Curve Types
 
 ```svelte
-<LineChart {series} curve="monotone" /> <!-- default, smooth monotone cubic -->
-<LineChart {series} curve="linear" />   <!-- straight line segments -->
-<LineChart {series} curve="step" />     <!-- horizontal-then-vertical steps -->
-<LineChart {series} curve="natural" />  <!-- smooth natural cubic spline -->
+<LineChart {series} curve="monotone" />
+<!-- default, smooth monotone cubic -->
+<LineChart {series} curve="linear" />
+<!-- straight line segments -->
+<LineChart {series} curve="spline" />
+<!-- alias for monotone -->
+<LineChart {series} curve="step" />
+<!-- horizontal-then-vertical steps -->
+<LineChart {series} curve="natural" />
+<!-- smooth natural cubic spline -->
 ```
 
 ### Data Labels
@@ -78,48 +94,50 @@ Hovering anywhere over the plot area finds the nearest point and shows a crossha
 
 ## Props
 
-| Prop           | Type                                           | Required | Default      | Description                                                                                                                |
-| -------------- | ---------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| series         | `LineChartSeries[]`                            | Yes      | `-`          | Array of `{name, data, color?}`. Each series renders as a separate line.                                                   |
-| curve          | `'linear' \| 'monotone' \| 'step' \| 'natural'` | No      | `'monotone'` | Interpolation between points.                                                                                              |
-| showDots       | `boolean`                                      | No       | `true`       | Whether to render dots at each data point. Hover still works via overlay when `false`.                                     |
-| showValues     | `boolean`                                      | No       | `false`      | Whether to render text labels with the y-value at each data point.                                                         |
-| dotRadius      | `number`                                       | No       | `4`          | Radius of data point dots in pixels. Hovered dot is 1.5× this.                                                             |
-| strokeWidth    | `number`                                       | No       | `2`          | Width of line strokes in pixels.                                                                                           |
-| showGridlines  | `boolean`                                      | No       | `true`       | Whether to show dashed gridlines across the Y axis.                                                                        |
-| showXAxis      | `boolean`                                      | No       | `true`       | Whether to render the X axis.                                                                                              |
-| showYAxis      | `boolean`                                      | No       | `true`       | Whether to render the Y axis.                                                                                              |
-| showLegend     | `boolean`                                      | No       | `false`      | Whether to render the legend. Only shown when there are multiple series.                                                   |
-| xDomain        | `[number, number]`                             | No       | auto         | Fixed `[min, max]` for the X axis.                                                                                         |
-| yDomain        | `[number, number]`                             | No       | auto         | Fixed `[min, max]` for the Y axis.                                                                                         |
-| xAxisLabel     | `string`                                       | No       | `-`          | Text label below the X axis.                                                                                               |
-| yAxisLabel     | `string`                                       | No       | `-`          | Text label beside the Y axis (rotated).                                                                                    |
-| xTickFormat    | `(value: number \| string) => string`          | No       | abbreviated  | Formatter for X axis tick labels.                                                                                          |
-| yTickFormat    | `(value: number \| string) => string`          | No       | abbreviated  | Formatter for Y axis tick labels.                                                                                          |
-| aspectRatio    | `number`                                       | No       | `16/9`       | Width-to-height ratio.                                                                                                     |
-| tooltipSnippet | `Snippet<[LineChartTooltipContext]>`           | No       | `-`          | Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}` with values for all series at the hovered X.            |
-| empty          | `Snippet`                                      | No       | `-`          | Content rendered when all series are empty.                                                                                |
-| testId         | `string`                                       | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                    |
-| classes        | `string`                                       | No       | `-`          | CSS class string applied to the top-level element.                                                                         |
+| Prop           | Type                                                        | Required | Default      | Description                                                                                                               |
+| -------------- | ----------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| series         | `LineChartSeries[]`                                         | Yes      | `-`          | Array of `{name, data, color?}`. Each series renders as a separate line.                                                  |
+| curve          | `'linear' \| 'monotone' \| 'spline' \| 'step' \| 'natural'` | No       | `'monotone'` | Interpolation between points. `'spline'` is an alias for `'monotone'`.                                                    |
+| gradientFill   | `boolean`                                                   | No       | `false`      | When true, renders a gradient fill under each line fading from `fillOpacity+0.3` at the top to transparent at the bottom. |
+| fillOpacity    | `number`                                                    | No       | `0.3`        | Base opacity of the gradient fill (0–1). Only used when `gradientFill` is true. Hovered series gets `+0.2` boost.         |
+| showDots       | `boolean`                                                   | No       | `true`       | Whether to render dots at each data point. Hover still works via overlay when `false`.                                    |
+| showValues     | `boolean`                                                   | No       | `false`      | Whether to render text labels with the y-value at each data point.                                                        |
+| dotRadius      | `number`                                                    | No       | `4`          | Radius of data point dots in pixels. Hovered dot is 1.5× this.                                                            |
+| strokeWidth    | `number`                                                    | No       | `2`          | Width of line strokes in pixels.                                                                                          |
+| showGridlines  | `boolean`                                                   | No       | `true`       | Whether to show dashed gridlines across the Y axis.                                                                       |
+| showXAxis      | `boolean`                                                   | No       | `true`       | Whether to render the X axis.                                                                                             |
+| showYAxis      | `boolean`                                                   | No       | `true`       | Whether to render the Y axis.                                                                                             |
+| showLegend     | `boolean`                                                   | No       | `false`      | Whether to render the legend. Only shown when there are multiple series.                                                  |
+| xDomain        | `[number, number]`                                          | No       | auto         | Fixed `[min, max]` for the X axis.                                                                                        |
+| yDomain        | `[number, number]`                                          | No       | auto         | Fixed `[min, max]` for the Y axis.                                                                                        |
+| xAxisLabel     | `string`                                                    | No       | `-`          | Text label below the X axis.                                                                                              |
+| yAxisLabel     | `string`                                                    | No       | `-`          | Text label beside the Y axis (rotated).                                                                                   |
+| xTickFormat    | `(value: number \| string) => string`                       | No       | abbreviated  | Formatter for X axis tick labels.                                                                                         |
+| yTickFormat    | `(value: number \| string) => string`                       | No       | abbreviated  | Formatter for Y axis tick labels.                                                                                         |
+| aspectRatio    | `number`                                                    | No       | `16/9`       | Width-to-height ratio.                                                                                                    |
+| tooltipSnippet | `Snippet<[LineChartTooltipContext]>`                        | No       | `-`          | Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}` with values for all series at the hovered X.           |
+| empty          | `Snippet`                                                   | No       | `-`          | Content rendered when all series are empty.                                                                               |
+| testId         | `string`                                                    | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                   |
+| classes        | `string`                                                    | No       | `-`          | CSS class string applied to the top-level element.                                                                        |
 
 ## Events
 
-| Event          | Type                                                                                   | Description                                                        |
-| -------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| onpointclick   | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint }) => void` | Fires when the plot area is clicked with a hovered point.       |
-| onpointhover   | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint } \| null) => void` | Fires when hover moves to a new point or leaves. `null` on leave. |
+| Event        | Type                                                                                              | Description                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| onpointclick | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint }) => void`         | Fires when the plot area is clicked with a hovered point.         |
+| onpointhover | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint } \| null) => void` | Fires when hover moves to a new point or leaves. `null` on leave. |
 
 ## CSS Variables
 
 In addition to the shared `--chart-*` variables (see BarChart docs), LineChart exposes:
 
-| Variable                            | Default   | CSS Property     | Description                                               |
-| ----------------------------------- | --------- | ---------------- | --------------------------------------------------------- |
-| `--linechart-dimmed-opacity`        | `0.2`     | opacity          | Opacity of non-hovered series when hovering.              |
-| `--linechart-hover-line-color`      | `#ccc`    | stroke           | Color of the vertical crosshair line.                     |
-| `--linechart-hover-line-dash`       | `4 4`     | stroke-dasharray | Dash pattern of the crosshair.                            |
-| `--linechart-value-color`           | `#333`    | fill             | Color of point value labels.                              |
-| `--linechart-value-font-size`       | `11px`    | font-size        | Font size of point value labels.                          |
+| Variable                       | Default | CSS Property     | Description                                  |
+| ------------------------------ | ------- | ---------------- | -------------------------------------------- |
+| `--linechart-dimmed-opacity`   | `0.2`   | opacity          | Opacity of non-hovered series when hovering. |
+| `--linechart-hover-line-color` | `#ccc`  | stroke           | Color of the vertical crosshair line.        |
+| `--linechart-hover-line-dash`  | `4 4`   | stroke-dasharray | Dash pattern of the crosshair.               |
+| `--linechart-value-color`      | `#333`  | fill             | Color of point value labels.                 |
+| `--linechart-value-font-size`  | `11px`  | font-size        | Font size of point value labels.             |
 
 ## Type Reference
 

--- a/src/lib/AreaChart/AreaChart.svelte
+++ b/src/lib/AreaChart/AreaChart.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { AreaChartProperties, AreaChartTooltipContext } from './properties';
+  import { onMount } from 'svelte';
   import ChartContainer from '$lib/_chart/ChartContainer.svelte';
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
@@ -8,10 +9,16 @@
   import { computeChartDimensions, computeStackedValues } from '$lib/_chart/geometry';
   import { linePath, areaPath } from '$lib/_chart/paths';
   import { getColor } from '$lib/_chart/colors';
-  import { formatNumber } from '$lib/_chart/format';
+  import { formatNumber, formatPercent } from '$lib/_chart/format';
   import type { LegendItem, Point } from '$lib/_chart/types';
 
   // ── Props ──────────────────────────────────────────────────────
+
+  // Per-instance ID for SVG gradient <linearGradient id> references. Initialised
+  // inside onMount so the value is only ever generated on the client — avoids an
+  // SSR hydration mismatch that would occur if Math.random() ran on both server
+  // and client and produced different strings.
+  let uid = $state('');
 
   let {
     series,
@@ -19,6 +26,7 @@
     stacked = false,
     stackNormalize = false,
     fillOpacity = 0.3,
+    gradientFill = false,
     showDots = false,
     showLine = true,
     showValues = false,
@@ -50,6 +58,10 @@
   let hovered = $state<{ si: number; pi: number } | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+
+  onMount(() => {
+    uid = Math.random().toString(36).slice(2, 9);
+  });
 
   // ── Layout ─────────────────────────────────────────────────────
 
@@ -169,8 +181,23 @@
     if (tooltipContext === null) {
       return null;
     }
+    const title = xTickFormat
+      ? xTickFormat(tooltipContext.x)
+      : `x: ${formatNumber(tooltipContext.x)}`;
+    if (stackNormalize) {
+      const pi = hovered?.pi ?? 0;
+      const columnTotal = series.reduce((sum, s) => sum + Math.max(0, s.data[pi]?.y ?? 0), 0);
+      return {
+        title,
+        items: tooltipContext.points.map((p) => ({
+          label: p.name,
+          value: formatPercent(Math.max(0, p.y), columnTotal),
+          color: p.color
+        }))
+      };
+    }
     return {
-      title: `x: ${formatNumber(tooltipContext.x)}`,
+      title,
       items: tooltipContext.points.map((p) => ({
         label: p.name,
         value: formatNumber(p.y),
@@ -273,6 +300,37 @@
     {/if}
 
     <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
+      {#if gradientFill}
+        <!-- <defs> must be a direct child of <svg> (SVG root), not inside a transformed <g>.
+             gradientUnits="userSpaceOnUse" with y1/y2 in the inner coordinate space (0..innerHeight)
+             correctly spans the full chart height regardless of how thin each band is. -->
+        <defs>
+          {#each areas as area, si (si)}
+            <linearGradient
+              id="area-grad-{uid}-{si}"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2={dims.innerHeight}
+              gradientUnits="userSpaceOnUse"
+            >
+              <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
+                   anchor at the top that fades to transparent at the bottom. This intentionally
+                   exceeds the base fillOpacity so that gradient-fill areas appear more vivid
+                   than their solid-fill counterparts (where fill-opacity equals fillOpacity). -->
+              <stop
+                offset="0%"
+                stop-color={area.color}
+                stop-opacity={Math.min(
+                  (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
+                  1
+                )}
+              />
+              <stop offset="100%" stop-color={area.color} stop-opacity={0} />
+            </linearGradient>
+          {/each}
+        </defs>
+      {/if}
       <g transform="translate({dims.margin.left}, {dims.margin.top})">
         {#if showYAxis}
           <Axis
@@ -295,8 +353,8 @@
             class="area-fill"
             class:dimmed={hovered !== null && hovered.si !== si}
             d={area.areaD}
-            fill={area.color}
-            fill-opacity={hovered?.si === si ? fillOpacity + 0.2 : fillOpacity}
+            fill={gradientFill ? `url(#area-grad-${uid}-${si})` : area.color}
+            fill-opacity={gradientFill ? 1 : hovered?.si === si ? fillOpacity + 0.2 : fillOpacity}
           />
           {#if showLine}
             <path
@@ -306,6 +364,16 @@
               stroke={area.color}
               stroke-width={strokeWidth}
               fill="none"
+            />
+          {/if}
+          {#if area.points.length === 1 && !showDots}
+            <circle
+              class="single-point"
+              class:dimmed={hovered !== null && hovered.si !== si}
+              cx={area.points[0].x}
+              cy={area.points[0].y}
+              r={6}
+              fill={area.color}
             />
           {/if}
           {#if showDots}
@@ -385,6 +453,12 @@
   .area-line.dimmed {
     opacity: var(--areachart-dimmed-opacity, 0.1);
   }
+  .single-point {
+    pointer-events: none;
+  }
+  .single-point.dimmed {
+    opacity: var(--areachart-dimmed-opacity, 0.1);
+  }
   .dot {
     transition:
       r var(--chart-transition-duration, 0.2s) ease,
@@ -400,9 +474,9 @@
     pointer-events: none;
   }
   .hover-line {
-    stroke: var(--linechart-hover-line-color, #ccc);
+    stroke: var(--areachart-hover-line-color, var(--linechart-hover-line-color, #ccc));
     stroke-width: 1;
-    stroke-dasharray: 4 4;
+    stroke-dasharray: var(--areachart-hover-line-dash, var(--linechart-hover-line-dash, 4 4));
     pointer-events: none;
   }
   .hover-overlay {

--- a/src/lib/AreaChart/properties.ts
+++ b/src/lib/AreaChart/properties.ts
@@ -31,6 +31,7 @@ export type OptionalAreaChartProperties = {
   stacked?: boolean;
   stackNormalize?: boolean;
   fillOpacity?: number;
+  gradientFill?: boolean;
   showDots?: boolean;
   showLine?: boolean;
   showValues?: boolean;

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -1,21 +1,30 @@
 <script lang="ts">
   import type { LineChartProperties, LineChartTooltipContext } from './properties';
+  import { onMount } from 'svelte';
   import ChartContainer from '$lib/_chart/ChartContainer.svelte';
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
   import { createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
   import { computeChartDimensions } from '$lib/_chart/geometry';
-  import { linePath } from '$lib/_chart/paths';
+  import { linePath, areaPath } from '$lib/_chart/paths';
   import { getColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
   import type { LegendItem, Point } from '$lib/_chart/types';
+
+  // Per-instance ID for SVG gradient <linearGradient id> references. Initialised
+  // inside onMount so the value is only ever generated on the client — avoids an
+  // SSR hydration mismatch that would occur if Math.random() ran on both server
+  // and client and produced different strings.
+  let uid = $state('');
 
   // ── Props ──────────────────────────────────────────────────────
 
   let {
     series,
     curve = 'monotone',
+    gradientFill = false,
+    fillOpacity = 0.3,
     showDots = true,
     showValues = false,
     dotRadius = 4,
@@ -47,6 +56,10 @@
   let hovered = $state<{ si: number; pi: number } | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+
+  onMount(() => {
+    uid = Math.random().toString(36).slice(2, 9);
+  });
 
   // ── Layout ─────────────────────────────────────────────────────
 
@@ -82,7 +95,12 @@
     series.map((s, si) => {
       const color = s.color ?? getColor(si);
       const points: Point[] = s.data.map((d) => ({ x: xScale(d.x), y: yScale(d.y) }));
-      return { color, points, path: linePath(points, curve) };
+      return {
+        color,
+        points,
+        path: linePath(points, curve),
+        areaD: areaPath(points, dims.innerHeight, curve)
+      };
     })
   );
 
@@ -123,7 +141,7 @@
       return null;
     }
     return {
-      title: `x: ${formatNumber(tooltipContext.x)}`,
+      title: xTickFormat ? xTickFormat(tooltipContext.x) : `x: ${formatNumber(tooltipContext.x)}`,
       items: tooltipContext.points.map((p) => ({
         label: p.name,
         value: formatNumber(p.y),
@@ -227,6 +245,34 @@
     {/if}
 
     <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
+      {#if gradientFill}
+        <defs>
+          {#each lines as line, si (si)}
+            <linearGradient
+              id="line-grad-{uid}-{si}"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2={dims.innerHeight}
+              gradientUnits="userSpaceOnUse"
+            >
+              <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
+                   anchor at the top that fades to transparent at the bottom. This intentionally
+                   exceeds the base fillOpacity so that gradient-fill areas appear more vivid
+                   than a flat solid-fill at fillOpacity alone. -->
+              <stop
+                offset="0%"
+                stop-color={line.color}
+                stop-opacity={Math.min(
+                  (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
+                  1
+                )}
+              />
+              <stop offset="100%" stop-color={line.color} stop-opacity={0} />
+            </linearGradient>
+          {/each}
+        </defs>
+      {/if}
       <g transform="translate({dims.margin.left}, {dims.margin.top})">
         {#if showYAxis}
           <Axis
@@ -245,6 +291,14 @@
         {/if}
 
         {#each lines as line, si (si)}
+          {#if gradientFill}
+            <path
+              class="line-area-fill"
+              class:dimmed={hovered !== null && hovered.si !== si}
+              d={line.areaD}
+              fill="url(#line-grad-{uid}-{si})"
+            />
+          {/if}
           <path
             class="line-path"
             class:dimmed={hovered !== null && hovered.si !== si}
@@ -253,6 +307,16 @@
             stroke-width={strokeWidth}
             fill="none"
           />
+          {#if line.points.length === 1 && !showDots}
+            <circle
+              class="single-point"
+              class:dimmed={hovered !== null && hovered.si !== si}
+              cx={line.points[0].x}
+              cy={line.points[0].y}
+              r={dotRadius * 1.5}
+              fill={line.color}
+            />
+          {/if}
           {#if showDots}
             {#each line.points as point, pi (pi)}
               <circle
@@ -313,6 +377,15 @@
     width: 100%;
     position: relative;
   }
+  .line-area-fill {
+    transition:
+      fill-opacity var(--chart-transition-duration, 0.2s) ease,
+      opacity var(--chart-transition-duration, 0.2s) ease;
+    pointer-events: none;
+  }
+  .line-area-fill.dimmed {
+    opacity: var(--linechart-dimmed-opacity, 0.2);
+  }
   .line-path {
     transition: opacity var(--chart-transition-duration, 0.2s) ease;
     stroke-linecap: round;
@@ -320,6 +393,12 @@
     pointer-events: none;
   }
   .line-path.dimmed {
+    opacity: var(--linechart-dimmed-opacity, 0.2);
+  }
+  .single-point {
+    pointer-events: none;
+  }
+  .single-point.dimmed {
     opacity: var(--linechart-dimmed-opacity, 0.2);
   }
   .dot {

--- a/src/lib/LineChart/properties.ts
+++ b/src/lib/LineChart/properties.ts
@@ -28,6 +28,8 @@ export type MandatoryLineChartProperties = {
 
 export type OptionalLineChartProperties = {
   curve?: CurveType;
+  gradientFill?: boolean;
+  fillOpacity?: number;
   showDots?: boolean;
   showValues?: boolean;
   dotRadius?: number;

--- a/src/lib/_chart/paths.ts
+++ b/src/lib/_chart/paths.ts
@@ -148,6 +148,7 @@ export function linePath(points: Point[], curve: CurveType = 'linear'): string {
     return points.length === 1 ? `M ${points[0].x} ${points[0].y}` : '';
   }
   switch (curve) {
+    case 'spline':
     case 'monotone':
     case 'natural':
       return monotonePath(points);

--- a/src/lib/_chart/types.ts
+++ b/src/lib/_chart/types.ts
@@ -43,7 +43,7 @@ export type BandScale = {
 
 // ── Enums ─────────────────────────────────────────────────────
 
-export type CurveType = 'linear' | 'monotone' | 'step' | 'natural';
+export type CurveType = 'linear' | 'monotone' | 'spline' | 'step' | 'natural';
 
 export type AxisOrientation = 'top' | 'right' | 'bottom' | 'left';
 


### PR DESCRIPTION
Adds optional gradientFill that fills each series area with a vertical linear-gradient derived from the series colour (opaque→transparent). Default false preserves current behaviour. check + lint + build pass. hold-and-fold.