### PR TITLE
feat(StatCard): add StatCard component with delta auto-inference and CSS-var theming

### DIFF
--- a/docs/StatCard.md
+++ b/docs/StatCard.md
@@ -1,0 +1,174 @@
+# StatCard
+
+A compact metric display card for dashboards. Shows a title label, a prominent value, an optional delta badge (with automatic positive/negative colour inference from the leading sign character), an optional subtitle, a footer snippet, and an optional custom value snippet for advanced rendering. All visual properties are controlled via CSS custom properties. When `onclick` is provided the root element becomes an accessible button (`role="button"`, `tabindex="0"`, Enter/Space keyboard support) without any API change for existing consumers that omit the prop.
+
+## Usage
+
+```svelte
+<script>
+  import { StatCard } from '@juspay/svelte-ui-components';
+</script>
+
+<StatCard title="Total Revenue" value="₹1.23Cr" delta="+12.5%" subtitle="vs last month" />
+```
+
+### Negative Delta
+
+```svelte
+<StatCard title="Refund Rate" value="3.2%" delta="-0.8%" subtitle="vs last week" />
+```
+
+Delta colour is inferred from the leading character: `+` → green (`--statcard-delta-positive-color`), `-` → red (`--statcard-delta-negative-color`), any other character → neutral grey (`--statcard-delta-color`).
+
+### Explicit Delta Polarity Override
+
+```svelte
+<!-- Force green even when delta string has no leading sign -->
+<StatCard title="Approval Rate" value="98.4%" delta="98.4%" deltaPositive={true} />
+```
+
+### With Footer Snippet
+
+```svelte
+<script>
+  import { StatCard } from '@juspay/svelte-ui-components';
+</script>
+
+<StatCard title="Orders" value="1,482">
+  {#snippet footer()}
+    <a href="/orders">View all orders →</a>
+  {/snippet}
+</StatCard>
+```
+
+### Custom Value Rendering
+
+```svelte
+<script>
+  import { StatCard } from '@juspay/svelte-ui-components';
+</script>
+
+<StatCard title="Conversion">
+  {#snippet valueSnippet()}
+    <strong style="color: #7c3aed;">68.2 %</strong>
+  {/snippet}
+</StatCard>
+```
+
+### Themed Card
+
+```svelte
+<div class="dark-stat">
+  <StatCard title="GMV" value="₹8.4Cr" delta="+5.1%" subtitle="7-day rolling" />
+</div>
+
+<style>
+  .dark-stat {
+    --statcard-background: #1a1a2e;
+    --statcard-border: 1px solid #2a2a3c;
+    --statcard-color: #e5e7eb;
+    --statcard-title-color: #9ca3af;
+    --statcard-delta-positive-color: #4ade80;
+    --statcard-delta-negative-color: #f87171;
+  }
+</style>
+```
+
+### Interactive Card
+
+```svelte
+<script>
+  import { StatCard } from '@juspay/svelte-ui-components';
+
+  const handleClick = (event: MouseEvent) => {
+    console.log('stat card clicked', event);
+  };
+</script>
+
+<StatCard
+  title="Transactions"
+  value="24,310"
+  delta="+8.3%"
+  onclick={handleClick}
+  testId="transactions-stat-card"
+/>
+```
+
+## Props
+
+| Prop          | Type                          | Required | Default | Description                                                                                                                                           |
+| ------------- | ----------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title         | `string`                      | No       | `-`     | Card heading label rendered above the value row.                                                                                                      |
+| value         | `string`                      | No       | `-`     | Pre-formatted metric value string (e.g. `"₹1.23Cr"`, `"98.4%"`). Ignored when `valueSnippet` is provided.                                             |
+| delta         | `string`                      | No       | `-`     | Pre-formatted delta string (e.g. `"+12.5%"`, `"-3.2%"`). Auto-infers `deltaPositive` from leading sign when `deltaPositive` is not set.               |
+| deltaPositive | `boolean`                     | No       | `-`     | Overrides automatic sign-based colour inference. `true` = positive (green), `false` = negative (red). Omit to let the leading sign decide.            |
+| subtitle      | `string`                      | No       | `-`     | Secondary label rendered below the value row.                                                                                                         |
+| footer        | `Snippet`                     | No       | `-`     | Snippet rendered in the card footer area, separated by a border-top line.                                                                             |
+| valueSnippet  | `Snippet`                     | No       | `-`     | Replaces the string `value` with a custom snippet for advanced value rendering.                                                                       |
+| classes       | `string`                      | No       | `-`     | Extra CSS class names appended to the root element. Useful for theming — define classes with CSS variable overrides and pass them to create variants. |
+| testId        | `string`                      | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                                                            |
+| onclick       | `(event: MouseEvent) => void` | No       | `-`     | Click handler. When provided, the card root becomes interactive: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler.        |
+
+## Events
+
+| Event   | Type                          | Description                                                                                                                                          |
+| ------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| onclick | `(event: MouseEvent) => void` | Fires when the card is clicked. When provided, the card gains `role="button"`, `tabindex="0"`, and keyboard support (Enter/Space). No-op if omitted. |
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                          | Default                  | CSS Property   | Description                                                                  |
+| --------------------------------- | ------------------------ | -------------- | ---------------------------------------------------------------------------- |
+| `--statcard-gap`                  | `4px`                    | gap            | Vertical gap between card sections.                                          |
+| `--statcard-padding`              | `16px`                   | padding        | Inner padding of the card.                                                   |
+| `--statcard-background`           | `#ffffff`                | background     | Background colour of the card.                                               |
+| `--statcard-border`               | `1px solid #e5e7eb`      | border         | Border of the card.                                                          |
+| `--statcard-border-radius`        | `8px`                    | border-radius  | Corner radius of the card.                                                   |
+| `--statcard-box-shadow`           | `none`                   | box-shadow     | Box shadow of the card.                                                      |
+| `--statcard-width`                | `auto`                   | width          | Width of the card.                                                           |
+| `--statcard-min-width`            | `0`                      | min-width      | Minimum width constraint.                                                    |
+| `--statcard-max-width`            | `none`                   | max-width      | Maximum width constraint.                                                    |
+| `--statcard-height`               | `auto`                   | height         | Height of the card.                                                          |
+| `--statcard-color`                | `inherit`                | color          | Foreground text colour inherited by all child text.                          |
+| `--statcard-cursor`               | `default`                | cursor         | Cursor on the card root. Overridden to `pointer` when `onclick` is provided. |
+| `--statcard-focus-outline`        | `2px solid currentColor` | outline        | Focus ring on keyboard focus (interactive mode only).                        |
+| `--statcard-focus-outline-offset` | `2px`                    | outline-offset | Offset of the focus ring from the card edge.                                 |
+| `--statcard-title-font-size`      | `12px`                   | font-size      | Font size of the title label.                                                |
+| `--statcard-title-font-weight`    | `500`                    | font-weight    | Font weight of the title label.                                              |
+| `--statcard-title-color`          | `#6b7280`                | color          | Colour of the title label.                                                   |
+| `--statcard-title-line-height`    | `1.4`                    | line-height    | Line height of the title label.                                              |
+| `--statcard-title-white-space`    | `nowrap`                 | white-space    | White-space of the title label. Set to `normal` to allow wrapping.           |
+| `--statcard-value-row-align`      | `baseline`               | align-items    | Vertical alignment of value and delta within the value row.                  |
+| `--statcard-value-row-gap`        | `8px`                    | gap            | Horizontal gap between value and delta in the value row.                     |
+| `--statcard-value-font-size`      | `24px`                   | font-size      | Font size of the metric value.                                               |
+| `--statcard-value-font-weight`    | `600`                    | font-weight    | Font weight of the metric value.                                             |
+| `--statcard-value-color`          | `inherit`                | color          | Colour of the metric value. Inherits card foreground by default.             |
+| `--statcard-value-line-height`    | `1.2`                    | line-height    | Line height of the metric value.                                             |
+| `--statcard-delta-font-size`      | `13px`                   | font-size      | Font size of the delta badge.                                                |
+| `--statcard-delta-font-weight`    | `500`                    | font-weight    | Font weight of the delta badge.                                              |
+| `--statcard-delta-color`          | `#6b7280`                | color          | Colour of a neutral delta (no sign detected / `deltaPositive` not set).      |
+| `--statcard-delta-line-height`    | `1.4`                    | line-height    | Line height of the delta badge.                                              |
+| `--statcard-delta-positive-color` | `#16a34a`                | color          | Colour of a positive delta (`+` prefix or `deltaPositive={true}`).           |
+| `--statcard-delta-negative-color` | `#dc2626`                | color          | Colour of a negative delta (`-` prefix or `deltaPositive={false}`).          |
+| `--statcard-subtitle-font-size`   | `12px`                   | font-size      | Font size of the subtitle label.                                             |
+| `--statcard-subtitle-font-weight` | `400`                    | font-weight    | Font weight of the subtitle label.                                           |
+| `--statcard-subtitle-color`       | `#9ca3af`                | color          | Colour of the subtitle label.                                                |
+| `--statcard-subtitle-line-height` | `1.4`                    | line-height    | Line height of the subtitle label.                                           |
+| `--statcard-footer-margin-top`    | `8px`                    | margin-top     | Top margin of the footer section.                                            |
+| `--statcard-footer-padding-top`   | `8px`                    | padding-top    | Top padding of the footer section (space between border and content).        |
+| `--statcard-footer-border-top`    | `1px solid #e5e7eb`      | border-top     | Top border line separating the footer from the card body.                    |
+
+## Web Component
+
+Tag: `<sui-stat-card>`
+
+```html
+<sui-stat-card
+  title="Total Revenue"
+  value="₹1.23Cr"
+  delta="+12.5%"
+  subtitle="vs last month"
+></sui-stat-card>
+```

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -228,6 +228,10 @@
     "description": "A row of related input fields for segmented values like OTP/PIN codes, RGB/HSL color channels, IP addresses, or time inputs. Supports per-field configuration (dataType, min/max, validation), auto-advance focus, paste distribution, keyboard navigation, and optional separators between fields. Uses the Input component internally."
   },
   {
+    "name": "StatCard",
+    "description": "A compact metric display card for dashboards. Shows a title label, a prominent value, an optional delta badge (with automatic positive/negative colour inference from the leading sign character), an optional subtitle, and a footer snippet. When onclick is provided, the card becomes an accessible interactive button (role=button, tabindex=0, Enter/Space keyboard support). All visual properties are CSS-var driven."
+  },
+  {
     "name": "Status",
     "description": "A full-screen status display with a centered icon image, title text, description text (supports HTML), and an optional action Button. Uses backdrop-filter blur for visual effect. Ideal for order success/failure screens."
   },

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import type { StatCardProperties } from './properties';
+
+  let {
+    title,
+    value,
+    delta,
+    deltaPositive,
+    subtitle,
+    footer,
+    valueSnippet,
+    testId,
+    classes,
+    onclick
+  }: StatCardProperties = $props();
+
+  const isInteractive = $derived(typeof onclick === 'function');
+
+  /**
+   * When `deltaPositive` is explicitly provided use it; otherwise infer from
+   * the leading character of `delta` — '+' → positive, '-' → negative,
+   * anything else (e.g. '0%') → undefined (neutral, no colour applied).
+   */
+  const resolvedDeltaPositive = $derived(
+    typeof deltaPositive === 'boolean'
+      ? deltaPositive
+      : typeof delta === 'string' && delta.trim().length > 0
+        ? delta.trimStart().startsWith('+')
+          ? true
+          : delta.trimStart().startsWith('-')
+            ? false
+            : null
+        : null
+  );
+
+  const hasDelta = $derived(typeof delta === 'string' && delta.trim().length > 0);
+
+  const handleKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      if (event.key === ' ') {
+        event.preventDefault();
+      }
+      if (event.currentTarget instanceof HTMLElement) {
+        event.currentTarget.click();
+      }
+    }
+  };
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+  class="statcard {classes ?? ''}"
+  class:statcard-interactive={isInteractive}
+  data-pw={typeof testId === 'string' ? testId : null}
+  role={isInteractive ? 'button' : null}
+  tabindex={isInteractive ? 0 : null}
+  onclick={isInteractive ? onclick : null}
+  onkeydown={isInteractive ? handleKeydown : null}
+>
+  {#if typeof title === 'string' && title.length > 0}
+    <div class="statcard-title">{title}</div>
+  {/if}
+
+  <div class="statcard-value-row">
+    {#if typeof valueSnippet === 'function'}
+      <div class="statcard-value">{@render valueSnippet()}</div>
+    {:else if typeof value === 'string' && value.length > 0}
+      <div class="statcard-value">{value}</div>
+    {/if}
+
+    {#if hasDelta}
+      <div
+        class="statcard-delta"
+        class:statcard-delta-positive={resolvedDeltaPositive === true}
+        class:statcard-delta-negative={resolvedDeltaPositive === false}
+      >
+        {delta}
+      </div>
+    {/if}
+  </div>
+
+  {#if typeof subtitle === 'string' && subtitle.length > 0}
+    <div class="statcard-subtitle">{subtitle}</div>
+  {/if}
+
+  {#if typeof footer === 'function'}
+    <div class="statcard-footer">{@render footer()}</div>
+  {/if}
+</div>
+
+<style>
+  .statcard {
+    display: flex;
+    flex-direction: column;
+    gap: var(--statcard-gap, 4px);
+    padding: var(--statcard-padding, 16px);
+    background: var(--statcard-background, #ffffff);
+    border: var(--statcard-border, 1px solid #e5e7eb);
+    border-radius: var(--statcard-border-radius, 8px);
+    box-shadow: var(--statcard-box-shadow, none);
+    width: var(--statcard-width, auto);
+    min-width: var(--statcard-min-width, 0);
+    max-width: var(--statcard-max-width, none);
+    height: var(--statcard-height, auto);
+    color: var(--statcard-color, inherit);
+    cursor: var(--statcard-cursor, default);
+    box-sizing: border-box;
+  }
+
+  .statcard-interactive {
+    cursor: var(--statcard-cursor, pointer);
+  }
+
+  .statcard-interactive:focus-visible {
+    outline: var(--statcard-focus-outline, 2px solid currentColor);
+    outline-offset: var(--statcard-focus-outline-offset, 2px);
+  }
+
+  .statcard-title {
+    font-size: var(--statcard-title-font-size, 12px);
+    font-weight: var(--statcard-title-font-weight, 500);
+    color: var(--statcard-title-color, #6b7280);
+    line-height: var(--statcard-title-line-height, 1.4);
+    white-space: var(--statcard-title-white-space, nowrap);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .statcard-value-row {
+    display: flex;
+    align-items: var(--statcard-value-row-align, baseline);
+    gap: var(--statcard-value-row-gap, 8px);
+    flex-wrap: wrap;
+  }
+
+  .statcard-value {
+    font-size: var(--statcard-value-font-size, 24px);
+    font-weight: var(--statcard-value-font-weight, 600);
+    color: var(--statcard-value-color, inherit);
+    line-height: var(--statcard-value-line-height, 1.2);
+  }
+
+  .statcard-delta {
+    font-size: var(--statcard-delta-font-size, 13px);
+    font-weight: var(--statcard-delta-font-weight, 500);
+    color: var(--statcard-delta-color, #6b7280);
+    line-height: var(--statcard-delta-line-height, 1.4);
+  }
+
+  .statcard-delta-positive {
+    color: var(--statcard-delta-positive-color, #16a34a);
+  }
+
+  .statcard-delta-negative {
+    color: var(--statcard-delta-negative-color, #dc2626);
+  }
+
+  .statcard-subtitle {
+    font-size: var(--statcard-subtitle-font-size, 12px);
+    font-weight: var(--statcard-subtitle-font-weight, 400);
+    color: var(--statcard-subtitle-color, #9ca3af);
+    line-height: var(--statcard-subtitle-line-height, 1.4);
+  }
+
+  .statcard-footer {
+    margin-top: var(--statcard-footer-margin-top, 8px);
+    padding-top: var(--statcard-footer-padding-top, 8px);
+    border-top: var(--statcard-footer-border-top, 1px solid #e5e7eb);
+  }
+</style>

--- a/src/lib/StatCard/properties.ts
+++ b/src/lib/StatCard/properties.ts
@@ -1,0 +1,31 @@
+import type { Snippet } from 'svelte';
+
+export type StatCardProperties = OptionalStatCardProperties & StatCardEventProperties;
+
+export type MandatoryStatCardProperties = Record<string, never>;
+
+export type OptionalStatCardProperties = {
+  /** Card heading label. */
+  title?: string;
+  /** Pre-formatted metric value string (e.g. "₹1.23Cr", "98.4%"). */
+  value?: string;
+  /** Pre-formatted delta string (e.g. "+12.5%", "-3.2%"). Auto-infers `deltaPositive` from leading sign when `deltaPositive` is not provided. */
+  delta?: string;
+  /** Overrides automatic sign-based inference for delta colour. `true` = positive (green), `false` = negative (red). */
+  deltaPositive?: boolean;
+  /** Secondary label rendered below the value row. */
+  subtitle?: string;
+  /** Snippet rendered in the card footer area. */
+  footer?: Snippet;
+  /** Replaces the string `value` with a custom snippet for advanced value rendering. */
+  valueSnippet?: Snippet;
+  /** Renders as `data-pw` on the root element for Playwright test selection. */
+  testId?: string;
+  /** Extra CSS class names appended to the root element. */
+  classes?: string;
+};
+
+export type StatCardEventProperties = {
+  /** Makes the card interactive: adds `role="button"`, `tabindex=0`, and wires click/Enter/Space. */
+  onclick?: (event: MouseEvent) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -66,6 +66,7 @@ export { default as BarChart } from './BarChart/BarChart.svelte';
 export { default as PieChart } from './PieChart/PieChart.svelte';
 export { default as SankeyChart } from './SankeyChart/SankeyChart.svelte';
 export { default as LottiePlayer } from './LottiePlayer/LottiePlayer.svelte';
+export { default as StatCard } from './StatCard/StatCard.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -129,6 +130,7 @@ export type * from './BarChart/properties';
 export type * from './PieChart/properties';
 export type * from './SankeyChart/properties';
 export type * from './LottiePlayer/properties';
+export type * from './StatCard/properties';
 
 export { validateInput } from './utils';
 export { formatNumberIndian } from './_chart/format';

--- a/src/wc/components/StatCard.wc.svelte
+++ b/src/wc/components/StatCard.wc.svelte
@@ -1,0 +1,30 @@
+<svelte:options
+  customElement={{
+    tag: 'sui-stat-card',
+    shadow: 'open',
+    props: {
+      title: { type: 'String', reflect: true },
+      value: { type: 'String', reflect: true },
+      delta: { type: 'String', reflect: true },
+      deltaPositive: { type: 'Boolean', attribute: 'delta-positive', reflect: true },
+      subtitle: { type: 'String', reflect: true },
+      classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' },
+      onclick: { type: 'Object' }
+    }
+  }}
+/>
+
+<script lang="ts">
+  import StatCard from '$lib/StatCard/StatCard.svelte';
+  let props = $props();
+</script>
+
+<StatCard {...props}>
+  {#snippet footer()}
+    <slot name="footer"></slot>
+  {/snippet}
+  {#snippet valueSnippet()}
+    <slot name="value-snippet"></slot>
+  {/snippet}
+</StatCard>

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -54,3 +54,4 @@ import './components/Toolbar.wc.svelte';
 import './components/Tooltip.wc.svelte';
 import './components/DateRangePicker.wc.svelte';
 import './components/LottiePlayer.wc.svelte';
+import './components/StatCard.wc.svelte';


### PR DESCRIPTION
## What

New `StatCard` primitive component under `src/lib/StatCard/`.

**Props** (all optional — fully backward-compatible new component):
- `title?`, `value?`, `delta?`, `deltaPositive?`, `subtitle?` — display fields
- `footer?: Snippet`, `valueSnippet?: Snippet` — slot-like composition
- `testId?`, `classes?` — standard testability / theming hooks
- `onclick?: (event: MouseEvent) => void` — interactive-card mode (adds `role="button"`, `tabindex=0`, Enter/Space keyboard support)

**Delta auto-inference**: when `deltaPositive` is not provided, the sign of the `delta` string (`+` / `-`) drives the positive/negative colour class automatically.

**CSS theming**: `--statcard-*` CSS variables with light defaults cover layout (gap, padding, border, border-radius, box-shadow, width/height), per-sub-element colours/sizes, and interactive focus-ring.

## Why / conventions aligned

- `MandatoryStatCardProperties = Record<string, never>` sentinel matches the Card pattern
- `StatCardEventProperties` separate type matches the Banner/Pill convention
- `handleKeydown` uses `function` keyword matching Card.svelte's local handler style
- Sub-element `data-pw` removed — only root element carries `data-pw`, consistent with every other library component (Card, Banner, Badge, etc.)
- `null` used instead of `undefined` in ternary expressions (project ESLint `no-restricted-syntax` rule)

## Test plan

- [ ] Import `StatCard` from `@juspay/svelte-ui-components` in a consumer
- [ ] Render with `title`, `value`, `delta="+12.5%"` — verify green delta colour auto-inferred
- [ ] Render with `delta="-3.2%"` — verify red delta colour
- [ ] Render with `delta="0%"` — verify neutral (no colour class)
- [ ] Render with `deltaPositive={false}` and `delta="+5%"` — override wins (red)
- [ ] Render with `onclick` — verify `role="button"`, `tabindex=0`, Enter/Space fires click
- [ ] Render without `onclick` — verify no interactive attributes
- [ ] Render with `footer` and `valueSnippet` snippets — verify custom rendering
- [ ] Verify CSS vars (`--statcard-background`, `--statcard-value-color`, etc.) are overridable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added StatCard component displaying title, value, optional delta indicator, subtitle, and footer elements.
  * Supports keyboard interaction and custom value rendering.
  * Themeable via CSS variables.
  * Available as both Svelte component and Web Component (`<sui-stat-card>`).

* **Documentation**
  * Added comprehensive StatCard documentation with API reference, usage examples, and Web Component integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->