### PR TITLE
style(DateRangePicker): fix prettier formatting to unblock release

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -682,7 +682,8 @@
                 {#if isInlineTime}
                   <div class="drp-date-time-group">
                     <div class="drp-date-input" data-pw={testId ? `${testId}-start-date` : null}>
-                      <span class="drp-date-input-value">{draftStartDateLabel || 'Start date'}</span>
+                      <span class="drp-date-input-value">{draftStartDateLabel || 'Start date'}</span
+                      >
                     </div>
                     <div
                       class="drp-time-input drp-time-input-inline"

--- a/src/routes/components/date-range-picker/+page.svelte
+++ b/src/routes/components/date-range-picker/+page.svelte
@@ -614,8 +614,8 @@
   <h2>Range mode — inline time layout (timeSelectionLayout="inline")</h2>
   <p class="section-note">
     With <code>timeSelectionLayout="inline"</code> the start/end time inputs render beside their date
-    inputs on the same row — always visible, with no clock toggle. Seeding, validation, and the
-    Apply-time fold behave exactly as in the default toggle layout.
+    inputs on the same row — always visible, with no clock toggle. Seeding, validation, and the Apply-time
+    fold behave exactly as in the default toggle layout.
   </p>
   <div class="demo-row">
     <DateRangePicker


### PR DESCRIPTION
## Why

The inline time-selection layout commits (#324) landed on `release` with two `prettier --check` violations, which **failed the "Release and Publish" CI lint step** (`pnpm lint` = `prettier --check src && eslint src`) — so `2.74.0` was never published (npm `latest` is still `2.73.0`).

Failed run: the `Run linting` step flagged `src/lib/DateRangePicker/DateRangePicker.svelte` and `src/routes/components/date-range-picker/+page.svelte`.

## What

`prettier --write` on the two files — formatting only, no behaviour change:
- `DateRangePicker.svelte`: wrap a long-line closing `</span>` onto its own line.
- demo `+page.svelte`: re-wrap one paragraph to the print width.

## Verify

`pnpm lint` now passes locally (`prettier --check src` clean, `eslint src` clean). Merging this re-runs the release pipeline so `2.74.0` publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments to component templates and documentation text wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->