### PR TITLE
feat(Status): fix vertical centering — move flex layout to .background which owns min-height

### DIFF
--- a/docs/Status.md
+++ b/docs/Status.md
@@ -14,13 +14,13 @@ A full-screen status display with a centered icon image, title text, description
 
 ## Props
 
-| Prop              | Type                                                                                                                                                                                                                                                                                        | Required | Default                          | Description                                                                                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| statusIcon        | `string`                                                                                                                                                                                                                                                                                    | No       | `'icons/order-success-icon.svg'` | URL of the status icon image displayed at the center (e.g., success checkmark, error cross).                                                                           |
-| statusText        | `string`                                                                                                                                                                                                                                                                                    | No       | `''`                             | Main status title text (e.g., 'Order Successful', 'Payment Failed').                                                                                                   |
-| statusDescription | `string`                                                                                                                                                                                                                                                                                    | No       | `''`                             | Description text below the title. Supports HTML content (rendered via {@html}).                                                                                        |
+| Prop              | Type               | Required | Default                          | Description                                                                                                                                                            |
+| ----------------- | ------------------ | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| statusIcon        | `string`           | No       | `'icons/order-success-icon.svg'` | URL of the status icon image displayed at the center (e.g., success checkmark, error cross).                                                                           |
+| statusText        | `string`           | No       | `''`                             | Main status title text (e.g., 'Order Successful', 'Payment Failed').                                                                                                   |
+| statusDescription | `string`           | No       | `''`                             | Description text below the title. Supports HTML content (rendered via {@html}).                                                                                        |
 | buttonProperties  | `ButtonProperties` | No       | `-`                              | Optional ButtonProperties object for an action button below the description (e.g., 'Try Again', 'Go Home').                                                            |
-| classes           | `string`                                                                                                                                                                                                                                                                                    | No       | `-`                              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| classes           | `string`           | No       | `-`                              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
 
 ## Events
 
@@ -32,12 +32,13 @@ A full-screen status display with a centered icon image, title text, description
 
 Override these custom properties to theme the component.
 
-| Variable                          | Default               | CSS Property | Description                                                                                                                          |
-| --------------------------------- | --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `--status-font-weight`            | `600`                 | font-weight  | Font weight of the status title text. Used with different fallbacks: `600` on status text and `400` on description.                  |
-| `--status-description-font-color` | `#2f3841`             | color        | Color of the description text. Used with different fallbacks: `#2f3841` on status text and `#436484cc` on the description paragraph. |
-| `--order-font`                    | `inherit`             | font-family  | Font family for the status text.                                                                                                     |
-| `--order-font-size`               | `14px`                | font-size    | Font size for the status text.                                                                                                       |
+| Variable                          | Default   | CSS Property | Description                                                                                                                          |
+| --------------------------------- | --------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--status-min-height`             | `100vh`   | min-height   | Minimum height of the `.background` container. Controls the overall height of the status screen.                                     |
+| `--status-font-weight`            | `600`     | font-weight  | Font weight of the status title text. Used with different fallbacks: `600` on status text and `400` on description.                  |
+| `--status-description-font-color` | `#2f3841` | color        | Color of the description text. Used with different fallbacks: `#2f3841` on status text and `#436484cc` on the description paragraph. |
+| `--order-font`                    | `inherit` | font-family  | Font family for the status text.                                                                                                     |
+| `--order-font-size`               | `14px`    | font-size    | Font size for the status text.                                                                                                       |
 
 ## Type Reference
 

--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -46,12 +46,16 @@
     margin-bottom: 25px;
   }
 
-  .order-status {
-    flex-direction: column;
+  .background {
+    min-height: var(--status-min-height, 100vh);
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 100vh;
+  }
+
+  .order-status {
+    flex-direction: column;
+    display: flex;
     font-family: var(--order-font, inherit);
     font-size: var(--order-font-size, 14px);
     text-align: center;


### PR DESCRIPTION
## What

Move `display:flex`, `justify-content:center`, and `align-items:center` from `.order-status` to `.background`, which now owns `min-height: var(--status-min-height, 100vh)`.

Previously, `.background` had the `min-height` but was not a flex container, so the centering directives on `.order-status` had no element height to work with and content was never actually centred vertically.

## Why

The `--status-min-height` CSS var was correctly added to `.background` (per spec), but decoupling the height from the flex layout container broke vertical centering. The fix keeps the CSS var on `.background` and makes `.background` the flex centering container, leaving `.order-status` responsible only for its column direction.

## Backward Compatibility

- Default value `100vh` preserved — existing consumers see identical behaviour.
- No new props; `properties.ts` unchanged.
- No Mandatory → Optional prop movement.
- `Status` export in `src/lib/index.ts` unchanged.

## Test

Open the Status story in Storybook: the icon/text/description/button are vertically centred in the viewport at default settings and when `--status-min-height` is overridden to any value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Status documentation formatting and expanded CSS Variables table with additional entries.

* **Style**
  * Adjusted CSS layout in Status component to optimize centering and sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->