### PR TITLE
feat(Stepper): vertical mode + rich per-step status

### DIFF
--- a/docs/Stepper.md
+++ b/docs/Stepper.md
@@ -1,75 +1,138 @@
 # Stepper
 
-A progress indicator showing numbered steps with completion and active states. Each step shows either a step number or a custom icon, a label, and a dashed separator line to the next step. Steps before `currentStepIndex` are styled as completed (green), the step at `currentStepIndex` is active (dark), and remaining steps are inactive (grey). Each step is clickable, firing `onhandleStepClick` with the selected index.
+A progress indicator showing numbered steps with completion and active states. Each step shows either a step number or a custom icon, a label, and a dashed separator line to the next step. Steps before `currentStepIndex` are styled as completed (green), the step at `currentStepIndex` is active (dark), and remaining steps are inactive (grey). Steps support explicit per-step `status` values (`completed`, `active`, `pending`, `failure`, `in-progress`). Each step is clickable, firing `onstepclick` with the 1-based selected index. The component supports both horizontal and vertical layouts.
 
 ## Usage
 
 ```svelte
 <script>
   import { Stepper } from '@juspay/svelte-ui-components';
+
+  let currentStep = $state(0);
 </script>
 
-<Stepper />
+<Stepper
+  steps={[{ label: 'Cart' }, { label: 'Shipping' }, { label: 'Payment' }]}
+  currentStepIndex={currentStep}
+  onstepclick={(e) => (currentStep = e.selectedIndex - 1)}
+/>
 ```
 
 ## Props
 
-| Prop             | Type            | Required | Default | Description                                                                                                                                                            |
-| ---------------- | --------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| steps            | `Array`<Step>`` | Yes      | `-`     | Array of Step objects defining each step. Each Step has a `label` string and optional `icon` URL.                                                                      |
-| currentStepIndex | `number`        | Yes      | `-`     | The 0-based index of the currently active step. Steps before this index are styled as completed, the step at this index is active.                                     |
-| classes          | `string`        | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop             | Type                         | Required | Default        | Description                                                                                                                                                            |
+| ---------------- | ---------------------------- | -------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| steps            | `Array<Step>`                | Yes      | `-`            | Array of Step objects defining each step. Each Step has a `label`, optional `icon` URL, optional `status`, and optional `badge` snippet.                               |
+| currentStepIndex | `number`                     | Yes      | `-`            | The 0-based index of the currently active step. Steps before this index are styled as completed, the step at this index is active, unless overridden by `step.status`. |
+| orientation      | `'horizontal' \| 'vertical'` | No       | `'horizontal'` | Layout direction. `'vertical'` renders steps in a column with vertical separators.                                                                                     |
+| classes          | `string`                     | No       | `-`            | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| testId           | `string`                     | No       | `-`            | Value for the `data-pw` attribute on the root element, used for test selectors.                                                                                        |
 
 ## Events
 
-| Event             | Type                                         | Description                                                                                     |
-| ----------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| onhandleStepClick | `(event: { selectedIndex: number }) => void` | Fires when any step is clicked. Receives { selectedIndex: number } with the 1-based step index. |
+| Event             | Type                                         | Description                                                                                                               |
+| ----------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| onstepclick       | `(event: { selectedIndex: number }) => void` | Fires when any step is clicked. Receives `{ selectedIndex: number }` with the **1-based** step index.                     |
+| onhandleStepClick | `(event: { selectedIndex: number }) => void` | **Deprecated.** Use `onstepclick` instead. Same signature, provided for backward compatibility with pre-v2 consumer code. |
 
 ## CSS Variables
 
 Override these custom properties to theme the component.
 
