### PR TITLE
fix(DateRangePicker): toggle the picker from its trigger (BZ-3892)

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -272,6 +272,17 @@
     onopentoggle?.({ open: false });
   }
 
+  // The trigger toggles: clicking it while the panel is already open dismisses
+  // the picker instead of re-opening it onto itself. The open-only handler left
+  // a second click feeling dead — the panel could only be closed by clicking away.
+  function togglePicker(): void {
+    if (isOpen) {
+      closePicker();
+    } else {
+      openPicker();
+    }
+  }
+
   function openComparePicker(): void {
     compareFocusReturnEl =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -504,7 +515,7 @@
   <!-- Trigger wrapper — bind:this here so outside-click detection works -->
   <div bind:this={triggerRef} class="drp-trigger-wrapper">
     <Button
-      onclick={openPicker}
+      onclick={togglePicker}
       ariaLabel="Open date picker"
       classes="drp-trigger {isOpen ? 'drp-trigger-open' : ''}"
     >

--- a/tests/date-range-picker-toggle.test.ts
+++ b/tests/date-range-picker-toggle.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('DateRangePicker — trigger toggles the panel', () => {
+  // Regression guard: the trigger used to only open the panel, so a second click
+  // re-opened it onto itself and the panel could only be dismissed by clicking
+  // elsewhere on the page. The trigger must toggle — a second click closes it.
+  test('clicking the trigger while open closes the picker, and re-opens on the next click', async ({
+    page
+  }) => {
+    await page.goto('/components/date-range-picker');
+
+    const picker = page.locator('[data-pw="drp-range-demo"]');
+    await expect(picker).toBeVisible();
+
+    const trigger = picker.getByRole('button', { name: 'Open date picker' });
+
+    await trigger.click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+
+    // Second click on the same trigger dismisses the picker.
+    await trigger.click();
+    await expect(picker.locator('.drp-panel')).toBeHidden();
+
+    // Trigger still works as an opener afterwards.
+    await trigger.click();
+    await expect(picker.locator('.drp-panel')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Problem (BZ-3892)
Clicking the date-picker trigger a second time while the panel is open did **not** close it. The trigger's `onclick` only ever ran the open path (`openPicker()` → `isOpen = true`), so a second click re-opened the picker onto itself and felt dead — the only way to dismiss was to click elsewhere on the page. Reported on the Lighthouse analytics filter bar, where both date pills are DateRangePicker instances.

## Fix
Route the trigger through a new `togglePicker()` that calls `closePicker()` when already open and `openPicker()` otherwise. The outside-click handler is unaffected — on the closing click `isOpen` is already `false` by the time the document handler runs, so it no-ops (no double-toggle).

## Test
Added `tests/date-range-picker-toggle.test.ts`: open via trigger → panel visible; click trigger again → panel hidden; click again → panel visible. **Passes** locally (`playwright test`).

## Gates
`pnpm run check` 0 errors · prettier + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date range picker trigger button now toggles the panel open and closed on click, instead of only opening when clicked.

* **Tests**
  * Added test suite to verify date range picker trigger toggle behavior across multiple clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->