### PR TITLE
feat(Accordion): fix blocker/major review issues — classes, type naming, handler, event, testId

### DIFF
--- a/docs/Accordion.md
+++ b/docs/Accordion.md
@@ -1,41 +1,72 @@
 # Accordion
 
-An expandable/collapsible container that uses CSS grid row animation for smooth open/close transitions. When `expand` is true, the content is visible (grid-template-rows: 1fr); when false, it collapses to 0fr. Transition takes 0.2s ease-out. Render children content using the default `children` snippet.
+An expandable/collapsible container that uses CSS grid row animation for smooth open/close transitions. When `expand` is true, the content is visible (grid-template-rows: 1fr); when false, it collapses to 0fr. Transition duration/easing is controlled via `--accordion-transition`. Render children content using the default `children` snippet. Pass an optional `trigger` snippet to render a built-in clickable/keyboard-accessible toggle header.
 
 ## Usage
 
 ```svelte
 <script>
   import { Accordion } from '@juspay/svelte-ui-components';
+  let open = $state(false);
 </script>
 
-<Accordion />
+<Accordion bind:expand={open}>
+  {#snippet trigger({ expanded })}
+    <span>{expanded ? 'Collapse' : 'Expand'}</span>
+  {/snippet}
+  <p>Expandable content here</p>
+</Accordion>
 ```
 
 ## Props
 
-| Prop    | Type      | Required | Default | Description                                                                                                                                                                                                                |
-| ------- | --------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| expand  | `boolean` | No       | `false` | Controls whether the accordion content is expanded (visible) or collapsed (hidden). Uses CSS grid animation.                                                                                                               |
-| classes | `string`  | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides (e.g., `.btn-primary { --button-color: #0070f3; }`) and pass them to create variant styles. |
+| Prop           | Type      | Required | Default | Description                                                                                                                                                                |
+| -------------- | --------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| expand         | `boolean` | No       | `false` | Controls whether the accordion content is expanded (visible) or collapsed (hidden). Supports two-way binding (`bind:expand`).                                              |
+| classes        | `string`  | No       | `-`     | CSS class string applied to the accordion content wrapper element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| triggerClasses | `string`  | No       | `-`     | CSS class string applied to the `accordion-trigger` wrapper div. Use to style the trigger area independently of the content panel.                                         |
+| testId         | `string`  | No       | `-`     | Value written to `data-pw` on the accordion content wrapper. Enables Playwright locators (`page.getByTestId(testId)`).                                                     |
+
+## Events
+
+| Event    | Payload                       | Description                                                                |
+| -------- | ----------------------------- | -------------------------------------------------------------------------- |
+| ontoggle | `(expanded: boolean) => void` | Fired after the trigger toggles `expand`. Receives the new expanded state. |
 
 ## Snippets
 
 Svelte 5 Snippet props — pass content blocks to the component.
 
-| Snippet  | Type      | Description                                     |
-| -------- | --------- | ----------------------------------------------- |
-| children | `Snippet` | Content rendered inside the accordion panel. |
+| Snippet  | Parameters              | Description                                                                                                                                                                                                                   |
+| -------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| children | _(none)_                | Content rendered inside the accordion panel (the collapsible region).                                                                                                                                                         |
+| trigger  | `{ expanded: boolean }` | When provided, renders a keyboard-accessible toggle header (`role="button"`, `tabindex="0"`, `aria-expanded`). The `expanded` parameter reflects the current open/closed state so you can render different UI for each state. |
+
+## CSS Variables
+
+| Variable                     | Default         | Description                                              |
+| ---------------------------- | --------------- | -------------------------------------------------------- |
+| `--accordion-trigger-cursor` | `pointer`       | Cursor style for the trigger element.                    |
+| `--accordion-transition`     | `0.2s ease-out` | Transition value for the `grid-template-rows` animation. |
 
 ## Web Component
 
 Tag: `<sui-accordion>`
 
 ```html
-<sui-accordion expand>
+<sui-accordion expand trigger-classes="my-trigger" test-id="my-accordion">
   <p>Expandable content here</p>
 </sui-accordion>
 ```
+
+### Props (HTML Attributes)
+
+| Attribute         | Maps to Prop     | Type    | Description                            |
+| ----------------- | ---------------- | ------- | -------------------------------------- |
+| `expand`          | `expand`         | Boolean | Reflects the expanded state.           |
+| `classes`         | `classes`        | String  | CSS classes for the content wrapper.   |
+| `trigger-classes` | `triggerClasses` | String  | CSS classes for the trigger wrapper.   |
+| `test-id`         | `testId`         | String  | Sets `data-pw` on the content wrapper. |
 
 ### Slots
 

--- a/src/lib/Accordion/Accordion.svelte
+++ b/src/lib/Accordion/Accordion.svelte
@@ -1,21 +1,60 @@
 <script lang="ts">
   import type { AccordionProperties } from './properties';
 