-| Variable                                            | Default   | CSS Property                       | Description                                                              |
-| --------------------------------------------------- | --------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| `--container-flex-direction`                        | `row`     | flex-direction                     | Layout direction of the steps (row for horizontal, column for vertical). |
-| `--step-text-active-color`                          | `#2f3841` | --step-text-color                  | Text color of the active step label.                                     |
-| `--separator-background-image-active-color`         | `#2f3841` | --separator-background-image-color | Color of the separator line for active steps.                            |
-| `--step-text-completed-color`                       | `#24aa5a` | --step-text-color                  | Text color of completed step labels.                                     |
-| `--separator-background-image-completed-color`      | `#24aa5a` | --separator-background-image-color | Color of the separator line for completed steps.                         |
-| `--step-index-container-active-background-color`    | `#2f3841` | background-color                   | Background color of the active step circle.                              |
-| `--step-index-container-completed-background-color` | `#24aa5a` | background-color                   | Background color of completed step circles.                              |
+### Stepper-level variables
 
-### Step Sub-component CSS Variables
+| Variable                                                 | Default   | CSS Property     | Description                                            |
+| -------------------------------------------------------- | --------- | ---------------- | ------------------------------------------------------ |
+| `--container-flex-direction`                             | `row`     | flex-direction   | Layout direction of the steps container.               |
+| `--step-text-active-color`                               | `#2f3841` | color            | Text color of the active step label.                   |
+| `--step-text-completed-color`                            | `#24aa5a` | color            | Text color of completed step labels.                   |
+| `--step-text-failure-color`                              | `#e53935` | color            | Text color of failed step labels.                      |
+| `--step-text-in-progress-color`                          | `#f59e0b` | color            | Text color of in-progress step labels.                 |
+| `--step-index-container-active-background-color`         | `#2f3841` | background-color | Background of the active step circle.                  |
+| `--step-index-container-completed-background-color`      | `#24aa5a` | background-color | Background of completed step circles.                  |
+| `--step-index-container-failure-background-color`        | `#e53935` | background-color | Background of failed step circles.                     |
+| `--step-index-container-in-progress-background-color`    | `#f59e0b` | background-color | Background of in-progress step circles.                |
+| `--stepper-status-failure-color`                         | `#e53935` | (alias)          | Shorthand alias for failure color (circle + text).     |
+| `--stepper-status-in-progress-color`                     | `#f59e0b` | (alias)          | Shorthand alias for in-progress color (circle + text). |
+| `--stepper-separator-background-image-active-color`      | `#2f3841` | (gradient color) | Separator color for active steps.                      |
+| `--stepper-separator-background-image-completed-color`   | `#24aa5a` | (gradient color) | Separator color for completed steps.                   |
+| `--stepper-separator-background-image-failure-color`     | `#e53935` | (gradient color) | Separator color for failed steps.                      |
+| `--stepper-separator-background-image-in-progress-color` | `#f59e0b` | (gradient color) | Separator color for in-progress steps.                 |
 
-These CSS variables are defined in the `Step` sub-component and control individual step styling.
+### Step sub-component CSS Variables
 
