### PR TITLE
feat(DateRangePicker): compare standalone trigger

### DIFF
--- a/docs/DateRangePicker.md
+++ b/docs/DateRangePicker.md
@@ -1,6 +1,6 @@
 # DateRangePicker
 
-A compound date-range picker built on top of Calendar. Provides a trigger button shell, an optional preset sidebar, dual-month or single-month calendar display, snippet-based time-picker and compare-range slots, and an apply/cancel footer with draft-state isolation. Supports range and single-date modes, min/max constraints, disabled dates, locale-aware formatting, and full CSS theming via custom properties. Opt-in features include a Clear button for single mode (`clearable`), an initial active-preset display seed (`initialPresetLabel`), and grouped preset sidebars with dividers via the `group` field on `DateRangePreset`.
+A compound date-range picker built on top of Calendar. Provides a trigger button shell, an optional preset sidebar, dual-month or single-month calendar display, snippet-based time-picker and compare-range slots, and an apply/cancel footer with draft-state isolation. Supports range and single-date modes, min/max constraints, disabled dates, locale-aware formatting, and full CSS theming via custom properties. Opt-in features include a Clear button for single mode (`clearable`), an initial active-preset display seed (`initialPresetLabel`), grouped preset sidebars with dividers via the `group` field on `DateRangePreset`, and a standalone compare-period trigger via the `compareTrigger` snippet + `openCompare` bindable prop.
 
 ## Usage
 
