### PR TITLE
fix(DateRangePicker): close on second trigger click (BZ-3892) + continuous multi-day range highlight (BZ-3893)

### DIFF
--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -409,7 +409,10 @@
   .grid {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    justify-items: center;
+    /* stretch (not center) so each day cell fills its 1fr column; otherwise a
+       fixed-width cell narrower than the column leaves gaps and the in-range
+       background paints as separate boxes instead of a continuous range. */
+    justify-items: stretch;
     row-gap: 2px;
   }
 
@@ -417,7 +420,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: var(--calendar-cell-size, 36px);
+    width: 100%;
     height: var(--calendar-cell-size, 36px);
     font-family: inherit;
     font-size: var(--calendar-cell-font-size, 14px);

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -221,6 +221,17 @@
     onopentoggle?.({ open: false });
   }
 
+  // Toggle on trigger click so a second click on the trigger closes the picker.
+  // The trigger's onclick fires before the document-level handler, so closing
+  // here makes handleDocumentClick early-return on the next (bubbled) event.
+  function togglePicker(): void {
+    if (isOpen) {
+      closePicker();
+    } else {
+      openPicker();
+    }
+  }
+
   function openComparePicker(): void {
     compareFocusReturnEl =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -442,7 +453,7 @@
   <!-- Trigger wrapper — bind:this here so outside-click detection works -->
   <div bind:this={triggerRef} class="drp-trigger-wrapper">
     <Button
-      onclick={openPicker}
+      onclick={togglePicker}
       ariaLabel="Open date picker"
       classes="drp-trigger {isOpen ? 'drp-trigger-open' : ''}"
     >


### PR DESCRIPTION
Two DateRangePicker/Calendar fixes consumed by Lighthouse (reported in the Svelte-5 migration thread).

- **BZ-3892** `DateRangePicker.svelte`: add `togglePicker` so a second click on the trigger closes the picker (previously `openPicker` ran unconditionally and the document-click handler skipped close on trigger-clicks, so it never closed).
- **BZ-3893** `Calendar.svelte`: change `.grid` to `justify-items: stretch` and cells to `width: 100%` so in-range day cells fill their column — the multi-day range now renders as one continuous highlight instead of separate boxes.

Built locally (`pnpm package`) and verified in Lighthouse (both fixes confirmed live; continuous-range after-proof captured). Branched off tag 2.68.0 to match the consumer pin; needs a version bump + publish, after which Lighthouse package.json is bumped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Calendar grid layout**: Day cells now properly stretch to fill their grid columns, providing improved alignment and visual consistency across the calendar display
* **Date range picker trigger**: The picker now correctly toggles between open and closed states when clicked, eliminating unintended re-opening behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->