### PR TITLE
feat(PieChart): semiCircle + legendShowValues

### DIFF
--- a/docs/PieChart.md
+++ b/docs/PieChart.md
@@ -1,6 +1,6 @@
 # PieChart
 
-A responsive SVG pie/donut chart with slice hover highlighting, custom labels, legend, and donut center content. When `innerRadius` is set, renders as a donut with optional content in the center hole via the `center` snippet.
+A responsive SVG pie/donut chart with slice hover highlighting, custom labels, legend, and donut center content. When `innerRadius` is set, renders as a donut with optional content in the center hole via the `center` snippet. Supports a semi-circle (half-donut) layout via `semiCircle`, a tabular value legend via `legendShowValues`, and configurable percentage decimal places via `percentDecimals`.
 
 ## Usage
 
@@ -45,6 +45,33 @@ A responsive SVG pie/donut chart with slice hover highlighting, custom labels, l
 <PieChart {data} showLabels showValues labelPosition="outside" />
 ```
 
+### Semi-Circle (Half-Donut)
+
+```svelte
+<PieChart {data} innerRadius={0.6} semiCircle />
+```
+
+The aspect ratio for the semi-circle layout defaults to `2:1` (width:height). Override it with the `aspectRatio` prop or with `--piechart-semi-aspect-ratio`:
+
+```svelte
+<PieChart {data} innerRadius={0.6} semiCircle aspectRatio={2.5} />
+```
+
+### With Value Legend
+
+Renders a tabular legend below the chart listing each slice's formatted value and percentage.
+
+```svelte
+<PieChart {data} showLegend legendShowValues />
+```
+
+Use `percentDecimals` to control decimal places in the percentage column and on-arc labels:
+
+```svelte
+<!-- Show percentages as "12.34%" instead of "12%" -->
+<PieChart {data} showLegend legendShowValues percentDecimals={2} />
+```
+
 ### Custom Tooltip
 
 ```svelte
@@ -59,43 +86,69 @@ A responsive SVG pie/donut chart with slice hover highlighting, custom labels, l
 
 ## Props
 
