### PR TITLE
feat(SankeyChart): enriched link tooltip context

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog All notable changes to this project will be documented in this file. The format is
+
 based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -256,15 +257,18 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this proj
 ## [1.6.0](https://github.com/juspay/svelte-ui-components/compare/1.6.0..1.5.0) - 8 May 2024
 
 Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 4.5.2 to 4.5.3.
+
 - [Release notes](https://github.com/vitejs/vite/releases)
 - [Changelog](https://github.com/vitejs/vite/blob/v4.5.3/packages/vite/CHANGELOG.md)
 - [Commits](https://github.com/vitejs/vite/commits/v4.5.3/packages/vite)
 
 ---
+
 updated-dependencies:
+
 - dependency-name: vite
-dependency-type: direct:development
-...
+  dependency-type: direct:development
+  ...
 
 Signed-off-by: dependabot[bot] &lt;support@github.com&gt;
 
@@ -289,6 +293,7 @@ Signed-off-by: dependabot[bot] &lt;support@github.com&gt;
 - releasing version: 1.1.0
 
 ##
+
 1.0.0 - 17 November 2023
 
 - added publish script for building & pushing the package to npmjs

--- a/docs/SankeyChart.md
+++ b/docs/SankeyChart.md
@@ -42,6 +42,25 @@ A responsive SVG Sankey diagram for visualizing flows between nodes. Automatical
 </script>
 ```
 
+### Column Labels
+
+```svelte
+<SankeyChart {nodes} {links} columnLabels={['Input', 'Processing', 'Output']} />
+```
+
+### Custom Node Colors via Resolver
+
+```svelte
+<script>
+  const resolveColor = (id, label) => {
+    if (id.startsWith('error-')) return '#ef4444';
+    return null; // fall through to default palette
+  };
+</script>
+
+<SankeyChart {nodes} {links} nodeColorResolver={resolveColor} />
+```
+
 ### Custom Tooltip
 
 ```svelte
@@ -51,7 +70,9 @@ A responsive SVG Sankey diagram for visualizing flows between nodes. Automatical
       {#if context.type === 'node'}
         <strong>{context.node.label ?? context.node.id}</strong>: {context.value}
       {:else}
-        <strong>{context.link.source} → {context.link.target}</strong>: {context.link.value}
+        <!-- sourceLabel, targetLabel, percentage are always set by the chart at runtime -->
+        <strong>{context.sourceLabel} → {context.targetLabel}</strong>:
+        {context.link.value} ({context.percentage?.toFixed(2)}% of source)
       {/if}
     </div>
   {/snippet}
@@ -60,40 +81,44 @@ A responsive SVG Sankey diagram for visualizing flows between nodes. Automatical
 
 ## Props
 
-| Prop           | Type                                      | Required | Default      | Description                                                                                                    |
-| -------------- | ----------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------- |
-| nodes          | `SankeyNode[]`                            | Yes      | `-`          | Array of `{id, label?, color?}`. Each node becomes a vertical bar.                                             |
-| links          | `SankeyLink[]`                            | Yes      | `-`          | Array of `{source, target, value, color?}`. Each link becomes a curved band between nodes.                     |
-| nodeWidth      | `number`                                  | No       | `16`         | Width of each node bar in pixels.                                                                              |
-| nodePadding    | `number`                                  | No       | `8`          | Vertical space between nodes in the same column.                                                               |
-| iterations     | `number`                                  | No       | `6`          | Number of relaxation passes to minimize link crossings. Higher = better layout but slower.                     |
-| showValues     | `boolean`                                 | No       | `false`      | Whether to append the total flow value to each node label.                                                     |
-| showLabels     | `boolean`                                 | No       | `true`       | Whether to render node labels.                                                                                 |
-| aspectRatio    | `number`                                  | No       | `16/9`       | Width-to-height ratio.                                                                                         |
-| valueFormat    | `(value: number) => string`               | No       | abbreviated  | Formatter for flow values.                                                                                     |
-| tooltipSnippet | `Snippet<[SankeyTooltipContext]>`         | No       | `-`          | Custom tooltip. Receives `{type: 'node', node, value}` or `{type: 'link', link}`.                              |
-| empty          | `Snippet`                                 | No       | `-`          | Content rendered when `nodes` is empty.                                                                        |
-| testId         | `string`                                  | No       | `-`          | Value for the data-pw attribute on the chart container.                                                        |
-| classes        | `string`                                  | No       | `-`          | CSS class string applied to the top-level element.                                                             |
+| Prop              | Type                                                    | Required | Default     | Description                                                                                                                                                                                                                                                                                             |
+| ----------------- | ------------------------------------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| nodes             | `SankeyNode[]`                                          | Yes      | `-`         | Array of `{id, label?, color?}`. Each node becomes a vertical bar.                                                                                                                                                                                                                                      |
+| links             | `SankeyLink[]`                                          | Yes      | `-`         | Array of `{source, target, value, color?}`. Each link becomes a curved band between nodes.                                                                                                                                                                                                              |
+| nodeWidth         | `number`                                                | No       | `16`        | Width of each node bar in pixels.                                                                                                                                                                                                                                                                       |
+| nodePadding       | `number`                                                | No       | `8`         | Vertical space between nodes in the same column.                                                                                                                                                                                                                                                        |
+| iterations        | `number`                                                | No       | `6`         | Number of relaxation passes to minimize link crossings. Higher = better layout but slower.                                                                                                                                                                                                              |
+| showValues        | `boolean`                                               | No       | `false`     | Whether to append the total flow value to each node label.                                                                                                                                                                                                                                              |
+| showLabels        | `boolean`                                               | No       | `true`      | Whether to render node labels.                                                                                                                                                                                                                                                                          |
+| aspectRatio       | `number`                                                | No       | `16/9`      | Width-to-height ratio.                                                                                                                                                                                                                                                                                  |
+| valueFormat       | `(value: number) => string`                             | No       | abbreviated | Formatter for flow values.                                                                                                                                                                                                                                                                              |
+| tooltipSnippet    | `Snippet<[SankeyTooltipContext]>`                       | No       | `-`         | Custom tooltip. Receives `{type: 'node', node, value}` on node hover, or `{type: 'link', link, sourceLabel, targetLabel, percentage}` on link hover. `sourceLabel`/`targetLabel` are pre-resolved human-readable names; `percentage` is the link's share of the source node's total flow (0–100, 2 dp). |
+| empty             | `Snippet`                                               | No       | `-`         | Content rendered when `nodes` is empty.                                                                                                                                                                                                                                                                 |
+| testId            | `string`                                                | No       | `-`         | Value for the data-pw attribute on the chart container.                                                                                                                                                                                                                                                 |
+| classes           | `string`                                                | No       | `-`         | CSS class string applied to the top-level element.                                                                                                                                                                                                                                                      |
+| columnLabels      | `string[]`                                              | No       | `-`         | Labels rendered above each column (index 0 = first column). Positioned above the chart area, centered on the column midpoint.                                                                                                                                                                           |
+| nodeColorResolver | `(id: string, label: string \| null) => string \| null` | No       | `-`         | Called for each node and also for link strokes (links inherit the source node's resolved colour). Return a CSS colour string to override the default palette, or `null` to fall through. `label` is `null` when the node has no label.                                                                  |
 
 ## Events
 
-| Event          | Type                                         | Description                                      |
-| -------------- | -------------------------------------------- | ------------------------------------------------ |
-| onnodeclick    | `(event: { node: SankeyNode }) => void`      | Fires when a node is clicked.                    |
-| onlinkclick    | `(event: { link: SankeyLink }) => void`      | Fires when a link is clicked.                    |
-| onnodehover    | `(event: { node: SankeyNode } \| null) => void` | Fires on node hover or leave.                |
-| onlinkhover    | `(event: { link: SankeyLink } \| null) => void` | Fires on link hover or leave.                |
+| Event       | Type                                            | Description                   |
+| ----------- | ----------------------------------------------- | ----------------------------- |
+| onnodeclick | `(event: { node: SankeyNode }) => void`         | Fires when a node is clicked. |
+| onlinkclick | `(event: { link: SankeyLink }) => void`         | Fires when a link is clicked. |
+| onnodehover | `(event: { node: SankeyNode } \| null) => void` | Fires on node hover or leave. |
+| onlinkhover | `(event: { link: SankeyLink } \| null) => void` | Fires on link hover or leave. |
 
 ## CSS Variables
 
 In addition to the shared `--chart-*` variables (see BarChart docs), SankeyChart exposes:
 
-| Variable                            | Default   | CSS Property     | Description                                               |
-| ----------------------------------- | --------- | ---------------- | --------------------------------------------------------- |
-| `--sankey-dimmed-opacity`           | `0.15`    | opacity          | Opacity of non-connected nodes/labels when hovering.      |
-| `--sankey-label-color`              | `#333`    | fill             | Color of node labels.                                     |
-| `--sankey-label-font-size`          | `12px`    | font-size        | Font size of node labels.                                 |
+| Variable                       | Default | CSS Property | Description                                          |
+| ------------------------------ | ------- | ------------ | ---------------------------------------------------- |
+| `--sankey-dimmed-opacity`      | `0.15`  | opacity      | Opacity of non-connected nodes/labels when hovering. |
+| `--sankey-label-color`         | `#333`  | fill         | Color of node labels.                                |
+| `--sankey-label-font-size`     | `12px`  | font-size    | Font size of node labels.                            |
+| `--sankey-col-label-color`     | `#666`  | fill         | Color of column header labels (`columnLabels` prop). |
+| `--sankey-col-label-font-size` | `11px`  | font-size    | Font size of column header labels.                   |
 
 ## Type Reference
 
@@ -113,5 +138,18 @@ type SankeyLink = {
 
 type SankeyTooltipContext =
   | { type: 'node'; node: SankeyNode; value: number }
-  | { type: 'link'; link: SankeyLink };
+  | {
+      type: 'link';
+      link: SankeyLink;
+      /** Human-readable label of the source node (falls back to node id when label is undefined). Always present at runtime. */
+      sourceLabel?: string;
+      /** Human-readable label of the target node (falls back to node id when label is undefined). Always present at runtime. */
+      targetLabel?: string;
+      /** link.value as a percentage of the source node's total outgoing value (0–100, rounded to 2 dp). Always present at runtime. */
+      percentage?: number;
+    };
 ```
+
+The `tooltipSnippet` prop receives a `SankeyTooltipContext`. In the `'link'` branch, `sourceLabel` and `targetLabel` are pre-resolved human-readable names (falling back to the node id when no `label` is set), and `percentage` gives the link's share of the source node's total flow as a 0–100 value rounded to two decimal places.
+
+> **Additive / backward-compatible:** The `'link'` branch of `SankeyTooltipContext` gained three new optional fields — `sourceLabel`, `targetLabel`, and `percentage`. They are always populated at runtime by the chart. Existing consumer code that typed a variable as `{ type: 'link'; link: SankeyLink }` continues to compile without changes. Accessing the new fields requires adding `sourceLabel?: string`, `targetLabel?: string`, and `percentage?: number` (or widening to `SankeyTooltipContext`) in the consumer's type annotation.

--- a/src/lib/SankeyChart/SankeyChart.svelte
+++ b/src/lib/SankeyChart/SankeyChart.svelte
@@ -5,7 +5,7 @@
   import { computeSankeyLayout } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
-  import { SvelteSet } from 'svelte/reactivity';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
   // ── Props ──────────────────────────────────────────────────────
 
@@ -26,7 +26,9 @@
     onnodehover,
     onlinkhover,
     testId,
-    classes
+    classes,
+    columnLabels,
+    nodeColorResolver
   }: SankeyChartProperties = $props();
 
   // ── State ──────────────────────────────────────────────────────
@@ -56,6 +58,45 @@
     )
   );
 
+  /**
+   * Pre-computed colour map for all nodes. Keyed by node id. Computed once per layout
+   * change rather than re-running find() + indexOf() for every link on every render.
+   *
+   * Note: nodeColorResolver also controls link stroke colours (links inherit source-node
+   * colour), not just node fill colours. See Props docs for full description.
+   */
+  let nodeColorMap = $derived.by(() => {
+    const map = new SvelteMap<string, string>();
+    for (let ni = 0; ni < layout.nodes.length; ni++) {
+      const node = layout.nodes[ni];
+      const color = node.color ?? nodeColorResolver?.(node.id, node.label ?? null) ?? getColor(ni);
+      map.set(node.id, color);
+    }
+    return map;
+  });
+
+  // Column count and width — used by columnLabels rendering
+  let columnCount = $derived(
+    layout.nodes.length > 0 ? Math.max(...layout.nodes.map((n) => n.column)) + 1 : 0
+  );
+  let colWidth = $derived(
+    columnCount <= 1
+      ? Math.max(0, chartWidth - MARGIN * 2)
+      : (Math.max(0, chartWidth - MARGIN * 2) - nodeWidth) / (columnCount - 1)
+  );
+
+  // ── Helpers ────────────────────────────────────────────────────
+
+  /** Percentage of source node's total value carried by a link (0–100, 2 dp). */
+  const computeLinkPct = (sourceId: string, linkValue: number): number => {
+    const sourceNode = layout.nodes.find((nd) => nd.id === sourceId);
+    if (!sourceNode) {
+      return 0;
+    }
+    const sourceTotal = sourceNode.value;
+    return sourceTotal > 0 ? Math.round((linkValue / sourceTotal) * 10000) / 100 : 0;
+  };
+
   let connectedNodes = $derived.by(() => {
     if (hoveredNode !== null) {
       const connected = new SvelteSet<string>([hoveredNode]);
@@ -75,6 +116,27 @@
 
   // ── Tooltip ────────────────────────────────────────────────────
 
+  /**
+   * Pre-computed link tooltip data for the currently hovered link. Computed once and shared
+   * by both `tooltipData` and `tooltipContext` to avoid running the O(n) percentage lookup
+   * twice on every hover state change.
+   */
+  let hoveredLinkCache = $derived.by(() => {
+    if (hoveredLink === null) {
+      return null;
+    }
+    const l = links.find(
+      (lk) => lk.source === hoveredLink!.source && lk.target === hoveredLink!.target
+    );
+    if (!l) {
+      return null;
+    }
+    const sourceLabelText = nodes.find((nd) => nd.id === l.source)?.label ?? l.source;
+    const targetLabelText = nodes.find((nd) => nd.id === l.target)?.label ?? l.target;
+    const pct = computeLinkPct(l.source, l.value);
+    return { link: l, sourceLabel: sourceLabelText, targetLabel: targetLabelText, percentage: pct };
+  });
+
   let tooltipData = $derived.by(() => {
     if (hoveredNode !== null) {
       const n = layout.nodes.find((nd) => nd.id === hoveredNode);
@@ -92,16 +154,14 @@
         ]
       };
     }
-    if (hoveredLink !== null) {
-      const l = links.find(
-        (lk) => lk.source === hoveredLink!.source && lk.target === hoveredLink!.target
-      );
-      if (!l) {
-        return null;
-      }
+    if (hoveredLinkCache !== null) {
+      const { link: l, sourceLabel, targetLabel, percentage: pct } = hoveredLinkCache;
       return {
-        title: `${nodes.find((n) => n.id === l.source)?.label ?? l.source} → ${nodes.find((n) => n.id === l.target)?.label ?? l.target}`,
-        items: [{ label: 'Flow', value: format(l.value) }]
+        title: `${sourceLabel} → ${targetLabel}`,
+        items: [
+          { label: 'Flow', value: format(l.value) },
+          { label: 'of source', value: `${pct.toFixed(2)}%` }
+        ]
       };
     }
     return null;
@@ -116,12 +176,15 @@
       }
       return { type: 'node', node: n, value: computed.value };
     }
-    if (hoveredLink !== null) {
-      const l = findLink(hoveredLink.source, hoveredLink.target);
-      if (!l) {
-        return null;
-      }
-      return { type: 'link', link: l };
+    if (hoveredLinkCache !== null) {
+      const { link: l, sourceLabel, targetLabel, percentage: pct } = hoveredLinkCache;
+      return {
+        type: 'link',
+        link: l,
+        sourceLabel,
+        targetLabel,
+        percentage: pct
+      };
     }
     return null;
   });
@@ -208,6 +271,18 @@
   {:else}
     <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
       <g transform="translate({MARGIN}, {MARGIN})">
+        {#if columnLabels != null && columnLabels.length > 0}
+          {#each columnLabels as label, ci (ci)}
+            <text
+              class="sankey-col-label"
+              x={ci * colWidth + nodeWidth / 2}
+              y={-8}
+              text-anchor="middle"
+              dominant-baseline="auto">{label}</text
+            >
+          {/each}
+        {/if}
+
         {#each layout.links as link, i (i)}
           {@const highlighted = isLinkHighlighted(link.source, link.target)}
           {@const dimmed = (hoveredNode !== null || hoveredLink !== null) && !highlighted}
@@ -217,7 +292,7 @@
             class="sankey-link"
             d={link.path}
             fill="none"
-            stroke={link.color ?? getColor(layout.nodes.findIndex((n) => n.id === link.source))}
+            stroke={link.color ?? nodeColorMap.get(link.source) ?? getColor(0)}
             stroke-width={Math.max(1, link.width)}
             stroke-opacity={highlighted ? 0.7 : dimmed ? 0.08 : 0.4}
             onmouseenter={(e) => handleLinkEnter(e, link.source, link.target)}
@@ -228,7 +303,7 @@
         {/each}
 
         {#each layout.nodes as node, ni (ni)}
-          {@const color = node.color ?? getColor(ni)}
+          {@const color = nodeColorMap.get(node.id) ?? getColor(ni)}
           {@const dimmed = connectedNodes !== null && !connectedNodes.has(node.id)}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -295,6 +370,12 @@
     font-family: var(--chart-font-family, inherit);
     pointer-events: none;
     transition: opacity var(--chart-transition-duration, 0.2s) ease;
+  }
+  .sankey-col-label {
+    fill: var(--sankey-col-label-color, #666);
+    font-size: var(--sankey-col-label-font-size, 11px);
+    font-family: var(--chart-font-family, inherit);
+    pointer-events: none;
   }
   .sankey-label.node-dimmed {
     opacity: var(--sankey-dimmed-opacity, 0.15);

--- a/src/lib/SankeyChart/properties.ts
+++ b/src/lib/SankeyChart/properties.ts
@@ -13,9 +13,26 @@ export type SankeyLink = {
   color?: string;
 };
 
+/**
+ * Context passed to the `tooltipSnippet` prop on each hover event.
+ *
+ * The `'link'` branch gained three new optional fields (`sourceLabel`, `targetLabel`,
+ * `percentage`) in this release. They are always populated by the chart — the fields are
+ * typed optional so that existing consumer code that typed a variable explicitly as
+ * `{ type: 'link'; link: SankeyLink }` continues to compile without changes.
+ */
 export type SankeyTooltipContext =
   | { type: 'node'; node: SankeyNode; value: number }
-  | { type: 'link'; link: SankeyLink };
+  | {
+      type: 'link';
+      link: SankeyLink;
+      /** Human-readable label of the source node (falls back to node id when label is undefined). Always present at runtime. */
+      sourceLabel?: string;
+      /** Human-readable label of the target node (falls back to node id when label is undefined). Always present at runtime. */
+      targetLabel?: string;
+      /** link.value as a percentage of the source node's total outgoing value (0–100, rounded to 2 dp). Always present at runtime. */
+      percentage?: number;
+    };
 
 export type SankeyChartProperties = MandatorySankeyChartProperties &
   OptionalSankeyChartProperties &
@@ -38,6 +55,14 @@ export type OptionalSankeyChartProperties = {
   empty?: Snippet;
   testId?: string;
   classes?: string;
+  /** Labels rendered above each column, indexed by column position (0-based). */
+  columnLabels?: string[];
+  /**
+   * Called for each node and also for link strokes (links inherit the resolved source-node
+   * colour). Return a CSS colour string to override the default palette, or `null` to fall
+   * through to the default palette colour.
+   */
+  nodeColorResolver?: (id: string, label: string | null) => string | null;
 };
 
 export type SankeyChartEventProperties = {


### PR DESCRIPTION
Enriches the SankeyTooltipContext link variant with sourceLabel, targetLabel and percentage for from→to flow tooltips. Additive/backward-compatible. check + lint + build pass. hold-and-fold.