### PR TITLE
feat(Table): fix selection toggle, stable IDs, onCellChange docs, focus ring, optional enabled

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -1,6 +1,6 @@
 # Table
 
-A sortable data table with clean, modern defaults. Supports column sorting (ascending/descending) for string, number, and boolean values. Features sticky headers, custom cell rendering via Svelte 5 snippets, row click interaction, customizable sort icons, a footer paginator slot, and per-row/cell `data-pw` test ID callbacks for end-to-end testing. Table data is an array of arrays (rows x columns).
+A sortable data table with clean, modern defaults. Supports column sorting (ascending/descending) for string, number, and boolean values. Features sticky headers, custom cell rendering via Svelte 5 snippets, row click interaction, customizable sort icons, a footer paginator slot, per-row/cell `data-pw` test ID callbacks, opt-in checkbox row selection (single and multiple mode), and a built-in search bar with client-side filtering or server-side delegation. Table data is an array of arrays (rows × columns).
 
 ## Usage
 
@@ -142,47 +142,149 @@ Use `getRowTestId` and `getCellTestId` to apply `data-pw` attributes for Playwri
 />
 ```
 
+### Checkbox Row Selection
+
+Pass `checkboxSelection` to render a leading checkbox column. Set `selectionMode` to `'single'` to allow at most one row selected at a time.
+
+```svelte
+<script>
+  import { Table } from '@juspay/svelte-ui-components';
+
+  let selectedIds = $state(new Set());
+</script>
+
+<!-- Multiple selection (default) -->
+<Table
+  tableHeaders={['Name', 'Department']}
+  tableData={rows}
+  checkboxSelection={{
+    selectionMode: 'multiple',
+    getRowId: (row, rowIndex) => String(row[0]),
+    disabledRowIds: new Set(['Alice']),
+    onSelectionChange: (ids) => {
+      selectedIds = ids;
+    }
+  }}
+/>
+
+<!-- Single selection -->
+<Table
+  tableHeaders={['Name', 'Department']}
+  tableData={rows}
+  checkboxSelection={{
+    selectionMode: 'single',
+    onSelectionChange: (ids) => {
+      selectedIds = ids;
+    }
+  }}
+/>
+```
+
+`disabledRowIds` expects a `Set<string>` of row IDs that should render as disabled (unchecked, non-interactive). `getRowId` derives a stable string key from each row; when omitted the default key is the row's pre-sort positional index as a string.
+
+### Search Bar
+
+Pass `searchConfig` to show a search input above the table. By default the table filters rows client-side across all columns. Pass `onSearchChange` to disable client-side filtering and delegate to the server instead.
+
+```svelte
+<!-- Server-side delegation: client filtering disabled, onSearchChange fires on every keystroke -->
+<script>
+  import { Table } from '@juspay/svelte-ui-components';
+  let filteredRows = $state(allRows);
+</script>
+
+<!-- Client-side filtering (searchableColumnIndices restricts which columns are searched) -->
+<Table
+  tableHeaders={['Name', 'Email', 'Role']}
+  tableData={rows}
+  searchConfig={{
+    placeholder: 'Search users…',
+    searchableColumnIndices: [0, 2],
+    testId: 'user-search'
+  }}
+/>
+<Table
+  tableHeaders={['Name', 'Email', 'Role']}
+  tableData={filteredRows}
+  searchConfig={{ placeholder: 'Search…' }}
+  onSearchChange={(term) => {
+    filteredRows = fetchRows(term);
+  }}
+/>
+```
+
+### Editable Cells (onCellChange pattern)
+
+`onCellChange` is accepted as a prop for components that want to pass a handler via the standard props channel (e.g. for type-checking at the call site), but Table does **not** call it internally. The correct wiring pattern is to close over your own handler directly inside the `cell` snippet, which runs in consumer scope:
+
+```svelte
+<script>
+  import { Table } from '@juspay/svelte-ui-components';
+  import { Input } from '@juspay/svelte-ui-components';
+
+  let rows = $state(myData);
+  const handleCellChange = (rowIndex, colIndex, newValue) => {
+    const updated = rows[rowIndex].slice();
+    updated[colIndex] = newValue;
+    rows = rows.map((row, idx) => (idx === rowIndex ? updated : row));
+  };
+</script>
+
+<Table tableData={rows} tableHeaders={['Name', 'Score']}>
+  {#snippet cell(value, rowIndex, colIndex)}
+    <Input
+      value={String(value ?? '')}
+      onInput={(newValue) => handleCellChange(rowIndex, colIndex, newValue)}
+    />
+  {/snippet}
+</Table>
+```
+
 ## Props
 
-| Prop                | Type                                   | Required | Default          | Description                                                                                                                                                            |
-| ------------------- | -------------------------------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| tableTitle          | `string \| null`                       | No       | `''`             | Optional title text displayed above the table.                                                                                                                         |
-| tableHeaders        | `string[]`                             | No       | `[]`             | Array of column header strings. Each header is clickable for sorting (when sortable).                                                                                  |
-| tableData           | `Array<JSONValue[]>`                   | No       | `[]`             | Array of row arrays. Each row is an array of cell values (string, number, or boolean). Columns correspond to tableHeaders by index.                                    |
-| sortable            | `boolean`                              | No       | `true`           | When false, disables sorting on all columns. Sort buttons are hidden.                                                                                                  |
-| sortableColumns     | `number[]`                             | No       | `-`              | Array of column indices that are sortable. When provided, only these columns show sort buttons. Other columns are non-sortable regardless of the `sortable` prop.      |
-| stickyHeader        | `boolean`                              | No       | `false`          | When true, the header row sticks to the top during scroll. Works with `isTableScrollable` or any parent scroll container. Offset via `--table-header-sticky-top`.      |
-| isTableScrollable   | `boolean`                              | No       | `false`          | When true, creates a bounded scroll area on the table container. Headers are automatically sticky. Use `--table-container-height` to set the scroll area height.       |
-| isContentScrollable | `boolean`                              | No       | `false`          | When true, individual cell content scrolls vertically if it overflows the fixed cell height.                                                                           |
-| testId              | `string`                               | No       | `-`              | Value for the data-pw attribute on the table container, used for end-to-end testing selectors.                                                                         |
-| caption             | `string`                               | No       | `-`              | Accessible caption for screen readers. Rendered as a visually hidden `<caption>` element.                                                                              |
-| sortAscIcon         | `Snippet`                              | No       | SVG chevron up   | Custom snippet rendered for the ascending sort indicator.                                                                                                              |
-| sortDescIcon        | `Snippet`                              | No       | SVG chevron down | Custom snippet rendered for the descending sort indicator.                                                                                                             |
-| sortDefaultIcon     | `Snippet`                              | No       | SVG chevron pair | Custom snippet rendered for columns that haven't been sorted yet. Default is a dimmed up/down chevron pair.                                                            |
-| cell                | `Snippet<[JSONValue, number, number]>` | No       | `-`              | Custom cell renderer. Receives `(value, rowIndex, colIndex)`. When not provided, cells render the raw value as text.                                                   |
-| empty               | `Snippet`                              | No       | `-`              | Content to show when `tableData` is empty. Rendered inside a full-width table row.                                                                                     |
-| classes             | `string`                               | No       | `-`              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
-| paginatorSlot       | `Snippet`                              | No       | `-`              | Snippet rendered in a footer region below the table. Use for pagination controls, row count info, or any per-page UI. |
-| getRowTestId        | `(row: JSONValue[], rowIndex: number) => string` | No | `-`   | Callback that returns a `data-pw` attribute value for each row `<tr>`. Useful for Playwright and other E2E test selectors. |
-| getCellTestId       | `(row: JSONValue[], column: JSONValue, rowIndex: number) => string` | No | `-` | Callback that returns a `data-pw` attribute value for each data cell `<td>`. Receives the full row, the cell value, and the row index. |
+| Prop                | Type                                                                | Required | Default          | Description                                                                                                                                                                             |
+| ------------------- | ------------------------------------------------------------------- | -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| tableTitle          | `string \| null`                                                    | No       | `''`             | Optional title text displayed above the table.                                                                                                                                          |
+| tableHeaders        | `string[]`                                                          | No       | `[]`             | Array of column header strings. Each header is clickable for sorting (when sortable).                                                                                                   |
+| tableData           | `Array<JSONValue[]>`                                                | No       | `[]`             | Array of row arrays. Each row is an array of cell values (string, number, or boolean). Columns correspond to tableHeaders by index.                                                     |
+| sortable            | `boolean`                                                           | No       | `true`           | When false, disables sorting on all columns. Sort buttons are hidden.                                                                                                                   |
+| sortableColumns     | `number[]`                                                          | No       | `-`              | Array of column indices that are sortable. When provided, only these columns show sort buttons. Other columns are non-sortable regardless of the `sortable` prop.                       |
+| stickyHeader        | `boolean`                                                           | No       | `false`          | When true, the header row sticks to the top during scroll. Works with `isTableScrollable` or any parent scroll container. Offset via `--table-header-sticky-top`.                       |
+| isTableScrollable   | `boolean`                                                           | No       | `false`          | When true, creates a bounded scroll area on the table container. Headers are automatically sticky. Use `--table-container-height` to set the scroll area height.                        |
+| isContentScrollable | `boolean`                                                           | No       | `false`          | When true, individual cell content scrolls vertically if it overflows the fixed cell height.                                                                                            |
+| testId              | `string`                                                            | No       | `-`              | Value for the data-pw attribute on the table container, used for end-to-end testing selectors.                                                                                          |
+| caption             | `string`                                                            | No       | `-`              | Accessible caption for screen readers. Rendered as a visually hidden `<caption>` element.                                                                                               |
+| sortAscIcon         | `Snippet`                                                           | No       | SVG chevron up   | Custom snippet rendered for the ascending sort indicator.                                                                                                                               |
+| sortDescIcon        | `Snippet`                                                           | No       | SVG chevron down | Custom snippet rendered for the descending sort indicator.                                                                                                                              |
+| sortDefaultIcon     | `Snippet`                                                           | No       | SVG chevron pair | Custom snippet rendered for columns that haven't been sorted yet. Default is a dimmed up/down chevron pair.                                                                             |
+| cell                | `Snippet<[JSONValue, number, number]>`                              | No       | `-`              | Custom cell renderer. Receives `(value, rowIndex, colIndex)`. When not provided, cells render the raw value as text.                                                                    |
+| empty               | `Snippet`                                                           | No       | `-`              | Content to show when `tableData` is empty. Rendered inside a full-width table row.                                                                                                      |
+| classes             | `string`                                                            | No       | `-`              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                  |
+| paginatorSlot       | `Snippet`                                                           | No       | `-`              | Snippet rendered in a footer region below the table. Use for pagination controls, row count info, or any per-page UI.                                                                   |
+| getRowTestId        | `(row: JSONValue[], rowIndex: number) => string`                    | No       | `-`              | Callback that returns a `data-pw` attribute value for each row `<tr>`. Useful for Playwright and other E2E test selectors.                                                              |
+| getCellTestId       | `(row: JSONValue[], column: JSONValue, rowIndex: number) => string` | No       | `-`              | Callback that returns a `data-pw` attribute value for each data cell `<td>`. Receives the full row, the cell value, and the row index.                                                  |
+| checkboxSelection   | `TableCheckboxSelectionConfig`                                      | No       | `-`              | Opt-in checkbox row-selection column. See `TableCheckboxSelectionConfig` type below.                                                                                                    |
+| searchConfig        | `TableSearchConfig`                                                 | No       | `-`              | Opt-in search bar rendered above the table. Client-side filtering is applied by default; pass `onSearchChange` to delegate filtering to the server. See `TableSearchConfig` type below. |
 
 ## Snippets
 
-| Snippet         | Parameters                              | Description                                                                                        |
-| --------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `sortAscIcon`   | none                                    | Custom ascending sort icon, replaces the default SVG chevron.                                      |
-| `sortDescIcon`  | none                                    | Custom descending sort icon, replaces the default SVG chevron.                                     |
-| `sortDefaultIcon` | none                                  | Custom default (unsorted) sort icon, replaces the dimmed up/down chevron pair.                     |
-| `cell`          | `(value: JSONValue, rowIndex: number, colIndex: number)` | Custom cell renderer. When not provided, cells render the raw value as text.    |
-| `empty`         | none                                    | Content shown when `tableData` is empty. Rendered inside a full-width table row.                   |
-| `paginatorSlot` | none                                    | Content rendered in a footer region below the table (e.g. pagination controls, row count).        |
+| Snippet           | Parameters                                               | Description                                                                                |
+| ----------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `sortAscIcon`     | none                                                     | Custom ascending sort icon, replaces the default SVG chevron.                              |
+| `sortDescIcon`    | none                                                     | Custom descending sort icon, replaces the default SVG chevron.                             |
+| `sortDefaultIcon` | none                                                     | Custom default (unsorted) sort icon, replaces the dimmed up/down chevron pair.             |
+| `cell`            | `(value: JSONValue, rowIndex: number, colIndex: number)` | Custom cell renderer. When not provided, cells render the raw value as text.               |
+| `empty`           | none                                                     | Content shown when `tableData` is empty. Rendered inside a full-width table row.           |
+| `paginatorSlot`   | none                                                     | Content rendered in a footer region below the table (e.g. pagination controls, row count). |
 
 ## Events
 
-| Event      | Type                                                      | Description                                                                                       |
-| ---------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| onRowClick | `(rowIndex: number, rowData: JSONValue[]) => void`        | Fires when a data row is clicked. The row becomes focusable and keyboard-navigable when provided. |
-| onSort     | `(columnIndex: number, direction: SortDirection) => void` | Fires after a column sort is toggled. `direction` is `'asc'` or `'desc'`.                         |
+| Event          | Type                                                                | Description                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| onRowClick     | `(rowIndex: number, rowData: JSONValue[]) => void`                  | Fires when a data row is clicked. The row becomes focusable and keyboard-navigable when provided.                                                                                                                                                                         |
+| onSort         | `(columnIndex: number, direction: SortDirection) => void`           | Fires after a column sort is toggled. `direction` is `'asc'` or `'desc'`.                                                                                                                                                                                                 |
+| onCellChange   | `(rowIndex: number, colIndex: number, newValue: JSONValue) => void` | Accepted as a prop for type-checking at the call site, but **not called by Table internally**. Wire your handler directly inside the `cell` snippet instead — snippets run in consumer scope and already have your handler in closure. See "Editable Cells" recipe above. |
+| onSearchChange | `(searchTerm: string) => void`                                      | When provided, disables built-in client-side filtering and calls this callback on every search input change. Use to delegate filtering to the server. Requires `searchConfig` to be set.                                                                                  |
 
 ## CSS Variables
 
@@ -212,15 +314,15 @@ Override these custom properties to theme the component.
 
 ### Cell Grid
 
-| Variable                     | Default             | CSS Property  | Description                                                                                                |
-| ---------------------------- | ------------------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
-| `--table-inner-border`       | `none`              | border        | Border of individual table cells. Set to `1px solid #ccc` for full grid.                                   |
-| `--table-row-border`         | `1px solid #f3f4f6` | border-bottom | Border on the bottom of each data row. Subtle row separators.                                              |
-| `--table-row-last-border`    | `none`              | border-bottom | Border on the last data row. Set to match `--table-row-border` if needed.                                  |
-| `--table-padding`            | `12px 16px`         | padding       | Padding inside table cells.                                                                                |
-| `--table-text-align`         | `left`              | text-align    | Text alignment inside table cells.                                                                         |
-| `--table-column-width`       | `-`                 | width         | Sets a uniform width for all table columns. Unset lets the table auto-size columns.                        |
-| `--scrollable-column-height` | `20px`              | height        | Height of scrollable cell content (when isContentScrollable).                                              |
+| Variable                     | Default             | CSS Property  | Description                                                                         |
+| ---------------------------- | ------------------- | ------------- | ----------------------------------------------------------------------------------- |
+| `--table-inner-border`       | `none`              | border        | Border of individual table cells. Set to `1px solid #ccc` for full grid.            |
+| `--table-row-border`         | `1px solid #f3f4f6` | border-bottom | Border on the bottom of each data row. Subtle row separators.                       |
+| `--table-row-last-border`    | `none`              | border-bottom | Border on the last data row. Set to match `--table-row-border` if needed.           |
+| `--table-padding`            | `12px 16px`         | padding       | Padding inside table cells.                                                         |
+| `--table-text-align`         | `left`              | text-align    | Text alignment inside table cells.                                                  |
+| `--table-column-width`       | `-`                 | width         | Sets a uniform width for all table columns. Unset lets the table auto-size columns. |
+| `--scrollable-column-height` | `20px`              | height        | Height of scrollable cell content (when isContentScrollable).                       |
 
 ### Header Cells
 
@@ -246,22 +348,23 @@ Override these custom properties to theme the component.
 
 ### Rows
 
-| Variable                       | Default   | CSS Property     | Description                                                                                  |
-| ------------------------------ | --------- | ---------------- | -------------------------------------------------------------------------------------------- |
-| `--table-row-background`       | `-`       | background-color | Background color of data rows.                                                               |
-| `--table-row-alt-background`   | `-`       | background-color | Background of even-numbered rows for striped effect. Falls back to `--table-row-background`. |
-| `--table-row-hover-background` | `-`       | background-color | Background color of data rows on hover.                                                      |
-| `--table-focus-outline-color`  | `#3b82f6` | outline          | Outline color for focused clickable rows.                                                    |
+| Variable                          | Default   | CSS Property     | Description                                                                                                           |
+| --------------------------------- | --------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `--table-row-background`          | `-`       | background-color | Background color of data rows.                                                                                        |
+| `--table-row-alt-background`      | `-`       | background-color | Background of even-numbered rows for striped effect. Falls back to `--table-row-background`.                          |
+| `--table-row-hover-background`    | `-`       | background-color | Background color of data rows on hover.                                                                               |
+| `--table-row-selected-background` | `#eff6ff` | background-color | Background of selected rows (when `checkboxSelection` is active). Applied to both the `<tr>` and its `<td>` children. |
+| `--table-focus-outline-color`     | `#3b82f6` | outline          | Outline color for focused clickable rows and focused search inputs.                                                   |
 
 ### Sort Controls
 
-| Variable                               | Default            | CSS Property     | Description                                       |
-| -------------------------------------- | ------------------ | ---------------- | ------------------------------------------------- |
-| `--table-sort-button-color`            | `inherit`          | color            | Color of the sort button icon.                    |
-| `--table-sort-button-hover-color`      | `-`                | color            | Color of the sort button icon on hover.           |
-| `--table-sort-button-hover-background` | `rgba(0,0,0,0.05)` | background-color | Background of the sort button on hover.           |
-| `--table-sort-icon-size`               | `14px`             | width, height    | Size of the sort indicator SVG icons.             |
-| `--table-sort-idle-opacity`            | `0.5`              | opacity          | Opacity of the default (unsorted) sort indicator. |
+| Variable                               | Default            | CSS Property     | Description                                                                 |
+| -------------------------------------- | ------------------ | ---------------- | --------------------------------------------------------------------------- |
+| `--table-sort-button-color`            | `inherit`          | color            | Color of the sort button icon.                                              |
+| `--table-sort-button-hover-color`      | `-`                | color            | Color of the sort button icon on hover.                                     |
+| `--table-sort-button-hover-background` | `rgba(0,0,0,0.05)` | background-color | Background of the sort button on hover.                                     |
+| `--table-sort-icon-size`               | `14px`             | width, height    | Size of the sort indicator SVG icons.                                       |
+| `--table-sort-idle-opacity`            | `0.5`              | opacity          | Opacity of the default (unsorted) sort indicator.                           |
 | `--table-sort-idle-hover-opacity`      | `0.85`             | opacity          | Opacity of the default sort indicator on hover (before a column is sorted). |
 
 ### Empty State
@@ -279,6 +382,51 @@ Override these custom properties to theme the component.
 | `--table-footer-padding`    | `8px 16px`          | padding          | Padding inside the footer region.                            |
 | `--table-footer-background` | `transparent`       | background-color | Background color of the footer region.                       |
 
+### Checkbox Selection
+
+These variables style the leading checkbox column that appears when `checkboxSelection` is set.
+
+| Variable                                      | Default                          | CSS Property     | Description                                                                |
+| --------------------------------------------- | -------------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| `--table-checkbox-col-width`                  | `44px`                           | width            | Width of the checkbox column header and data cells.                        |
+| `--table-checkbox-col-padding`                | `12px 12px`                      | padding          | Padding of the checkbox column cells.                                      |
+| `--table-checkbox-size`                       | `18px`                           | width, height    | Size (width and height) of the checkbox box element.                       |
+| `--table-checkbox-border`                     | `2px solid #9ca3af`              | border           | Border of the unchecked checkbox.                                          |
+| `--table-checkbox-border-radius`              | `3px`                            | border-radius    | Border radius of the checkbox box.                                         |
+| `--table-checkbox-background`                 | `transparent`                    | background-color | Background of the unchecked checkbox.                                      |
+| `--table-checkbox-hover-border-color`         | `#6b7280`                        | border-color     | Border color of the checkbox on hover (when not disabled).                 |
+| `--table-checkbox-checked-background`         | `#2563eb`                        | background-color | Background of the checked checkbox.                                        |
+| `--table-checkbox-checked-border-color`       | `#2563eb`                        | border-color     | Border color of the checked checkbox.                                      |
+| `--table-checkbox-indeterminate-background`   | `#2563eb`                        | background-color | Background of the header checkbox in indeterminate (partial-select) state. |
+| `--table-checkbox-indeterminate-border-color` | `#2563eb`                        | border-color     | Border color of the header checkbox in indeterminate state.                |
+| `--table-checkbox-disabled-opacity`           | `0.4`                            | opacity          | Opacity of a disabled checkbox row.                                        |
+| `--table-checkbox-focus-ring`                 | `0 0 0 3px rgba(59,130,246,0.3)` | box-shadow       | Focus ring shown on the checkbox element when focused via keyboard.        |
+| `--table-checkbox-icon-size`                  | `12px`                           | width, height    | Size of the checkmark / minus SVG icon inside the checkbox box.            |
+| `--table-checkbox-icon-color`                 | `#ffffff`                        | color            | Color of the checkmark / minus icon.                                       |
+
+### Search Bar
+
+These variables style the search input rendered above the table when `searchConfig` is set.
+
+| Variable                                | Default             | CSS Property     | Description                                                     |
+| --------------------------------------- | ------------------- | ---------------- | --------------------------------------------------------------- |
+| `--table-search-gap`                    | `8px`               | gap              | Gap between the search icon, input, and clear button.           |
+| `--table-search-padding`                | `8px 12px`          | padding          | Padding inside the search bar container.                        |
+| `--table-search-border`                 | `1px solid #e5e7eb` | border           | Border of the search bar container.                             |
+| `--table-search-border-radius`          | `8px`               | border-radius    | Border radius of the search bar container.                      |
+| `--table-search-background`             | `#ffffff`           | background-color | Background of the search bar container.                         |
+| `--table-search-margin-bottom`          | `8px`               | margin-bottom    | Margin below the search bar, separating it from the table.      |
+| `--table-search-icon-color`             | `#9ca3af`           | color            | Color of the search magnifier icon.                             |
+| `--table-search-icon-size`              | `16px`              | width, height    | Size of the search magnifier icon.                              |
+| `--table-search-font-size`              | `14px`              | font-size        | Font size of the search input text.                             |
+| `--table-search-color`                  | `#111827`           | color            | Text color of the search input.                                 |
+| `--table-search-placeholder-color`      | `#9ca3af`           | color            | Placeholder text color of the search input.                     |
+| `--table-search-focus-border-radius`    | `2px`               | border-radius    | Border radius of the focus-visible outline on the search input. |
+| `--table-search-clear-color`            | `#6b7280`           | color            | Color of the clear (✕) button icon.                             |
+| `--table-search-clear-hover-color`      | `#111827`           | color            | Color of the clear button icon on hover.                        |
+| `--table-search-clear-hover-background` | `rgba(0,0,0,0.05)`  | background-color | Background of the clear button on hover.                        |
+| `--table-search-clear-icon-size`        | `14px`              | width, height    | Size of the clear button icon.                                  |
+
 ## Type Reference
 
 ```typescript
@@ -286,6 +434,28 @@ type SortDirection = 'asc' | 'desc';
 
 // JSONValue is imported from 'type-decoder'
 // JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue }
+
+type TableCheckboxSelectionConfig = {
+  /** Activate the checkbox column. Defaults to true when the config object is present. */
+  enabled?: boolean;
+  /** 'single' allows at most one row selected at a time; 'multiple' (default) allows many. */
+  selectionMode?: 'single' | 'multiple';
+  /** Called whenever the selection set changes, receives the new set of selected row IDs. */
+  onSelectionChange?: (selectedIds: Set<string>) => void;
+  /** Derives a stable string ID from a row and its pre-sort index. Defaults to String(rowIndex). */
+  getRowId?: (row: JSONValue[], rowIndex: number) => string;
+  /** Rows whose IDs appear here render a disabled, non-interactive checkbox. */
+  disabledRowIds?: Set<string>;
+};
+
+type TableSearchConfig = {
+  /** Placeholder text for the search input. Default: 'Search…' */
+  placeholder?: string;
+  /** Restrict client-side filtering to these column indices. When omitted all columns are searched. */
+  searchableColumnIndices?: number[];
+  /** Value for the data-pw attribute on the search input element. */
+  testId?: string;
+};
 ```
 
 ## Web Component
@@ -305,12 +475,12 @@ Tag: `<sui-table>`
 
 ### Slots
 
-| Slot Name           | Maps to Snippet   | Description                                                             |
-| ------------------- | ----------------- | ----------------------------------------------------------------------- |
-| `empty`             | `empty`           | Content shown when the table has no data.                               |
-| `sort-asc-icon`     | `sortAscIcon`     | Custom ascending sort icon.                                             |
-| `sort-desc-icon`    | `sortDescIcon`    | Custom descending sort icon.                                            |
-| `sort-default-icon` | `sortDefaultIcon` | Custom default (unsorted) sort icon.                                    |
-| `paginator-slot`    | `paginatorSlot`   | Footer content below the table, typically pagination controls.          |
+| Slot Name           | Maps to Snippet   | Description                                                    |
+| ------------------- | ----------------- | -------------------------------------------------------------- |
+| `empty`             | `empty`           | Content shown when the table has no data.                      |
+| `sort-asc-icon`     | `sortAscIcon`     | Custom ascending sort icon.                                    |
+| `sort-desc-icon`    | `sortDescIcon`    | Custom descending sort icon.                                   |
+| `sort-default-icon` | `sortDefaultIcon` | Custom default (unsorted) sort icon.                           |
+| `paginator-slot`    | `paginatorSlot`   | Footer content below the table, typically pagination controls. |
 
 > **Note:** `tableHeaders`, `tableData`, and `sortableColumns` are arrays — set them via JavaScript properties. The `cell`, `getRowTestId`, and `getCellTestId` props are function-typed and only available via JavaScript.

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  import type { TableProperties } from './properties';
+  import type { TableProperties, TableCheckboxSelectionConfig } from './properties';
   import type { JSONValue } from 'type-decoder';
+  import { SvelteSet } from 'svelte/reactivity';
   import Button from '../Button/Button.svelte';
   import chevronUpSvg from '$lib/assets/chevron-up.svg?raw';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
   import sortDefaultSvg from '$lib/assets/sort-default.svg?raw';
+  import searchSvg from '$lib/assets/search.svg?raw';
+  import closeSvg from '$lib/assets/close.svg?raw';
+  import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
+  import minusSvg from '$lib/assets/minus.svg?raw';
 
   let {
     tableTitle = '',
@@ -24,16 +29,21 @@
     empty,
     onRowClick,
     onSort,
+    onCellChange: _onCellChange,
     classes,
     paginatorSlot,
     getRowTestId,
-    getCellTestId
+    getCellTestId,
+    checkboxSelection,
+    searchConfig,
+    onSearchChange
   }: TableProperties = $props();
 
+  // ─── Sort state ──────────────────────────────────────────────────────────────
   let sortColumn = $state<number | null>(null);
   let sortDirection = $state<'asc' | 'desc'>('asc');
 
-  function isColumnSortable(colIndex: number): boolean {
+  const isColumnSortable = (colIndex: number): boolean => {
     if (!sortable) {
       return false;
     }
@@ -41,8 +51,61 @@
       return sortableColumns.includes(colIndex);
     }
     return true;
-  }
+  };
 