-| Prop           | Type                                 | Required | Default       | Description                                                                                                  |
-| -------------- | ------------------------------------ | -------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
-| data           | `PieChartSlice[]`                    | Yes      | `-`           | Array of `{label, value, color?}`. Each item becomes one slice. Slice angle is proportional to value.       |
-| innerRadius    | `number`                             | No       | `0`           | Inner radius as a fraction of outer radius (0-1). `0` renders a pie; `>0` renders a donut.                  |
-| padAngle       | `number`                             | No       | `0.02`        | Angular gap between slices in radians.                                                                       |
-| showLabels     | `boolean`                            | No       | `false`       | Whether to render slice labels (either inside or outside depending on `labelPosition`).                     |
-| showValues     | `boolean`                            | No       | `false`       | Whether to render the slice percentage as a label.                                                           |
-| labelPosition  | `'inside' \| 'outside'`              | No       | `'outside'`   | Where to render slice labels.                                                                                |
-| showLegend     | `boolean`                            | No       | `false`       | Whether to render a legend above the chart.                                                                  |
-| startAngle     | `number`                             | No       | `-Math.PI/2`  | Starting angle in radians. Default starts at 12 o'clock position.                                            |
-| aspectRatio    | `number`                             | No       | `1`           | Width-to-height ratio. `1` produces a circular container.                                                    |
-| valueFormat    | `(value: number) => string`          | No       | abbreviated   | Formatter for slice values in the default tooltip.                                                           |
-| tooltipSnippet | `Snippet<[PieChartSlice, number]>`   | No       | `-`           | Custom tooltip content. Receives the hovered slice and its index.                                            |
-| center         | `Snippet`                            | No       | `-`           | Content rendered inside the donut hole (only when `innerRadius > 0`). Rendered via SVG `foreignObject`.      |
-| empty          | `Snippet`                            | No       | `-`           | Content rendered when `data` is empty or all values are zero.                                                |
-| testId         | `string`                             | No       | `-`           | Value for the data-pw attribute on the chart container.                                                      |
-| classes        | `string`                             | No       | `-`           | CSS class string applied to the top-level element.                                                           |
+| Prop             | Type                               | Required | Default      | Description                                                                                                |
+| ---------------- | ---------------------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
+| data             | `PieChartSlice[]`                  | Yes      | `-`          | Array of `{label, value, color?}`. Each item becomes one slice. Slice angle is proportional to value.      |
+| innerRadius      | `number`                           | No       | `0`          | Inner radius as a fraction of outer radius (0-1). `0` renders a pie; `>0` renders a donut.                 |
+| padAngle         | `number`                           | No       | `0.02`       | Angular gap between slices in radians.                                                                     |
+| showLabels       | `boolean`                          | No       | `false`      | Whether to render slice labels (either inside or outside depending on `labelPosition`).                    |
+| showValues       | `boolean`                          | No       | `false`      | Whether to render the slice percentage as a label.                                                         |
+| labelPosition    | `'inside' \| 'outside'`            | No       | `'outside'`  | Where to render slice labels.                                                                              |
+| showLegend       | `boolean`                          | No       | `false`      | Whether to render a legend above the chart.                                                                |
+| startAngle       | `number`                           | No       | `-Math.PI/2` | Starting angle in radians. Default starts at 12 o'clock position.                                          |
+| aspectRatio      | `number`                           | No       | `1`          | Width-to-height ratio. `1` produces a circular container.                                                  |
+| valueFormat      | `(value: number) => string`        | No       | abbreviated  | Formatter for slice values in the default tooltip.                                                         |
+| tooltipSnippet   | `Snippet<[PieChartSlice, number]>` | No       | `-`          | Custom tooltip content. Receives the hovered slice and its index.                                          |
+| center           | `Snippet`                          | No       | `-`          | Content rendered inside the donut hole (only when `innerRadius > 0`). Rendered via SVG `foreignObject`.    |
+| empty            | `Snippet`                          | No       | `-`          | Content rendered when `data` is empty or all values are zero.                                              |
+| semiCircle       | `boolean`                          | No       | `false`      | Render as a semi-circle (half-pie/donut). Arc spans the top 180°. Aspect ratio defaults to 2:1.            |
+| legendShowValues | `boolean`                          | No       | `false`      | When `showLegend` is also true, renders a tabular legend with formatted values and percentages per slice.  |
+| percentDecimals  | `number`                           | No       | `0`          | Decimal places used for percentage formatting in on-arc labels (`showValues`) and the legend value column. |
+| testId           | `string`                           | No       | `-`          | Value for the data-pw attribute on the chart container.                                                    |
+| classes          | `string`                           | No       | `-`          | CSS class string applied to the top-level element.                                                         |
 
 ## Events
 
-| Event          | Type                                                      | Description                                                                             |
-| -------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| onsliceclick   | `(event: { index: number; slice: PieChartSlice }) => void` | Fires when a slice is clicked.                                                         |
-| onslicehover   | `(event: { index: number; slice: PieChartSlice } \| null) => void` | Fires on slice hover enter or leave. `null` on leave.                           |
+| Event        | Type                                                               | Description                                           |
+| ------------ | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| onsliceclick | `(event: { index: number; slice: PieChartSlice }) => void`         | Fires when a slice is clicked.                        |
+| onslicehover | `(event: { index: number; slice: PieChartSlice } \| null) => void` | Fires on slice hover enter or leave. `null` on leave. |
 
 ## CSS Variables
 
 In addition to the shared `--chart-*` variables (see BarChart docs), PieChart exposes:
 
