### PR TITLE
feat(Modal): expose disabled-state vars for footer buttons

### DIFF
--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -335,6 +335,19 @@
     --cursor: var(--modal-footer-secondary-button-cursor, pointer);
     --opacity: var(--modal-footer-secondary-button-opacity, 1);
     --button-border: var(--modal-footer-secondary-button-border, none);
+    --disabled-background-color: var(
+      --modal-footer-secondary-button-disabled-color,
+      var(--modal-footer-secondary-button-color, #3a4550)
+    );
+    --disabled-text-color: var(
+      --modal-footer-secondary-button-disabled-text-color,
+      var(--modal-footer-secondary-button-text-color, white)
+    );
+    --disabled-border: var(
+      --modal-footer-secondary-button-disabled-border,
+      var(--modal-footer-secondary-button-border, none)
+    );
+    --disabled-opacity: var(--modal-footer-secondary-button-disabled-opacity, 0.4);
     --button-justify-content: var(--modal-footer-secondary-button-justify-content, center);
     --button-content-flex-direction: var(
       --modal-footer-secondary-button-content-flex-direction,
@@ -363,6 +376,19 @@
     --cursor: var(--modal-footer-primary-button-cursor, pointer);
     --opacity: var(--modal-footer-primary-button-opacity, 1);
     --button-border: var(--modal-footer-primary-button-border, none);
+    --disabled-background-color: var(
+      --modal-footer-primary-button-disabled-color,
+      var(--modal-footer-primary-button-color, #3a4550)
+    );
+    --disabled-text-color: var(
+      --modal-footer-primary-button-disabled-text-color,
+      var(--modal-footer-primary-button-text-color, white)
+    );
+    --disabled-border: var(
+      --modal-footer-primary-button-disabled-border,
+      var(--modal-footer-primary-button-border, none)
+    );
+    --disabled-opacity: var(--modal-footer-primary-button-disabled-opacity, 0.4);
     --button-justify-content: var(--modal-footer-primary-button-justify-content, center);
     --button-content-flex-direction: var(--modal-footer-primary-button-content-flex-direction, row);
     --button-content-gap: var(--modal-footer-primary-button-content-gap, 16px);


### PR DESCRIPTION
## Summary

Footer primary/secondary buttons exposed no disabled-state escape hatches, so a disabled footer button fell back to its own `--button-color` as the disabled background — e.g. a disabled primary action stays **solid blue**, only faded by the Button's default `opacity: 0.4`. That reads as a faded-blue button rather than a clearly disabled one.

## Change

Wire the library Button's disabled escape-hatch vars on `.footer-primary-button` and `.footer-secondary-button` to new, themeable tokens:

- `--modal-footer-{primary,secondary}-button-disabled-color` → `--disabled-background-color`
- `--modal-footer-{primary,secondary}-button-disabled-text-color` → `--disabled-text-color`
- `--modal-footer-{primary,secondary}-button-disabled-border` → `--disabled-border`
- `--modal-footer-{primary,secondary}-button-disabled-opacity` → `--disabled-opacity`

**Purely additive / non-breaking:** each default preserves the current behaviour (disabled bg = the button's colour, disabled text = the button's text, `0.4` opacity, the button's border). Consumers can now opt into a clear disabled state — e.g. a grey bg with muted text — without forking the Modal.

## Downstream

Unblocks the Lighthouse (Breeze) report that a disabled "Add Zone" modal-footer button isn't clearly distinguishable from its enabled state — they'll set `--modal-footer-primary-button-disabled-color` to a neutral grey.

## Gates

`lint` ✓ · `check` ✓ (0 errors) · `build`/`publint` ✓. Change is CSS-var-only (26 insertions, +0/−0 behaviour for existing consumers).