-| Variable                                  | Default             | CSS Property     | Description                                  |
-| ----------------------------------------- | ------------------- | ---------------- | -------------------------------------------- |
-| `--step-flex-direction`                   | `row`               | flex-direction   | Layout direction of each step.               |
-| `--step-index-container-height`           | `30px`              | height           | Height of the step number circle.            |
-| `--step-index-container-width`            | `30px`              | width            | Width of the step number circle.             |
-| `--step-index-container-radius`           | `50%`               | border-radius    | Border radius of the step number circle.     |
-| `--step-index-container-background-color` | `#798fa5cc`         | background-color | Background color of inactive step circles.   |
-| `--step-index-font-size`                  | `14px`              | font-size        | Font size of the step number.                |
-| `--step-index-color`                      | `white`             | color            | Text color of the step number.               |
-| `--separator-display`                     | `block`             | display          | Display mode of the step separator.          |
-| `--separator-height`                      | `1px`               | height           | Height of the separator line.                |
-| `--separator-width`                       | `50px`              | width            | Width of the separator line.                 |
-| `--separator-margin`                      | `0px 12px 0px 12px` | margin           | Margin around the separator.                 |
-| `--separator-background-image-color`      | `#798fa5cc`         | (gradient color) | Color used in the dashed separator gradient. |
-| `--step-text-margin`                      | `0px 0px 0px 12px`  | margin           | Margin around the step label text.           |
-| `--step-text-font-size`                   | `12px`              | font-size        | Font size of the step label.                 |
-| `--step-text-color`                       | `#798fa5cc`         | color            | Color of the step label text.                |
+| Variable                                     | Default                        | CSS Property     | Description                                                                                          |
+| -------------------------------------------- | ------------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `--step-flex-direction`                      | `row`                          | flex-direction   | Layout direction of each step.                                                                       |
+| `--step-index-container-height`              | `30px`                         | height           | Height of the step number/icon circle.                                                               |
+| `--step-index-container-width`               | `30px`                         | width            | Width of the step number/icon circle.                                                                |
+| `--step-index-container-radius`              | `50%`                          | border-radius    | Border radius of the step number/icon circle.                                                        |
+| `--step-index-container-background-color`    | `#798fa5cc`                    | background-color | Background of inactive step circles.                                                                 |
+| `--step-index-font-size`                     | `14px`                         | font-size        | Font size of the step number.                                                                        |
+| `--step-index-color`                         | `white`                        | color            | Text/icon color inside step circles.                                                                 |
+| `--step-icon-size`                           | `18px`                         | width / height   | Size of the custom icon image.                                                                       |
+| `--step-spinner-size`                        | `18px`                         | width / height   | Size of the in-progress spinner SVG.                                                                 |
+| `--stepper-separator-display`                | `block`                        | display          | Display of the separator (`none` on last step automatically). Replaces legacy `--separator-display`. |
+| `--stepper-separator-height`                 | `1px`                          | height           | Height of the horizontal separator. Replaces legacy `--separator-height`.                            |
+| `--stepper-separator-width`                  | `50px`                         | width            | Width of the horizontal separator. Replaces legacy `--separator-width`.                              |
+| `--stepper-separator-margin`                 | `0px 12px 0px 12px`            | margin           | Margin around the horizontal separator. Replaces legacy `--separator-margin`.                        |
+| `--stepper-separator-background-image`       | `repeating-linear-gradient(…)` | background-image | Full background-image for the separator (overrides color).                                           |
+| `--stepper-separator-background-image-color` | `#798fa5cc`                    | (gradient color) | Color used in the dashed separator gradient. Replaces legacy `--separator-background-image-color`.   |
+| `--stepper-separator-vertical-height`        | `32px`                         | height           | Height of the separator in vertical orientation.                                                     |
+| `--stepper-separator-vertical-width`         | `1px`                          | width            | Width of the separator in vertical orientation.                                                      |
+| `--stepper-separator-vertical-margin`        | `4px 0px 4px 14px`             | margin           | Margin around the separator in vertical orientation.                                                 |
+| `--step-text-margin`                         | `0px 0px 0px 12px`             | margin           | Margin around the step label (horizontal).                                                           |
+| `--step-text-vertical-margin`                | `4px 0px 0px 0px`              | margin           | Margin around the step label (vertical).                                                             |
+| `--step-text-font-size`                      | `12px`                         | font-size        | Font size of the step label.                                                                         |
+| `--step-text-color`                          | `#798fa5cc`                    | color            | Default step label color (overridden by status classes above).                                       |
+| `--step-badge-margin`                        | `0 0 0 4px`                    | margin           | Margin around the badge slot (horizontal).                                                           |
+| `--step-badge-vertical-margin`               | `4px 0 0 0`                    | margin           | Margin around the badge slot (vertical).                                                             |
+
+> **Migration note (CSS variables):** The CSS variables `--separator-display`, `--separator-height`, `--separator-width`, `--separator-margin`, and `--separator-background-image-color` defined by v1 are still honoured as fallbacks (e.g. `var(--stepper-separator-display, var(--separator-display, block))`). New code should use the `--stepper-separator-*` names.
+
+## Badge snippets
+
+Each step accepts an optional `badge` snippet rendered inline after the step label. Use it for count pills, status chips, or any small inline decoration.
+
+```svelte
+<script>
+  import { Stepper } from '@juspay/svelte-ui-components';
+</script>
+
+<Stepper
+  steps={[
+    { label: 'Cart', status: 'completed', badge: cartBadge },
+    { label: 'Shipping', status: 'active', badge: shippingBadge },
+    { label: 'Payment', status: 'pending' }
+  ]}
+  currentStepIndex={1}
+/>
+
+{#snippet cartBadge()}
+  <span class="badge badge-done">Done</span>
+{/snippet}
+
+{#snippet shippingBadge()}
+  <span class="badge badge-eta">ETA 2d</span>
+{/snippet}
+```
+
+> **Note:** In horizontal layout the badge appears to the right of the label; in vertical layout it appears below the label.
 
 ## Type Reference