+  const handleSort = (colIndex: number): void => {
+    if (!isColumnSortable(colIndex)) {
+      return;
+    }
+
+    if (sortColumn === colIndex) {
+      sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortColumn = colIndex;
+      sortDirection = 'asc';
+    }
+    onSort?.(colIndex, sortDirection);
+  };
+
+  // ─── Row click ───────────────────────────────────────────────────────────────
+  const handleRowClick = (rowIndex: number, rowData: JSONValue[]): void => {
+    onRowClick?.(rowIndex, rowData);
+  };
+
+  const handleRowKeydown = (event: KeyboardEvent, rowIndex: number, rowData: JSONValue[]): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onRowClick?.(rowIndex, rowData);
+    }
+  };
+
+  let isRowClickable = $derived(typeof onRowClick === 'function');
+  let isStickyHeader = $derived(stickyHeader || isTableScrollable);
+
+  // ─── C2-3: Search ─────────────────────────────────────────────────────────
+  let searchTerm = $state('');
+  let hasSearchConfig = $derived(!!searchConfig);
+  let isServerSearch = $derived(typeof onSearchChange === 'function');
+  let searchInputRef = $state<HTMLInputElement | null>(null);
+
+  const handleSearchInput = (): void => {
+    if (!searchInputRef) {
+      return;
+    }
+    searchTerm = searchInputRef.value;
+    if (isServerSearch) {
+      onSearchChange?.(searchTerm);
+    }
+  };
+
+  const clearSearch = (): void => {
+    searchTerm = '';
+    if (isServerSearch) {
+      onSearchChange?.('');
+    }
+  };
+
+  // ─── Sort + Search pipeline ──────────────────────────────────────────────────
   let sortedTableData = $derived.by(() => {
     if (sortColumn === null) {
       return [...tableData];
@@ -76,33 +139,158 @@
     });
   });
 
