### PR TITLE
feat(Select): render multi-select option indicator as a design-system checkbox box

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -46,7 +46,7 @@ Pin arbitrary content (e.g. a "Manage…" link) to the bottom of the dropdown:
 
 ### With Custom optionIndicator Snippet (Multi-Select)
 
-Replace the default ☐/☑ glyphs with a custom indicator:
+Replace the default checkbox indicator with a custom one:
 
 ```svelte
 <Select {items} multiple placeholder="Pick items">
@@ -108,7 +108,7 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | Snippet         | Type                                                  | Description                                                                                                                                                                                                              |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | bottomContent   | `Snippet`                                             | Arbitrary content rendered at the bottom of the open dropdown, separated by a border. Use for "Manage options" links or bulk actions.                                                                                    |
-| optionIndicator | `Snippet<[{ checked: boolean }]>`                     | Custom indicator rendered before each option label in multi-select mode. Receives `{ checked }` and replaces the default ☐/☑ glyphs when provided.                                                                       |
+| optionIndicator | `Snippet<[{ checked: boolean }]>`                     | Custom indicator rendered before each option label in multi-select mode. Receives `{ checked }` and replaces the default checkbox-box indicator when provided.                                                           |
 | triggerSummary  | `Snippet<[{ value: string[]; items: SelectItem[] }]>` | Compact trigger summary for multi-select mode. Receives `{ value, items }` so the consumer can render e.g. "All" or "3 selected" instead of one Pill per value. When omitted, the default Pill-per-value layout is used. |
 
 ## Events
@@ -192,18 +192,26 @@ Override these custom properties to theme the component.
 
 ### Options
 
-| Variable                                    | Default                                        | CSS Property | Description                                                               |
-| ------------------------------------------- | ---------------------------------------------- | ------------ | ------------------------------------------------------------------------- |
-| `--select-option-padding`                   | `8px 12px`                                     | padding      | Padding inside each dropdown option.                                      |
-| `--select-option-color`                     | `#333333`                                      | color        | Text color of dropdown options.                                           |
-| `--select-option-font-size`                 | `inherit`                                      | font-size    | Font size of dropdown options.                                            |
-| `--select-option-gap`                       | `0`                                            | gap          | Gap between the option indicator and the label text in multi-select mode. |
-| `--select-option-hover-background`          | `#f0f0f0`                                      | background   | Background of options on hover or keyboard highlight.                     |
-| `--select-option-hover-color`               | inherits `--select-option-color`               | color        | Text color of options on hover or keyboard highlight.                     |
-| `--select-option-selected-background`       | `#e8f0fe`                                      | background   | Background of selected options.                                           |
-| `--select-option-selected-color`            | inherits `--select-option-color`               | color        | Text color of selected options.                                           |
-| `--select-option-selected-hover-background` | inherits `--select-option-selected-background` | background   | Background of selected options on hover.                                  |
-| `--select-option-indicator-color`           | `currentColor`                                 | color        | Color of the default ☐/☑ indicator shown per option in multi-select mode. |
+| Variable                                         | Default                                        | CSS Property  | Description                                                                                                                              |
+| ------------------------------------------------ | ---------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--select-option-padding`                        | `8px 12px`                                     | padding       | Padding inside each dropdown option.                                                                                                     |
+| `--select-option-color`                          | `#333333`                                      | color         | Text color of dropdown options.                                                                                                          |
+| `--select-option-font-size`                      | `inherit`                                      | font-size     | Font size of dropdown options.                                                                                                           |
+| `--select-option-gap`                            | `0`                                            | gap           | Gap between the option indicator and the label text in multi-select mode.                                                                |
+| `--select-option-hover-background`               | `#f0f0f0`                                      | background    | Background of options on hover or keyboard highlight.                                                                                    |
+| `--select-option-hover-color`                    | inherits `--select-option-color`               | color         | Text color of options on hover or keyboard highlight.                                                                                    |
+| `--select-option-selected-background`            | `#e8f0fe`                                      | background    | Background of selected options.                                                                                                          |
+| `--select-option-selected-color`                 | inherits `--select-option-color`               | color         | Text color of selected options.                                                                                                          |
+| `--select-option-selected-hover-background`      | inherits `--select-option-selected-background` | background    | Background of selected options on hover.                                                                                                 |
+| `--select-option-indicator-size`                 | `18px`                                         | width, height | Size of the default multi-select checkbox indicator box.                                                                                 |
+| `--select-option-indicator-border`               | `2px solid #757575`                            | border        | Border of the unchecked indicator box.                                                                                                   |
+| `--select-option-indicator-border-radius`        | `3px`                                          | border-radius | Corner rounding of the indicator box.                                                                                                    |
+| `--select-option-indicator-background`           | `transparent`                                  | background    | Background of the unchecked indicator box.                                                                                               |
+| `--select-option-indicator-checked-background`   | `#2196f3`                                      | background    | Background of the checked indicator box.                                                                                                 |
+| `--select-option-indicator-checked-border-color` | `#2196f3`                                      | border-color  | Border color of the checked indicator box.                                                                                               |
+| `--select-option-indicator-check-size`           | `12px`                                         | width, height | Size of the checkmark inside a checked indicator.                                                                                        |
+| `--select-option-indicator-check-color`          | `#ffffff`                                      | color         | Color of the checkmark inside a checked indicator.                                                                                       |
+| `--select-option-indicator-color`                | `currentColor`                                 | color         | Legacy text-color hook on the indicator wrapper. Inert for the default checkbox box; only affects a text-glyph custom `optionIndicator`. |
 
 ### Bottom Content
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -4,6 +4,7 @@
   import Pill from '$lib/Pill/Pill.svelte';
   import Img from '$lib/Img/Img.svelte';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