-
-Custom types used by this component's props and events:
 
 ### Step
 
 ```typescript
-type Step = { label: string; icon?: string };
+type Step = {
+  label: string;
+  /** URL of a custom icon image. When provided, takes precedence over status-driven rendering (including the in-progress spinner). */
+  icon?: string;
+  /** Explicit per-step status. When omitted, status is derived from currentStepIndex. */
+  status?: 'completed' | 'active' | 'pending' | 'failure' | 'in-progress';
+  /** Optional Svelte snippet rendered after the step label (e.g. a badge or tag). */
+  badge?: Snippet;
+};
 ```
 
 ## Web Component

--- a/src/lib/Stepper/Step.svelte
+++ b/src/lib/Stepper/Step.svelte
@@ -1,17 +1,76 @@
 <script lang="ts">
   import type { StepProperties } from './properties';
 
-  let { stepIndex, label, icon, classes, onclick, onkeydown }: StepProperties = $props();
+  let {
+    stepIndex,
+    label,
+    icon,
+    status,
+    badge,
+    orientation = 'horizontal',
+    classes,
+    ariaLabel,
+    onclick,
+    onkeydown
+  }: StepProperties = $props();
 
-  function handleStepClick() {
+  const handleStepClick = (): void => {
     onclick?.({ selectedIndex: stepIndex });
-  }
+  };
+
+  const handleKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleStepClick();
+    }
+    onkeydown?.(event);
+  };
+
+  let isVertical = $derived(orientation === 'vertical');
+
+  let stepClass = $derived(
+    ['step', isVertical ? 'step-vertical' : '', classes ?? ''].filter((c) => c.length > 0).join(' ')
+  );
 </script>
 
