### PR TITLE
feat(EmptyState): add titleSnippet and descriptionSnippet snippet props

### DIFF
--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -44,21 +44,55 @@ A centered placeholder component for empty lists, search results, or views. Disp
 
 ## Props
 
-| Prop        | Type     | Required | Default | Description                                                                                                                                                            |
-| ----------- | -------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string` | Yes      | `-`     | Primary heading text displayed prominently.                                                                                                                            |
-| description | `string` | No       | `-`     | Supporting text displayed below the title. The description row is omitted entirely when this prop is absent or empty.                                                  |
-| classes     | `string` | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
-| testId      | `string` | No       | `-`     | Value applied to the `data-pw` attribute on the root element for test selection.                                                                                       |
+| Prop               | Type      | Required | Default | Description                                                                                                                                                                         |
+| ------------------ | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title              | `string`  | Yes      | `-`     | Primary heading text. When `titleSnippet` is provided this value is not rendered, but the prop is still required for backward-compatibility (pass `""` as the minimal valid value). |
+| description        | `string`  | No       | `-`     | Supporting text displayed below the title. Omitted entirely when absent or empty. Silently discarded when `descriptionSnippet` is provided.                                         |
+| titleSnippet       | `Snippet` | No       | `-`     | Optional snippet that replaces the `title` string at render time. Use for rich markup (e.g. formatted text, inline icons). Takes full rendering priority over `title`.              |
+| descriptionSnippet | `Snippet` | No       | `-`     | Optional snippet that replaces the `description` string at render time. Use for rich markup (e.g. links, emphasis). Takes full rendering priority over `description`.               |
+| classes            | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.              |
+| testId             | `string`  | No       | `-`     | Value applied to the `data-pw` attribute on the root element for test selection.                                                                                                    |
 
 ## Snippets
 
 Svelte 5 Snippet props — pass content blocks to the component.
 
-| Snippet  | Type      | Description                                                                                                          |
-| -------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
-| icon     | `Snippet` | Icon or illustration area above the title. Rendered inside a sized container with configurable dimensions and color. |
-| children | `Snippet` | Action area below the description. Typically used for buttons like "Create new", "Clear filters", "Try again", etc.  |
+| Snippet            | Type      | Description                                                                                                                                                       |
+| ------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| icon               | `Snippet` | Icon or illustration area above the title. Rendered inside a sized container with configurable dimensions and color.                                              |
+| titleSnippet       | `Snippet` | Rich-markup override for the title area. When provided, it takes full rendering priority over the `title` string prop — only the snippet is rendered.             |
+| descriptionSnippet | `Snippet` | Rich-markup override for the description area. When provided, it takes full rendering priority over the `description` string prop — only the snippet is rendered. |
+| children           | `Snippet` | Action area below the description. Typically used for buttons like "Create new", "Clear filters", "Try again", etc.                                               |
+
+### Rich-Markup Title and Description via Snippets
+
+Use `titleSnippet` and `descriptionSnippet` when the plain string props are not enough — for example, to add inline icons, links, or formatted text.
+
+```svelte
+<script>
+  import { EmptyState, Button } from '@juspay/svelte-ui-components';
+</script>
+
+<!-- Rich title with an inline badge -->
+<EmptyState title="No results">
+  {#snippet titleSnippet()}
+    <span>No results <em>yet</em></span>
+  {/snippet}
+  {#snippet descriptionSnippet()}
+    Try a <a href="/help">different search</a> or clear your filters.
+  {/snippet}
+  <Button text="Clear filters" />
+</EmptyState>
+```
+
+```svelte
+<!-- Minimal snippet usage — title only -->
+<EmptyState title="">
+  {#snippet titleSnippet()}
+    <strong>Nothing here</strong> — check back later
+  {/snippet}
+</EmptyState>
+```
 
 ## CSS Variables
 

--- a/src/lib/EmptyState/EmptyState.svelte
+++ b/src/lib/EmptyState/EmptyState.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
   import type { EmptyStateProperties } from './properties';
 
-  let { title, description, icon, children, classes, testId }: EmptyStateProperties = $props();
+  let {
+    title,
+    description,
+    icon,
+    children,
+    classes,
+    testId,
+    titleSnippet,
+    descriptionSnippet
+  }: EmptyStateProperties = $props();
 </script>
 
 <div class="empty-state {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
@@ -10,8 +19,18 @@
       {@render icon()}
     </div>
   {/if}
-  <div class="empty-state-title">{title}</div>
-  {#if typeof description === 'string' && description.length > 0}
+  <div class="empty-state-title">
+    {#if typeof titleSnippet === 'function'}
+      {@render titleSnippet()}
+    {:else}
+      {title}
+    {/if}
+  </div>
+  {#if typeof descriptionSnippet === 'function'}
+    <div class="empty-state-description">
+      {@render descriptionSnippet()}
+    </div>
+  {:else if typeof description === 'string' && description.length > 0}
     <div class="empty-state-description">{description}</div>
   {/if}
   {#if typeof children === 'function'}

--- a/src/lib/EmptyState/properties.ts
+++ b/src/lib/EmptyState/properties.ts
@@ -3,6 +3,13 @@ import type { Snippet } from 'svelte';
 export type EmptyStateProperties = MandatoryEmptyStateProperties & OptionalEmptyStateProperties;
 
 export type MandatoryEmptyStateProperties = {
+  /**
+   * Fallback text title rendered when `titleSnippet` is not provided.
+   * This prop is required for backward-compatibility. When `titleSnippet` is supplied,
+   * `title` is still required by TypeScript but its value is not rendered — the snippet
+   * takes priority. Pass an empty string (`title=""`) as the minimal valid value when
+   * using `titleSnippet`.
+   */
   title: string;
 };
 
@@ -12,4 +19,17 @@ export type OptionalEmptyStateProperties = {
   children?: Snippet;
   classes?: string;
   testId?: string;
+  /**
+   * Optional snippet that replaces the `title` string at render time.
+   * When provided, the mandatory `title` prop is still required for backward-compatibility
+   * but its value is not rendered — the snippet takes full priority.
+   * Use this when the title needs rich markup (e.g. formatted text, icons inline).
+   */
+  titleSnippet?: Snippet;
+  /**
+   * Optional snippet that replaces the `description` string at render time.
+   * When provided, `description` is silently discarded — only one is rendered.
+   * Use this when the description needs rich markup (e.g. links, emphasis).
+   */
+  descriptionSnippet?: Snippet;
 };


### PR DESCRIPTION
## What

Adds two optional `Snippet` props to the `EmptyState` component:

- **`titleSnippet?: Snippet`** — renders arbitrary markup in place of the `title` string; when provided, `title` is still required for backward-compatibility but is not rendered (documented via JSDoc)
- **`descriptionSnippet?: Snippet`** — renders arbitrary markup in place of the `description` string; when provided, `description` is silently discarded (documented via JSDoc noting the mutual exclusion)

## Why

Consumers frequently need rich markup in EmptyState titles and descriptions (inline icons, styled links, emphasis spans) that a plain `string` prop cannot express. The snippet escape hatch is the standard library pattern (see `Banner.title`, `Modal.headerSnippet`) and avoids introducing untyped HTML props.

## Backward-compatibility

- Both props land in `OptionalEmptyStateProperties` — no mandatory prop is demoted, no existing call site breaks.
- `title: string` remains mandatory in `MandatoryEmptyStateProperties` per the hold-and-fold policy.
- Render logic uses `{#if typeof titleSnippet === 'function'} {:else} {title} {/if}` — the existing string path is the unconditional fallback.

## Hold-and-fold

This PR extends an existing branch before it merges. All changes are additive. Zero breaking changes.