-| Variable                          | Default   | CSS Property | Description                                                    |
-| --------------------------------- | --------- | ------------ | -------------------------------------------------------------- |
-| `--piechart-stroke-color`         | `#fff`    | stroke       | Color of the stroke between slices.                            |
-| `--piechart-stroke-width`         | `2`       | stroke-width | Width of the stroke between slices.                            |
-| `--piechart-hover-scale`          | `1.05`    | transform    | Scale factor applied to the hovered slice.                     |
-| `--piechart-dimmed-opacity`       | `0.3`     | opacity      | Opacity of non-hovered slices when hovering.                   |
-| `--piechart-label-color`          | `#333`    | fill         | Color of slice labels.                                         |
-| `--piechart-label-font-size`      | `12px`    | font-size    | Font size of slice labels.                                     |
+| Variable                            | Default      | CSS Property  | Description                                                                                          |
+| ----------------------------------- | ------------ | ------------- | ---------------------------------------------------------------------------------------------------- |
+| `--piechart-stroke-color`           | `#fff`       | stroke        | Color of the stroke between slices.                                                                  |
+| `--piechart-stroke-width`           | `2`          | stroke-width  | Width of the stroke between slices.                                                                  |
+| `--piechart-hover-scale`            | `1.05`       | transform     | Scale factor applied to the hovered slice.                                                           |
+| `--piechart-dimmed-opacity`         | `0.3`        | opacity       | Opacity of non-hovered slices when hovering.                                                         |
+| `--piechart-label-color`            | `#333`       | fill          | Color of slice labels.                                                                               |
+| `--piechart-label-font-size`        | `12px`       | font-size     | Font size of slice labels.                                                                           |
+| `--piechart-semi-aspect-ratio`      | `2`          | —             | Aspect ratio (width÷height) used when `semiCircle` is true and `aspectRatio` prop is not set.        |
+| `--piechart-legend-gap`             | `8px`        | gap           | Row gap in the `legendShowValues` table.                                                             |
+| `--piechart-legend-padding`         | `12px 0 0 0` | padding       | Padding on the `legendShowValues` container.                                                         |
+| `--piechart-legend-label-min-width` | `120px`      | min-width     | Minimum width of the label column in the `legendShowValues` table; aligns value columns across rows. |
+| `--piechart-legend-value-min-width` | `60px`       | min-width     | Minimum width of the value column; combined with `text-align: right` for tabular alignment.          |
+| `--piechart-legend-value-font-size` | `12px`       | font-size     | Font size of the value column text in the `legendShowValues` table.                                  |
+| `--piechart-legend-value-color`     | `#333`       | color         | Text color of the value column in the `legendShowValues` table.                                      |
+| `--piechart-legend-row-gap`         | `6px`        | gap           | Inline gap between swatch, label, and value within each legend row.                                  |
+| `--piechart-legend-swatch-radius`   | `2px`        | border-radius | Border radius of the color swatch in each legend row.                                                |
+
+## Utility: formatNumberIndian
+
+`formatNumberIndian` is exported from the library root and formats a number in the Indian denomination system (Cr / L / K), useful as a `valueFormat` callback:
+
+```svelte
+<script>
+  import { PieChart, formatNumberIndian } from '@juspay/svelte-ui-components';
+</script>
+
+<PieChart {data} valueFormat={formatNumberIndian} legendShowValues percentDecimals={1} />
+```
+
+Thresholds: ≥ 1 Cr (10 million) → `"1.5Cr"`, ≥ 1 L (100 thousand) → `"2.3L"`, ≥ 1 K (1 thousand) → `"4.7K"`, otherwise `toLocaleString('en-IN')`.
 
 ## Type Reference
 

--- a/src/lib/PieChart/PieChart.svelte
+++ b/src/lib/PieChart/PieChart.svelte
@@ -6,7 +6,7 @@
   import { arcPath } from '$lib/_chart/paths';
   import { computePieLayout } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
-  import { formatNumber, formatPercent } from '$lib/_chart/format';
+  import { formatNumber } from '$lib/_chart/format';
   import type { LegendItem } from '$lib/_chart/types';
 
   // ── Props ──────────────────────────────────────────────────────
