### PR TITLE
fix(DateRangePicker): match active preset by label, not same calendar day

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -391,6 +391,14 @@
     ) {
       return preset.label === activePresetLabel;
     }
+    // A preset was explicitly chosen this session — match it by label, not by date.
+    // Several presets can share a calendar day (e.g. "Today", "Last 30 minutes" and
+    // "Last 12 hours" all start today), so same-day matching would light up all of
+    // them at once. selectedPresetLabel is cleared on a direct calendar click, so the
+    // date-based fallbacks below still drive highlighting for manual selections.
+    if (selectedPresetLabel !== null) {
+      return preset.label === selectedPresetLabel;
+    }
     if (mode === 'single') {
       if (draftValue === null) {
         return false;

--- a/src/routes/components/date-range-picker/+page.svelte
+++ b/src/routes/components/date-range-picker/+page.svelte
@@ -255,6 +255,41 @@
     }
   ];
 
+  // Several presets that all fall on the *same* calendar day. Picking one must
+  // highlight only that preset — not every preset that shares the day.
+  const sameDayPresets: DateRangePreset[] = [
+    {
+      label: 'Today',
+      getValue: () => {
+        const start = new SvelteDate();
+        start.setHours(0, 0, 0, 0);
+        const end = new SvelteDate(start);
+        end.setHours(23, 59, 59, 999);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Today morning',
+      getValue: () => {
+        const start = new SvelteDate();
+        start.setHours(0, 0, 0, 0);
+        const end = new SvelteDate(start);
+        end.setHours(11, 59, 59, 999);
+        return { start, end };
+      }
+    },
+    {
+      label: 'Today evening',
+      getValue: () => {
+        const start = new SvelteDate();
+        start.setHours(12, 0, 0, 0);
+        const end = new SvelteDate(start);
+        end.setHours(23, 59, 59, 999);
+        return { start, end };
+      }
+    }
+  ];
+
   let clearableDate = $state<Date | null>(null);
 
   const today = new SvelteDate();
@@ -513,6 +548,23 @@
       presets={groupedPresets}
       placeholder="Select range (grouped)"
       testId="drp-groups-demo"
+    />
+  </div>
+</section>
+
+<!-- ── 10. Same-day presets (regression: only the picked preset highlights) ── -->
+<section class="demo-section">
+  <h2>Range mode — same-day presets (single active highlight)</h2>
+  <p class="section-note">
+    When multiple presets fall on the same calendar day, picking one must highlight only that preset
+    — not every preset that starts on the same day.
+  </p>
+  <div class="demo-row">
+    <DateRangePicker
+      mode="range"
+      presets={sameDayPresets}
+      placeholder="Select range (same-day presets)"
+      testId="drp-same-day-presets-demo"
     />
   </div>
 </section>

--- a/tests/date-range-picker.test.ts
+++ b/tests/date-range-picker.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('DateRangePicker — preset highlight', () => {
+  // Regression guard: when several presets fall on the same calendar day,
+  // selecting one preset must highlight only that preset. isPresetActive()
+  // previously matched by same-day instead of the chosen preset's label, so
+  // "Today", "Today morning" and "Today evening" all highlighted at once.
+  test('selecting one same-day preset highlights only that preset', async ({ page }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-same-day-presets-demo"]');
+    await expect(picker).toBeVisible();
+
+    // Open the dropdown.
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+
+    // All three same-day presets render; none is selected before a pick.
+    await expect(picker.locator('.drp-preset-item')).toHaveCount(3);
+    await expect(picker.locator('.drp-preset-item[aria-selected="true"]')).toHaveCount(0);
+
+    // Pick "Today" (exact, so it does not also match "Today morning"/"Today evening").
+    await picker.getByRole('option', { name: 'Today', exact: true }).click();
+
+    // Exactly one preset is highlighted, and it is the one we picked.
+    const active = picker.locator('.drp-preset-item[aria-selected="true"]');
+    await expect(active).toHaveCount(1);
+    await expect(active).toHaveText('Today');
+  });
+});


### PR DESCRIPTION
## Problem

In **single mode**, `isPresetActive()` returned `isSameDay(draftValue, preset.start)`. Because many presets share a calendar day, selecting any one of them highlighted **all** of them at once — selecting **Today** also highlighted **Last 30 minutes**, **Last 1 hour**, **Last 6 hours** and **Last 12 hours** (every preset that starts *today*). This surfaced in the Lighthouse dashboard (BZ-3733): the analytics date picker's timeline presets all appeared selected together.

## Root cause

`isPresetActive()` decided the active preset purely from the draft date's calendar day, so it could not distinguish two presets that begin on the same day. Range mode had the same latent issue (two presets sharing both start-day and end-day).

## Fix

The component already records the explicitly chosen preset in **`selectedPresetLabel`** — set in `handlePreset()` and cleared to `null` on a direct calendar click (`handleSingleSelect` / `handleRangeSelect`). So when a preset was actually picked, match it by **label**; only fall back to the existing same-day date logic for manual calendar selections.

```ts
// A preset was explicitly chosen this session — match it by label, not by date.
if (selectedPresetLabel !== null) {
  return preset.label === selectedPresetLabel;
}
```

- **No new state** — reuses `selectedPresetLabel`.
- **No behaviour change** for direct calendar clicks (`selectedPresetLabel` is `null` there, so the date-based fallbacks still run).
- Fixes both single and range modes.

## Tests

Added a **Playwright regression test** (`tests/date-range-picker.test.ts`) plus a same-day-presets demo fixture (`Today` / `Today morning` / `Today evening`, all on the same calendar day) on `/components/date-range-picker`. The test opens the picker, selects `Today`, and asserts exactly **one** preset is `aria-selected`.

Verified it actually guards the regression:
- **Without** the fix → fails: `expect(active).toHaveCount(1)` receives **3** (all same-day presets highlighted).
- **With** the fix → passes (only the chosen preset highlighted).

## Validation

- `pnpm run check` (svelte-check) → **0 errors** (4 pre-existing warnings, unrelated)
- `prettier --check` + `eslint` → clean
- `playwright test tests/date-range-picker.test.ts` → **1 passed**

## Notes / follow-up

Related but **separate**: the preset sidebar renders no selection tick/checkmark on the active preset (Lighthouse BZ-3734). That is a visual/design addition rather than a correctness fix, so it is intentionally left out of this PR — glad to follow up if the team wants it.
