### PR TITLE
feat(Button): add state box-shadow and active-background CSS variables

### DIFF
--- a/docs/Button.md
+++ b/docs/Button.md
@@ -61,56 +61,61 @@ Svelte 5 Snippet props — pass content blocks to the component.
 
 ## Events
 
-| Event   | Type                             | Description                                                                                                                     |
-| ------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| onclick | `(event: MouseEvent) => void`    | Fires when the button is clicked. Does NOT fire when `showProgressBar` is active (clicks are silently ignored during progress). |
+| Event   | Type                             | Description                                                                                                                                             |
+| ------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| onclick | `(event: MouseEvent) => void`    | Fires when the button is clicked. Does NOT fire when `showProgressBar` is active (clicks are silently ignored during progress).                         |
 | onkeyup | `(event: KeyboardEvent) => void` | Fires when a key is released while the button has focus. Defaults to a no-op `() => {}` (always fires, unlike other events which default to undefined). |
 
 ## CSS Variables
 
 Override these custom properties to theme the component.
 
-| Variable                                    | Default                        | CSS Property       | Description                                                                                               |
-| ------------------------------------------- | ------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------- |
-| `--button-width`                            | `fit-content`                  | width              | Width of the button container and button element.                                                         |
-| `--button-max-height`                       | `-`                            | max-height         | Maximum height of the button.                                                                             |
-| `--button-max-width`                        | `-`                            | max-width          | Maximum width of the button.                                                                              |
-| `--button-font-family`                      | `-`                            | font-family        | Font family for the button text.                                                                          |
-| `--button-font-weight`                      | `500`                          | font-weight        | Font weight of the button text.                                                                           |
-| `--button-font-size`                        | `14px`                         | font-size          | Font size of the button text.                                                                             |
-| `--button-color`                            | `#3a4550`                      | background-color   | **Background color** of the button (note: name is misleading — this controls background, not text color). |
-| `--button-text-color`                       | `white`                        | color              | Text/icon color of the button label.                                                                      |
-| `--button-height`                           | `fit-content`                  | height             | Height of the button.                                                                                     |
-| `--button-padding`                          | `16px`                         | padding            | Inner padding of the button.                                                                              |
-| `--button-margin`                           | `-`                            | margin             | Outer margin of the button.                                                                               |
-| `--button-border-radius`                    | `0px`                          | border-radius      | Corner rounding of the button.                                                                            |
-| `--cursor`                                  | `pointer`                      | cursor             | Cursor style on hover.                                                                                    |
-| `--opacity`                                 | `1`                            | opacity            | Opacity of the button.                                                                                    |
-| `--button-border`                           | `none`                         | border             | Border style of the button.                                                                               |
-| `--button-justify-content`                  | `center`                       | justify-content    | Horizontal alignment of content inside the button (flex justify-content).                                 |
-| `--button-content-flex-direction`           | `row`                          | flex-direction     | Layout direction of icon/text inside the button (row or column).                                          |
-| `--button-content-gap`                      | `16px`                         | gap                | Gap between icon and text inside the button.                                                              |
-| `--button-visibility`                       | `visible`                      | visibility         | Controls button visibility (visible/hidden).                                                              |
-| `--button-box-shadow`                       | `none`                         | box-shadow         | Box shadow of the button.                                                                                 |
-| `--disabled-cursor`                         | `not-allowed`                  | cursor             | Cursor shown when the button is disabled.                                                                 |
-| `--disabled-opacity`                        | `0.4`                          | opacity            | Opacity when the button is disabled.                                                                      |
-| `--disabled-text-color`                     | `-`                            | color              | Text color when the button is disabled.                                                                   |
-| `--disabled-font-size`                      | `-`                            | font-size          | Font size when the button is disabled.                                                                    |
-| `--disabled-font-weight`                    | `-`                            | font-weight        | Font weight when the button is disabled.                                                                  |
-| `--disabled-border`                         | `-`                            | border             | Border when the button is disabled.                                                                       |
-| `--disabled-background-color`               | `-`                            | background         | Background color when the button is disabled.                                                             |
-| `--button-loader-order`                     | `1`                            | order              | Flex order of the circular loader relative to icon/text.                                                  |
-| `--button-icon-order`                       | `2`                            | order              | Flex order of the icon relative to loader/text.                                                           |
-| `--button-icon-display`                     | `-`                            | display            | Display property of the icon container.                                                                   |
-| `--button-text-order`                       | `3`                            | order              | Flex order of the text relative to loader/icon.                                                           |
-| `--button-text-display`                     | `-`                            | display            | Display property of the text container.                                                                   |
-| `--button-hover-color`                      | inherits `--button-color`      | background         | Background color on hover.                                                                                |
-| `--button-hover-text-color`                 | inherits `--button-text-color` | color              | Text color on hover.                                                                                      |
-| `--button-hover-border`                     | inherits `--button-border`     | border             | Border style on hover.                                                                                    |
-| `--button-hover-transform`                  | `-`                            | transform          | CSS transform applied on hover (e.g., `scale(1.05)`). Allows hover scale effects without `:global()`.    |
+| Variable                                    | Default                        | CSS Property       | Description                                                                                                         |
+| ------------------------------------------- | ------------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `--button-width`                            | `fit-content`                  | width              | Width of the button container and button element.                                                                   |
+| `--button-max-height`                       | `-`                            | max-height         | Maximum height of the button.                                                                                       |
+| `--button-max-width`                        | `-`                            | max-width          | Maximum width of the button.                                                                                        |
+| `--button-font-family`                      | `-`                            | font-family        | Font family for the button text.                                                                                    |
+| `--button-font-weight`                      | `500`                          | font-weight        | Font weight of the button text.                                                                                     |
+| `--button-font-size`                        | `14px`                         | font-size          | Font size of the button text.                                                                                       |
+| `--button-color`                            | `#3a4550`                      | background-color   | **Background color** of the button (note: name is misleading — this controls background, not text color).           |
+| `--button-text-color`                       | `white`                        | color              | Text/icon color of the button label.                                                                                |
+| `--button-height`                           | `fit-content`                  | height             | Height of the button.                                                                                               |
+| `--button-padding`                          | `16px`                         | padding            | Inner padding of the button.                                                                                        |
+| `--button-margin`                           | `-`                            | margin             | Outer margin of the button.                                                                                         |
+| `--button-border-radius`                    | `0px`                          | border-radius      | Corner rounding of the button.                                                                                      |
+| `--cursor`                                  | `pointer`                      | cursor             | Cursor style on hover.                                                                                              |
+| `--opacity`                                 | `1`                            | opacity            | Opacity of the button.                                                                                              |
+| `--button-border`                           | `none`                         | border             | Border style of the button.                                                                                         |
+| `--button-justify-content`                  | `center`                       | justify-content    | Horizontal alignment of content inside the button (flex justify-content).                                           |
+| `--button-content-flex-direction`           | `row`                          | flex-direction     | Layout direction of icon/text inside the button (row or column).                                                    |
+| `--button-content-gap`                      | `16px`                         | gap                | Gap between icon and text inside the button.                                                                        |
+| `--button-visibility`                       | `visible`                      | visibility         | Controls button visibility (visible/hidden).                                                                        |
+| `--button-box-shadow`                       | `none`                         | box-shadow         | Box shadow of the button.                                                                                           |
+| `--disabled-cursor`                         | `not-allowed`                  | cursor             | Cursor shown when the button is disabled.                                                                           |
+| `--disabled-opacity`                        | `0.4`                          | opacity            | Opacity when the button is disabled.                                                                                |
+| `--disabled-text-color`                     | `-`                            | color              | Text color when the button is disabled.                                                                             |
+| `--disabled-font-size`                      | `-`                            | font-size          | Font size when the button is disabled.                                                                              |
+| `--disabled-font-weight`                    | `-`                            | font-weight        | Font weight when the button is disabled.                                                                            |
+| `--disabled-border`                         | `-`                            | border             | Border when the button is disabled.                                                                                 |
+| `--disabled-background-color`               | `-`                            | background         | Background color when the button is disabled.                                                                       |
+| `--button-disabled-box-shadow`              | inherits `--button-box-shadow` | box-shadow         | Box shadow when the button is disabled. Set to `none` to drop the resting shadow on disabled buttons.               |
+| `--button-loader-order`                     | `1`                            | order              | Flex order of the circular loader relative to icon/text.                                                            |
+| `--button-icon-order`                       | `2`                            | order              | Flex order of the icon relative to loader/text.                                                                     |
+| `--button-icon-display`                     | `-`                            | display            | Display property of the icon container.                                                                             |
+| `--button-text-order`                       | `3`                            | order              | Flex order of the text relative to loader/icon.                                                                     |
+| `--button-text-display`                     | `-`                            | display            | Display property of the text container.                                                                             |
+| `--button-hover-color`                      | inherits `--button-color`      | background         | Background color on hover.                                                                                          |
+| `--button-hover-text-color`                 | inherits `--button-text-color` | color              | Text color on hover.                                                                                                |
+| `--button-hover-border`                     | inherits `--button-border`     | border             | Border style on hover.                                                                                              |
+| `--button-hover-transform`                  | `-`                            | transform          | CSS transform applied on hover (e.g., `scale(1.05)`). Allows hover scale effects without `:global()`.               |
 | `--button-active-transform`                 | `-`                            | transform          | CSS transform applied on active/pressed state (e.g., `scale(0.95)`). Allows press-down effects without `:global()`. |
