### PR TITLE
feat(FileInput): export openFilePicker as callable imperative method

### DIFF
--- a/src/lib/FileInput/FileInput.svelte
+++ b/src/lib/FileInput/FileInput.svelte
@@ -16,11 +16,11 @@
   let dragOver = $state(false);
   let inputEl: HTMLInputElement | null = $state(null);
 
-  function openFilePicker(): void {
+  export const openFilePicker = (): void => {
     if (!disabled) {
       inputEl?.click();
     }
-  }
+  };
 
   function isAccepted(file: File): boolean {
     if (typeof accept !== 'string' || accept.length === 0) {


### PR DESCRIPTION
## What

Convert the internal `function openFilePicker()` declaration in `FileInput.svelte` to `export const openFilePicker = (): void => { ... }`.

## Why

In Svelte 5, `bind:this` on a component instance only exposes identifiers that are explicitly exported from the `<script>` block. An unexported `function` declaration is not reachable from outside the component. Consumers who hold a ref via `bind:this` and call `ref.openFilePicker()` would get a runtime error (`undefined is not a function`) without this change.

The `export const` pattern — and not `export function` — is the correct Svelte 5 idiom for exposing imperative methods on a component instance.

## Change details

- **Logic unchanged**: `if (!disabled) inputEl?.click()` — identical behaviour.
- **Internally callable**: `export const` in a `<script>` block remains in scope; `handleKeyDown` (line 107) and the `trigger` snippet render (line 138) both reference it without issue.
- **Type-safe**: `FileInputSnippetProps.openFilePicker: () => void` already matches the new signature — no type file touched.
- **No new props**: fully backward-compatible — zero API surface added or removed.
- **CSS vars untouched**: all follow `--file-input-*` naming convention.
- **Only the intended-for-external-callers method is exported**: all other helpers (`isAccepted`, `processFiles`, `handleInputChange`, etc.) remain unexported `function` declarations.
- **Index exports unchanged**: `FileInput` and its types are already exported from `src/lib/index.ts` (lines 59 and 120).

## Verification

```
pnpm exec svelte-kit sync && pnpm run check  → 0 errors, 4 pre-existing warnings
pnpm run lint                                → prettier ✓, eslint ✓
```