+  import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
 
   let {
     items: rawItems,
@@ -378,9 +379,16 @@
               {#if typeof optionIndicator === 'function'}
                 {@render optionIndicator({ checked: value.includes(item.id) })}
               {:else}
-                <span class="select-option-indicator" aria-hidden="true"
-                  >{value.includes(item.id) ? '☑' : '☐'}</span
+                <span
+                  class="select-option-indicator"
+                  class:checked={value.includes(item.id)}
+                  aria-hidden="true"
                 >
+                  {#if value.includes(item.id)}
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <span class="select-option-check">{@html checkmarkSvg}</span>
+                  {/if}
+                </span>
               {/if}
             {/if}
             {item.label}
@@ -557,8 +565,37 @@
   .select-option-indicator {
     display: inline-flex;
     align-items: center;
-    color: var(--select-option-indicator-color, currentColor);
+    justify-content: center;
     flex-shrink: 0;
+    box-sizing: border-box;
+    width: var(--select-option-indicator-size, 18px);
+    height: var(--select-option-indicator-size, 18px);
+    border: var(--select-option-indicator-border, 2px solid #757575);
+    border-radius: var(--select-option-indicator-border-radius, 3px);
+    background-color: var(--select-option-indicator-background, transparent);
+    color: var(--select-option-indicator-color, currentColor);
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+  }
+
+  .select-option-indicator.checked {
+    background-color: var(--select-option-indicator-checked-background, #2196f3);
+    border-color: var(--select-option-indicator-checked-border-color, #2196f3);
+  }
+
+  .select-option-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--select-option-indicator-check-size, 12px);
+    height: var(--select-option-indicator-check-size, 12px);
+    color: var(--select-option-indicator-check-color, #ffffff);
+  }
+
+  .select-option-check :global(svg) {
+    width: 100%;
+    height: 100%;
   }
 
   .select-empty {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -24,6 +24,14 @@ export type OptionalSelectProperties = {
   placeholder?: string;
   disabled?: boolean;
   bottomContent?: Snippet;
+  /**
+   * Snippet for rendering a custom multi-select option indicator, receiving `{ checked }`.
+   * When omitted, multiple-mode options render a design-system checkbox box (bordered square
+   * that fills and shows a checkmark when selected), themeable via the `--select-option-indicator-*`
+   * CSS variables: `-size` (18px), `-border`, `-border-radius`, `-background`,
+   * `-checked-background`, `-checked-border-color`, `-check-size`, `-check-color`. Provide this
+   * snippet to fully replace the indicator (e.g. to restore the legacy ☑/☐ glyph).
+   */
   optionIndicator?: Snippet<[{ checked: boolean }]>;
   testId?: string;
   /** Fallback per-option test id prefix. Each option emits `data-pw="{itemTestId}-{id}"` when its own `item.testId` is not set. */

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -82,7 +82,13 @@
 
 <h3>Multi select</h3>
 <div class="demo-row" style="max-width: 400px;">
-  <Select items={fruits} multiple bind:value={multiValue} placeholder="Pick fruits" />
+  <Select
+    items={fruits}
+    multiple
+    bind:value={multiValue}
+    placeholder="Pick fruits"
+    testId="select-multi-demo"
+  />
   {#if multiValue.length > 0}
     <p class="demo-info">Selected IDs: {multiValue.join(', ')}</p>
   {/if}
@@ -138,7 +144,7 @@
 </div>
 
 <h3>optionIndicator snippet (multi-select)</h3>
-<p>Replace the default ☐/☑ glyphs with a custom indicator rendered per option.</p>
+<p>Replace the default checkbox indicator with a custom one rendered per option.</p>
 <div class="demo-row" style="max-width: 400px;">
   <Select items={languages} multiple bind:value={customIndicatorValue} placeholder="Pick languages">
     {#snippet optionIndicator({ checked })}

--- a/tests/select-multi-indicator.test.ts
+++ b/tests/select-multi-indicator.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Select — multi-select checkbox indicator', () => {
+  // The default multi-select option indicator is a design-system checkbox box:
+  // an unchecked bordered square that fills and shows a checkmark when selected
+  // (replacing the legacy ☐/☑ text glyph).
+  test('renders a checkbox box that fills with a checkmark when an option is selected', async ({
+    page
+  }) => {
+    await page.goto('/components/select');
+
+    const select = page.locator('[data-pw="select-multi-demo"]');
+    await expect(select).toBeVisible();
+
+    // Open the dropdown.
+    await select.getByRole('combobox').click();
+    const listbox = select.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+
+    // Every option carries a checkbox-box indicator; none are checked initially.
+    const indicators = listbox.locator('.select-option-indicator');
+    expect(await indicators.count()).toBeGreaterThan(0);
+    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(0);
+
+    // Selecting an option fills exactly one box and renders a checkmark svg inside it.
+    await listbox.getByRole('option', { name: 'Apple', exact: true }).click();
+    const checked = listbox.locator('.select-option-indicator.checked');
+    await expect(checked).toHaveCount(1);
+    await expect(checked.locator('svg')).toHaveCount(1);
+
+    // Multi-select keeps the dropdown open; a second pick adds a second checked box.
+    await listbox.getByRole('option', { name: 'Cherry', exact: true }).click();
+    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
## Summary

In multi-select mode, `Select` rendered each option's selection state as a **unicode `☑`/`☐` glyph** (`select-option-indicator`). Consumers reported it renders as a *tiny, unstyled square* inconsistent with the design system (even the checked state was just a thin grey glyph).

This replaces the default indicator with a **presentational checkbox box** that matches the `Checkbox` component's look: a bordered square that fills accent-blue with a white checkmark when selected.

| State | Before | After |
|---|---|---|
| Unchecked | grey `☐` text glyph (~13×21px, font-dependent) | **18×18 bordered box** (`2px solid #757575`, 3px radius) |
| Checked | grey `☑` text glyph | **blue box `#2196f3` + white checkmark svg** |

## Why a presentational box (not the `Checkbox` component)

The option row (`role="option"`) already owns selection + `aria-selected` and toggles on click. Rendering the interactive `<Checkbox>` here would nest a focusable `role="checkbox"` inside `role="option"` (invalid a11y) and double-fire the toggle. So the indicator is a **presentational** box reusing the bundled `checkmark.svg` and the same visual tokens — no interactivity, clicks pass through to the option.

## Backward compatibility / theming

- The **`optionIndicator` snippet still fully overrides** the indicator (e.g. to restore the legacy glyph) — unchanged.
- New themeable CSS variables (all defaulted to match `Checkbox`): `--select-option-indicator-size` (18px), `-border`, `-border-radius`, `-background`, `-checked-background`, `-checked-border-color`, `-check-size`, `-check-color`.
- `--select-option-indicator-color` is kept as an inert legacy hook (only affects a text-glyph custom indicator).
- Note: consumers that sized the old glyph via `font-size` on `.select-option-indicator` will find that inert; size via `--select-option-indicator-size` instead.

## Changes
- `src/lib/Select/Select.svelte` — default multi indicator → presentational checkbox box (import `checkmark.svg`, `class:checked`, box + check CSS).
- `src/lib/Select/properties.ts` — documented the new default + CSS vars on `optionIndicator`.
- `docs/Select.md` + demo `+page.svelte` — updated wording, added the new CSS-var rows, added a `testId` to the multi demo.
- `tests/select-multi-indicator.test.ts` — new integration test.

## Verification
- New integration test passes (checkbox box renders; selecting fills exactly one box + checkmark; second pick → 2 checked).
- `vitest` 21 passed · `svelte-check` 0 errors · `eslint`/`prettier` clean.
- Pre-existing `tooltip.test.ts` / `test.ts` failures are unrelated (verified identical on the clean `release` baseline without this change).
- Manually verified on the live demo: unchecked = `2px solid rgb(117,117,117)` 18px box; checked = `rgb(33,150,243)` fill + white checkmark svg.

Fixes the downstream "multi-select checkboxes render as tiny unstyled squares" report (Lighthouse BZ-3769).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-select Select component now displays SVG checkmarks in option indicators for improved clarity.
  * Expanded CSS variables for detailed indicator styling control (size, border, border-radius, background, colors).

* **Documentation**
  * Refined Select documentation with updated `optionIndicator` descriptions and comprehensive CSS variables reference.

* **Tests**
  * Added test coverage for multi-select indicator behavior and selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->