### PR TITLE
fix(DateRangePicker): reflect open/closed state in the trigger aria-label

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -516,7 +516,7 @@
   <div bind:this={triggerRef} class="drp-trigger-wrapper">
     <Button
       onclick={togglePicker}
-      ariaLabel="Open date picker"
+      ariaLabel={isOpen ? 'Close date picker' : 'Open date picker'}
       classes="drp-trigger {isOpen ? 'drp-trigger-open' : ''}"
     >
       {#if typeof triggerSnippet === 'function'}


### PR DESCRIPTION
## What

The DateRangePicker trigger became a **toggle** in 2.69.1 (#320) — it now both opens *and* closes the panel. But its `ariaLabel` stayed the static `"Open date picker"`, so screen-reader users heard "Open date picker" even when the click would *close* the panel.

This makes the label track the open state:

```svelte
ariaLabel={isOpen ? 'Close date picker' : 'Open date picker'}
```

## Why

Follow-up to the **MAJOR accessibility finding** on #320 (which merged before that comment was addressed). One-line, additive, no API change.

## Verification

- `pnpm check` — 0 errors.
- Single commit on top of `release`.