-| `--button-progress-loader-background-color` | `#00000030`                    | background         | Background color of the progress bar overlay.                                                             |
-| `--button-progress-loader-duration`         | `8s`                           | animation-duration | Duration of the progress bar fill animation.                                                              |
+| `--button-hover-box-shadow`                 | inherits `--button-box-shadow` | box-shadow         | Box shadow on hover. Allows raise-on-hover effects without `:global()`.                                             |
+| `--button-active-background`                | inherits `--button-color`      | background         | Background color on active/pressed state (e.g., a darker pressed shade).                                            |
+| `--button-active-box-shadow`                | inherits `--button-box-shadow` | box-shadow         | Box shadow on active/pressed state.                                                                                 |
+| `--button-focus-visible-box-shadow`         | inherits `--button-box-shadow` | box-shadow         | Box shadow on keyboard focus (`:focus-visible`), e.g. a focus ring, without `:global()`.                            |
+| `--button-progress-loader-background-color` | `#00000030`                    | background         | Background color of the progress bar overlay.                                                                       |
+| `--button-progress-loader-duration`         | `8s`                           | animation-duration | Duration of the progress bar fill animation.                                                                        |
 
 ## Type Reference
 

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -105,6 +105,7 @@
     font-weight: var(--disabled-font-weight);
     border: var(--disabled-border);
     background: var(--disabled-background-color, var(--button-color, #3a4550));
+    box-shadow: var(--button-disabled-box-shadow, var(--button-box-shadow, none));
   }
 
   .button-loader {
@@ -126,10 +127,17 @@
     color: var(--button-hover-text-color, var(--button-text-color, white));
     border: var(--button-hover-border, var(--button-border, none));
     transform: var(--button-hover-transform);
+    box-shadow: var(--button-hover-box-shadow, var(--button-box-shadow, none));
   }
 
   button:active {
     transform: var(--button-active-transform);
+    background: var(--button-active-background, var(--button-color, #3a4550));
+    box-shadow: var(--button-active-box-shadow, var(--button-box-shadow, none));
+  }
+
+  button:focus-visible {
+    box-shadow: var(--button-focus-visible-box-shadow, var(--button-box-shadow, none));
   }
 
   .button-progress-bar {


### PR DESCRIPTION
## What

Adds five state-level CSS custom properties to `Button`:

| Variable | State | Default |
|---|---|---|
| `--button-hover-box-shadow` | `:hover` | inherits `--button-box-shadow` |
| `--button-active-background` | `:active` | inherits `--button-color` |
| `--button-active-box-shadow` | `:active` | inherits `--button-box-shadow` |
| `--button-focus-visible-box-shadow` | `:focus-visible` | inherits `--button-box-shadow` |
| `--button-disabled-box-shadow` | `.disabled` | inherits `--button-box-shadow` |

## Why

Per GUIDELINES §9, theme variants belong in consumer CSS via the `classes` prop + CSS vars. Today a consumer can theme the *resting* shadow (`--button-box-shadow`) but **not** the per-state shadows or the pressed-state background — `:hover`/`:active`/`:focus-visible` have no box-shadow hook and `:active` has no background hook. So a button "variant" recipe that wants a raise-on-hover shadow, a pressed shade, or a focus ring is forced to reach the inner `<button>` element through a descendant selector:

```css
/* before — reaches the inner element, not a var */
.my-btn button:hover { box-shadow: 0 4px 8px rgba(0,0,0,.12); }
.my-btn button:active { background: #1d4ed8; }
.my-btn button:focus-visible { box-shadow: 0 0 0 3px rgba(37,99,235,.4); }
```

```css
/* after — pure CSS-var theming via classes, no element selectors */
.my-btn {
  --button-hover-box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
  --button-active-background: #1d4ed8;
  --button-focus-visible-box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.4);
}
```

This is the same shape as the already-shipped `--button-hover-color` / `--button-hover-transform` / `--button-active-transform` hooks — it just completes the state coverage so the §9 `classes` recipe never has to fall back to `:global()`.

## Backward compatibility

Every new variable falls back to `--button-box-shadow` (or `--button-color` for the active background), so each state inherits the resting value exactly as it does today. With no variable set, rendering is identical. The new `:focus-visible` rule only sets `box-shadow` (defaulting to the resting shadow) and does not touch `outline`, so the browser's default focus ring is preserved.

## Changes

- `src/lib/Button/Button.svelte` — add the five state box-shadow / active-background hooks.
- `docs/Button.md` — document them.

## Verification

- `pnpm run check` → 0 errors.
- `pnpm exec prettier --check` → clean.