### PR TITLE
feat(LottiePlayer): add Lottie animation player component

### DIFF
--- a/docs/LottiePlayer.md
+++ b/docs/LottiePlayer.md
@@ -1,0 +1,132 @@
+# LottiePlayer
+
+A lightweight Lottie animation player that dynamically loads `lottie-web` and renders animations from a URL or inline JSON data. Supports SVG, canvas, and HTML renderers, imperative play/pause/stop control via `bind:this`, configurable loop and autoplay, and optional callbacks for completion and load errors. The `lottie-web` package is an optional peer dependency — include it in your project's dependencies when using this component.
+
+## Usage
+
+```svelte
+<script>
+  import { LottiePlayer } from '@juspay/svelte-ui-components';
+</script>
+
+<LottiePlayer src="/animations/confetti.json" />
+```
+
+### With Imperative Control (bind:this)
+
+```svelte
+<script>
+  import { LottiePlayer } from '@juspay/svelte-ui-components';
+
+  let player;
+</script>
+
+<LottiePlayer bind:this={player} src="/animations/loader.json" autoplay={false} loop={false} />
+
+<button onclick={() => player.play()}>Play</button>
+<button onclick={() => player.pause()}>Pause</button>
+<button onclick={() => player.stop()}>Stop</button>
+```
+
+### From Inline Animation Data
+
+```svelte
+<script>
+  import { LottiePlayer } from '@juspay/svelte-ui-components';
+  import animationData from './my-animation.json';
+</script>
+
+<LottiePlayer {animationData} loop={false} oncomplete={() => console.log('done')} />
+```
+
+### Canvas Renderer
+
+```svelte
+<LottiePlayer src="/animations/chart.json" renderer="canvas" />
+```
+
+## Props
+
+| Prop          | Type                          | Required | Default | Description                                                                                            |
+| ------------- | ----------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| src           | `string`                      | No       | `-`     | URL or path to the Lottie animation JSON file. Ignored when `animationData` is provided.               |
+| animationData | `Record<string, unknown>`     | No       | `-`     | Inline animation data object. Takes precedence over `src` when both are provided.                      |
+| autoplay      | `boolean`                     | No       | `true`  | Whether the animation starts playing automatically on mount.                                           |
+| loop          | `boolean`                     | No       | `true`  | Whether the animation loops continuously.                                                              |
+| speed         | `number`                      | No       | `1`     | Playback speed multiplier. `2` is double speed, `0.5` is half speed.                                   |
+| renderer      | `'svg' \| 'canvas' \| 'html'` | No       | `'svg'` | Rendering backend. SVG is recommended for most use cases.                                              |
+| ariaHidden    | `boolean`                     | No       | `true`  | Whether the player element is hidden from assistive technology. Keep `true` for decorative animations. |
+| testId        | `string`                      | No       | `-`     | Value for the `data-pw` attribute on the container element.                                            |
+| classes       | `string`                      | No       | `-`     | CSS class string applied to the container element for theming via CSS variable overrides.              |
+
+## Methods (via bind:this)
+
+| Method    | Signature    | Description                                         |
+| --------- | ------------ | --------------------------------------------------- |
+| `play()`  | `() => void` | Starts or resumes playback of the animation.        |
+| `pause()` | `() => void` | Pauses playback at the current frame.               |
+| `stop()`  | `() => void` | Stops playback and resets the animation to frame 0. |
+
+## Events
+
+| Event        | Type         | Description                                                                      |
+| ------------ | ------------ | -------------------------------------------------------------------------------- |
+| `oncomplete` | `() => void` | Fired when the animation completes one full cycle (only fires when not looping). |
+| `onerror`    | `() => void` | Fired when the animation data fails to load.                                     |
+
+## Web Component
+
+The component is also available as a standard web component (`<sui-lottie-player>`). Import it from the web component build:
+
+```html
+<script type="module" src="path/to/sui-lottie-player.js"></script>
+
+<sui-lottie-player src="/animations/confetti.json" autoplay loop></sui-lottie-player>
+```
+
+### Web Component Props
+
+All props from the [Props table](#props) above are available as attributes or properties, with the following notes:
+
+- Boolean attributes follow HTML conventions: presence means `true`, absence means `false`.
+- `animationData` must be set as a JavaScript property (not an HTML attribute) since it is an object.
+- `ariaHidden` maps to the `aria-hidden` HTML attribute.
+
+```js
+const player = document.querySelector('sui-lottie-player');
+player.animationData = {
+  /* inline lottie JSON */
+};
+```
+
+### Web Component Events
+
+The web component dispatches DOM custom events that bubble and are composed (cross shadow-DOM boundaries):
+
+| Event      | Description                                                                |
+| ---------- | -------------------------------------------------------------------------- |
+| `complete` | Fired when the animation completes one full cycle (only when not looping). |
+| `error`    | Fired when the animation data fails to load.                               |
+
+```js
+const player = document.querySelector('sui-lottie-player');
+player.addEventListener('complete', () => console.log('animation done'));
+player.addEventListener('error', () => console.error('animation failed to load'));
+```
+
+### Web Component Limitations
+
+- Imperative `play()`, `pause()`, and `stop()` methods are not available on the web component element. Use `autoplay` and `loop` attributes for declarative control instead.
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                        | Default        | CSS Property  | Description                                             |
+| ------------------------------- | -------------- | ------------- | ------------------------------------------------------- |
+| `--lottie-player-display`       | `inline-block` | display       | Display mode of the player container.                   |
+| `--lottie-player-width`         | `100%`         | width         | Width of the player container.                          |
+| `--lottie-player-height`        | `100%`         | height        | Height of the player container.                         |
+| `--lottie-player-background`    | `transparent`  | background    | Background color or image behind the animation.         |
+| `--lottie-player-border-radius` | `0px`          | border-radius | Corner rounding of the player container.                |
+| `--lottie-player-overflow`      | `hidden`       | overflow      | Overflow handling — use `hidden` to clip the animation. |

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -25,7 +25,7 @@
   },
   {
     "name": "BarChart",
-    "description": "A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal orientations, single or multi-series data (grouped/stacked), value labels, custom colors per data point, hover tooltips, and click events. Zero external dependencies — built from pure SVG with CSS custom property theming."
+    "description": "A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal orientations, single or multi-series data (grouped/stacked), value labels, custom colors per data point, hover tooltips, and click events. Zero external dependencies \u2014 built from pure SVG with CSS custom property theming."
   },
   {
     "name": "Book",
@@ -49,7 +49,7 @@
   },
   {
     "name": "Card",
-    "description": "A generic layout container with an optional title/description header and a content body. Supports box-shadow, width/min-width/max-width/max-height/margin CSS vars for sizing, and an onclick prop that makes the card an accessible interactive button (role=button, tabindex=0, Enter/Space keyboard support) when provided. All visual properties are CSS-var driven with sensible defaults — no consumer overrides required for basic usage. Custom multi-zone layouts (metric tiles, integration rows) are achieved via the children snippet using plain flexbox in the consumer."
+    "description": "A generic layout container with an optional title/description header and a content body. Supports box-shadow, width/min-width/max-width/max-height/margin CSS vars for sizing, and an onclick prop that makes the card an accessible interactive button (role=button, tabindex=0, Enter/Space keyboard support) when provided. All visual properties are CSS-var driven with sensible defaults \u2014 no consumer overrides required for basic usage. Custom multi-zone layouts (metric tiles, integration rows) are achieved via the children snippet using plain flexbox in the consumer."
   },
   {
     "name": "Carousel",
@@ -190,6 +190,10 @@
   {
     "name": "SankeyChart",
     "description": "A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Link widths are proportional to flow values. Hovering highlights all connected nodes and dims unrelated ones."
+  },
+  {
+    "name": "LottiePlayer",
+    "description": "A lightweight Lottie animation player that dynamically loads lottie-web and renders animations from a URL or inline JSON data. Supports SVG, canvas, and HTML renderers, imperative play/pause/stop control via bind:this, configurable loop and autoplay, and optional callbacks for completion and load errors."
   },
   {
     "name": "Scroller",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,13 @@
   ],
   "peerDependencies": {
     "svelte": "^5.41.2",
-    "type-decoder": "^2.1.0"
+    "type-decoder": "^2.1.0",
+    "lottie-web": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "lottie-web": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",
@@ -79,6 +85,7 @@
     "type-decoder": "^2.3.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1",
+    "lottie-web": "^5.13.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      lottie-web:
+        specifier: ^5.13.0
+        version: 5.13.0
       marked:
         specifier: ^18.0.5
         version: 18.0.5
@@ -1103,6 +1106,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lottie-web@5.13.0:
+    resolution: {integrity: sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2486,6 +2492,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lottie-web@5.13.0: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/src/lib/LottiePlayer/LottiePlayer.svelte
+++ b/src/lib/LottiePlayer/LottiePlayer.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { AnimationItem } from 'lottie-web';
+  import type { LottiePlayerProperties } from './properties';
+
+  type LocalAnimationItem = Pick<
+    AnimationItem,
+    'play' | 'pause' | 'stop' | 'destroy' | 'setSpeed' | 'addEventListener' | 'removeEventListener'
+  >;
+
+  let {
+    src,
+    animationData,
+    autoplay = true,
+    loop = true,
+    speed = 1,
+    renderer = 'svg',
+    ariaHidden = true,
+    testId,
+    classes,
+    oncomplete,
+    onerror
+  }: LottiePlayerProperties = $props();
+
+  let containerEl: HTMLDivElement | null = $state(null);
+  let animationItem: LocalAnimationItem | null = $state(null);
+
+  let rootClass = $derived(['lottie-player', classes ?? ''].filter((c) => c.length > 0).join(' '));
+
+  export function play(): void {
+    animationItem?.play();
+  }
+
+  export function pause(): void {
+    animationItem?.pause();
+  }
+
+  export function stop(): void {
+    animationItem?.stop();
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (animationItem !== null) {
+      animationItem.setSpeed(speed);
+    }
+  });
+
+  onMount(() => {
+    if (containerEl === null) {
+      return;
+    }
+
+    let item: LocalAnimationItem | null = null;
+
+    const handleComplete = (): void => {
+      oncomplete?.();
+    };
+
+    const handleError = (): void => {
+      onerror?.();
+    };
+
+    void import('lottie-web').then((lottie) => {
+      if (containerEl === null) {
+        return;
+      }
+
+      const lottieApi = lottie.default ?? lottie;
+
+      const config: Parameters<typeof lottieApi.loadAnimation>[0] = {
+        container: containerEl,
+        renderer,
+        loop,
+        autoplay,
+        ...(animationData != null
+          ? { animationData }
+          : typeof src === 'string' && src.length > 0
+            ? { path: src }
+            : {})
+      };
+
+      const loaded = lottieApi.loadAnimation(config);
+      item = loaded;
+      animationItem = item;
+
+      loaded.setSpeed(speed);
+
+      loaded.addEventListener('complete', handleComplete);
+      loaded.addEventListener('data_failed', handleError);
+    });
+
+    return () => {
+      if (item !== null) {
+        item.removeEventListener('complete', handleComplete);
+        item.removeEventListener('data_failed', handleError);
+        item.destroy();
+        animationItem = null;
+      }
+    };
+  });
+</script>
+
+<div
+  class={rootClass}
+  bind:this={containerEl}
+  aria-hidden={ariaHidden ? 'true' : null}
+  role={ariaHidden ? null : 'img'}
+  data-pw={typeof testId === 'string' ? testId : null}
+></div>
+
+<style>
+  .lottie-player {
+    display: var(--lottie-player-display, inline-block);
+    width: var(--lottie-player-width, 100%);
+    height: var(--lottie-player-height, 100%);
+    background: var(--lottie-player-background, transparent);
+    border-radius: var(--lottie-player-border-radius, 0px);
+    overflow: var(--lottie-player-overflow, hidden);
+  }
+</style>

--- a/src/lib/LottiePlayer/properties.ts
+++ b/src/lib/LottiePlayer/properties.ts
@@ -1,0 +1,42 @@
+export type LottieRendererType = 'svg' | 'canvas' | 'html';
+
+export type LottiePlayerProperties = MandatoryLottiePlayerProperties &
+  OptionalLottiePlayerProperties &
+  LottiePlayerEventProperties;
+
+/**
+ * Placeholder for future mandatory props. Follows the library-wide pattern used by Card, Badge,
+ * etc. — kept so the type shape is consistent when mandatory props are added later.
+ */
+export type MandatoryLottiePlayerProperties = Record<never, never>;
+
+export type OptionalLottiePlayerProperties = {
+  /**
+   * URL or path to the Lottie animation JSON file. Ignored when `animationData` is provided.
+   */
+  src?: string;
+  /**
+   * Inline animation data object. Takes precedence over `src` when both are provided.
+   */
+  animationData?: Record<string, unknown>;
+  autoplay?: boolean;
+  loop?: boolean;
+  /** Playback speed multiplier. Default 1. */
+  speed?: number;
+  /** Rendering backend. Default 'svg'. */
+  renderer?: LottieRendererType;
+  /**
+   * Whether the player element is hidden from assistive technology.
+   * Default true — decorative animations should be invisible to screen readers.
+   */
+  ariaHidden?: boolean;
+  testId?: string;
+  classes?: string;
+};
+
+export type LottiePlayerEventProperties = {
+  /** Fired when the animation completes (non-looping). */
+  oncomplete?: () => void;
+  /** Fired when the animation fails to load. */
+  onerror?: () => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -65,6 +65,7 @@ export { default as AreaChart } from './AreaChart/AreaChart.svelte';
 export { default as BarChart } from './BarChart/BarChart.svelte';
 export { default as PieChart } from './PieChart/PieChart.svelte';
 export { default as SankeyChart } from './SankeyChart/SankeyChart.svelte';
+export { default as LottiePlayer } from './LottiePlayer/LottiePlayer.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -127,6 +128,7 @@ export type * from './AreaChart/properties';
 export type * from './BarChart/properties';
 export type * from './PieChart/properties';
 export type * from './SankeyChart/properties';
+export type * from './LottiePlayer/properties';
 
 export { validateInput } from './utils';
 export { formatNumberIndian } from './_chart/format';

--- a/src/wc/components/LottiePlayer.wc.svelte
+++ b/src/wc/components/LottiePlayer.wc.svelte
@@ -1,0 +1,33 @@
+<svelte:options
+  customElement={{
+    tag: 'sui-lottie-player',
+    shadow: 'open',
+    props: {
+      src: { type: 'String', reflect: true },
+      animationData: { type: 'Object' },
+      autoplay: { type: 'Boolean', reflect: true },
+      loop: { type: 'Boolean', reflect: true },
+      speed: { type: 'Number', reflect: true },
+      renderer: { type: 'String', reflect: true },
+      ariaHidden: { type: 'Boolean', reflect: true, attribute: 'aria-hidden' },
+      classes: { type: 'String' }
+    }
+  }}
+/>
+
+<script lang="ts">
+  import LottiePlayer from '$lib/LottiePlayer/LottiePlayer.svelte';
+  let props = $props();
+
+  const host = $host<HTMLElement>();
+
+  function handleComplete(): void {
+    host.dispatchEvent(new CustomEvent('complete', { bubbles: true, composed: true }));
+  }
+
+  function handleError(): void {
+    host.dispatchEvent(new CustomEvent('error', { bubbles: true, composed: true }));
+  }
+</script>
+
+<LottiePlayer {...props} oncomplete={handleComplete} onerror={handleError} />

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -53,3 +53,4 @@ import './components/Toast.wc.svelte';
 import './components/Toolbar.wc.svelte';
 import './components/Tooltip.wc.svelte';
 import './components/DateRangePicker.wc.svelte';
+import './components/LottiePlayer.wc.svelte';


### PR DESCRIPTION
## What

Adds a new `LottiePlayer` component to `@juspay/svelte-ui-components`.

- Dynamic `import('lottie-web')` inside `onMount` (SSR-safe, no server-side animation load)
- Supports `svg` / `canvas` / `html` renderers
- `animationData` (inline object) takes precedence over `src` (URL path)
- Imperative `play()` / `pause()` / `stop()` methods via `export function` declarations — matching the library pattern used by Input, InputButton, Combobox, SplitInput
- `speed` set unconditionally on animation load (removes the `!== 1` guard)
- Event listeners cleaned up in the `onMount` return callback (not `onDestroy`)
- `ariaHidden` defaults to `true` — decorative animations are invisible to screen readers by default
- Root CSS class built with `$derived` filter (no trailing space when `classes` is omitted) — matching Banner pattern
- Full `--lottie-player-*` CSS variable surface: `display`, `width`, `height`, `background`, `border-radius`, `overflow`
- Three-way property type split: `MandatoryLottiePlayerProperties` / `OptionalLottiePlayerProperties` / `LottiePlayerEventProperties` — all props optional, `MandatoryLottiePlayerProperties = Record<string, never>` matching Card pattern
- Exported from `src/lib/index.ts` (component + `export type *`)
- `lottie-web >=5.0.0` in `peerDependencies` (optional), `^5.13.0` in `devDependencies`

## Why

Lighthouse and other consumers need to render Lottie animations. This primitive fills that gap in the library so consumers don't ship their own one-off wrappers.

## Backward-compatibility

- New component, no existing API changed
- All props are optional with sensible defaults
- `lottie-web` is a peer dependency (optional) so consumers who don't use this component pay no bundle cost

## Test plan

- [ ] Import `LottiePlayer` from `@juspay/svelte-ui-components` and pass a `src` URL — animation loads and plays
- [ ] Pass `animationData` — inline animation renders (takes precedence over `src`)
- [ ] Bind `this` to a `LottiePlayer` ref and call `.play()` / `.pause()` / `.stop()` imperatively
- [ ] Set `loop={false}` and verify `oncomplete` fires
- [ ] Pass an invalid `src` and verify `onerror` fires
- [ ] Pass `ariaHidden={false}` — `aria-hidden` attribute absent from DOM
- [ ] Pass `classes="my-class"` — rendered element has `lottie-player my-class` (no trailing space)
- [ ] Pass `speed={0.5}` — animation plays at half speed
- [ ] CSS vars (`--lottie-player-width`, etc.) applied correctly
- [ ] `pnpm run check` — 0 errors
- [ ] `pnpm run lint` — passes
- [ ] `pnpm run build` — succeeds