-  function handleSort(colIndex: number) {
-    if (!isColumnSortable(colIndex)) {
+  /**
+   * Client-side filtered rows. When `onSearchChange` is provided (server
+   * delegation) or `searchConfig` is absent, the sorted data passes through
+   * untouched.
+   */
+  let filteredTableData = $derived.by(() => {
+    if (!hasSearchConfig || isServerSearch || searchTerm.trim() === '') {
+      return sortedTableData;
+    }
+
+    const term = searchTerm.trim().toLowerCase();
+    const colIndices = searchConfig?.searchableColumnIndices;
+
+    return sortedTableData.filter((row) => {
+      const indicesToSearch = colIndices ? colIndices : row.map((_cell, idx) => idx);
+      return indicesToSearch.some((idx) => {
+        const cellValue = row[idx];
+        return cellValue !== null && String(cellValue).toLowerCase().includes(term);
+      });
+    });
+  });
+
+  // ─── C2-1: Checkbox selection ─────────────────────────────────────────────
+  const resolveRowId = (
+    cfg: TableCheckboxSelectionConfig,
+    row: JSONValue[],
+    rowIndex: number
+  ): string => {
+    return cfg.getRowId ? cfg.getRowId(row, rowIndex) : String(rowIndex);
+  };
+
+  let selectedIds = new SvelteSet<string>();
+
+  const isRowDisabled = (rowId: string): boolean => {
+    return checkboxSelection?.disabledRowIds?.has(rowId) ?? false;
+  };
+
+  const isRowSelected = (rowId: string): boolean => {
+    return selectedIds.has(rowId);
+  };
+
+  /**
+   * Stable string ID for every row in the currently visible (filtered) view.
+   *
+   * Each entry is resolved by iterating `filteredTableData` and looking up the
+   * row's pre-sort position via `sortedTableData.indexOf(row)`. Using the
+   * pre-filter index as the default numeric ID keeps `String(originalIndex)`
+   * stable even when the visible set shrinks or expands as the search term
+   * changes — so a row that was "row 2" in the full set keeps ID `"2"` even
+   * when it becomes the only visible result.
+   */
+  let filteredRowIds = $derived.by((): string[] => {
+    return filteredTableData.map((row, fallbackIndex) => {
+      const originalIndex = sortedTableData.indexOf(row);
+      const stableIndex = originalIndex === -1 ? fallbackIndex : originalIndex;
+      if (checkboxSelection && checkboxSelection.enabled !== false) {
+        return resolveRowId(checkboxSelection, row, stableIndex);
+      }
+      return String(stableIndex);
+    });
+  });
+
+  /**
+   * IDs of all selectable (non-disabled) rows in the currently filtered view.
+   *
+   * Iterates `filteredTableData` (the post-filter, post-sort visible rows) and
+   * resolves each row's stable ID using `sortedTableData.indexOf(row)` for the
+   * pre-filter positional index. When `getRowId` is absent this keeps the
+   * default numeric ID (`String(originalIndex)`) unchanged regardless of which
+   * rows the current search term hides, preventing ID collisions as the visible
+   * set changes.
+   */
+  let selectableRowIds = $derived.by((): string[] => {
+    if (!checkboxSelection || checkboxSelection.enabled === false) {
+      return [];
+    }
+    return filteredRowIds.filter((rowId) => !isRowDisabled(rowId));
+  });
+
+  /**
+   * Header checkbox tri-state.
+   * - `'all'`   → every selectable row is selected → show checked
+   * - `'some'`  → some but not all → show indeterminate
+   * - `'none'`  → nothing selected → show unchecked
+   */
+  let headerCheckboxState = $derived.by((): 'all' | 'some' | 'none' => {
+    if (
+      !checkboxSelection ||
+      checkboxSelection.enabled === false ||
+      selectableRowIds.length === 0
+    ) {
+      return 'none';
+    }
+    const selectedCount = selectableRowIds.filter((rowId) => selectedIds.has(rowId)).length;
+    if (selectedCount === 0) {
+      return 'none';
+    }
+    if (selectedCount === selectableRowIds.length) {
+      return 'all';
+    }
+    return 'some';
+  });
+
+  const toggleRowSelection = (rowId: string): void => {
+    if (!checkboxSelection || checkboxSelection.enabled === false || isRowDisabled(rowId)) {
       return;
     }
 
-    if (sortColumn === colIndex) {
-      sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+    if (checkboxSelection.selectionMode === 'single') {
+      const wasSelected = selectedIds.has(rowId);
+      selectedIds.clear();
+      if (!wasSelected) {
+        selectedIds.add(rowId);
+      }
     } else {
-      sortColumn = colIndex;
-      sortDirection = 'asc';
+      if (selectedIds.has(rowId)) {
+        selectedIds.delete(rowId);
+      } else {
+        selectedIds.add(rowId);
+      }
     }
-    onSort?.(colIndex, sortDirection);
-  }
+    checkboxSelection.onSelectionChange?.(new Set(selectedIds));
+  };
 
-  function handleRowClick(rowIndex: number, rowData: JSONValue[]) {
-    onRowClick?.(rowIndex, rowData);
-  }
+  const toggleAllSelection = (): void => {
+    if (!checkboxSelection || checkboxSelection.enabled === false) {
+      return;
+    }
+    // selectableRowIds already excludes disabled rows
+    if (headerCheckboxState === 'all') {
+      // deselect all selectable rows in the current view
+      for (const rowId of selectableRowIds) {
+        selectedIds.delete(rowId);
+      }
+    } else {
+      // select all selectable rows in the current view
+      for (const rowId of selectableRowIds) {
+        selectedIds.add(rowId);
+      }
+    }
+    checkboxSelection.onSelectionChange?.(new Set(selectedIds));
+  };
 
-  function handleRowKeydown(event: KeyboardEvent, rowIndex: number, rowData: JSONValue[]) {
-    if (event.key === 'Enter' || event.key === ' ') {
+  const handleCheckboxKeydown = (event: KeyboardEvent, action: () => void): void => {
+    if (event.key === ' ' || event.key === 'Enter') {
       event.preventDefault();
-      onRowClick?.(rowIndex, rowData);
+      action();
     }
-  }
+  };
 
-  let isRowClickable = $derived(typeof onRowClick === 'function');
-  let isStickyHeader = $derived(stickyHeader || isTableScrollable);
+  let isCheckboxMode = $derived(!!checkboxSelection && checkboxSelection.enabled !== false);
+  let isSingleSelect = $derived(checkboxSelection?.selectionMode === 'single');
 </script>
 
 {#if typeof tableTitle === 'string' && tableTitle.length > 0}
@@ -110,6 +298,37 @@
     {tableTitle}
   </div>
 {/if}
+
+{#if hasSearchConfig}
+  <div class="table-search">
+    <span class="table-search-icon">
+      <!-- eslint-disable svelte/no-at-html-tags -->
+      {@html searchSvg}
+    </span>
+    <input
+      bind:this={searchInputRef}
+      class="table-search-input"
+      type="search"
+      placeholder={searchConfig?.placeholder ?? 'Search…'}
+      value={searchTerm}
+      oninput={handleSearchInput}
+      data-pw={searchConfig?.testId ?? null}
+      aria-label={searchConfig?.placeholder ?? 'Search'}
+    />
+    {#if searchTerm.length > 0}
+      <button
+        class="table-search-clear"
+        type="button"
+        onclick={clearSearch}
+        aria-label="Clear search"
+      >
+        <!-- eslint-disable svelte/no-at-html-tags -->
+        {@html closeSvg}
+      </button>
+    {/if}
+  </div>
+{/if}
+
 {#if tableHeaders.length !== 0 || tableData.length !== 0}
   <div
     class="table-container {isTableScrollable ? 'scrollable-table' : ''} {classes ?? ''}"
@@ -121,6 +340,37 @@
       {/if}
       <thead>
         <tr>
+          {#if isCheckboxMode && !isSingleSelect}
+            <th class="table-header table-checkbox-col" class:table-header-sticky={isStickyHeader}>
+              <!-- Header tri-state checkbox -->
+              <span
+                class="table-checkbox-box"
+                class:checked={headerCheckboxState === 'all'}
+                class:indeterminate={headerCheckboxState === 'some'}
+                role="checkbox"
+                tabindex={0}
+                aria-checked={headerCheckboxState === 'some'
+                  ? 'mixed'
+                  : headerCheckboxState === 'all'}
+                aria-label="Select all rows"
+                onclick={toggleAllSelection}
+                onkeydown={(keyboardEvent) =>
+                  handleCheckboxKeydown(keyboardEvent, toggleAllSelection)}
+              >
+                {#if headerCheckboxState === 'all'}
+                  <!-- eslint-disable svelte/no-at-html-tags -->
+                  <span class="table-checkbox-icon">{@html checkmarkSvg}</span>
+                {:else if headerCheckboxState === 'some'}
+                  <!-- eslint-disable svelte/no-at-html-tags -->
+                  <span class="table-checkbox-icon">{@html minusSvg}</span>
+                {/if}
+              </span>
+            </th>
+          {:else if isCheckboxMode && isSingleSelect}
+            <!-- In single-select mode the header cell is an empty spacer -->
+            <th class="table-header table-checkbox-col" class:table-header-sticky={isStickyHeader}>
+            </th>
+          {/if}
           {#each tableHeaders as header, colIndex (colIndex)}
             <th class="table-header" class:table-header-sticky={isStickyHeader}>
               <span class="table-header-content">
@@ -163,17 +413,24 @@
         </tr>
       </thead>
       <tbody>
-        {#if sortedTableData.length === 0 && typeof empty === 'function'}
+        {#if filteredTableData.length === 0 && typeof empty === 'function'}
           <tr>
-            <td class="table-empty" colspan={tableHeaders.length}>
+            <td
+              class="table-empty"
+              colspan={isCheckboxMode ? tableHeaders.length + 1 : tableHeaders.length}
+            >
               {@render empty()}
             </td>
           </tr>
         {:else}
-          {#each sortedTableData as row, rowIndex (rowIndex)}
+          {#each filteredTableData as row, rowIndex (filteredRowIds[rowIndex])}
+            {@const rowId = filteredRowIds[rowIndex]}
+            {@const rowDisabled = isCheckboxMode && isRowDisabled(rowId)}
+            {@const rowSelected = isCheckboxMode && isRowSelected(rowId)}
             <tr
               class="table-row"
               class:table-row-clickable={isRowClickable}
+              class:table-row-selected={rowSelected}
               data-pw={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
               onclick={isRowClickable ? () => handleRowClick(rowIndex, row) : null}
               onkeydown={isRowClickable
@@ -181,6 +438,32 @@
                 : null}
               tabindex={isRowClickable ? 0 : null}
             >
+              {#if isCheckboxMode}
+                <td class="table-content table-checkbox-col">
+                  <span
+                    class="table-checkbox-box"
+                    class:checked={rowSelected}
+                    class:disabled={rowDisabled}
+                    role="checkbox"
+                    tabindex={rowDisabled ? -1 : 0}
+                    aria-checked={rowSelected}
+                    aria-disabled={rowDisabled}
+                    onclick={(mouseEvent) => {
+                      mouseEvent.stopPropagation();
+                      toggleRowSelection(rowId);
+                    }}
+                    onkeydown={(keyboardEvent) => {
+                      keyboardEvent.stopPropagation();
+                      handleCheckboxKeydown(keyboardEvent, () => toggleRowSelection(rowId));
+                    }}
+                  >
+                    {#if rowSelected}
+                      <!-- eslint-disable svelte/no-at-html-tags -->
+                      <span class="table-checkbox-icon">{@html checkmarkSvg}</span>
+                    {/if}
+                  </span>
+                </td>
+              {/if}
               {#each row as cellValue, colIndex (colIndex)}
                 <td
                   class="table-content"
@@ -211,6 +494,7 @@
 {/if}
 
 <style>
+  /* ── Title ─────────────────────────────────────────────────────────────── */
   .table-title {
     margin: var(--table-title-margin, 0px 0px 12px 0px);
     font-size: var(--table-title-font-size, var(--table-tile-font-size, 18px));
@@ -220,6 +504,78 @@
     padding: var(--table-title-padding);
   }
 
+  /* ── C2-3 Search bar ────────────────────────────────────────────────────── */
+  .table-search {
+    display: flex;
+    align-items: center;
+    gap: var(--table-search-gap, 8px);
+    padding: var(--table-search-padding, 8px 12px);
+    border: var(--table-search-border, 1px solid #e5e7eb);
+    border-radius: var(--table-search-border-radius, 8px);
+    background-color: var(--table-search-background, #ffffff);
+    margin-bottom: var(--table-search-margin-bottom, 8px);
+  }
+
+  .table-search-icon {
+    display: inline-flex;
+    align-items: center;
+    color: var(--table-search-icon-color, #9ca3af);
+    flex-shrink: 0;
+  }
+
+  .table-search-icon :global(svg) {
+    width: var(--table-search-icon-size, 16px);
+    height: var(--table-search-icon-size, 16px);
+  }
+
+  .table-search-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: var(--table-search-font-size, 14px);
+    color: var(--table-search-color, #111827);
+    min-width: 0;
+  }
+
+  .table-search-input:focus-visible {
+    outline: 2px solid var(--table-focus-outline-color, #3b82f6);
+    outline-offset: 2px;
+    border-radius: var(--table-search-focus-border-radius, 2px);
+  }
+
+  .table-search-input::placeholder {
+    color: var(--table-search-placeholder-color, #9ca3af);
+  }
+
+  /* Hide browser-default clear button on search inputs */
+  .table-search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  .table-search-clear {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px;
+    border: none;
+    background: transparent;
+    color: var(--table-search-clear-color, #6b7280);
+    cursor: pointer;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .table-search-clear:hover {
+    color: var(--table-search-clear-hover-color, #111827);
+    background-color: var(--table-search-clear-hover-background, rgba(0, 0, 0, 0.05));
+  }
+
+  .table-search-clear :global(svg) {
+    width: var(--table-search-clear-icon-size, 14px);
+    height: var(--table-search-clear-icon-size, 14px);
+  }
+
+  /* ── Container ──────────────────────────────────────────────────────────── */
   .table-container {
     border: var(--table-border, 1px solid #e5e7eb);
     border-radius: var(--table-border-radius, 8px);
@@ -313,6 +669,77 @@
     outline-offset: -2px;
   }
 
+  /* C2-1: Selected row highlight */
+  .table-row-selected {
+    background-color: var(--table-row-selected-background, #eff6ff);
+  }
+
+  .table-row-selected > .table-content {
+    background-color: var(--table-row-selected-background, #eff6ff);
+  }
+
+  /* ── C2-1 Checkbox column ───────────────────────────────────────────────── */
+  .table-checkbox-col {
+    width: var(--table-checkbox-col-width, 44px);
+    padding: var(--table-checkbox-col-padding, 12px 12px);
+  }
+
+  .table-checkbox-box {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--table-checkbox-size, 18px);
+    height: var(--table-checkbox-size, 18px);
+    border: var(--table-checkbox-border, 2px solid #9ca3af);
+    border-radius: var(--table-checkbox-border-radius, 3px);
+    background-color: var(--table-checkbox-background, transparent);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+    user-select: none;
+  }
+
+  .table-checkbox-box:focus-visible {
+    outline: none;
+    box-shadow: var(--table-checkbox-focus-ring, 0 0 0 3px rgba(59, 130, 246, 0.3));
+  }
+
+  .table-checkbox-box:not(.disabled):hover {
+    border-color: var(--table-checkbox-hover-border-color, #6b7280);
+  }
+
+  .table-checkbox-box.checked {
+    background-color: var(--table-checkbox-checked-background, #2563eb);
+    border-color: var(--table-checkbox-checked-border-color, #2563eb);
+  }
+
+  .table-checkbox-box.indeterminate {
+    background-color: var(--table-checkbox-indeterminate-background, #2563eb);
+    border-color: var(--table-checkbox-indeterminate-border-color, #2563eb);
+  }
+
+  .table-checkbox-box.disabled {
+    opacity: var(--table-checkbox-disabled-opacity, 0.4);
+    cursor: not-allowed;
+  }
+
+  .table-checkbox-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--table-checkbox-icon-size, 12px);
+    height: var(--table-checkbox-icon-size, 12px);
+    color: var(--table-checkbox-icon-color, #ffffff);
+  }
+
+  .table-checkbox-icon :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* ── Sort button ────────────────────────────────────────────────────────── */
   .sort-button {
     --button-color: transparent;
     --button-border: none;
@@ -351,18 +778,21 @@
     opacity: var(--table-sort-idle-hover-opacity, 0.85);
   }
 
+  /* ── Empty ──────────────────────────────────────────────────────────────── */
   .table-empty {
     padding: var(--table-empty-padding, 32px 24px);
     text-align: center;
     color: var(--table-empty-color, #9ca3af);
   }
 
+  /* ── Footer ─────────────────────────────────────────────────────────────── */
   .table-footer {
     border-top: var(--table-footer-border, 1px solid #e5e7eb);
     padding: var(--table-footer-padding, 8px 16px);
     background-color: var(--table-footer-background, transparent);
   }
 
+  /* ── Accessibility ──────────────────────────────────────────────────────── */
   .sr-only {
     position: absolute;
     width: 1px;

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -3,6 +3,47 @@ import type { Snippet } from 'svelte';
 
 export type SortDirection = 'asc' | 'desc';
 
+/**
+ * Configuration for row checkbox selection (C2-1).
+ *
+ * - `enabled` — activates the checkbox column.
+ * - `selectionMode` — `'single'` allows at most one row selected at a time;
+ *   `'multiple'` (default) allows arbitrary many.
+ * - `onSelectionChange` — called whenever the selection set changes, receives
+ *   the new set of selected row IDs.
+ * - `getRowId` — derives a stable string ID from a row + its index. Defaults
+ *   to `String(rowIndex)` when omitted.
+ * - `disabledRowIds` — rows whose IDs appear in this set render a disabled,
+ *   unchecked checkbox and cannot be selected.
+ */
+export type TableCheckboxSelectionConfig = {
+  /**
+   * Whether to activate the checkbox column. Defaults to `true` when the
+   * config object is provided — the presence of `checkboxSelection` already
+   * signals the intent to enable selection, so `enabled: false` is redundant.
+   * Kept for explicit opt-out without removing the config object.
+   */
+  enabled?: boolean;
+  selectionMode?: 'single' | 'multiple';
+  onSelectionChange?: (selectedIds: Set<string>) => void;
+  getRowId?: (row: JSONValue[], rowIndex: number) => string;
+  disabledRowIds?: Set<string>;
+};
+
+/**
+ * Configuration for the built-in search bar (C2-3).
+ *
+ * - `placeholder` — input placeholder text (default "Search…").
+ * - `searchableColumnIndices` — restrict filtering to these column indices.
+ *   When omitted all columns are searched.
+ * - `testId` — `data-pw` attribute on the search input element.
+ */
+export type TableSearchConfig = {
+  placeholder?: string;
+  searchableColumnIndices?: number[];
+  testId?: string;
+};
+
 export type TableProperties = OptionalTableProperties & TableEventProperties;
 
 export type OptionalTableProperties = {
@@ -28,9 +69,58 @@ export type OptionalTableProperties = {
   getRowTestId?: (row: JSONValue[], rowIndex: number) => string;
   /** Return a data-pw value for the given cell. */
   getCellTestId?: (row: JSONValue[], column: JSONValue, rowIndex: number) => string;
+  /**
+   * C2-1: Opt-in checkbox row-selection.
+   * Pass `{ enabled: true }` to show a leading checkbox column.
+   */
+  checkboxSelection?: TableCheckboxSelectionConfig;
+  /**
+   * C2-3: Opt-in built-in search bar rendered above the table.
+   * Client-side filtering is performed by default; pass `onSearchChange` to
+   * delegate to the server instead.
+   */
+  searchConfig?: TableSearchConfig;
 };
 
 export type TableEventProperties = {
   onRowClick?: (rowIndex: number, rowData: JSONValue[]) => void;
   onSort?: (columnIndex: number, direction: SortDirection) => void;
+  /**
+   * C2-2: Callback invoked when a cell value changes via an editable element
+   * inside the consumer's `cell` snippet (e.g. an `<Input>` or `<Select>`).
+   *
+   * **How to wire it**: Svelte 5 snippets execute in the consumer's scope, so
+   * `onCellChange` is NOT forwarded by Table — you must close over your own
+   * handler directly inside the snippet:
+   *
+   * ```svelte
+   * <script>
+   *   let rows = $state(myData);
+   *   const handleCellChange = (rowIndex, colIndex, newValue) => {
+   *     rows[rowIndex][colIndex] = newValue;
+   *   };
+   * </script>
+   *
+   * <Table tableData={rows}>
+   *   {#snippet cell(value, rowIndex, colIndex)}
+   *     <Input
+   *       value={String(value ?? '')}
+   *       onInput={(newValue) => handleCellChange(rowIndex, colIndex, newValue)}
+   *     />
+   *   {/snippet}
+   * </Table>
+   * ```
+   *
+   * Table never mutates `tableData`; the consumer owns the source-of-truth
+   * array. Pass `onCellChange` as a top-level prop if you want Table to expose
+   * this handler to parent components via the standard props channel — it does
+   * not change the wiring inside the snippet.
+   */
+  onCellChange?: (rowIndex: number, colIndex: number, newValue: JSONValue) => void;
+  /**
+   * C2-3: When provided, the built-in client-side filtering is disabled and
+   * this callback is called on every search input change instead, letting the
+   * server decide what rows to show.
+   */
+  onSearchChange?: (searchTerm: string) => void;
 };

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -39,6 +39,58 @@
     ['Ivy Chen', 'Sales', 91, 'Active'],
     ['Jack Taylor', 'Engineering', 76, 'Review']
   ];
+
+  // ── Checkbox selection demos ─────────────────────────────────────────────────
+  let multipleSelectedIds = $state<Set<string>>(new Set());
+  let singleSelectedId = $state<string | null>(null);
+
+  const employeeData: Array<[string, string, string]> = [
+    ['Alice Johnson', 'Engineering', 'Staff Engineer'],
+    ['Bob Smith', 'Design', 'Product Designer'],
+    ['Carol White', 'Marketing', 'Growth Lead'],
+    ['Dan Brown', 'Engineering', 'Senior Engineer'],
+    ['Eve Davis', 'Sales', 'Account Executive']
+  ];
+
+  // ── Search demos ─────────────────────────────────────────────────────────────
+  let serverSearchTerm = $state('');
+
+  // Simulate server-side rows reacting to the search term
+  const allProductRows: Array<[string, string, string]> = [
+    ['MacBook Pro 16"', 'Laptops', '$3,499'],
+    ['MacBook Air M3', 'Laptops', '$1,299'],
+    ['iPhone 15 Pro', 'Phones', '$999'],
+    ['iPhone 15', 'Phones', '$799'],
+    ['iPad Pro 13"', 'Tablets', '$1,099'],
+    ['AirPods Pro 2', 'Audio', '$249'],
+    ['Apple Watch S9', 'Wearables', '$399']
+  ];
+
+  let serverFilteredRows = $derived(
+    serverSearchTerm.trim() === ''
+      ? allProductRows
+      : allProductRows.filter((row) =>
+          row.some((cell) => cell.toLowerCase().includes(serverSearchTerm.trim().toLowerCase()))
+        )
+  );
+
+  // ── onCellChange wiring demo ─────────────────────────────────────────────────
+  let editableRows = $state<Array<[string, string]>>([
+    ['Alice Johnson', 'Engineering'],
+    ['Bob Smith', 'Design'],
+    ['Carol White', 'Marketing']
+  ]);
+
+  const handleCellChange = (rowIndex: number, colIndex: number, newValue: JSONValue): void => {
+    editableRows = editableRows.map((row, idx) => {
+      if (idx !== rowIndex) {
+        return row;
+      }
+      const nextRow: [string, string] = [row[0], row[1]];
+      nextRow[colIndex] = String(newValue ?? '');
+      return nextRow;
+    });
+  };
 </script>
 
 <div class="page-header">
@@ -213,6 +265,130 @@
   {#if lastCellTestId}
     <p class="state-display">Last clicked row data-pw prefix: {lastCellTestId}</p>
   {/if}
+</div>
+
+<!-- Checkbox Selection — Multiple Mode -->
+<h3>Checkbox Selection (multiple)</h3>
+<div class="demo-row" style="max-width: 700px; flex-direction: column; gap: 8px;">
+  <Table
+    tableHeaders={['Name', 'Department', 'Role']}
+    tableData={employeeData}
+    checkboxSelection={{
+      selectionMode: 'multiple',
+      getRowId: (_row, rowIndex) => `emp-${rowIndex}`,
+      disabledRowIds: new Set(['emp-2']),
+      onSelectionChange: (ids) => {
+        multipleSelectedIds = ids;
+      }
+    }}
+    --table-row-selected-background="#eff6ff"
+  />
+  {#if multipleSelectedIds.size > 0}
+    <p class="state-display">
+      Selected IDs: {[...multipleSelectedIds].join(', ')}
+    </p>
+  {/if}
+</div>
+
+<!-- Checkbox Selection — Single Mode -->
+<h3>Checkbox Selection (single)</h3>
+<div class="demo-row" style="max-width: 700px; flex-direction: column; gap: 8px;">
+  <Table
+    tableHeaders={['Name', 'Department', 'Role']}
+    tableData={employeeData}
+    checkboxSelection={{
+      selectionMode: 'single',
+      getRowId: (_row, rowIndex) => `single-emp-${rowIndex}`,
+      onSelectionChange: (ids) => {
+        singleSelectedId = ids.size > 0 ? [...ids][0] : null;
+      }
+    }}
+    --table-row-selected-background="#f0fdf4"
+    --table-checkbox-checked-background="#16a34a"
+    --table-checkbox-checked-border-color="#16a34a"
+  />
+  {#if singleSelectedId}
+    <p class="state-display">Selected: {singleSelectedId}</p>
+  {/if}
+</div>
+
+<!-- Search — Client-Side Filtering -->
+<h3>Search (client-side filtering)</h3>
+<div class="demo-row" style="max-width: 700px;">
+  <Table
+    tableHeaders={['Name', 'Department', 'Score', 'Status']}
+    tableData={[
+      ['Alice Johnson', 'Engineering', 94, 'Active'],
+      ['Bob Smith', 'Design', 78, 'Pending'],
+      ['Carol White', 'Marketing', 65, 'Inactive'],
+      ['Dan Brown', 'Engineering', 88, 'Review'],
+      ['Eve Davis', 'Sales', 92, 'Active'],
+      ['Frank Miller', 'Engineering', 71, 'Pending']
+    ]}
+    searchConfig={{
+      placeholder: 'Search employees…',
+      searchableColumnIndices: [0, 1, 3],
+      testId: 'employee-search'
+    }}
+    --table-row-hover-background="#f9fafb"
+  >
+    {#snippet cell(value, _rowIndex, colIndex)}
+      {#if colIndex === 3 && typeof value === 'string'}
+        <Pill text={value} classes={statusClasses[value] ?? ''} />
+      {:else}
+        {value}
+      {/if}
+    {/snippet}
+  </Table>
+</div>
+
+<!-- Search — Server-Side Delegation -->
+<h3>Search (server-side delegation via onSearchChange)</h3>
+<div class="demo-row" style="max-width: 700px; flex-direction: column; gap: 8px;">
+  <Table
+    tableHeaders={['Product', 'Category', 'Price']}
+    tableData={serverFilteredRows}
+    searchConfig={{ placeholder: 'Search products…', testId: 'product-search' }}
+    onSearchChange={(term) => {
+      serverSearchTerm = term;
+    }}
+    --table-row-hover-background="#f9fafb"
+  />
+  <p class="state-display">
+    Showing {serverFilteredRows.length} of {allProductRows.length} products
+    {serverSearchTerm ? `— filtered by "${serverSearchTerm}"` : ''}
+  </p>
+</div>
+
+<!-- onCellChange Wiring Pattern -->
+<h3>Editable Cells (onCellChange pattern)</h3>
+<p style="color: #6b7280; margin: 0 0 8px 0;">
+  Table does not forward <code>onCellChange</code> internally — wire your handler directly inside
+  the <code>cell</code> snippet, which runs in consumer scope.
+</p>
+<div class="demo-row" style="max-width: 600px; flex-direction: column; gap: 8px;">
+  <Table
+    tableHeaders={['Name', 'Department']}
+    tableData={editableRows}
+    onCellChange={handleCellChange}
+  >
+    {#snippet cell(value, rowIndex, colIndex)}
+      <!-- The snippet runs in consumer scope — handleCellChange is already in closure -->
+      <input
+        type="text"
+        value={String(value ?? '')}
+        oninput={(inputEvent) => {
+          if (inputEvent.target instanceof HTMLInputElement) {
+            handleCellChange(rowIndex, colIndex, inputEvent.target.value);
+          }
+        }}
+        style="border: 1px solid #e5e7eb; border-radius: 4px; padding: 4px 8px; width: 100%; background: transparent;"
+      />
+    {/snippet}
+  </Table>
+  <div style="margin-top: 4px;">
+    <p class="state-display">Live data: {JSON.stringify(editableRows)}</p>
+  </div>
 </div>
 
 <style>


### PR DESCRIPTION
## What

Fixes all gate-review blockers and majors for the Table C2 feature branch.

## Changes

### Blocker — C2-1: single-select toggle broken
`toggleRowSelection()` called `selectedIds.clear()` before `selectedIds.has(rowId)`, making the `has()` check always return `false` on the now-empty set. Clicking an already-selected row re-selected it instead of deselecting. Fix: capture `const wasSelected = selectedIds.has(rowId)` before `clear()` and branch on it.

### Blocker — C2-2: `onCellChange` was a dead prop with a misleading recipe
The JSDoc showed `onCellChange?.(rowIndex, colIndex, newValue)` inside a consumer `cell` Snippet as if Table would forward the call. Svelte 5 snippets execute in consumer scope — Table itself never calls this callback. The recipe was actively misleading. The prop is retained (it's valid as a parent-component API surface), but the internal destructured binding is renamed to `_onCellChange` (satisfies the unused-var lint rule), and the JSDoc is rewritten to make clear that consumers must close over their own handler directly inside the snippet.

### Major — C2-1 + C2-3: positional IDs shifted on filter change
`selectableRowIds` mapped over `filteredTableData` with a local `rowIndex`, so default IDs (`String(0)`, `String(1)`, …) were positional in the *filtered* view. When the search term changed, the filtered list shrank/shifted and the same data row got a different ID — corrupting selection state. Fix: resolve each row's original index via `sortedTableData.indexOf(row)` so the default ID tracks the pre-filter position. The per-row `rowId` computation in the `{#each}` block applies the same pre-filter index lookup.

### Minor — C2-3: search input had no focus-visible ring
`.table-search-input { outline: none }` stripped the browser focus indicator with no replacement, making keyboard focus invisible. Added a `:focus-visible` rule using the existing `--table-focus-outline-color` CSS variable (same token already used on `.table-row-clickable`).

### Minor — C2-1: `enabled` field was a required boolean
`enabled: boolean` forced every consumer to write `checkboxSelection={{ enabled: true, … }}`. Changed to `enabled?: boolean` — presence of the config object implies intent to enable, `enabled: false` is still valid for explicit opt-out. All internal guards updated from `checkboxSelection?.enabled` to `!!checkboxSelection && checkboxSelection.enabled !== false`. Backward-compatible: existing consumers passing `enabled: true` are unaffected.

## Compatibility

- All new props remain optional; no existing required prop moved to optional.
- `TableCheckboxSelectionConfig.enabled` change: `boolean` → `boolean | undefined` (adding `undefined` widens the accepted type, not a breaking change; consumers already passing `true`/`false` continue to work).
- CSS: one new `:focus-visible` rule added; no existing vars removed.