### PR TITLE
feat(Loader): add testId prop with canonical typeof string guard

### DIFF
--- a/src/lib/Loader/Loader.svelte
+++ b/src/lib/Loader/Loader.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { LoaderProperties } from './properties';
 
-  let { classes }: LoaderProperties = $props();
+  let { classes, testId }: LoaderProperties = $props();
 </script>
 
-<div class="loader {classes ?? ''}"></div>
+<div class="loader {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}></div>
 
 <style>
   .loader {

--- a/src/lib/Loader/properties.ts
+++ b/src/lib/Loader/properties.ts
@@ -1,3 +1,4 @@
 export type LoaderProperties = {
   classes?: string;
+  testId?: string;
 };


### PR DESCRIPTION
## What

- Adds `testId?: string` optional prop to `LoaderProperties` type in `src/lib/Loader/properties.ts`
- Applies `data-pw={typeof testId === 'string' ? testId : null}` on the root `.loader` element in `Loader.svelte`

## Why

The `testId ?? null` pattern used initially is functionally equivalent under TypeScript strict mode, but the canonical library form established by `Shimmer.svelte` (line 8) uses the `typeof testId === 'string' ? testId : null` ternary guard. This defensive form ensures non-string truthy values are never passed as the attribute value if TypeScript narrowing is bypassed at a callsite.

## Compatibility

- Fully backward-compatible: `testId` is optional with no default, so existing usages without `testId` are unaffected
- No new mandatory props introduced
- The flat single-type shape in `LoaderProperties` (no Mandatory/Optional split) is consistent with the `Shimmer` precedent — both are zero-mandatory, zero-event simple wrappers
- `Loader` and `LoaderProperties` were already exported from `src/lib/index.ts`