### PR TITLE
feat(DateRangePicker): built-in date inputs + time-of-day selection

### DIFF
--- a/docs/DateRangePicker.md
+++ b/docs/DateRangePicker.md
@@ -80,6 +80,20 @@ The component does not build time input UI. Pass a `timePicker` snippet to rende
 </DateRangePicker>
 ```
 
+### Built-in date inputs + time selection
+
+For a richer panel without owning any time state, opt into `showDateInputs` (read-only start/end date boxes at the top of the calendar) and `showTimeSelection` (a clock toggle revealing start/end time inputs). The entered times are folded onto the committed range on Apply; Apply is blocked while a time is malformed or — when both ends are the same day — the start time is after the end time. Both are range-mode only.
+
+```svelte
+<DateRangePicker
+  mode="range"
+  {presets}
+  showDateInputs
+  showTimeSelection
+  placeholder="Select range + time"
+/>
+```
+
 ### With compare calendar (consumer snippet)
 
 Pass a `compareCalendar` snippet to render a comparison period section inside the panel. The consumer controls all compare state and wires `onapplycompare` to commit it.
@@ -252,6 +266,8 @@ Add a `group` key to any `DateRangePreset`. A thin divider (with an optional gro
 | maxDate            | `Date \| null`                        | No       | `null`          | Latest selectable date.                                                                                                                                                                                                                                                                                                         |
 | disabledDates      | `Date[] \| ((date: Date) => boolean)` | No       | `[]`            | Dates that cannot be selected. Pass an array or a predicate function.                                                                                                                                                                                                                                                           |
 | presets            | `DateRangePreset[] \| null`           | No       | `null`          | Preset options shown in the sidebar. Omit or pass null to hide the sidebar.                                                                                                                                                                                                                                                     |
+| showDateInputs     | `boolean`                             | No       | `false`         | Range mode only. Show read-only start/end date boxes at the top of the calendar area, reflecting the current draft selection.                                                                                                                                                                                                   |
+| showTimeSelection  | `boolean`                             | No       | `false`         | Range mode only. Show a clock toggle in the date-input row that reveals start/end time inputs (`HH:MM AM/PM`); the entered times are folded onto the committed range's start/end on Apply. Implies the date-input row, and blocks Apply while a time is malformed or (same day) the start time is after the end time.           |
 | placeholder        | `string`                              | No       | `'Select date'` | Text shown on the trigger when no date is selected.                                                                                                                                                                                                                                                                             |
 | dualMonth          | `boolean`                             | No       | `undefined`     | Show two months side by side. Defaults to true for range mode, false for single. Pass an explicit boolean to override.                                                                                                                                                                                                          |
 | timePicker         | `Snippet`                             | No       | —               | Snippet rendered inside a `.drp-time-row` wrapper below the calendars. Consumer owns all time state and input elements.                                                                                                                                                                                                         |
@@ -292,79 +308,89 @@ Add a `group` key to any `DateRangePreset`. A thin divider (with an optional gro
 
 Override these custom properties to theme the component.
 
-| Variable                               | Default                       | Description                                                           |
-| -------------------------------------- | ----------------------------- | --------------------------------------------------------------------- |
-| `--drp-trigger-background`             | `inherit`                     | Trigger button background color.                                      |
-| `--drp-trigger-border`                 | `1px solid currentColor`      | Trigger button border.                                                |
-| `--drp-trigger-border-radius`          | `6px`                         | Trigger button corner rounding.                                       |
-| `--drp-trigger-color`                  | `inherit`                     | Trigger button text color.                                            |
-| `--drp-trigger-padding`                | `8px 12px`                    | Trigger button inner padding.                                         |
-| `--drp-trigger-min-width`              | `200px`                       | Minimum width of the trigger button.                                  |
-| `--drp-trigger-gap`                    | `8px`                         | Gap between label and icon in the trigger.                            |
-| `--drp-trigger-hover-border-color`     | `currentColor`                | Trigger border color on hover.                                        |
-| `--drp-trigger-open-border-color`      | `#000000`                     | Trigger border color when the panel is open.                          |
-| `--drp-trigger-open-shadow`            | `0 0 0 2px rgba(0,0,0,0.1)`   | Trigger box-shadow when the panel is open.                            |
-| `--drp-trigger-icon-color`             | `inherit`                     | Color of the trigger chevron icon.                                    |
-| `--drp-panel-offset`                   | `6px`                         | Vertical gap between the trigger and the panel.                       |
-| `--drp-panel-z-index`                  | `1000`                        | Panel stack order.                                                    |
-| `--drp-panel-background`               | `inherit`                     | Panel background color.                                               |
-| `--drp-panel-border`                   | `1px solid #e0e0e0`           | Panel border.                                                         |
-| `--drp-panel-border-radius`            | `10px`                        | Panel corner rounding.                                                |
-| `--drp-panel-shadow`                   | `0 8px 24px rgba(0,0,0,0.12)` | Panel drop shadow.                                                    |
-| `--drp-panel-min-width`                | `320px`                       | Minimum width of the panel.                                           |
-| `--drp-panel-max-width`                | `760px`                       | Maximum width of the panel.                                           |
-| `--drp-sidebar-padding`                | `12px 8px`                    | Padding inside the presets sidebar.                                   |
-| `--drp-sidebar-border`                 | `1px solid #e8e8e8`           | Right border of the presets sidebar.                                  |
-| `--drp-sidebar-min-width`              | `140px`                       | Minimum width of the presets sidebar.                                 |
-| `--drp-sidebar-max-height`             | `400px`                       | Maximum height of the presets sidebar (scrollable).                   |
-| `--drp-preset-padding`                 | `7px 12px`                    | Padding of each preset button.                                        |
-| `--drp-preset-border-radius`           | `5px`                         | Corner rounding of preset buttons.                                    |
-| `--drp-preset-color`                   | `inherit`                     | Text color of preset buttons.                                         |
-| `--drp-preset-hover-background`        | `#f5f5f5`                     | Background of preset buttons on hover.                                |
-| `--drp-preset-active-background`       | `currentColor`                | Background of the active/selected preset button.                      |
-| `--drp-preset-active-color`            | `#ffffff`                     | Text color of the active/selected preset button.                      |
-| `--drp-preset-active-hover-background` | `#333333`                     | Background of the active preset button on hover.                      |
-| `--drp-calendars-padding`              | `16px`                        | Padding around the calendar area.                                     |
-| `--drp-calendars-gap`                  | `16px`                        | Gap between calendar area sections (header, calendars, footer slots). |
-| `--drp-month-label-color`              | `inherit`                     | Color of the dual-month header labels.                                |
-| `--drp-nav-btn-size`                   | `32px`                        | Size of the dual-month navigation buttons.                            |
-| `--drp-nav-btn-border-radius`          | `4px`                         | Corner rounding of navigation buttons.                                |
-| `--drp-nav-btn-color`                  | `inherit`                     | Color of navigation button chevrons.                                  |
-| `--drp-nav-btn-hover-background`       | `#f0f0f0`                     | Background of navigation buttons on hover.                            |
-| `--drp-nav-chevron-border`             | `2px solid currentColor`      | Chevron border style for navigation arrows.                           |
-| `--drp-months-gap`                     | `24px`                        | Gap between the two calendars in dual-month mode.                     |
-| `--drp-time-row-gap`                   | `16px`                        | Gap between elements in the time-picker row wrapper.                  |
-| `--drp-time-row-padding-top`           | `8px`                         | Top padding of the time-picker row wrapper.                           |
-| `--drp-time-divider`                   | `1px solid #e8e8e8`           | Top border of the time-picker row wrapper.                            |
-| `--drp-compare-padding-top`            | `12px`                        | Top padding of the compare-calendar section wrapper.                  |
-| `--drp-compare-divider`                | `1px solid #e8e8e8`           | Top border of the compare-calendar section wrapper.                   |
-| `--drp-footer-gap`                     | `8px`                         | Gap between footer buttons.                                           |
-| `--drp-footer-padding`                 | `12px 16px`                   | Padding of the footer.                                                |
-| `--drp-footer-border`                  | `1px solid #e8e8e8`           | Top border of the footer.                                             |
-| `--drp-cancel-border-color`            | `#d0d0d0`                     | Cancel button border color.                                           |
-| `--drp-cancel-color`                   | `inherit`                     | Cancel button text color.                                             |
-| `--drp-cancel-hover-background`        | `#f5f5f5`                     | Cancel button background on hover.                                    |
-| `--drp-apply-background`               | `currentColor`                | Apply button background color.                                        |
-| `--drp-apply-color`                    | `#ffffff`                     | Apply button text color.                                              |
-| `--drp-apply-hover-background`         | `#333333`                     | Apply button background on hover.                                     |
-| `--drp-apply-disabled-background`      | `#cccccc`                     | Apply button background when disabled.                                |
-| `--drp-apply-disabled-color`           | `#888888`                     | Apply button text color when disabled.                                |
-| `--drp-clear-border-color`             | `#d0d0d0`                     | Clear button border color (single-mode `clearable`).                  |
-| `--drp-clear-color`                    | `inherit`                     | Clear button text color.                                              |
-| `--drp-clear-hover-background`         | `#f5f5f5`                     | Clear button background on hover.                                     |
-| `--drp-preset-divider-border`          | `1px solid #e8e8e8`           | Border style for the preset group divider line.                       |
-| `--drp-preset-divider-gap`             | `6px`                         | Gap between the divider line and the group label.                     |
-| `--drp-preset-divider-margin`          | `4px 0`                       | Vertical margin above and below each preset group divider.            |
-| `--drp-preset-group-label-color`       | `#999999`                     | Text color of the preset group label rendered beside the divider.     |
-| `--drp-preset-divider-leader-width`    | `8px`                         | Width of the leading line segment before the group label.             |
-| `--drp-compare-trigger-background`     | `inherit`                     | Compare trigger button background.                                    |
-| `--drp-compare-trigger-border`         | `1px solid currentColor`      | Compare trigger button border.                                        |
-| `--drp-compare-trigger-border-radius`  | `6px`                         | Compare trigger button corner rounding.                               |
-| `--drp-compare-trigger-color`          | `inherit`                     | Compare trigger button text color.                                    |
-| `--drp-compare-trigger-padding`        | `8px 12px`                    | Compare trigger button inner padding.                                 |
-| `--drp-compare-trigger-min-width`      | `160px`                       | Compare trigger button minimum width.                                 |
-| `--drp-compare-panel-left`             | `0`                           | Left offset of the standalone compare panel relative to its trigger.  |
-| `--drp-compare-panel-min-width`        | `280px`                       | Minimum width of the standalone compare panel.                        |
+| Variable                               | Default                       | Description                                                                  |
+| -------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------- |
+| `--drp-trigger-background`             | `inherit`                     | Trigger button background color.                                             |
+| `--drp-trigger-border`                 | `1px solid currentColor`      | Trigger button border.                                                       |
+| `--drp-trigger-border-radius`          | `6px`                         | Trigger button corner rounding.                                              |
+| `--drp-trigger-color`                  | `inherit`                     | Trigger button text color.                                                   |
+| `--drp-trigger-padding`                | `8px 12px`                    | Trigger button inner padding.                                                |
+| `--drp-trigger-min-width`              | `200px`                       | Minimum width of the trigger button.                                         |
+| `--drp-trigger-gap`                    | `8px`                         | Gap between label and icon in the trigger.                                   |
+| `--drp-trigger-hover-border-color`     | `currentColor`                | Trigger border color on hover.                                               |
+| `--drp-trigger-open-border-color`      | `#000000`                     | Trigger border color when the panel is open.                                 |
+| `--drp-trigger-open-shadow`            | `0 0 0 2px rgba(0,0,0,0.1)`   | Trigger box-shadow when the panel is open.                                   |
+| `--drp-trigger-icon-color`             | `inherit`                     | Color of the trigger chevron icon.                                           |
+| `--drp-panel-offset`                   | `6px`                         | Vertical gap between the trigger and the panel.                              |
+| `--drp-panel-z-index`                  | `1000`                        | Panel stack order.                                                           |
+| `--drp-panel-background`               | `inherit`                     | Panel background color.                                                      |
+| `--drp-panel-border`                   | `1px solid #e0e0e0`           | Panel border.                                                                |
+| `--drp-panel-border-radius`            | `10px`                        | Panel corner rounding.                                                       |
+| `--drp-panel-shadow`                   | `0 8px 24px rgba(0,0,0,0.12)` | Panel drop shadow.                                                           |
+| `--drp-panel-min-width`                | `320px`                       | Minimum width of the panel.                                                  |
+| `--drp-panel-max-width`                | `760px`                       | Maximum width of the panel.                                                  |
+| `--drp-sidebar-padding`                | `12px 8px`                    | Padding inside the presets sidebar.                                          |
+| `--drp-sidebar-border`                 | `1px solid #e8e8e8`           | Right border of the presets sidebar.                                         |
+| `--drp-sidebar-min-width`              | `140px`                       | Minimum width of the presets sidebar.                                        |
+| `--drp-sidebar-max-height`             | `400px`                       | Maximum height of the presets sidebar (scrollable).                          |
+| `--drp-preset-padding`                 | `7px 12px`                    | Padding of each preset button.                                               |
+| `--drp-preset-border-radius`           | `5px`                         | Corner rounding of preset buttons.                                           |
+| `--drp-preset-color`                   | `inherit`                     | Text color of preset buttons.                                                |
+| `--drp-preset-hover-background`        | `#f5f5f5`                     | Background of preset buttons on hover.                                       |
+| `--drp-preset-active-background`       | `currentColor`                | Background of the active/selected preset button.                             |
+| `--drp-preset-active-color`            | `#ffffff`                     | Text color of the active/selected preset button.                             |
+| `--drp-preset-active-hover-background` | `#333333`                     | Background of the active preset button on hover.                             |
+| `--drp-calendars-padding`              | `16px`                        | Padding around the calendar area.                                            |
+| `--drp-calendars-gap`                  | `16px`                        | Gap between calendar area sections (header, calendars, footer slots).        |
+| `--drp-month-label-color`              | `inherit`                     | Color of the dual-month header labels.                                       |
+| `--drp-nav-btn-size`                   | `32px`                        | Size of the dual-month navigation buttons.                                   |
+| `--drp-nav-btn-border-radius`          | `4px`                         | Corner rounding of navigation buttons.                                       |
+| `--drp-nav-btn-color`                  | `inherit`                     | Color of navigation button chevrons.                                         |
+| `--drp-nav-btn-hover-background`       | `#f0f0f0`                     | Background of navigation buttons on hover.                                   |
+| `--drp-nav-chevron-border`             | `2px solid currentColor`      | Chevron border style for navigation arrows.                                  |
+| `--drp-months-gap`                     | `24px`                        | Gap between the two calendars in dual-month mode.                            |
+| `--drp-time-row-gap`                   | `16px`                        | Gap between elements in the time-picker row wrapper.                         |
+| `--drp-time-row-padding-top`           | `8px`                         | Top padding of the time-picker row wrapper.                                  |
+| `--drp-time-divider`                   | `1px solid #e8e8e8`           | Top border of the time-picker row wrapper.                                   |
+| `--drp-compare-padding-top`            | `12px`                        | Top padding of the compare-calendar section wrapper.                         |
+| `--drp-compare-divider`                | `1px solid #e8e8e8`           | Top border of the compare-calendar section wrapper.                          |
+| `--drp-footer-gap`                     | `8px`                         | Gap between footer buttons.                                                  |
+| `--drp-footer-padding`                 | `12px 16px`                   | Padding of the footer.                                                       |
+| `--drp-footer-border`                  | `1px solid #e8e8e8`           | Top border of the footer.                                                    |
+| `--drp-cancel-border-color`            | `#d0d0d0`                     | Cancel button border color.                                                  |
+| `--drp-cancel-color`                   | `inherit`                     | Cancel button text color.                                                    |
+| `--drp-cancel-hover-background`        | `#f5f5f5`                     | Cancel button background on hover.                                           |
+| `--drp-apply-background`               | `currentColor`                | Apply button background color.                                               |
+| `--drp-apply-color`                    | `#ffffff`                     | Apply button text color.                                                     |
+| `--drp-apply-hover-background`         | `#333333`                     | Apply button background on hover.                                            |
+| `--drp-apply-disabled-background`      | `#cccccc`                     | Apply button background when disabled.                                       |
+| `--drp-apply-disabled-color`           | `#888888`                     | Apply button text color when disabled.                                       |
+| `--drp-clear-border-color`             | `#d0d0d0`                     | Clear button border color (single-mode `clearable`).                         |
+| `--drp-clear-color`                    | `inherit`                     | Clear button text color.                                                     |
+| `--drp-clear-hover-background`         | `#f5f5f5`                     | Clear button background on hover.                                            |
+| `--drp-preset-divider-border`          | `1px solid #e8e8e8`           | Border style for the preset group divider line.                              |
+| `--drp-preset-divider-gap`             | `6px`                         | Gap between the divider line and the group label.                            |
+| `--drp-preset-divider-margin`          | `4px 0`                       | Vertical margin above and below each preset group divider.                   |
+| `--drp-preset-group-label-color`       | `#999999`                     | Text color of the preset group label rendered beside the divider.            |
+| `--drp-preset-divider-leader-width`    | `8px`                         | Width of the leading line segment before the group label.                    |
+| `--drp-compare-trigger-background`     | `inherit`                     | Compare trigger button background.                                           |
+| `--drp-compare-trigger-border`         | `1px solid currentColor`      | Compare trigger button border.                                               |
+| `--drp-compare-trigger-border-radius`  | `6px`                         | Compare trigger button corner rounding.                                      |
+| `--drp-compare-trigger-color`          | `inherit`                     | Compare trigger button text color.                                           |
+| `--drp-compare-trigger-padding`        | `8px 12px`                    | Compare trigger button inner padding.                                        |
+| `--drp-compare-trigger-min-width`      | `160px`                       | Compare trigger button minimum width.                                        |
+| `--drp-compare-panel-left`             | `0`                           | Left offset of the standalone compare panel relative to its trigger.         |
+| `--drp-compare-panel-min-width`        | `280px`                       | Minimum width of the standalone compare panel.                               |
+| `--drp-datetime-divider`               | `1px solid #e8e8e8`           | Divider below the date + time header (`showDateInputs`/`showTimeSelection`). |
+| `--drp-date-input-border`              | `1px solid #d4d4d4`           | Border of the read-only date boxes.                                          |
+| `--drp-date-input-background`          | `#ffffff`                     | Background of the read-only date boxes.                                      |
+| `--drp-date-input-color`               | `#333333`                     | Text color of the read-only date boxes.                                      |
+| `--drp-time-toggle-background`         | `#f6f7f9`                     | Background of the clock toggle button.                                       |
+| `--drp-time-toggle-border`             | `1px solid #d4d4d4`           | Border of the clock toggle button.                                           |
+| `--drp-time-toggle-active-color`       | `#1b85ff`                     | Clock toggle icon/border color when the time row is open.                    |
+| `--drp-time-input-border`              | `1px solid #d4d4d4`           | Border of the time inputs.                                                   |
+| `--drp-time-input-invalid-border`      | `#e5484d`                     | Border of a time input holding an invalid value.                             |
+| `--drp-time-field-color`               | `#333333`                     | Text color of the time inputs.                                               |
 
 ### Selector specificity note
 

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -6,6 +6,16 @@
   import Button from '../Button/Button.svelte';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
   import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
