### PR TITLE
feat(Button): add pointer-event props for hold-and-release interactions

### DIFF
--- a/docs/Button.md
+++ b/docs/Button.md
@@ -61,10 +61,16 @@ Svelte 5 Snippet props — pass content blocks to the component.
 
 ## Events
 
-| Event   | Type                             | Description                                                                                                                                             |
-| ------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| onclick | `(event: MouseEvent) => void`    | Fires when the button is clicked. Does NOT fire when `showProgressBar` is active (clicks are silently ignored during progress).                         |
-| onkeyup | `(event: KeyboardEvent) => void` | Fires when a key is released while the button has focus. Defaults to a no-op `() => {}` (always fires, unlike other events which default to undefined). |
+| Event        | Type                             | Description                                                                                                                                             |
+| ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| onclick      | `(event: MouseEvent) => void`    | Fires when the button is clicked. Does NOT fire when `showProgressBar` is active (clicks are silently ignored during progress).                         |
+| onkeydown    | `(event: KeyboardEvent) => void` | Fires when a key is pressed down while the button has focus. Use together with `onkeyup` to implement keyboard hold-and-release interactions.           |
+| onkeyup      | `(event: KeyboardEvent) => void` | Fires when a key is released while the button has focus. Defaults to a no-op `() => {}` (always fires, unlike other events which default to undefined). |
+| onmousedown  | `(event: MouseEvent) => void`    | Fires when a mouse button is pressed down on the button. Use together with `onmouseup`/`onmouseleave` to implement hold-and-release interactions.       |
+| onmouseup    | `(event: MouseEvent) => void`    | Fires when a mouse button is released over the button. Use together with `onmousedown` to detect the end of a hold gesture.                             |
+| onmouseleave | `(event: MouseEvent) => void`    | Fires when the pointer leaves the button area. Use together with `onmousedown` to cancel a hold gesture if the pointer drifts off the button.           |
+| ontouchstart | `(event: TouchEvent) => void`    | Fires when a touch point is placed on the button. Use together with `ontouchend` to implement hold-and-release interactions on touch devices.           |
+| ontouchend   | `(event: TouchEvent) => void`    | Fires when a touch point is removed from the button. Use together with `ontouchstart` to detect the end of a touch hold gesture.                        |
 
 ## CSS Variables
 

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -15,7 +15,13 @@
     ariaSelected,
     role,
     onclick,
+    onkeydown,
     onkeyup = () => {},
+    onmousedown,
+    onmouseup,
+    onmouseleave,
+    ontouchstart,
+    ontouchend,
     showProgressBar = $bindable(false),
     icon,
     children,
@@ -42,7 +48,13 @@
   <button
     class:disabled={isDisabled}
     onclick={handleButtonClick}
+    {onkeydown}
     {onkeyup}
+    {onmousedown}
+    {onmouseup}
+    {onmouseleave}
+    {ontouchstart}
+    {ontouchend}
     disabled={isDisabled}
     {type}
     data-pw={testId}

--- a/src/lib/Button/properties.ts
+++ b/src/lib/Button/properties.ts
@@ -24,5 +24,11 @@ export type OptionalButtonProperties = {
 
 export type ButtonEventProperties = {
   onclick?: (event: MouseEvent) => void;
+  onkeydown?: (event: KeyboardEvent) => void;
   onkeyup?: (event: KeyboardEvent) => void;
+  onmousedown?: (event: MouseEvent) => void;
+  onmouseup?: (event: MouseEvent) => void;
+  onmouseleave?: (event: MouseEvent) => void;
+  ontouchstart?: (event: TouchEvent) => void;
+  ontouchend?: (event: TouchEvent) => void;
 };

--- a/src/wc/components/Button.wc.svelte
+++ b/src/wc/components/Button.wc.svelte
@@ -15,7 +15,13 @@
       ariaExpanded: { type: 'Boolean', attribute: 'aria-expanded' },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      onkeyup: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      onkeyup: { type: 'Object' },
+      onmousedown: { type: 'Object' },
+      onmouseup: { type: 'Object' },
+      onmouseleave: { type: 'Object' },
+      ontouchstart: { type: 'Object' },
+      ontouchend: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
## What

Add five new optional event handler props to `Button`:

- `onmousedown?: (event: MouseEvent) => void`
- `onmouseup?: (event: MouseEvent) => void`
- `onmouseleave?: (event: MouseEvent) => void`
- `ontouchstart?: (event: TouchEvent) => void`
- `ontouchend?: (event: TouchEvent) => void`

All five are declared in `ButtonEventProperties` (alongside the existing `onclick`/`onkeyup`) and wired to the `<button>` element via Svelte 5 shorthand attribute spread.

## Why

Consumers implementing hold-and-release (hold-and-fold) or push-to-talk (PTT) mic button patterns (e.g. C6-11 spec) need low-level pointer and touch lifecycle events. Without these props they had to reach for `bind:this` + manual `addEventListener` in their own component — an unnecessary workaround given the library already exposes `onclick`/`onkeyup` declaratively.

## Backward compatibility

- All five props are **optional** (`?:`). No existing props removed or made mandatory.
- The `ButtonProperties` union type (`OptionalButtonProperties & ButtonEventProperties`) is unchanged in structure.
- Type re-export via `export type * from './Button/properties'` in `index.ts` picks up the new types automatically — no `index.ts` change needed.
- Version bump: `2.36.0 → 2.37.0` (minor, consistent with a feature addition).

## Note on passive touch listeners

Svelte's declarative attribute approach (`{ontouchstart}`) does not support `{ passive: true }`. Consumers who need passive listeners (scroll-performance opt-in) must use `bind:this` + `addEventListener` in their own component. This is a known, deliberate limitation of the library's declarative event pattern — not a regression introduced by this change.