@@ -20,7 +20,7 @@
     labelPosition = 'outside',
     showLegend = false,
     startAngle = -Math.PI / 2,
-    aspectRatio = 1,
+    aspectRatio,
     valueFormat,
     tooltipSnippet,
     center,
@@ -28,7 +28,10 @@
     onsliceclick,
     onslicehover,
     testId,
-    classes
+    classes,
+    semiCircle = false,
+    legendShowValues = false,
+    percentDecimals = 0
   }: PieChartProperties = $props();
 
   // ── State ──────────────────────────────────────────────────────
@@ -40,38 +43,106 @@
   let mouseX = $state(0);
   let mouseY = $state(0);
 
+  // Aspect ratio read from --piechart-semi-aspect-ratio CSS variable.
+  // Uses $effect so it re-reads whenever containerEl binds or semiCircle changes
+  // (e.g. media-query theme switch), not just on initial mount.
+  let semiAspectRatioCssVar = $state(2);
+
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    // Track semiCircle and containerEl so the effect re-runs when either changes.
+    void semiCircle;
+    void containerEl;
+    if (typeof window === 'undefined' || containerEl === null) {
+      return;
+    }
+    const rawValue = getComputedStyle(containerEl)
+      .getPropertyValue('--piechart-semi-aspect-ratio')
+      .trim();
+    const parsed = parseFloat(rawValue);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      semiAspectRatioCssVar = parsed;
+    }
+  });
+
   // ── Layout ─────────────────────────────────────────────────────
 
   let format = $derived(valueFormat ?? formatNumber);
   let total = $derived(data.reduce((sum, d) => sum + Math.max(0, d.value), 0));
+  let pctFormat = $derived.by(
+    () =>
+      (v: number): string =>
+        total === 0 ? '0%' : ((v / total) * 100).toFixed(percentDecimals) + '%'
+  );
   let isEmpty = $derived(data.length === 0 || total === 0);
 
+  // When semiCircle is true the effective aspect ratio is driven by:
+  // 1. The explicit `aspectRatio` prop (highest priority — always wins).
+  // 2. The `--piechart-semi-aspect-ratio` CSS variable (consumer CSS override).
+  // 3. The hardcoded default of 2 (width:height = 2:1).
+  // For a full circle the caller-provided `aspectRatio` or a square (1:1) default is used.
+  let effectiveAspectRatio = $derived(aspectRatio ?? (semiCircle ? semiAspectRatioCssVar : 1));
+
   let cx = $derived(chartWidth / 2);
-  let cy = $derived(chartHeight / 2);
+  // For a half-donut the SVG origin sits at the bottom of the drawing area so
+  // arcs radiate upward into the top half of the viewBox.
+  let cy = $derived(semiCircle ? chartHeight : chartHeight / 2);
   let outerR = $derived(
-    Math.max(10, Math.min(cx, cy) - (showLabels && labelPosition === 'outside' ? 40 : 10))
+    semiCircle
+      ? Math.max(10, chartWidth / 2 - (showLabels && labelPosition === 'outside' ? 40 : 10))
+      : Math.max(10, Math.min(cx, cy) - (showLabels && labelPosition === 'outside' ? 40 : 10))
   );
   let innerR = $derived(innerRadius > 0 ? outerR * Math.min(0.95, innerRadius) : 0);
 
