### PR TITLE
fix(DateRangePicker): keep the committed preset highlighted across the open cycle

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -112,6 +112,13 @@
 
   let activePresetLabel: string | null = $state(resolvedInitialPresetLabel);
 
+  // The preset whose range is currently committed (seeded from initialPresetLabel,
+  // updated on every Apply). Unlike activePresetLabel — which is cleared the moment
+  // the user interacts so the trigger can fall back to a date range — this survives
+  // the open/apply cycle so re-opening the picker re-highlights the committed preset
+  // by label instead of date-matching (which lights up every same-day preset at once).
+  let committedPresetLabel: string | null = $state(resolvedInitialPresetLabel);
+
   // Seed draft from initialPresetLabel whenever presets become available so
   // the calendar shows the preset's date selection when the picker is first
   // opened — even if presets arrive asynchronously after initial render.
@@ -194,8 +201,9 @@
     draftCompareStart = compareStart;
     draftCompareEnd = compareEnd;
 
-    // Reset preset tracking so each picker session starts clean.
-    selectedPresetLabel = null;
+    // Re-seed the session from the committed preset so the sidebar re-highlights it
+    // by label. A direct calendar click later clears this, reverting to date matching.
+    selectedPresetLabel = committedPresetLabel;
 
     // Navigate left calendar so it shows the committed start month (or today)
     const anchor = rangeStart !== null ? rangeStart : value !== null ? value : now;
@@ -266,6 +274,7 @@
       if (draftStart !== null && draftEnd !== null) {
         rangeStart = draftStart;
         rangeEnd = draftEnd;
+        committedPresetLabel = selectedPresetLabel;
         onapply?.({ rangeStart: draftStart, rangeEnd: draftEnd, presetLabel: selectedPresetLabel });
       }
       if (
@@ -284,6 +293,7 @@
     } else {
       if (draftValue !== null) {
         value = draftValue;
+        committedPresetLabel = selectedPresetLabel;
         onapplysingle?.({ date: draftValue, presetLabel: selectedPresetLabel });
       }
     }
@@ -293,6 +303,7 @@
   function handleClear(): void {
     value = null;
     draftValue = null;
+    committedPresetLabel = null;
     onclear?.();
     closePicker();
   }

--- a/tests/date-range-picker-reopen.test.ts
+++ b/tests/date-range-picker-reopen.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('DateRangePicker — committed preset persists across the open cycle', () => {
+  // Regression guard: after applying a preset, re-opening the picker must
+  // re-highlight that preset by label. openPicker() previously reset the session
+  // (selectedPresetLabel = null), so a second open fell back to same-day matching
+  // and lit up "Today" / "Today morning" / "Today evening" all at once again.
+  test('re-opening after applying a same-day preset highlights only the applied preset', async ({
+    page
+  }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-same-day-presets-demo"]');
+    await expect(picker).toBeVisible();
+
+    // Open, pick "Today" (exact), confirm a single highlight, then apply.
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await picker.getByRole('option', { name: 'Today', exact: true }).click();
+    await expect(picker.locator('.drp-preset-item[aria-selected="true"]')).toHaveCount(1);
+    await picker.getByRole('button', { name: 'Apply date selection' }).click();
+    await expect(picker.locator('.drp-panel')).toBeHidden();
+
+    // Re-open: only "Today" stays highlighted — not all three same-day presets.
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+    const active = picker.locator('.drp-preset-item[aria-selected="true"]');
+    await expect(active).toHaveCount(1);
+    await expect(active).toHaveText('Today');
+  });
+
+  // initialPresetLabel must seed the OPEN-state highlight, not just the trigger.
+  // Before the fix the open panel date-matched and could highlight more than the
+  // seeded preset; now exactly the seeded preset is active on first open.
+  test('initialPresetLabel highlights only the seeded preset on first open', async ({ page }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-initial-preset-demo"]');
+    await expect(picker).toBeVisible();
+
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+
+    const active = picker.locator('.drp-preset-item[aria-selected="true"]');
+    await expect(active).toHaveCount(1);
+    await expect(active).toHaveText('All time');
+  });
+});


### PR DESCRIPTION
## Problem

Follow-up to #310 (same-day preset highlight). That fix made an **explicit in-session click** match the active preset by **label**, but the active highlight still reverts to fuzzy `isSameDay()` matching the moment the picker is re-opened:

- `openPicker()` resets `selectedPresetLabel = null` on every open, and
- `handleApply()` clears `activePresetLabel`.

So after you apply a preset and re-open the picker — or on the very first open when `initialPresetLabel` is set — `isPresetActive()` falls through to date matching and re-highlights **every** preset that shares the committed day at once (e.g. `Today`, `Last 30 minutes`, `Last 12 Hours`). The `presetCheckmark` from #311 makes this more visible (multiple ticks).

## Fix

Track a `committedPresetLabel` — the preset whose range is actually committed:

- seeded from `initialPresetLabel`,
- updated to the applied preset on each **Apply** (or `null` for a custom calendar range),
- cleared on **Clear**.

`openPicker()` now re-seeds `selectedPresetLabel` from `committedPresetLabel` instead of `null`, so the active highlight is driven by **label** across the whole open/apply lifecycle:

- `initialPresetLabel` highlights only the seeded preset on first open;
- re-opening after applying a preset re-highlights only that preset;
- a direct calendar click still clears it, reverting to date-based matching for genuinely custom ranges (unchanged).

`activePresetLabel` (the trigger-display label) and the date-based fallback are untouched, so no existing behaviour changes for custom ranges.

## Test

`tests/date-range-picker-reopen.test.ts` — covers both the **re-open-after-apply** and **`initialPresetLabel`** cases. The re-open test is **proven to fail on the current `release` behaviour** (re-opening shows >1 active same-day preset) and passes with this change.

```
Running 4 tests using 3 workers
  4 passed   (date-range-picker + date-range-picker-checkmark + date-range-picker-reopen)
```

`svelte-check` 0 errors · `prettier` + `eslint` clean.

## Scope / limitation

`committedPresetLabel` reflects what was applied **through the picker**. A consumer that mutates `rangeStart`/`rangeEnd` externally (bypassing Apply) and wants the highlight to follow should pass `initialPresetLabel`; otherwise the label may be momentarily stale until the next Apply. This matches how `activePresetLabel` already behaves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DateRangePicker now remembers the last applied preset and keeps it highlighted when reopening for improved continuity.

* **Tests**
  * Added test coverage for preset persistence behavior and initial preset label handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->