-<div class="step {classes ?? ''}" onclick={handleStepClick} {onkeydown} role="button" tabindex="0">
+<div
+  class={stepClass}
+  onclick={handleStepClick}
+  onkeydown={handleKeydown}
+  role="button"
+  tabindex="0"
+  aria-label={ariaLabel ?? null}
+  aria-labelledby={ariaLabel ? null : `step-label-${stepIndex}`}
+  aria-current={status === 'active' ? 'step' : null}
+>
   {#if typeof icon === 'string' && icon.length > 0}
     <div class="step-icon-container">
       <img class="step-icon" src={icon} alt="" />
+    </div>
+  {:else if status === 'in-progress'}
+    <div class="step-index-container">
+      <svg
+        class="step-spinner"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          stroke="currentColor"
+          stroke-opacity="0.25"
+          stroke-width="3"
+        />
+        <path
+          d="M12 3a9 9 0 0 1 9 9"
+          stroke="currentColor"
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+      </svg>
     </div>
   {:else}
     <div class="step-index-container">
@@ -20,9 +79,17 @@
       </div>
     </div>
   {/if}
-  <div class="step-text">
+
+  <div class="step-text" id="step-label-{stepIndex}">
     {label}
   </div>
+
+  {#if typeof badge === 'function'}
+    <div class="step-badge">
+      {@render badge()}
+    </div>
+  {/if}
+
   <div class="separator"></div>
 </div>
 
@@ -33,6 +100,11 @@
     align-items: center;
   }
 
+  .step-vertical {
+    --step-flex-direction: column;
+    align-items: flex-start;
+  }
+
   .step-index-container {
     display: flex;
     justify-content: center;
@@ -41,22 +113,87 @@
     width: var(--step-index-container-width, 30px);
     border-radius: var(--step-index-container-radius, 50%);
     background-color: var(--step-index-container-background-color, #798fa5cc);
+    color: var(--step-index-color, white);
+    flex-shrink: 0;
+  }
+
+  .step-icon-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: var(--step-index-container-height, 30px);
+    width: var(--step-index-container-width, 30px);
+    border-radius: var(--step-index-container-radius, 50%);
+    background-color: var(--step-index-container-background-color, #798fa5cc);
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+
+  .step-icon {
+    width: var(--step-icon-size, 18px);
+    height: var(--step-icon-size, 18px);
+    object-fit: contain;
+  }
+
+  .step-spinner {
+    width: var(--step-spinner-size, 18px);
+    height: var(--step-spinner-size, 18px);
+    animation: stepper-spin 0.8s linear infinite;
+  }
+
+  @keyframes stepper-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 
   .separator {
-    display: var(--separator-display, block);
-    height: var(--separator-height, 1px);
-    width: var(--separator-width, 50px);
-    margin: var(--separator-margin, 0px 12px 0px 12px);
+    display: var(--stepper-separator-display, var(--separator-display, block));
+    height: var(--stepper-separator-height, var(--separator-height, 1px));
+    width: var(--stepper-separator-width, var(--separator-width, 50px));
+    margin: var(--stepper-separator-margin, var(--separator-margin, 0px 12px 0px 12px));
     background-image: var(
-      --separator-background-image,
-      repeating-linear-gradient(
-        to right,
-        var(--separator-background-image-color, #798fa5cc),
-        var(--separator-background-image-color, #798fa5cc) 6px,
-        transparent 6px,
-        transparent 10px
+      --stepper-separator-background-image,
+      var(
+        --separator-background-image,
+        repeating-linear-gradient(
+          to right,
+          var(
+            --stepper-separator-background-image-color,
+            var(--separator-background-image-color, #798fa5cc)
+          ),
+          var(
+              --stepper-separator-background-image-color,
+              var(--separator-background-image-color, #798fa5cc)
+            )
+            6px,
+          transparent 6px,
+          transparent 10px
+        )
       )
+    );
+  }
+
+  .step-vertical .separator {
+    height: var(--stepper-separator-vertical-height, 32px);
+    width: var(--stepper-separator-vertical-width, 1px);
+    margin: var(--stepper-separator-vertical-margin, 4px 0px 4px 14px);
+    background-image: repeating-linear-gradient(
+      to bottom,
+      var(
+        --stepper-separator-background-image-color,
+        var(--separator-background-image-color, #798fa5cc)
+      ),
+      var(
+          --stepper-separator-background-image-color,
+          var(--separator-background-image-color, #798fa5cc)
+        )
+        6px,
+      transparent 6px,
+      transparent 10px
     );
   }
 
@@ -66,8 +203,20 @@
     color: var(--step-text-color, #798fa5cc);
   }
 
+  .step-vertical .step-text {
+    margin: var(--step-text-vertical-margin, 4px 0px 0px 0px);
+  }
+
   .step-index-text {
     font-size: var(--step-index-font-size, 14px);
     color: var(--step-index-color, white);
+  }
+
+  .step-badge {
+    margin: var(--step-badge-margin, 0 0 0 4px);
+  }
+
+  .step-vertical .step-badge {
+    margin: var(--step-badge-vertical-margin, 4px 0 0 0);
   }
 </style>

--- a/src/lib/Stepper/Stepper.svelte
+++ b/src/lib/Stepper/Stepper.svelte
@@ -1,22 +1,57 @@
 <script lang="ts">
-  import type { StepperProperties } from './properties';
+  import type { StepperProperties, StepStatus } from './properties';
   import Step from './Step.svelte';
 
-  let { steps, currentStepIndex, classes, onhandleStepClick }: StepperProperties = $props();
+  let {
+    steps,
+    currentStepIndex,
+    orientation = 'horizontal',
+    classes,
+    testId,
+    onstepclick,
+    onhandleStepClick
+  }: StepperProperties = $props();
+
+  const resolveStatus = (stepIndex: number, explicitStatus: StepStatus | null): StepStatus => {
+    if (explicitStatus !== null) {
+      return explicitStatus;
+    }
+    if (stepIndex < currentStepIndex) {
+      return 'completed';
+    }
+    if (stepIndex === currentStepIndex) {
+      return 'active';
+    }
+    return 'pending';
+  };
+
+  // Support the deprecated onhandleStepClick alias — onstepclick takes priority.
+  const effectiveStepClick = $derived(onstepclick ?? onhandleStepClick);
+
+  let containerClass = $derived(
+    ['container', orientation === 'vertical' ? 'container-vertical' : '', classes ?? '']
+      .filter((c) => c.length > 0)
+      .join(' ')
+  );
 </script>
 
-<div class="container {classes ?? ''}">
+<div class={containerClass} data-pw={typeof testId === 'string' ? testId : null} role="list">
   {#each steps as currentStep, stepIndex (stepIndex)}
+    {@const effectiveStatus = resolveStatus(stepIndex, currentStep.status ?? null)}
     <div
-      class:active-step={currentStepIndex === stepIndex}
-      class:completed-step={currentStepIndex > stepIndex}
-      class="step-container"
+      role="listitem"
+      class="step-container status-{effectiveStatus} {effectiveStatus === 'active'
+        ? 'active-step'
+        : ''} {effectiveStatus === 'completed' ? 'completed-step' : ''}"
     >
       <Step
-        onclick={onhandleStepClick}
+        onclick={effectiveStepClick}
         label={currentStep.label}
         icon={currentStep.icon}
         stepIndex={stepIndex + 1}
+        status={effectiveStatus}
+        badge={currentStep.badge}
+        {orientation}
       />
     </div>
   {/each}
@@ -29,8 +64,13 @@
     align-items: center;
   }
 
+  .container-vertical {
+    --container-flex-direction: column;
+    align-items: flex-start;
+  }
+
   .step-container:last-child {
-    --separator-display: none;
+    --stepper-separator-display: none;
   }
 
   .step-container {
@@ -38,21 +78,81 @@
     align-items: center;
   }
 
-  .active-step {
+  /* status-completed */
+  .status-completed {
+    --step-text-color: var(--step-text-completed-color, #24aa5a);
+    --stepper-separator-background-image-color: var(
+      --stepper-separator-background-image-completed-color,
+      #24aa5a
+    );
+    --step-index-container-background-color: var(
+      --step-index-container-completed-background-color,
+      #24aa5a
+    );
+  }
+
+  /* status-active */
+  .status-active {
     --step-text-color: var(--step-text-active-color, #2f3841);
-    --separator-background-image-color: var(--separator-background-image-active-color, #2f3841);
+    --stepper-separator-background-image-color: var(
+      --stepper-separator-background-image-active-color,
+      #2f3841
+    );
     --step-index-container-background-color: var(
       --step-index-container-active-background-color,
       #2f3841
     );
   }
 
-  .completed-step {
-    --step-text-color: var(--step-text-completed-color, #24aa5a);
-    --separator-background-image-color: var(--separator-background-image-completed-color, #24aa5a);
+  /* status-pending: no override — falls through to #798fa5cc grey default in Step.svelte */
+
+  /* status-failure */
+  .status-failure {
+    --step-text-color: var(--step-text-failure-color, #e53935);
+    --stepper-separator-background-image-color: var(
+      --stepper-separator-background-image-failure-color,
+      #e53935
+    );
     --step-index-container-background-color: var(
-      --step-index-container-completed-background-color,
-      #24aa5a
+      --step-index-container-failure-background-color,
+      var(--stepper-status-failure-color, #e53935)
+    );
+  }
+
+  /* status-in-progress */
+  .status-in-progress {
+    --step-text-color: var(--step-text-in-progress-color, #f59e0b);
+    --stepper-separator-background-image-color: var(
+      --stepper-separator-background-image-in-progress-color,
+      #f59e0b
+    );
+    --step-index-container-background-color: var(
+      --step-index-container-in-progress-background-color,
+      var(--stepper-status-in-progress-color, #f59e0b)
+    );
+  }
+
+  :global([theme='dark']) .status-failure {
+    --step-text-color: var(--step-text-failure-color, #ef5350);
+    --stepper-separator-background-image-color: var(
+      --stepper-separator-background-image-failure-color,
+      #ef5350
+    );
+    --step-index-container-background-color: var(
+      --step-index-container-failure-background-color,
+      var(--stepper-status-failure-color, #ef5350)
+    );
+  }
+
+  :global([theme='dark']) .status-in-progress {
+    --step-text-color: var(--step-text-in-progress-color, #fbbf24);
+    --stepper-separator-background-image-color: var(
+      --stepper-separator-background-image-in-progress-color,
+      #fbbf24
+    );
+    --step-index-container-background-color: var(
+      --step-index-container-in-progress-background-color,
+      var(--stepper-status-in-progress-color, #fbbf24)
     );
   }
 </style>

--- a/src/lib/Stepper/properties.ts
+++ b/src/lib/Stepper/properties.ts
@@ -1,23 +1,49 @@
-export type StepperProperties = {
-  steps: Array<Step>;
-  currentStepIndex: number;
-  classes?: string;
-  onhandleStepClick?: (event: { selectedIndex: number }) => void;
-};
+import type { Snippet } from 'svelte';
+
+export type StepStatus = 'completed' | 'active' | 'pending' | 'failure' | 'in-progress';
 
 export type Step = {
   label: string;
+  /**
+   * URL of a custom icon image. When provided, the icon takes precedence over
+   * any `status`-driven rendering (including the `in-progress` spinner).
+   */
   icon?: string;
+  status?: StepStatus;
+  /**
+   * Optional Svelte snippet rendered inline after the step label (to its right
+   * in horizontal layout, below it in vertical layout). Use it for badges,
+   * tags, or other inline metadata — e.g. a count pill, a status chip, or a
+   * "New" label.
+   */
+  badge?: Snippet;
 };
 
-export type StepProperties = OptionalStepProperties &
-  StepEventProperties & {
-    stepIndex: number;
-    label: string;
-  };
+export type MandatoryStepperProperties = {
+  steps: Array<Step>;
+  currentStepIndex: number;
+};
+
+export type OptionalStepperProperties = {
+  orientation?: 'horizontal' | 'vertical';
+  classes?: string;
+  testId?: string;
+};
+
+export type StepperEventProperties = {
+  onstepclick?: (event: { selectedIndex: number }) => void;
+  /** @deprecated Use `onstepclick` instead. */
+  onhandleStepClick?: (event: { selectedIndex: number }) => void;
+};
+
+export type StepperProperties = MandatoryStepperProperties &
+  OptionalStepperProperties &
+  StepperEventProperties;
 
 export type OptionalStepProperties = {
   icon?: string;
+  status?: StepStatus;
+  badge?: Snippet;
   classes?: string;
 };
 
@@ -25,3 +51,18 @@ export type StepEventProperties = {
   onclick?: (event: { selectedIndex: number }) => void;
   onkeydown?: (event: KeyboardEvent) => void;
 };
+
+export type StepProperties = OptionalStepProperties &
+  StepEventProperties & {
+    /** 1-based display index — Stepper passes `stepIndex + 1` so that clicking step 1 returns `selectedIndex: 1`. */
+    stepIndex: number;
+    label: string;
+    orientation?: 'horizontal' | 'vertical';
+    /**
+     * Accessible label for the step button. When provided, set as `aria-label` on
+     * the `role="button"` element, overriding the default `aria-labelledby` association
+     * with the visible label text. Use when the visible label alone is insufficient
+     * context for screen reader users (e.g. "Step 1 — Cart (completed)").
+     */
+    ariaLabel?: string;
+  };

--- a/src/routes/components/stepper/+page.svelte
+++ b/src/routes/components/stepper/+page.svelte
@@ -2,6 +2,7 @@
   import Stepper from '$lib/Stepper/Stepper.svelte';
 
   let currentStep = $state(1);
+  let currentVerticalStep = $state(1);
 </script>
 
 <div class="page-header">
@@ -10,9 +11,66 @@
 </div>
 
 <div class="demo-row" style="max-width: 600px;">
+  <h2 class="txt-heading-md">Horizontal (click a step)</h2>
   <Stepper
     steps={[{ label: 'Cart' }, { label: 'Shipping' }, { label: 'Payment' }, { label: 'Confirm' }]}
     currentStepIndex={currentStep}
-    onhandleStepClick={(e) => (currentStep = e.selectedIndex)}
+    onstepclick={(event) => (currentStep = event.selectedIndex - 1)}
   />
 </div>
+
+<div class="demo-row" style="max-width: 600px; margin-top: 32px;">
+  <h2 class="txt-heading-md">Vertical (click a step)</h2>
+  <Stepper
+    orientation="vertical"
+    steps={[{ label: 'Cart' }, { label: 'Shipping' }, { label: 'Payment' }, { label: 'Confirm' }]}
+    currentStepIndex={currentVerticalStep}
+    onstepclick={(event) => (currentVerticalStep = event.selectedIndex - 1)}
+  />
+</div>
+
+<div class="demo-row" style="max-width: 600px; margin-top: 32px;">
+  <h2 class="txt-heading-md">Per-step explicit status</h2>
+  <Stepper
+    steps={[
+      { label: 'Cart', status: 'completed' },
+      { label: 'Shipping', status: 'in-progress' },
+      { label: 'Payment', status: 'active' },
+      { label: 'Confirm', status: 'failure' },
+      { label: 'Done', status: 'pending' }
+    ]}
+    currentStepIndex={1}
+  />
+</div>
+
+<div class="demo-row" style="max-width: 600px; margin-top: 32px;">
+  <h2 class="txt-heading-md">Badge snippets</h2>
+  <Stepper
+    steps={[
+      {
+        label: 'Cart',
+        status: 'completed',
+        badge: cartBadge
+      },
+      {
+        label: 'Shipping',
+        status: 'active',
+        badge: shippingBadge
+      },
+      { label: 'Payment', status: 'pending' }
+    ]}
+    currentStepIndex={1}
+  />
+</div>
+
+{#snippet cartBadge()}
+  <span style="background:#24aa5a;color:#fff;border-radius:8px;padding:1px 6px;font-size:10px;">
+    Done
+  </span>
+{/snippet}
+
+{#snippet shippingBadge()}
+  <span style="background:#f59e0b;color:#fff;border-radius:8px;padding:1px 6px;font-size:10px;">
+    ETA 2d
+  </span>
+{/snippet}

--- a/src/wc/components/Stepper.wc.svelte
+++ b/src/wc/components/Stepper.wc.svelte
@@ -5,7 +5,10 @@
     props: {
       steps: { type: 'Object' },
       currentStepIndex: { type: 'Number', reflect: true, attribute: 'current-step-index' },
+      orientation: { type: 'String', reflect: true },
       classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' },
+      onstepclick: { type: 'Object' },
       onhandleStepClick: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
Adds orientation (horizontal|vertical timeline), per-step status (completed|active|pending|failure|in-progress) driving circle colour/icon, and optional per-step badge snippet. Default horizontal unchanged. check+lint+build pass. hold-and-fold.