### PR TITLE
feat(Card): add cssVars prop for per-instance CSS variable injection

### DIFF
--- a/docs/Card.md
+++ b/docs/Card.md
@@ -191,6 +191,7 @@ This pattern gives full layout control to the consumer (any number of zones, any
 | footer      | `Snippet`                     | No       | `-`     | Snippet rendered in a `<footer>` element below the content area. When omitted no footer element is rendered.                                                                 |
 | stretch     | `boolean`                     | No       | `false` | When true, the card root gets `height: 100%` and becomes a flex column so the content area grows to fill remaining space. Useful in equal-height grid/flex layouts.         |
 | scrollable  | `boolean`                     | No       | `false` | When true, the content area becomes vertically scrollable (max-height via `--card-content-max-height`, default 400px). The region also gains `role="region"` and `tabindex="0"` for keyboard accessibility. |
+| cssVars     | `Record<string, string \| number>` | No  | `-`     | Per-instance CSS custom properties applied as inline `style` on the card root (e.g. `{ '--bottom-sections-count': 3 }`). Feeds a dynamic value into a recipe class whose selectors/media queries read that variable — something a static `classes` string cannot express. Omit to render no `style` attribute. |
 
 ## Events
 

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -11,10 +11,19 @@
     headerRight,
     footer,
     stretch = false,
-    scrollable = false
+    scrollable = false,
+    cssVars
   }: CardProperties = $props();
 
   const isInteractive = $derived(typeof onclick === 'function');
+
+  const styleAttr = $derived(
+    cssVars
+      ? Object.entries(cssVars)
+          .map(([name, value]) => `${name}: ${value}`)
+          .join('; ')
+      : null
+  );
 
   const handleKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -34,6 +43,7 @@
   class:card-interactive={isInteractive}
   class:card-stretch={stretch}
   class:card-has-scroll={scrollable}
+  style={styleAttr}
   data-pw={typeof testId === 'string' ? testId : null}
   role={isInteractive ? 'button' : null}
   tabindex={isInteractive ? 0 : null}

--- a/src/lib/Card/properties.ts
+++ b/src/lib/Card/properties.ts
@@ -44,4 +44,13 @@ export type OptionalCardProperties = {
    * Defaults to false.
    */
   scrollable?: boolean;
+  /**
+   * Per-instance CSS custom properties applied as inline style on the root `.card`.
+   * Keys must be CSS variable names (e.g. `--bottom-sections-count`); values are
+   * emitted verbatim. This lets a consumer feed a dynamic, per-instance value into a
+   * recipe class whose selectors or media queries read that variable — something a
+   * static `classes` string cannot express. When omitted, no `style` attribute is
+   * rendered, so existing consumers are unchanged.
+   */
+  cssVars?: Record<string, string | number>;
 };

--- a/src/wc/components/Card.wc.svelte
+++ b/src/wc/components/Card.wc.svelte
@@ -7,7 +7,8 @@
       description: { type: 'String', reflect: true },
       classes: { type: 'String' },
       stretch: { type: 'Boolean', reflect: true },
-      scrollable: { type: 'Boolean', reflect: true }
+      scrollable: { type: 'Boolean', reflect: true },
+      cssVars: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
## What

Adds an optional `cssVars?: Record<string, string | number>` prop to `Card`. When provided, its entries are serialized to an inline `style` on the root `.card` element (e.g. `{ '--bottom-sections-count': 3 }` → `style="--bottom-sections-count: 3"`). When omitted, no `style` attribute is rendered, so existing consumers are byte-for-byte unchanged.

## Why

A static `classes` string can theme a Card via CSS-variable recipes, but it cannot carry a **per-instance, dynamic** value. Consumers that need a recipe whose selectors/media-queries read a runtime value (e.g. a stats card that widens via `@media (width>=769px) { min-width: calc(... * var(--bottom-sections-count)) }`) currently can't fold onto the library Card — there's no way to pass the count to the root element (you can't put `style:` on a component). `cssVars` is the narrow, typed escape hatch for exactly this: per-instance CSS custom properties only, aligned with the library's "theme via CSS variables" doctrine rather than a raw `style` prop.

## Changes
- `src/lib/Card/Card.svelte` — new `cssVars` prop, derived `styleAttr` serializer, `style={styleAttr}` on root (null when unset).
- `src/lib/Card/properties.ts` — typed prop + JSDoc.
- `src/wc/components/Card.wc.svelte` — `cssVars: { type: 'Object' }`.
- `docs/Card.md` — Props table row.

## Gates
- `pnpm run check` → 0 errors (4 pre-existing warnings, none in Card).
- `pnpm run lint` → clean.
- `pnpm run build` → packages cleanly (publint: only the pre-existing repo.url suggestion).

## Backward compatibility
Fully additive. `cssVars` is optional; omitting it renders no `style` attribute (identical DOM to before).