-  let { expand = false, children, classes }: AccordionProperties = $props();
+  let {
+    expand = $bindable(false),
+    children,
+    trigger,
+    ontoggle,
+    triggerClasses,
+    classes,
+    testId
+  }: AccordionProperties = $props();
+
+  function handleTriggerClick(): void {
+    expand = !expand;
+    ontoggle?.(expand);
+  }
 </script>
 
-<div class="accordion {classes ?? ''}" class:expanded={expand}>
+{#if trigger}
+  <div
+    class="accordion-trigger {triggerClasses ?? ''}"
+    role="button"
+    tabindex="0"
+    aria-expanded={expand}
+    onclick={handleTriggerClick}
+    onkeydown={(event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleTriggerClick();
+      }
+    }}
+  >
+    {@render trigger({ expanded: expand })}
+  </div>
+{/if}
+
+<div
+  class="accordion {classes ?? ''}"
+  class:expanded={expand}
+  data-pw={typeof testId === 'string' ? testId : null}
+>
   <div class="accordion-content">
     {@render children?.()}
   </div>
 </div>
 
 <style>
+  .accordion-trigger {
+    cursor: var(--accordion-trigger-cursor, pointer);
+  }
+
   .accordion {
     display: grid;
     grid-template-rows: 0fr;
     overflow: hidden;
-    transition: grid-template-rows 0.2s ease-out;
+    transition: grid-template-rows var(--accordion-transition, 0.2s ease-out);
   }
 
   .accordion.expanded {

--- a/src/lib/Accordion/properties.ts
+++ b/src/lib/Accordion/properties.ts
@@ -1,7 +1,16 @@
 import type { Snippet } from 'svelte';
 
-export type AccordionProperties = {
+export type AccordionProperties = OptionalAccordionProperties & AccordionEventProperties;
+
+export type OptionalAccordionProperties = {
   expand?: boolean;
   children?: Snippet;
+  trigger?: Snippet<[{ expanded: boolean }]>;
+  triggerClasses?: string;
   classes?: string;
+  testId?: string;
+};
+
+export type AccordionEventProperties = {
+  ontoggle?: (expanded: boolean) => void;
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -79,6 +79,7 @@ export type * from './Toolbar/properties';
 export type * from './Carousel/properties';
 export type * from './Badge/properties';
 export type * from './Banner/properties';
+export type * from './Accordion/properties';
 export type * from './Table/properties';
 export type * from './Stepper/properties';
 export type * from './Toast/properties';

--- a/src/wc/components/Accordion.wc.svelte
+++ b/src/wc/components/Accordion.wc.svelte
@@ -4,7 +4,9 @@
     shadow: 'open',
     props: {
       expand: { type: 'Boolean', reflect: true },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      triggerClasses: { type: 'String', attribute: 'trigger-classes' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />


### PR DESCRIPTION
## What

Resolves all blocker and major issues from the previous review of the Accordion trigger implementation (C6-1).

- **BLOCKER — `classes` double-application**: `classes` was applied to both `.accordion-trigger` and `.accordion` root divs simultaneously. Introduced `triggerClasses?: string` for the trigger wrapper; `classes` now scopes exclusively to the accordion content div, preserving the pre-existing prop contract. Existing consumers passing `classes` are unaffected — they never saw the trigger div before this feature.
- **MAJOR — type naming word-order**: Renamed `AccordionOptionalProperties` → `OptionalAccordionProperties` to match the canonical library pattern (`OptionalBannerProperties`, `OptionalButtonProperties`). Also exports the type group from `src/lib/index.ts` (was missing entirely).
- **MAJOR — private handler uses `const` arrow**: `const handleTriggerClick = () =>` is the `export const` pattern reserved for publicly-exported imperative methods. Private handlers follow `function handleTriggerClick(): void {}` — matches `handleClick`/`handleDismiss`/`handleKeydown` in Banner and Button.
- **MINOR — event prop casing**: `onToggle` → `ontoggle` — all-lowercase consistent with `onclick`, `ondismiss`, `onkeyup` across the library.
- **MINOR — `testId` support**: Added `testId?: string` to `OptionalAccordionProperties`; bound to `data-pw` on the accordion root element to enable Playwright `getByTestId` locators.

## Backward compatibility

All new props are optional. Consumers that do not pass `trigger`, `triggerClasses`, `ontoggle`, or `testId` see zero change in rendered output. The `classes` fix is technically a breaking change only for consumers who simultaneously use `classes` AND `trigger` AND relied on the accidental double-styling — which is the buggy behavior being corrected.

## Hold-and-fold

`pnpm run check` → 0 errors, 4 pre-existing warnings (Modal/ThemeSwitcher, tsconfig — unchanged from before this PR).
`pnpm run lint` → all matched files use Prettier code style, no ESLint errors.