-  let slices = $derived(
-    computePieLayout(data, startAngle, padAngle).map((s) => {
+  let slices = $derived.by(() => {
+    // For a full circle layout start at the caller-provided startAngle.
+    // For semi-circle: compute a full-circle layout anchored at -PI/2, then
+    // remap each angle so the entire sweep is compressed into PI radians
+    // (the top-half arc from -PI/2 to PI/2).
+    const layoutStartAngle = semiCircle ? -Math.PI / 2 : startAngle;
+    const rawSlices = computePieLayout(data, layoutStartAngle, padAngle);
+
+    return rawSlices.map((s) => {
+      let mappedStart = s.startAngle;
+      let mappedEnd = s.endAngle;
+      let mappedMid = s.midAngle;
+
+      if (semiCircle) {
+        // The raw layout spans [-PI/2, -PI/2 + 2*PI]. We compress it to
+        // [-PI/2, PI/2] by halving the angular distance from -PI/2.
+        const origin = -Math.PI / 2;
+        mappedStart = origin + (s.startAngle - origin) / 2;
+        mappedEnd = origin + (s.endAngle - origin) / 2;
+        mappedMid = origin + (s.midAngle - origin) / 2;
+      }
+
       const color = s.color ?? data[s.index]?.color ?? getColor(s.index);
       const labelR = labelPosition === 'outside' ? outerR + 16 : (innerR + outerR) / 2;
       return {
         ...s,
+        startAngle: mappedStart,
+        endAngle: mappedEnd,
+        midAngle: mappedMid,
         color,
-        path: arcPath(0, 0, innerR, outerR, s.startAngle, s.endAngle),
-        labelX: labelR * Math.cos(s.midAngle),
-        labelY: labelR * Math.sin(s.midAngle)
+        path: arcPath(0, 0, innerR, outerR, mappedStart, mappedEnd),
+        labelX: labelR * Math.cos(mappedMid),
+        labelY: labelR * Math.sin(mappedMid)
       };
-    })
-  );
+    });
+  });
 
   let legendItems = $derived<LegendItem[]>(
     data.map((d, i) => ({ label: d.label, color: d.color ?? getColor(i) }))
   );
 
   let centerBoxSize = $derived(innerR > 0 ? Math.max(0, innerR * 1.3) : 0);
+
+  // The foreignObject for the center snippet is positioned relative to the <g>
+  // origin (which is at cx, cy in SVG space). The box is always centred on
+  // the translated origin: for a full circle that is the geometric centre, and
+  // for a semiCircle the <g> origin sits at the chord line (bottom of the arc),
+  // so the snippet is centred on the chord as specified.
+  let centerFOY = $derived(-centerBoxSize / 2);
 
   // ── Tooltip ────────────────────────────────────────────────────
 
@@ -85,7 +156,7 @@
       items: [
         {
           label: s.label,
-          value: `${format(s.value)} (${formatPercent(s.value, total)})`,
+          value: `${format(s.value)} (${pctFormat(s.value)})`,
           color: s.color
         }
       ]
@@ -123,11 +194,15 @@
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
   {:else}