+  import chevronRightSvg from '$lib/assets/chevron-right.svg?raw';
+  import {
+    TIME_DISPLAY_PATTERN,
+    applyTimeDisplay,
+    formatTimeDisplay,
+    toMinutesOfDay
+  } from './timeUtils';
+
+  const clockSvg =
+    '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="6.25" stroke="currentColor" stroke-width="1.5"/><path d="M8 4.5V8l2.25 1.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
 
   let {
     rangeStart = $bindable(null),
@@ -18,6 +28,8 @@
     maxRangeDays = null,
     presets = null,
     presetCheckmark = false,
+    showDateInputs = false,
+    showTimeSelection = false,
     placeholder = 'Select date',
     dualMonth,
     timePicker,
@@ -57,6 +69,14 @@
   // Tracks the label of the currently active preset, or null when the user
   // made a custom calendar selection (or before any selection is made).
   let selectedPresetLabel: string | null = $state(null);
+
+  // Built-in time-of-day selection (opt-in via showTimeSelection). Display strings
+  // are 12-hour ("02:30 PM"); they seed from the draft dates when the picker opens
+  // and are combined back onto the committed range in handleApply. showTimeRow drives
+  // the collapsible time inputs, toggled by the clock button in the date-input row.
+  let startTimeDisplay: string = $state('12:00 AM');
+  let endTimeDisplay: string = $state('11:59 PM');
+  let showTimeRow: boolean = $state(false);
 
   const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -170,6 +190,29 @@
     return d.toLocaleDateString(locale, { month: 'short', day: 'numeric', year: 'numeric' });
   }
 
