### PR TITLE
fix(Select): close multi-select searchable dropdown on trigger click

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -139,9 +139,10 @@
       }
       return;
     }
-    if (multiple && searchable) {
-      openDropdown();
-    } else if (open) {
+    // Clicks on the search input are handled above (kept open while typing), so a click
+    // on the trigger chrome — including the chevron — can toggle even for a multi-select
+    // searchable Select. The previous multiple && searchable branch never closed on click.
+    if (open) {
       close();
     } else {
       openDropdown();


### PR DESCRIPTION
## Problem

A `multiple` + `searchable` `Select` can't be closed by clicking its trigger (the chevron / trigger chrome). `handleTriggerClick` has a `multiple && searchable` branch that **always** calls `openDropdown()`, so the dropdown re-opens instead of toggling shut — there's no way to dismiss it via the trigger.

## Fix

Drop the `multiple && searchable` special-case so the trigger toggles like every other `Select`:

```diff
-    if (multiple && searchable) {
-      openDropdown();
-    } else if (open) {
+    if (open) {
       close();
     } else {
       openDropdown();
     }
```

## Why it's safe

The guard directly above already handles clicks on the search field:

```js
if (event.target instanceof HTMLInputElement) {
  if (!open) { openDropdown(); }
  return;
}
```

So typing/searching still keeps the dropdown open. The removed branch only affected clicks on the **trigger chrome (including the chevron)** — where toggling-to-close is the expected dropdown behavior.

## Context

Surfaced in a consumer (Breeze / Lighthouse) that currently ships a local `patches/@juspay__svelte-ui-components@*.patch` to get a zone multi-select dropdown to close on trigger click. Raising upstream so that patch can be dropped.

## Verification

- `pnpm run check` (svelte-check): **0 errors**
- `pnpm run lint` (prettier + eslint): **clean**
