### PR TITLE
fix(Calendar): continuous multi-day range highlight (BZ-3893 / BZ-3742)

### DIFF
--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -393,9 +393,15 @@
     --button-hover-color: var(--calendar-nav-button-hover-background, #f0f0f0);
   }
 
+  /* Size the columns to the cell, not 1fr, and centre the whole grid. With 1fr
+     columns the fixed-width cells sat centred inside wider tracks, leaving
+     horizontal gaps between days — which broke the range highlight into
+     disconnected boxes instead of one continuous pill. The day-name header must
+     use the same track sizing so it stays aligned with the day grid below. */
   .day-names {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, var(--calendar-cell-size, 36px));
+    justify-content: center;
     text-align: center;
   }
 
@@ -408,8 +414,8 @@
 
   .grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    justify-items: center;
+    grid-template-columns: repeat(7, var(--calendar-cell-size, 36px));
+    justify-content: center;
     row-gap: 2px;
   }
 


### PR DESCRIPTION
## Problem (BZ-3893, recreated from BZ-3742)
A selected multi-day range rendered as a row of **disconnected boxes** instead of one continuous pill.

**Root cause:** the day grid used `grid-template-columns: repeat(7, 1fr)` while each `.cell` is a fixed 36px. The calendar is 280px wide (`--calendar-width`), so each `1fr` column is 40px and the 36px cell sat centred with a **~4px gap on each side**. The `range-start` / `in-range` / `range-end` backgrounds therefore never touched.

## Fix
Size the grid columns to the cell (`repeat(7, var(--calendar-cell-size, 36px))`) and centre the grid, applying the same track sizing to the day-name header so it stays aligned. Adjacent day backgrounds are now flush → the range reads as a single continuous highlight. Cell size stays configurable via `--calendar-cell-size`; single-date circles are unchanged.

## Gates
`pnpm run check` 0 errors · prettier + eslint clean. Visual: 280px calendar with the 252px (7×36) grid centred; range cells flush.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar date range highlights that were previously displaying as disconnected boxes instead of continuous highlighting.
  * Improved alignment between calendar day names and the day grid for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->