@@ -107,6 +107,40 @@ Pass a `compareCalendar` snippet to render a comparison period section inside th
   {/snippet}
 </DateRangePicker>
 ```
+
+### Standalone compare trigger
+
+Pass a `compareTrigger` snippet to render a separate trigger button for the compare-period panel. The panel opens adjacent to its own trigger (not the main DRP panel). Use `bind:openCompare` to observe or programmatically control the compare panel's open state.
+
+```svelte
+<script>
+  import { DateRangePicker, Calendar } from '@juspay/svelte-ui-components';
+
+  let compareStart = $state(null);
+  let compareEnd = $state(null);
+  let isCompareOpen = $state(false);
+</script>
+
+<DateRangePicker
+  mode="range"
+  bind:compareStart
+  bind:compareEnd
+  bind:openCompare={isCompareOpen}
+  onapplycompare={(e) => {
+    compareStart = e.compareStart;
+    compareEnd = e.compareEnd;
+  }}
+>
+  {#snippet compareTrigger(label)}
+    Compare: {label}
+  {/snippet}
+  {#snippet compareCalendar()}
+    <Calendar mode="range" bind:rangeStart={compareStart} bind:rangeEnd={compareEnd} />
+  {/snippet}
+</DateRangePicker>
+```
+
+When `compareTrigger` is provided the `compareCalendar` snippet is rendered inside the standalone compare panel, not inside the main DRP panel. Passing both to the same instance renders the compare calendar in exactly one place (the Svelte 5 runtime would error if the same snippet were rendered in two locations simultaneously).
 
 ### Custom trigger
 
@@ -230,15 +264,18 @@ Add a `group` key to any `DateRangePreset`. A thin divider (with an optional gro
 | classes            | `string`                              | No       | —               | Extra CSS class string applied to the root wrapper. Use to pass CSS variable overrides.                                                                                                                                 |
 | clearable          | `boolean`                             | No       | `false`         | When `true` and `mode='single'`, shows a Clear button in the footer whenever a date is committed. Clicking it resets `value` to `null` and fires `onclear`. Has no effect in range mode.                                |
 | initialPresetLabel | `string`                              | No       | `undefined`     | Label of the preset to show as active on mount, without firing `onapply`. The trigger displays the preset label and the sidebar highlights it. Only evaluated once at mount; if no preset matches, the prop is ignored. |
+| compareTrigger     | `Snippet<[string]>`                   | No       | —               | Snippet rendered as a standalone compare-period trigger button adjacent to the main trigger. Receives the formatted compare label string (`"start – end"` or the placeholder). When provided, the `compareCalendar` snippet moves into the standalone compare panel instead of the main DRP panel. |
+| openCompare        | `boolean`                             | No       | `false`         | Bindable. Whether the standalone compare-period panel is open. The component writes back on open/close; use `bind:openCompare` to observe state or drive it programmatically. Works even without `compareTrigger`. |
 
 ## Snippets
 
-| Snippet         | Argument        | Description                                                                                                                                       |
-| --------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| triggerSnippet  | `label: string` | Custom trigger content. Receives the current formatted label string. When provided, the default label+icon layout is replaced entirely.           |
-| triggerIcon     | —               | Custom icon rendered inside the default trigger layout, replacing the default chevron-down SVG.                                                   |
-| timePicker      | —               | Rendered in the time-picker slot (`.drp-time-row`) below the calendars. Use this to add start/end time inputs. Consumer owns all time state.      |
-| compareCalendar | —               | Rendered in the compare slot (`.drp-compare-section`) below the calendars. Use this to add a comparison-period Calendar. Consumer owns all state. |
+| Snippet         | Argument        | Description                                                                                                                                                                                                                                                     |
+| --------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| triggerSnippet  | `label: string` | Custom trigger content. Receives the current formatted label string. When provided, the default label+icon layout is replaced entirely.                                                                                                                         |
+| triggerIcon     | —               | Custom icon rendered inside the default trigger layout, replacing the default chevron-down SVG.                                                                                                                                                                 |
+| timePicker      | —               | Rendered in the time-picker slot (`.drp-time-row`) below the calendars. Use this to add start/end time inputs. Consumer owns all time state.                                                                                                                    |
+| compareCalendar | —               | When `compareTrigger` is **not** provided: rendered in the compare slot (`.drp-compare-section`) below the calendars inside the main panel. When `compareTrigger` **is** provided: rendered inside the standalone compare panel (`.drp-compare-panel-body`). |
+| compareTrigger  | `label: string` | Standalone compare trigger button. Receives the formatted compare label string. When provided, a separate trigger+panel widget is rendered adjacent to the main trigger so the compare period can be picked independently of the main panel.                    |
 
 ## Events
 
@@ -320,6 +357,18 @@ Override these custom properties to theme the component.
 | `--drp-preset-divider-margin`          | `4px 0`                       | Vertical margin above and below each preset group divider.            |
 | `--drp-preset-group-label-color`       | `#999999`                     | Text color of the preset group label rendered beside the divider.     |
 | `--drp-preset-divider-leader-width`    | `8px`                         | Width of the leading line segment before the group label.             |
+| `--drp-compare-trigger-background`     | `inherit`                     | Compare trigger button background.                                    |
+| `--drp-compare-trigger-border`         | `1px solid currentColor`      | Compare trigger button border.                                        |
+| `--drp-compare-trigger-border-radius`  | `6px`                         | Compare trigger button corner rounding.                               |
+| `--drp-compare-trigger-color`          | `inherit`                     | Compare trigger button text color.                                    |
+| `--drp-compare-trigger-padding`        | `8px 12px`                    | Compare trigger button inner padding.                                 |
+| `--drp-compare-trigger-min-width`      | `160px`                       | Compare trigger button minimum width.                                 |
+| `--drp-compare-panel-left`             | `0`                           | Left offset of the standalone compare panel relative to its trigger.  |
+| `--drp-compare-panel-min-width`        | `280px`                       | Minimum width of the standalone compare panel.                        |
+
+### Selector specificity note
+
+The `.drp-trigger` global class selector was tightened to `.drp-trigger-wrapper .drp-trigger` in this version. If you were overriding `.drp-trigger` styles from an outer stylesheet, update your selector to `.drp-trigger-wrapper .drp-trigger` (or add the wrapper class to your existing rule) to maintain the same specificity.
 
 ## Web Component
 
@@ -415,9 +464,9 @@ The `timePicker` snippet gives full control over time input UI and state. A mini
 </DateRangePicker>
 ```
 
-### Compare range
+### Compare range (inline, inside main panel)
 
-The `compareCalendar` snippet lets you embed a second Calendar for period comparison. Wire its selection back through `onapplycompare`:
+The `compareCalendar` snippet lets you embed a second Calendar for period comparison inside the main DRP panel. Wire its selection back through `onapplycompare`:
 
 ```svelte
 <script>
@@ -438,6 +487,36 @@ The `compareCalendar` snippet lets you embed a second Calendar for period compar
 >
   {#snippet compareCalendar()}
     <p>Compare period</p>
+    <Calendar mode="range" bind:rangeStart={compareStart} bind:rangeEnd={compareEnd} />
+  {/snippet}
+</DateRangePicker>
+```
+
+### Compare range (standalone trigger, separate panel)
+
+Pass both `compareTrigger` and `compareCalendar` for an independent compare picker button. The compare panel renders anchored to its own trigger, leaving the main picker unaffected:
+
+```svelte
+<script>
+  import { DateRangePicker, Calendar } from '@juspay/svelte-ui-components';
+
+  let compareStart = $state(null);
+  let compareEnd = $state(null);
+</script>
+
+<DateRangePicker
+  mode="range"
+  bind:compareStart
+  bind:compareEnd
+  onapplycompare={(e) => {
+    compareStart = e.compareStart;
+    compareEnd = e.compareEnd;
+  }}
+>
+  {#snippet compareTrigger(label)}
+    Compare: {label}
+  {/snippet}
+  {#snippet compareCalendar()}
     <Calendar mode="range" bind:rangeStart={compareStart} bind:rangeEnd={compareEnd} />
   {/snippet}
 </DateRangePicker>

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { DateRangePickerProperties, DateRangePreset } from './properties';
-  import { untrack } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import { SvelteDate } from 'svelte/reactivity';
   import Calendar from '../Calendar/Calendar.svelte';
   import Button from '../Button/Button.svelte';
@@ -30,6 +30,8 @@
     triggerIcon,
     clearable = false,
     initialPresetLabel,
+    compareTrigger,
+    openCompare = $bindable(false),
     onapply,
     onapplysingle,
     onapplycompare,
@@ -87,6 +89,10 @@
   let isOpen: boolean = $state(false);
   let panelRef: HTMLDivElement | null = $state(null);
   let triggerRef: HTMLDivElement | null = $state(null);
+  let comparePanelRef: HTMLDivElement | null = $state(null);
+  let compareTriggerRef: HTMLDivElement | null = $state(null);
+  // Stores the element that opened the compare panel so focus can be restored on close.
+  let compareFocusReturnEl: HTMLElement | null = null;
 
   // Tracks the active preset label for the trigger display (seeded from initialPresetLabel on mount)
   const resolvedInitialPresetLabel: string | null = untrack(() => {
@@ -104,14 +110,14 @@
 
   let activePresetLabel: string | null = $state(resolvedInitialPresetLabel);
 
+  const now = new SvelteDate();
+
   // Dual-month navigation: track the year+month of the left calendar
-  let leftYear: number = $state(new SvelteDate().getFullYear());
-  let leftMonth: number = $state(new SvelteDate().getMonth());
+  let leftYear: number = $state(now.getFullYear());
+  let leftMonth: number = $state(now.getMonth());
 
   // A key counter — incrementing forces Calendar to re-mount with new initialMonth
   let calendarKey: number = $state(0);
-
-  const now = new SvelteDate();
 
   const leftInitialMonth: Date = $derived(new SvelteDate(leftYear, leftMonth, 1));
   const rightInitialMonth: Date = $derived(new SvelteDate(leftYear, leftMonth + 1, 1));
@@ -145,6 +151,13 @@
     return placeholder;
   });
 
+  const compareTriggerLabel: string = $derived.by(() => {
+    if (compareStart !== null && compareEnd !== null) {
+      return `${formatDate(compareStart)} – ${formatDate(compareEnd)}`;
+    }
+    return placeholder;
+  });
+
   function openPicker(): void {
     // Seed draft from current committed values
     draftStart = rangeStart !== null ? rangeStart : null;
@@ -169,6 +182,46 @@
   function closePicker(): void {
     isOpen = false;
     onopentoggle?.({ open: false });
+  }
+
+  function openComparePicker(): void {
+    compareFocusReturnEl =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    draftCompareStart = compareStart ?? null;
+    draftCompareEnd = compareEnd ?? null;
+    openCompare = true;
+    tick().then(() => {
+      const firstFocusable = comparePanelRef?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      firstFocusable?.focus();
+    });
+  }
+
+  function closeComparePicker(): void {
+    openCompare = false;
+    const returnEl = compareFocusReturnEl;
+    compareFocusReturnEl = null;
+    tick().then(() => {
+      returnEl?.focus();
+    });
+  }
+
+  function handleApplyCompare(): void {
+    if (draftCompareStart !== null && draftCompareEnd !== null) {
+      compareStart = draftCompareStart;
+      compareEnd = draftCompareEnd;
+      onapplycompare?.({
+        compareStart: draftCompareStart,
+        compareEnd: draftCompareEnd,
+        presetLabel: selectedPresetLabel
+      });
+    }
+    closeComparePicker();
+  }
+
+  function handleCancelCompare(): void {
+    closeComparePicker();
   }
 
   function navigateDualMonths(delta: number): void {
@@ -253,7 +306,7 @@
 
   // Close on outside-click
   function handleDocumentClick(event: MouseEvent): void {
-    if (!isOpen) {
+    if (!isOpen && !openCompare) {
       return;
     }
     const target = event.target;
@@ -262,14 +315,35 @@
     }
     const clickedInsidePanel = panelRef !== null && panelRef.contains(target);
     const clickedTrigger = triggerRef !== null && triggerRef.contains(target);
-    if (!clickedInsidePanel && !clickedTrigger) {
+    const clickedInsideComparePanel = comparePanelRef !== null && comparePanelRef.contains(target);
+    const clickedCompareTrigger = compareTriggerRef !== null && compareTriggerRef.contains(target);
+    if (
+      isOpen &&
+      !clickedInsidePanel &&
+      !clickedTrigger &&
+      !clickedInsideComparePanel &&
+      !clickedCompareTrigger
+    ) {
       closePicker();
+    }
+    if (
+      openCompare &&
+      !clickedInsideComparePanel &&
+      !clickedCompareTrigger &&
+      !clickedInsidePanel &&
+      !clickedTrigger
+    ) {
+      closeComparePicker();
     }
   }
 
   function handleDocumentKeyDown(event: KeyboardEvent): void {
-    if (event.key === 'Escape' && isOpen) {
-      handleCancel();
+    if (event.key === 'Escape') {
+      if (openCompare) {
+        handleCancelCompare();
+      } else if (isOpen) {
+        handleCancel();
+      }
     }
   }
 
@@ -339,6 +413,75 @@
       {/if}
     </Button>
   </div>
+
+  <!-- Compare trigger wrapper (standalone): position:relative so the compare panel
+       anchors below this trigger rather than the drp-root corner. -->
+  {#if typeof compareTrigger === 'function'}
+    <div bind:this={compareTriggerRef} class="drp-compare-trigger-wrapper">
+      <Button
+        onclick={openComparePicker}
+        ariaLabel="Open compare period picker"
+        classes="drp-compare-trigger {openCompare ? 'drp-compare-trigger-open' : ''}"
+      >
+        {@render compareTrigger(compareTriggerLabel)}
+      </Button>
+
+      <!-- Compare period picker panel (standalone): nested here so position:absolute
+           resolves against .drp-compare-trigger-wrapper, not .drp-root. -->
+      {#if openCompare}
+        <div
+          bind:this={comparePanelRef}
+          class="drp-compare-panel"
+          role="dialog"
+          aria-label="Compare period picker"
+          aria-modal="true"
+          tabindex="-1"
+          onkeydown={(event) => {
+            if (event.key === 'Tab') {
+              const focusable = comparePanelRef?.querySelectorAll<HTMLElement>(
+                'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+              );
+              if (!focusable || focusable.length === 0) {
+                return;
+              }
+              const first = focusable[0];
+              const last = focusable[focusable.length - 1];
+              if (event.shiftKey) {
+                if (document.activeElement === first) {
+                  event.preventDefault();
+                  last.focus();
+                }
+              } else {
+                if (document.activeElement === last) {
+                  event.preventDefault();
+                  first.focus();
+                }
+              }
+            }
+          }}
+        >
+          {#if typeof compareCalendar === 'function'}
+            <div class="drp-compare-panel-body">
+              {@render compareCalendar()}
+            </div>
+          {/if}
+          <div class="drp-footer">
+            <Button
+              onclick={handleCancelCompare}
+              ariaLabel="Cancel compare selection"
+              classes="drp-btn-cancel">Cancel</Button
+            >
+            <Button
+              onclick={handleApplyCompare}
+              ariaLabel="Apply compare selection"
+              classes="drp-btn-apply"
+              disabled={draftCompareStart === null || draftCompareEnd === null}>Apply</Button
+            >
+          </div>
+        </div>
+      {/if}
+    </div>
+  {/if}
 
   <!-- Dropdown panel -->
   {#if isOpen}
@@ -464,8 +607,11 @@
             </div>
           {/if}
 
-          <!-- Compare calendar slot: consumer controls all compare UI -->
-          {#if typeof compareCalendar === 'function'}
+          <!-- Compare calendar slot: only rendered here when there is no standalone
+               compareTrigger. When compareTrigger is provided the consumer uses the
+               separate compare panel; rendering the same Snippet in two places at once
+               causes a Svelte 5 runtime error. -->
+          {#if typeof compareCalendar === 'function' && typeof compareTrigger !== 'function'}
             <div class="drp-compare-section">
               {@render compareCalendar()}
             </div>
@@ -516,20 +662,22 @@
     --button-padding: var(--drp-trigger-padding, 8px 12px);
     --button-min-width: var(--drp-trigger-min-width, 200px);
     --button-gap: var(--drp-trigger-gap, 8px);
-    --button-hover-border-color: var(--drp-trigger-hover-border-color, currentColor);
+    --button-hover-border: var(
+      --drp-trigger-hover-border,
+      var(--drp-trigger-border, 1px solid currentColor)
+    );
   }
 
-  :global(.drp-trigger) {
-    display: inline-flex !important;
+  :global(.drp-trigger-wrapper .drp-trigger) {
+    display: inline-flex;
     align-items: center;
     gap: var(--drp-trigger-gap, 8px);
     white-space: nowrap;
     min-width: var(--drp-trigger-min-width, 200px);
-    font-family: inherit;
   }
 
-  :global(.drp-trigger-open) {
-    border-color: var(--drp-trigger-open-border-color, #000000) !important;
+  :global(.drp-trigger-wrapper .drp-trigger-open) {
+    border-color: var(--drp-trigger-open-border-color, #000000);
     box-shadow: var(--drp-trigger-open-shadow, 0 0 0 2px rgba(0, 0, 0, 0.1));
   }
 
@@ -591,7 +739,6 @@
     cursor: pointer;
     white-space: nowrap;
     transition: background 0.12s ease;
-    font-family: inherit;
   }
 
   .drp-preset-item:hover {
@@ -778,7 +925,44 @@
     --button-border: none;
     --button-text-color: var(--drp-apply-color, #ffffff);
     --button-hover-color: var(--drp-apply-hover-background, #333333);
-    --button-disabled-color: var(--drp-apply-disabled-background, #cccccc);
-    --button-disabled-text-color: var(--drp-apply-disabled-color, #888888);
+    --disabled-background-color: var(--drp-apply-disabled-background, #cccccc);
+    --disabled-text-color: var(--drp-apply-disabled-color, #888888);
+  }
+
+  /* ── Compare standalone trigger ── */
+  .drp-compare-trigger-wrapper {
+    display: inline-block;
+    position: relative;
+    --button-color: var(--drp-compare-trigger-background, inherit);
+    --button-border: var(--drp-compare-trigger-border, 1px solid currentColor);
+    --button-border-radius: var(--drp-compare-trigger-border-radius, 6px);
+    --button-text-color: var(--drp-compare-trigger-color, inherit);
+    --button-padding: var(--drp-compare-trigger-padding, 8px 12px);
+    --button-min-width: var(--drp-compare-trigger-min-width, 160px);
+  }
+
+  :global(.drp-compare-trigger-open) {
+    border-color: var(--drp-trigger-open-border-color, #000000);
+    box-shadow: var(--drp-trigger-open-shadow, 0 0 0 2px rgba(0, 0, 0, 0.1));
+  }
+
+  /* ── Compare standalone panel ── */
+  .drp-compare-panel {
+    position: absolute;
+    top: calc(100% + var(--drp-panel-offset, 6px));
+    left: var(--drp-compare-panel-left, 0);
+    z-index: var(--drp-panel-z-index, 1000);
+    background: var(--drp-panel-background, inherit);
+    border: var(--drp-panel-border, 1px solid #e0e0e0);
+    border-radius: var(--drp-panel-border-radius, 10px);
+    box-shadow: var(--drp-panel-shadow, 0 8px 24px rgba(0, 0, 0, 0.12));
+    display: flex;
+    flex-direction: column;
+    min-width: var(--drp-compare-panel-min-width, 280px);
+    overflow: hidden;
+  }
+
+  .drp-compare-panel-body {
+    padding: var(--drp-calendars-padding, 16px);
   }
 </style>

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -70,6 +70,23 @@ export type OptionalDateRangePickerProperties = {
    * Only takes effect once on mount; subsequent prop changes are not tracked.
    */
   initialPresetLabel?: string;
+  /**
+   * Snippet rendered as the standalone compare-period trigger. When provided,
+   * the component renders this snippet in its own wrapper div
+   * (.drp-compare-trigger-wrapper) adjacent to the main trigger. Clicking the
+   * wrapper toggles openCompare. Receives the current compare trigger label
+   * string as its argument (formatted "start – end" or placeholder).
+   */
+  compareTrigger?: Snippet<[string]>;
+  /**
+   * Bindable. Controls whether the compare-period picker panel is open.
+   * The component writes back on open/close, so `bind:openCompare` lets a
+   * parent open/close it programmatically or observe the state. When
+   * compareTrigger is not provided this prop is still functional — the parent
+   * can drive it without a built-in trigger element.
+   * Default: false.
+   */
+  openCompare?: boolean;
 };
 
 export type DateRangePickerEventProperties = {

--- a/src/wc/components/DateRangePicker.wc.svelte
+++ b/src/wc/components/DateRangePicker.wc.svelte
@@ -21,6 +21,7 @@
       classes: { type: 'String' },
       clearable: { type: 'Boolean', reflect: true },
       initialPresetLabel: { type: 'String', attribute: 'initial-preset-label' },
+      openCompare: { type: 'Boolean', reflect: true, attribute: 'open-compare' },
       onapply: { type: 'Object' },
       onapplysingle: { type: 'Object' },
       onapplycompare: { type: 'Object' },


### PR DESCRIPTION
Adds compareTrigger snippet + bindable openCompare so the compare-period picker can open from its own trigger. Backward-compatible. check+lint+build pass. hold-and-fold.