### PR TITLE
BZ-3839: feat: add alignment for DateRangePicker

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -21,6 +21,7 @@
     placeholder = 'Select date',
     dualMonth,
     timePicker,
+    align = 'left',
     compareStart = $bindable(null),
     compareEnd = $bindable(null),
     compareCalendar,
@@ -535,6 +536,8 @@
     <div
       bind:this={panelRef}
       class="drp-panel"
+      class:drp-panel-align-left={align === 'left'}
+      class:drp-panel-align-right={align === 'right'}
       role="dialog"
       aria-label="Date range picker"
       aria-modal="true"
@@ -747,7 +750,6 @@
   .drp-panel {
     position: absolute;
     top: calc(100% + var(--drp-panel-offset, 6px));
-    left: 0;
     z-index: var(--drp-panel-z-index, 1000);
     background: var(--drp-panel-background, inherit);
     border: var(--drp-panel-border, 1px solid #e0e0e0);
@@ -758,6 +760,16 @@
     min-width: var(--drp-panel-min-width, 320px);
     max-width: var(--drp-panel-max-width, 760px);
     overflow: hidden;
+  }
+
+  .drp-panel-align-left {
+    left: 0;
+    right: auto;
+  }
+
+  .drp-panel-align-right {
+    right: 0;
+    left: auto;
   }
 
   .drp-panel-inner {

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -13,6 +13,7 @@ export type DateRangePreset = {
 };
 
 export type DateRangePickerMode = 'range' | 'single';
+export type DateRangePickerAlign = 'left' | 'right';
 
 export type OptionalDateRangePickerProperties = {
   /** Currently selected start of range (bindable). */
@@ -43,6 +44,8 @@ export type OptionalDateRangePickerProperties = {
   placeholder?: string;
   /** Show two months side by side. Defaults to true for range mode, false for single. */
   dualMonth?: boolean;
+  /** Align the dropdown panel to the left or right edge of the trigger. Default: 'left'. */
+  align?: DateRangePickerAlign;
   /** Snippet rendered in the time-picker slot. Consumer controls all time UI. */
   timePicker?: Snippet;
   /** Start of compare range (bindable). Used when compareCalendar snippet is provided. */

--- a/src/wc/components/DateRangePicker.wc.svelte
+++ b/src/wc/components/DateRangePicker.wc.svelte
@@ -13,6 +13,7 @@
       presets: { type: 'Object' },
       placeholder: { type: 'String' },
       dualMonth: { type: 'Boolean', reflect: true, attribute: 'dual-month' },
+      align: { type: 'String', reflect: true },
       compareStart: { type: 'Object' },
       compareEnd: { type: 'Object' },
       weekStartsOn: { type: 'Number', reflect: true, attribute: 'week-starts-on' },


### PR DESCRIPTION
- add alignment for DateRangePicker
- Left align to align the datePicker component left side
- Right align to align the datePicker component right side
DEV PROOF:
Before:

<img width="1721" height="933" alt="Screenshot 2026-06-17 at 2 04 52 AM" src="https://github.com/user-attachments/assets/21c19597-2499-4348-ad62-c1f2a48caa9c" />

After:
IN MANDATE DASHBOARD
<img width="1104" height="511" alt="Screenshot 2026-06-17 at 8 57 50 PM" src="https://github.com/user-attachments/assets/0b852cd9-033a-4030-b05c-9bdd76c0b616" />

IN ANALYTICS DASHBOARD
<img width="924" height="727" alt="Screenshot 2026-06-17 at 8 57 58 PM" src="https://github.com/user-attachments/assets/c4eb8e88-3265-4e30-901f-ba50d9803698" />