-    {#if showLegend}
+    {#if showLegend && !legendShowValues}
       <Legend items={legendItems} position="top" />
     {/if}
 
-    <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
+    <ChartContainer
+      bind:width={chartWidth}
+      bind:height={chartHeight}
+      aspectRatio={effectiveAspectRatio}
+    >
       <g transform="translate({cx}, {cy})">
         {#each slices as slice (slice.index)}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -155,7 +230,7 @@
             >
               {#if showLabels}{slice.label}{/if}
               {#if showValues}
-                {formatPercent(slice.value, total)}{/if}
+                {pctFormat(slice.value)}{/if}
             </text>
           {/if}
         {/each}
@@ -163,7 +238,7 @@
         {#if innerR > 0 && typeof center === 'function' && centerBoxSize > 0}
           <foreignObject
             x={-centerBoxSize / 2}
-            y={-centerBoxSize / 2}
+            y={centerFOY}
             width={centerBoxSize}
             height={centerBoxSize}
           >
@@ -174,6 +249,20 @@
         {/if}
       </g>
     </ChartContainer>
+
+    {#if showLegend && legendShowValues}
+      <ul class="pie-legend-values">
+        {#each data as d, i (i)}
+          <li class="pie-legend-row">
+            <span class="pie-legend-swatch" style="background: {d.color ?? getColor(i)}"></span>
+            <span class="pie-legend-label">{d.label}</span>
+            <span class="pie-legend-value">
+              {format(d.value)}&nbsp;{pctFormat(d.value)}
+            </span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
 
     {#if typeof tooltipSnippet === 'function' && hoveredIndex !== null && data[hoveredIndex]}
       <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
@@ -232,5 +321,38 @@
     padding: var(--chart-empty-padding, 32px 24px);
     color: var(--chart-empty-color, #9ca3af);
     text-align: center;
+  }
+  .pie-legend-values {
+    display: flex;
+    flex-direction: column;
+    gap: var(--piechart-legend-gap, 8px);
+    padding: var(--piechart-legend-padding, 12px 0 0 0);
+    font-family: var(--chart-font-family, inherit);
+    list-style: none;
+    margin: 0;
+  }
+  .pie-legend-row {
+    display: flex;
+    align-items: center;
+    gap: var(--piechart-legend-row-gap, 6px);
+  }
+  .pie-legend-swatch {
+    display: inline-block;
+    width: var(--chart-legend-swatch-size, 12px);
+    height: var(--chart-legend-swatch-size, 12px);
+    border-radius: var(--piechart-legend-swatch-radius, 2px);
+    flex-shrink: 0;
+  }
+  .pie-legend-label {
+    font-size: var(--chart-legend-font-size, 12px);
+    color: var(--chart-legend-color, #333);
+    min-width: var(--piechart-legend-label-min-width, 120px);
+  }
+  .pie-legend-value {
+    margin-left: auto;
+    font-size: var(--piechart-legend-value-font-size, 12px);
+    color: var(--piechart-legend-value-color, #333);
+    min-width: var(--piechart-legend-value-min-width, 60px);
+    text-align: right;
   }
 </style>

--- a/src/lib/PieChart/properties.ts
+++ b/src/lib/PieChart/properties.ts
@@ -29,6 +29,9 @@ export type OptionalPieChartProperties = {
   empty?: Snippet;
   testId?: string;
   classes?: string;
+  semiCircle?: boolean;
+  legendShowValues?: boolean;
+  percentDecimals?: number;
 };
 
 export type PieChartEventProperties = {

--- a/src/lib/_chart/ChartContainer.svelte
+++ b/src/lib/_chart/ChartContainer.svelte
@@ -13,22 +13,36 @@
   }: ChartContainerProperties = $props();
 
   let containerEl: HTMLDivElement | null = $state(null);
+  let isMounted = false;
+
+  function measure() {
+    if (containerEl === null) {
+      return;
+    }
+    const rect = containerEl.getBoundingClientRect();
+    const w = Math.round(rect.width);
+    width = w;
+    height = Math.max(minHeight, Math.round(w / aspectRatio));
+  }
+
+  // Re-measure whenever aspectRatio changes at runtime (e.g. semiCircle toggled).
+  // isMounted guards against running after the onMount cleanup has disconnected
+  // the ResizeObserver and the component is being torn down.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    // Reading aspectRatio here makes this effect re-run whenever it changes.
+    void aspectRatio;
+    if (isMounted) {
+      measure();
+    }
+  });
 
   onMount(() => {
     if (containerEl === null) {
       return;
     }
 
-    function measure() {
-      if (containerEl === null) {
-        return;
-      }
-      const rect = containerEl.getBoundingClientRect();
-      const w = Math.round(rect.width);
-      width = w;
-      height = Math.max(minHeight, Math.round(w / aspectRatio));
-    }
-
+    isMounted = true;
     measure();
 
     // Coalesce bursts of resize events into a single measure per frame, always
@@ -41,6 +55,7 @@
     observer.observe(containerEl);
 
     return () => {
+      isMounted = false;
       cancelAnimationFrame(frame);
       observer.disconnect();
     };

--- a/src/lib/_chart/format.test.ts
+++ b/src/lib/_chart/format.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { formatNumberIndian } from './format';
+
+describe('formatNumberIndian', () => {
+  it('formats values >= 1 Cr (10 million) with Cr suffix', () => {
+    expect(formatNumberIndian(15000000)).toBe('1.5Cr');
+    expect(formatNumberIndian(10000000)).toBe('1Cr');
+    expect(formatNumberIndian(100000000)).toBe('10Cr');
+  });
+
+  it('strips trailing zeros in Cr values', () => {
+    expect(formatNumberIndian(10000000)).toBe('1Cr');
+    expect(formatNumberIndian(20000000)).toBe('2Cr');
+  });
+
+  it('formats values >= 1 L (100 thousand) with L suffix', () => {
+    expect(formatNumberIndian(250000)).toBe('2.5L');
+    expect(formatNumberIndian(100000)).toBe('1L');
+    expect(formatNumberIndian(500000)).toBe('5L');
+  });
+
+  it('strips trailing zeros in L values', () => {
+    expect(formatNumberIndian(100000)).toBe('1L');
+    expect(formatNumberIndian(500000)).toBe('5L');
+  });
+
+  it('formats values >= 1 K (1 thousand) with K suffix', () => {
+    expect(formatNumberIndian(5000)).toBe('5K');
+    expect(formatNumberIndian(1000)).toBe('1K');
+    expect(formatNumberIndian(1500)).toBe('1.5K');
+  });
+
+  it('strips trailing zeros in K values', () => {
+    expect(formatNumberIndian(1000)).toBe('1K');
+    expect(formatNumberIndian(2500)).toBe('2.5K');
+  });
+
+  it('formats small values using en-IN locale', () => {
+    expect(formatNumberIndian(999)).toBe('999');
+    expect(formatNumberIndian(0)).toBe('0');
+    expect(formatNumberIndian(1)).toBe('1');
+  });
+
+  it('handles negative values correctly', () => {
+    expect(formatNumberIndian(-15000000)).toBe('-1.5Cr');
+    expect(formatNumberIndian(-250000)).toBe('-2.5L');
+    expect(formatNumberIndian(-5000)).toBe('-5K');
+  });
+
+  it('handles boundary values correctly', () => {
+    // Exactly at Cr threshold
+    expect(formatNumberIndian(1e7)).toBe('1Cr');
+    // Just above Cr threshold
+    expect(formatNumberIndian(1.5e7)).toBe('1.5Cr');
+    // Exactly at L threshold
+    expect(formatNumberIndian(1e5)).toBe('1L');
+    // Just above L threshold
+    expect(formatNumberIndian(1.5e5)).toBe('1.5L');
+    // Exactly at K threshold
+    expect(formatNumberIndian(1e3)).toBe('1K');
+    // Just below K threshold — locale format
+    expect(formatNumberIndian(999)).toBe('999');
+  });
+});

--- a/src/lib/_chart/format.ts
+++ b/src/lib/_chart/format.ts
@@ -28,3 +28,17 @@ export function defaultTickFormat(value: number | string): string {
   }
   return formatNumber(value);
 }
+
+export function formatNumberIndian(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1e7) {
+    return (value / 1e7).toFixed(2).replace(/\.?0+$/, '') + 'Cr';
+  }
+  if (abs >= 1e5) {
+    return (value / 1e5).toFixed(2).replace(/\.?0+$/, '') + 'L';
+  }
+  if (abs >= 1e3) {
+    return (value / 1e3).toFixed(2).replace(/\.?0+$/, '') + 'K';
+  }
+  return value.toLocaleString('en-IN');
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -128,3 +128,4 @@ export type * from './PieChart/properties';
 export type * from './SankeyChart/properties';
 
 export { validateInput } from './utils';
+export { formatNumberIndian } from './_chart/format';


### PR DESCRIPTION
Adds optional semiCircle (half-donut) mode and legendShowValues (right-aligned value column in legend). Backward-compatible. check + lint + build pass. hold-and-fold.