+  // Read-only date-input box contents (opt-in via showDateInputs), reflecting the draft.
+  const draftStartDateLabel: string = $derived(draftStart !== null ? formatDate(draftStart) : '');
+  const draftEndDateLabel: string = $derived(draftEnd !== null ? formatDate(draftEnd) : '');
+
+  const isStartTimeValid: boolean = $derived(TIME_DISPLAY_PATTERN.test(startTimeDisplay.trim()));
+  const isEndTimeValid: boolean = $derived(TIME_DISPLAY_PATTERN.test(endTimeDisplay.trim()));
+  // Apply is blocked while a time is malformed, or while both ends fall on the same
+  // calendar day and the start time is after the end time. Different days are fine.
+  const isTimeRangeValid: boolean = $derived.by(() => {
+    if (!showTimeSelection) {
+      return true;
+    }
+    if (!isStartTimeValid || !isEndTimeValid) {
+      return false;
+    }
+    if (draftStart === null || draftEnd === null || !isSameDay(draftStart, draftEnd)) {
+      return true;
+    }
+    const startMinutes = toMinutesOfDay(startTimeDisplay);
+    const endMinutes = toMinutesOfDay(endTimeDisplay);
+    return startMinutes === null || endMinutes === null || startMinutes <= endMinutes;
+  });
+
   const triggerLabel: string = $derived.by(() => {
     // If an initial preset label is active (seeded on mount, not yet overridden), show it
     if (activePresetLabel !== null) {
@@ -205,6 +248,14 @@
     // Re-seed the session from the committed preset so the sidebar re-highlights it
     // by label. A direct calendar click later clears this, reverting to date matching.
     selectedPresetLabel = committedPresetLabel;
+
+    // Seed the time inputs from the committed range's time-of-day, and collapse the
+    // time row so each open starts from the date view.
+    if (showTimeSelection) {
+      startTimeDisplay = draftStart !== null ? formatTimeDisplay(draftStart) : '12:00 AM';
+      endTimeDisplay = draftEnd !== null ? formatTimeDisplay(draftEnd) : '11:59 PM';
+      showTimeRow = false;
+    }
 
     // Navigate left calendar so it shows the committed start month (or today)
     const anchor = rangeStart !== null ? rangeStart : value !== null ? value : now;
@@ -273,10 +324,21 @@
     activePresetLabel = null;
     if (mode === 'range') {
       if (draftStart !== null && draftEnd !== null) {
-        rangeStart = draftStart;
-        rangeEnd = draftEnd;
+        // Fold the time-of-day inputs onto the committed dates when time selection is on.
+        const appliedStart = showTimeSelection
+          ? (applyTimeDisplay(draftStart, startTimeDisplay) ?? draftStart)
+          : draftStart;
+        const appliedEnd = showTimeSelection
+          ? (applyTimeDisplay(draftEnd, endTimeDisplay) ?? draftEnd)
+          : draftEnd;
+        rangeStart = appliedStart;
+        rangeEnd = appliedEnd;
         committedPresetLabel = selectedPresetLabel;
-        onapply?.({ rangeStart: draftStart, rangeEnd: draftEnd, presetLabel: selectedPresetLabel });
+        onapply?.({
+          rangeStart: appliedStart,
+          rangeEnd: appliedEnd,
+          presetLabel: selectedPresetLabel
+        });
       }
       if (
         typeof compareCalendar === 'function' &&
@@ -389,7 +451,7 @@
 
   const canApply: boolean = $derived.by(() => {
     if (mode === 'range') {
-      return draftStart !== null && draftEnd !== null;
+      return draftStart !== null && draftEnd !== null && isTimeRangeValid;
     }
     return draftValue !== null;
   });
@@ -578,6 +640,68 @@
 
         <!-- Calendar area -->
         <div class="drp-calendars">
+          {#if (showDateInputs || showTimeSelection) && mode === 'range'}
+            <div class="drp-datetime-header">
+              <div class="drp-date-input-row">
+                <div class="drp-date-input" data-pw={testId ? `${testId}-start-date` : null}>
+                  <span class="drp-date-input-value">{draftStartDateLabel || 'Start date'}</span>
+                </div>
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                <span class="drp-datetime-arrow" aria-hidden="true">{@html chevronRightSvg}</span>
+                <div class="drp-date-input" data-pw={testId ? `${testId}-end-date` : null}>
+                  <span class="drp-date-input-value">{draftEndDateLabel || 'End date'}</span>
+                </div>
+                {#if showTimeSelection}
+                  <button
+                    type="button"
+                    class="drp-time-toggle"
+                    class:drp-time-toggle-active={showTimeRow}
+                    aria-label="Toggle time selection"
+                    aria-pressed={showTimeRow}
+                    data-pw={testId ? `${testId}-time-toggle` : null}
+                    onclick={() => (showTimeRow = !showTimeRow)}
+                  >
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <span class="drp-time-toggle-icon" aria-hidden="true">{@html clockSvg}</span>
+                  </button>
+                {/if}
+              </div>
+              {#if showTimeSelection && showTimeRow}
+                <div class="drp-time-input-row">
+                  <div class="drp-time-input" class:drp-time-input-invalid={!isStartTimeValid}>
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <span class="drp-time-input-icon" aria-hidden="true">{@html clockSvg}</span>
+                    <input
+                      type="text"
+                      class="drp-time-field"
+                      bind:value={startTimeDisplay}
+                      maxlength="8"
+                      placeholder="12:00 AM"
+                      aria-label="Start time"
+                      aria-invalid={!isStartTimeValid}
+                      data-pw={testId ? `${testId}-start-time` : null}
+                    />
+                  </div>
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                  <span class="drp-datetime-arrow" aria-hidden="true">{@html chevronRightSvg}</span>
+                  <div class="drp-time-input" class:drp-time-input-invalid={!isEndTimeValid}>
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <span class="drp-time-input-icon" aria-hidden="true">{@html clockSvg}</span>
+                    <input
+                      type="text"
+                      class="drp-time-field"
+                      bind:value={endTimeDisplay}
+                      maxlength="8"
+                      placeholder="11:59 PM"
+                      aria-label="End time"
+                      aria-invalid={!isEndTimeValid}
+                      data-pw={testId ? `${testId}-end-time` : null}
+                    />
+                  </div>
+                </div>
+              {/if}
+            </div>
+          {/if}
           {#if isDualMonth}
             <!-- Dual-month layout with shared nav -->
             <div class="drp-dual-header">
@@ -928,6 +1052,132 @@
     padding-top: var(--drp-time-row-padding-top, 8px);
     border-top: var(--drp-time-divider, 1px solid #e8e8e8);
     flex-wrap: wrap;
+  }
+
+  /* ── Built-in date + time inputs (showDateInputs / showTimeSelection) ── */
+  .drp-datetime-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--drp-datetime-gap, 8px);
+    padding-bottom: var(--drp-datetime-padding-bottom, 12px);
+    margin-bottom: var(--drp-datetime-margin-bottom, 4px);
+    border-bottom: var(--drp-datetime-divider, 1px solid #e8e8e8);
+  }
+
+  .drp-date-input-row,
+  .drp-time-input-row {
+    display: flex;
+    align-items: center;
+    gap: var(--drp-datetime-row-gap, 12px);
+  }
+
+  .drp-date-input {
+    flex: 1;
+    min-width: 0;
+    padding: var(--drp-date-input-padding, 10px 14px);
+    border: var(--drp-date-input-border, 1px solid #d4d4d4);
+    border-radius: var(--drp-date-input-radius, 8px);
+    background: var(--drp-date-input-background, #ffffff);
+  }
+
+  .drp-date-input-value {
+    display: block;
+    color: var(--drp-date-input-color, #333333);
+    font-size: var(--drp-date-input-font-size, 13px);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .drp-datetime-arrow {
+    flex-shrink: 0;
+    display: inline-flex;
+    width: var(--drp-datetime-arrow-size, 16px);
+    height: var(--drp-datetime-arrow-size, 16px);
+    color: var(--drp-datetime-arrow-color, #888888);
+  }
+
+  .drp-datetime-arrow :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .drp-time-toggle {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--drp-time-toggle-size, 40px);
+    height: var(--drp-time-toggle-size, 40px);
+    padding: 0;
+    border: var(--drp-time-toggle-border, 1px solid #d4d4d4);
+    border-radius: var(--drp-time-toggle-radius, 8px);
+    background: var(--drp-time-toggle-background, #f6f7f9);
+    color: var(--drp-time-toggle-color, #555555);
+    cursor: pointer;
+  }
+
+  .drp-time-toggle-active {
+    border-color: var(--drp-time-toggle-active-border, currentColor);
+    color: var(--drp-time-toggle-active-color, #1b85ff);
+  }
+
+  .drp-time-toggle-icon {
+    display: inline-flex;
+    width: var(--drp-time-toggle-icon-size, 16px);
+    height: var(--drp-time-toggle-icon-size, 16px);
+  }
+
+  .drp-time-toggle-icon :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .drp-time-input {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    border: var(--drp-time-input-border, 1px solid #d4d4d4);
+    border-radius: var(--drp-time-input-radius, 8px);
+    background: var(--drp-time-input-background, #ffffff);
+  }
+
+  .drp-time-input-invalid {
+    border-color: var(--drp-time-input-invalid-border, #e5484d);
+  }
+
+  .drp-time-input-icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    width: var(--drp-time-input-icon-size, 16px);
+    height: var(--drp-time-input-icon-size, 16px);
+    margin-left: var(--drp-time-input-icon-gap, 12px);
+    color: var(--drp-time-input-icon-color, #888888);
+    pointer-events: none;
+  }
+
+  .drp-time-input-icon :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .drp-time-field {
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+    padding: var(--drp-time-field-padding, 10px 14px 10px 8px);
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--drp-time-field-color, #333333);
+    font-size: var(--drp-time-field-font-size, 13px);
+    font-family: inherit;
+  }
+
+  .drp-time-field::placeholder {
+    color: var(--drp-time-field-placeholder-color, #aaaaaa);
   }
 
   /* ── Compare calendar slot ── */

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -40,6 +40,18 @@ export type OptionalDateRangePickerProperties = {
    * its highlighted background regardless of this flag. Default: false.
    */
   presetCheckmark?: boolean;
+  /**
+   * Show read-only start/end date boxes at the top of the calendar area (range mode),
+   * reflecting the current draft selection. Opt-in. Default: false.
+   */
+  showDateInputs?: boolean;
+  /**
+   * Show built-in time-of-day selection (range mode): a clock toggle in the date-input
+   * row that reveals start/end time inputs ("HH:MM AM/PM"). On Apply the entered times
+   * are folded onto the committed range's start/end. Implies the date-input row.
+   * Opt-in. Default: false.
+   */
+  showTimeSelection?: boolean;
   /** Placeholder shown when no range is selected. */
   placeholder?: string;
   /** Show two months side by side. Defaults to true for range mode, false for single. */

--- a/src/lib/DateRangePicker/timeUtils.ts
+++ b/src/lib/DateRangePicker/timeUtils.ts
@@ -1,0 +1,48 @@
+// Time-of-day helpers for the DateRangePicker's built-in date + time inputs.
+
+/** Matches a 12-hour clock display such as "2:30 PM" or "02:05 am". */
+export const TIME_DISPLAY_PATTERN = /^(1[0-2]|0?[1-9]):([0-5][0-9])\s?(AM|PM)$/i;
+
+const pad = (n: number): string => n.toString().padStart(2, '0');
+
+/** Parse a 12-hour display string into 24-hour hours/minutes, or null when invalid. */
+export const parseTimeDisplay = (display: string): { hours: number; minutes: number } | null => {
+  const match = TIME_DISPLAY_PATTERN.exec(display.trim());
+  if (match === null) {
+    return null;
+  }
+  let hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const meridiem = match[3].toUpperCase();
+  if (meridiem === 'PM' && hours !== 12) {
+    hours += 12;
+  } else if (meridiem === 'AM' && hours === 12) {
+    hours = 0;
+  }
+  return { hours, minutes };
+};
+
+/** Format a Date's time-of-day as a 12-hour display string, e.g. "02:30 PM". */
+export const formatTimeDisplay = (date: Date): string => {
+  const hours24 = date.getHours();
+  const meridiem = hours24 >= 12 ? 'PM' : 'AM';
+  const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
+  return `${pad(hours12)}:${pad(date.getMinutes())} ${meridiem}`;
+};
+
+/** Return a new Date with the time-of-day from a 12-hour display string applied, or null when invalid. */
+export const applyTimeDisplay = (date: Date, display: string): Date | null => {
+  const parsed = parseTimeDisplay(display);
+  if (parsed === null) {
+    return null;
+  }
+  const next = new Date(date.getTime());
+  next.setHours(parsed.hours, parsed.minutes, 0, 0);
+  return next;
+};
+
+/** Minutes-since-midnight for ordering comparisons, or null when the display is invalid. */
+export const toMinutesOfDay = (display: string): number | null => {
+  const parsed = parseTimeDisplay(display);
+  return parsed === null ? null : parsed.hours * 60 + parsed.minutes;
+};

--- a/src/routes/components/date-range-picker/+page.svelte
+++ b/src/routes/components/date-range-picker/+page.svelte
@@ -587,6 +587,28 @@
   </div>
 </section>
 
+<!-- ── 12. Built-in date inputs + time selection (showDateInputs / showTimeSelection) ── -->
+<section class="demo-section">
+  <h2>Range mode — built-in date inputs + time selection</h2>
+  <p class="section-note">
+    <code>showDateInputs</code> adds read-only start/end date boxes at the top of the calendar;
+    <code>showTimeSelection</code> adds a clock toggle that reveals start/end time inputs ("HH:MM AM/PM")
+    and folds the entered times onto the committed range on Apply.
+  </p>
+  <div class="demo-row">
+    <DateRangePicker
+      mode="range"
+      presets={commonPresets}
+      presetCheckmark
+      showDateInputs
+      showTimeSelection
+      initialPresetLabel="Today"
+      placeholder="Select range + time"
+      testId="drp-datetime-demo"
+    />
+  </div>
+</section>
+
 <style>
   .page-description {
     color: #666;

--- a/src/wc/components/DateRangePicker.wc.svelte
+++ b/src/wc/components/DateRangePicker.wc.svelte
@@ -11,6 +11,8 @@
       maxDate: { type: 'Object' },
       disabledDates: { type: 'Object' },
       presets: { type: 'Object' },
+      showDateInputs: { type: 'Boolean', reflect: true, attribute: 'show-date-inputs' },
+      showTimeSelection: { type: 'Boolean', reflect: true, attribute: 'show-time-selection' },
       placeholder: { type: 'String' },
       dualMonth: { type: 'Boolean', reflect: true, attribute: 'dual-month' },
       align: { type: 'String', reflect: true },

--- a/tests/date-range-picker-date-time.test.ts
+++ b/tests/date-range-picker-date-time.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('DateRangePicker — built-in date inputs + time selection', () => {
+  // showDateInputs renders read-only start/end date boxes; showTimeSelection adds a
+  // clock toggle that reveals start/end time inputs and gates Apply on time validity.
+  test('shows date boxes, toggles time inputs, and gates Apply on time validity', async ({
+    page
+  }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-datetime-demo"]');
+    await expect(picker).toBeVisible();
+
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+
+    // Read-only date boxes are present (seeded from the "Today" preset).
+    await expect(page.locator('[data-pw="drp-datetime-demo-start-date"]')).toBeVisible();
+    await expect(page.locator('[data-pw="drp-datetime-demo-end-date"]')).toBeVisible();
+
+    // Time inputs are hidden until the clock toggle is clicked.
+    await expect(page.locator('[data-pw="drp-datetime-demo-start-time"]')).toHaveCount(0);
+    await page.locator('[data-pw="drp-datetime-demo-time-toggle"]').click();
+
+    const startTime = page.locator('[data-pw="drp-datetime-demo-start-time"]');
+    await expect(startTime).toBeVisible();
+
+    const applyButton = picker.getByRole('button', { name: 'Apply date selection' });
+    await expect(applyButton).toBeEnabled();
+
+    // A malformed time blocks Apply.
+    await startTime.fill('99:99 ZZ');
+    await expect(applyButton).toBeDisabled();
+
+    // A valid time re-enables Apply.
+    await startTime.fill('09:30 AM');
+    await expect(applyButton).toBeEnabled();
+  });
+
+  test('blocks Apply when start time is after end time on the same day', async ({ page }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-datetime-demo"]');
+    await picker.getByRole('button', { name: 'Open date picker' }).click();
+    await page.locator('[data-pw="drp-datetime-demo-time-toggle"]').click();
+
+    const startTime = page.locator('[data-pw="drp-datetime-demo-start-time"]');
+    const endTime = page.locator('[data-pw="drp-datetime-demo-end-time"]');
+    const applyButton = picker.getByRole('button', { name: 'Apply date selection' });
+
+    // The seeded "Today" preset puts start and end on the same calendar day, so a
+    // start time later than the end time is an invalid range and blocks Apply.
+    await startTime.fill('11:00 PM');
+    await endTime.fill('09:00 AM');
+    await expect(applyButton).toBeDisabled();
+
+    // Restoring start <= end re-enables Apply.
+    await endTime.fill('11:30 PM');
+    await expect(applyButton).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## What

Adds two opt-in props to `DateRangePicker` that restore the rich "date + time" header the Lighthouse analytics picker had before its migration to this library:

- **`showDateInputs`** — read-only start/end **date boxes** at the top of the calendar area, reflecting the current draft selection (BZ-3737).
- **`showTimeSelection`** — a **clock toggle** in the date-input row that reveals start/end **time inputs** (`HH:MM AM/PM`); on Apply the entered times are folded onto the committed range's start/end (BZ-3736). Apply is blocked while a time is malformed, or while both ends are the same day and start-time > end-time.

Both are opt-in (default `false`) and range-mode only — existing pickers are unchanged.

## Why

The BZ-1323 migration replaced Lighthouse's 1192-line project `DatePicker` with this slim library component, dropping the in-panel date boxes and the clock/time selection. QA filed BZ-3736/3737 for the missing time icon + date inputs. Rather than re-add a project wrapper, these belong in the library so every consumer gets them.

## Design

- New `timeUtils.ts`: `TIME_DISPLAY_PATTERN`, `parseTimeDisplay`, `formatTimeDisplay`, `applyTimeDisplay`, `toMinutesOfDay` — 12/24-hour conversion + validation, no deps.
- Date boxes are read-only (driven by `draftStart`/`draftEnd`); the clock toggle reveals editable native time fields; times seed from the committed range on open and combine in `handleApply`.
- Fully themeable via `--drp-date-input-*`, `--drp-time-*`, `--drp-datetime-*` CSS vars (light defaults).

## Files
- `src/lib/DateRangePicker/DateRangePicker.svelte` — props, state, date+time header, apply integration, CSS
- `src/lib/DateRangePicker/timeUtils.ts` — time helpers (new)
- `src/lib/DateRangePicker/properties.ts` — prop types + docs
- `src/routes/components/date-range-picker/+page.svelte` — demo (`drp-datetime-demo`)
- `tests/date-range-picker-date-time.test.ts` — Playwright regression (date boxes, time toggle, Apply gating)

## Gates
svelte-check 0 errors · prettier + eslint ✓ · build/publint ✓ · new Playwright test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional time-of-day selection for date ranges in `DateRangePicker`. When enabled, users can input and validate start/end times via dedicated time inputs with a clock toggle. The "Apply" button is blocked if time selection is enabled and the time range is invalid.

* **Documentation**
  * Added demo section showcasing the new time-selection capability in range mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->