### PR TITLE
feat(DateRangePicker): opt-in checkmark on the active preset

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -5,6 +5,7 @@
   import Calendar from '../Calendar/Calendar.svelte';
   import Button from '../Button/Button.svelte';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
+  import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
 
   let {
     rangeStart = $bindable(null),
@@ -16,6 +17,7 @@
     disabledDates = [],
     maxRangeDays = null,
     presets = null,
+    presetCheckmark = false,
     placeholder = 'Select date',
     dualMonth,
     timePicker,
@@ -545,11 +547,16 @@
                 type="button"
                 class="drp-preset-item"
                 class:drp-preset-active={isPresetActive(preset)}
+                class:drp-preset-checkable={presetCheckmark}
                 role="option"
                 aria-selected={isPresetActive(preset)}
                 onclick={() => handlePreset(preset)}
               >
                 {preset.label}
+                {#if presetCheckmark && isPresetActive(preset)}
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                  <span class="drp-preset-check" aria-hidden="true">{@html checkmarkSvg}</span>
+                {/if}
               </button>
             {/each}
           </div>
@@ -784,6 +791,29 @@
 
   .drp-preset-active:hover {
     background: var(--drp-preset-active-hover-background, #333333);
+  }
+
+  /* Opt-in checkmark layout: reserve a trailing slot so the active preset's tick
+     sits flush-right while the label stays left. A preset with no tick (or a
+     label-only preset) keeps its single flex child at the start, unchanged. */
+  .drp-preset-checkable {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--drp-preset-check-gap, 8px);
+  }
+
+  .drp-preset-check {
+    display: inline-flex;
+    flex-shrink: 0;
+    width: var(--drp-preset-check-size, 16px);
+    height: var(--drp-preset-check-size, 16px);
+    color: var(--drp-preset-check-color, inherit);
+  }
+
+  .drp-preset-check :global(svg) {
+    width: 100%;
+    height: 100%;
   }
 
   /* ── Calendar area ── */

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -33,6 +33,12 @@ export type OptionalDateRangePickerProperties = {
   maxRangeDays?: number | null;
   /** Preset options shown in the sidebar. Omit to hide the sidebar. */
   presets?: DateRangePreset[] | null;
+  /**
+   * Show a trailing checkmark on the active preset in the sidebar. Opt-in, so
+   * existing layouts are unchanged; the active preset is always distinguished by
+   * its highlighted background regardless of this flag. Default: false.
+   */
+  presetCheckmark?: boolean;
   /** Placeholder shown when no range is selected. */
   placeholder?: string;
   /** Show two months side by side. Defaults to true for range mode, false for single. */

--- a/src/routes/components/date-range-picker/+page.svelte
+++ b/src/routes/components/date-range-picker/+page.svelte
@@ -569,6 +569,24 @@
   </div>
 </section>
 
+<!-- ── 11. Active-preset checkmark (opt-in via presetCheckmark) ── -->
+<section class="demo-section">
+  <h2>Range mode — active-preset checkmark (presetCheckmark)</h2>
+  <p class="section-note">
+    With <code>presetCheckmark</code>, the active preset shows a trailing checkmark alongside its
+    highlighted background. Opt-in — pickers without the flag are unchanged.
+  </p>
+  <div class="demo-row">
+    <DateRangePicker
+      mode="range"
+      presets={commonPresets}
+      presetCheckmark
+      placeholder="Select range (with checkmark)"
+      testId="drp-preset-checkmark-demo"
+    />
+  </div>
+</section>
+
 <style>
   .page-description {
     color: #666;

--- a/tests/date-range-picker-checkmark.test.ts
+++ b/tests/date-range-picker-checkmark.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('DateRangePicker — active-preset checkmark', () => {
+  // With presetCheckmark enabled, the active preset shows a trailing checkmark;
+  // inactive presets show none, and no checkmark renders before a preset is picked.
+  test('shows a checkmark only on the active preset', async ({ page }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-preset-checkmark-demo"]');
+    await expect(picker).toBeVisible();
+
+    // Open the dropdown.
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+
+    // No checkmark before any preset is picked.
+    await expect(picker.locator('.drp-preset-check')).toHaveCount(0);
+
+    // Pick the "Today" preset.
+    await picker.getByRole('option', { name: 'Today', exact: true }).click();
+
+    // Exactly one checkmark, and it sits on the active "Today" preset.
+    await expect(picker.locator('.drp-preset-check')).toHaveCount(1);
+    const active = picker.locator('.drp-preset-item.drp-preset-active');
+    await expect(active).toContainText('Today');
+    await expect(active.locator('.drp-preset-check')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## What

Adds an **opt-in `presetCheckmark`** prop to `DateRangePicker`. When enabled, the active preset in the sidebar shows a trailing checkmark alongside its highlighted background.

```svelte
<DateRangePicker mode="range" presets={presets} presetCheckmark />
```

## Why

The sidebar marks the active preset only with a background/colour change. Consumers migrating from older in-house date pickers (e.g. Lighthouse, BZ-3734) relied on an explicit checkmark as the selection affordance, which this component didn't offer. This restores it without forcing the change on anyone.

## Design

- **Opt-in, default `false`** — pickers that don't set the flag render exactly as before (no markup, no layout change).
- Reuses the existing `assets/checkmark.svg` (`stroke="currentColor"`), so the tick inherits the active preset's colour (white on the filled active state) for free.
- The checkmark slot is only laid out when enabled: `.drp-preset-checkable` switches the preset button to `flex` + `space-between`; a label-only preset keeps its single child at the start, unchanged.
- Themeable via CSS variables: `--drp-preset-check-size` (16px), `--drp-preset-check-color` (inherit), `--drp-preset-check-gap` (8px).
- The tick is `aria-hidden` — selection state is already conveyed by `aria-selected` / `role="option"`.

## Files

- `src/lib/DateRangePicker/DateRangePicker.svelte` — prop, checkmark markup, styles
- `src/lib/DateRangePicker/properties.ts` — `presetCheckmark?: boolean` with docs
- `src/routes/components/date-range-picker/+page.svelte` — demo section
- `tests/date-range-picker-checkmark.test.ts` — Playwright test

## Validation

- `pnpm run check` (svelte-check) → **0 errors** (4 pre-existing warnings, unrelated)
- `prettier --check` + `eslint` → clean
- `playwright test tests/date-range-picker-checkmark.test.ts` → **1 passed** (checkmark appears on the active preset, none on inactive presets or before a pick)

## Relation to #310

Independent follow-up to #310 (which fixes the same-day false-multi-highlight in `isPresetActive`). This PR is purely additive (new opt-in prop); it does not change `isPresetActive`. Either can merge first.
