### PR TITLE
fix(DateRangePicker): reseed time inputs when a preset is selected

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -420,6 +420,15 @@
     if (mode === 'range') {
       draftStart = start;
       draftEnd = end;
+      // Reseed the time-of-day inputs from the preset's own start/end so a
+      // time-bearing preset (e.g. "Last 30 minutes" / "Last 12 Hours") is not
+      // silently overwritten by a stale display string in handleApply's
+      // applyTimeDisplay. Without this, the committed range snaps back to the
+      // previous display time (often 12:00 AM) instead of the preset's window.
+      if (showTimeSelection) {
+        startTimeDisplay = formatTimeDisplay(start);
+        endTimeDisplay = formatTimeDisplay(end);
+      }
       // Navigate left calendar to show the preset's start month
       leftYear = start.getFullYear();
       leftMonth = start.getMonth();


### PR DESCRIPTION
## Problem

`handlePreset` sets `draftStart`/`draftEnd` from the preset's `getValue()` — which carries the correct time-of-day for intraday presets (e.g. **Last 30 minutes**, **Last 1/6/12 Hours**, and **Today** on re-open) — but it never updates `startTimeDisplay`/`endTimeDisplay`.

When the user clicks **Apply**, `handleApply` folds the time inputs back onto the draft via `applyTimeDisplay(draftStart, startTimeDisplay)`. Because the display strings are stale (seeded only from the last committed range), the preset's correct time is silently overwritten — typically snapping the start to `12:00 AM`. So an intraday preset commits a midnight-anchored range instead of its intended window.

This only affects callers that pass `showTimeSelection={true}` (the time inputs path).

## Fix

In `handlePreset`, after setting `draftStart`/`draftEnd`, reseed `startTimeDisplay`/`endTimeDisplay` from the preset's `start`/`end` when `showTimeSelection` is active — mirroring the seeding `openPicker` already does from the committed range. Uses only in-scope identifiers (`showTimeSelection` prop, `formatTimeDisplay` import, the two display `$state`s); no API change.

```svelte
if (showTimeSelection) {
  startTimeDisplay = formatTimeDisplay(start);
  endTimeDisplay = formatTimeDisplay(end);
}
```

## Impact / testing
- With `showTimeSelection`: clicking a time-bearing preset now updates the visible time inputs and Apply commits the preset's actual window. Boundary presets (e.g. Last 7 Days at 00:00 / 23:59) correctly show their boundary times.
- No effect when `showTimeSelection` is false (the inputs aren't rendered and `handleApply` doesn't touch the time path).

Found while fixing the Lighthouse analytics calendar (BZ-4046), where the granularity/time presets did not update the applied time range. Replaces an interim pnpm-patch in the consumer; once released we'll bump the package version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the date range picker where the displayed time would become out of sync when selecting a preset range with time selection enabled. The component now properly synchronizes time displays when applying preset date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->