### PR TITLE
feat: chart-system — DeltaIndicator, DualAxisBarChart, FunnelChart + chart highlight hook

### DIFF
--- a/docs/BarChart.md
+++ b/docs/BarChart.md
@@ -1,6 +1,6 @@
 # BarChart
 
-A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal orientations, single or multi-series data (grouped/stacked), value labels, custom colors per data point, hover tooltips, and click events. Zero external dependencies — built from pure SVG with CSS custom property theming.
+A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal orientations, single or multi-series data (grouped/stacked), value labels, custom colors per data point, hover tooltips, click events, declarative and imperative bar highlighting, first-point normalisation across series, top-N clipping with overflow aggregation, and a graphics-free legend/label-only rendering mode. Zero external dependencies — built from pure SVG with CSS custom property theming.
 
 ## Usage
 
@@ -84,34 +84,100 @@ A responsive SVG bar chart for comparing categorical values. Supports vertical a
 </BarChart>
 ```
 
+### Declarative Highlight
+
+Set `highlightedIndex` to a zero-based category index to emphasise that bar and dim the others. Set to `null` to clear.
+
+```svelte
+<script>
+  let highlighted = $state(2);
+</script>
+
+<BarChart {data} highlightedIndex={highlighted} />
+<button onclick={() => (highlighted = null)}>Clear highlight</button>
+```
+
+### Imperative Highlight via `onChartReady`
+
+Receive a `ChartHighlightAPI` handle on mount to drive highlighting from outside the chart (e.g. synchronised with a voice narrator or a sibling component). The handle's `type` is always `'bar-chart'`.
+
+```svelte
+<script>
+  import type { ChartHighlightAPI } from '@juspay/svelte-ui-components';
+
+  let chartApi: ChartHighlightAPI | null = null;
+
+  const handleReady = (api: ChartHighlightAPI) => {
+    chartApi = api;
+  };
+
+  const highlightSecond = () => chartApi?.highlight(1);
+  const clear = () => chartApi?.highlight(null);
+</script>
+
+<BarChart {data} onChartReady={handleReady} />
+<button onclick={highlightSecond}>Highlight Feb</button>
+<button onclick={clear}>Clear</button>
+```
+
+### Normalise to First Point
+
+Each series' values are expressed as a percentage of its own first data point (baseline = 100). Useful when comparing relative growth across series with very different starting magnitudes.
+
+```svelte
+<BarChart {series} normaliseToFirstPoint groupMode="grouped" showLegend showValues />
+```
+
+### Top-N Clipping
+
+Show only the top `topN` bars individually and aggregate the remainder into a single overflow bar.
+
+```svelte
+<BarChart {data} topN={5} overflowLabel="Everything else" showValues />
+```
+
+### Hide Bar Graphics
+
+Render axes, gridlines, and legend without drawing any bar rectangles — useful for label-only or legend-only companion views.
+
+```svelte
+<BarChart {data} hideBarGraphics showXAxis showYAxis />
+```
+
 ## Props
 
-| Prop           | Type                                   | Required | Default      | Description                                                                                                                                                                                                                                                                   |
-| -------------- | -------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data           | `BarChartDataPoint[]`                  | No       | `-`          | Array of `{label, value, range?, color?}` for a single series. Provide either `data` or `series`. Each data point maps to one bar. `range` enables floating/range bars (`[low, high]`). `color` accepts a plain color string, a pattern fill, or a gradient fill (`BarFill`). |
-| series         | `BarChartSeries[]`                     | No       | `-`          | Array of `{name, data, color?}` for multi-series charts. When provided, overrides `data`. `color` accepts a plain color string, a pattern fill, or a gradient fill (`BarFill`).                                                                                               |
-| groupMode      | `'grouped' \| 'stacked'`               | No       | `'grouped'`  | Layout mode for multi-series. `grouped` places bars side-by-side within each category; `stacked` stacks them vertically.                                                                                                                                                      |
-| orientation    | `'vertical' \| 'horizontal'`           | No       | `'vertical'` | Bar orientation.                                                                                                                                                                                                                                                              |
-| showValues     | `boolean`                              | No       | `false`      | Whether to render the numeric value as a text label at the end of each bar. Disabled in stacked mode.                                                                                                                                                                         |
-| showGridlines  | `boolean`                              | No       | `true`       | Whether to show dashed gridlines across the value axis.                                                                                                                                                                                                                       |
-| showXAxis      | `boolean`                              | No       | `true`       | Whether to render the X axis (ticks, labels, axis line).                                                                                                                                                                                                                      |
-| showYAxis      | `boolean`                              | No       | `true`       | Whether to render the Y axis.                                                                                                                                                                                                                                                 |
-| showLegend     | `boolean`                              | No       | `false`      | Whether to render the legend above the chart. Only applies when `series` is provided.                                                                                                                                                                                         |
-| barPadding     | `number`                               | No       | `0.2`        | Space between bars as a fraction of bar width (0 = no gaps, 0.5 = half-width gaps).                                                                                                                                                                                           |
-| barRadius      | `number`                               | No       | `4`          | Corner radius of each bar in pixels.                                                                                                                                                                                                                                          |
-| aspectRatio    | `number`                               | No       | `16/9`       | Width-to-height ratio for the chart. Used when parent height is not constrained.                                                                                                                                                                                              |
-| xAxisLabel     | `string`                               | No       | `-`          | Text label shown below the X axis.                                                                                                                                                                                                                                            |
-| yAxisLabel     | `string`                               | No       | `-`          | Text label shown beside the Y axis (rotated 90°).                                                                                                                                                                                                                             |
-| yDomain        | `[number, number]`                     | No       | auto         | Fixed `[min, max]` for the value axis. When omitted, domain is derived from data with nice rounding.                                                                                                                                                                          |
-| valueFormat    | `(value: number) => string`            | No       | abbreviated  | Formatter for bar values. Default abbreviates with K/M/B suffixes (e.g., 1500 → "1.5K").                                                                                                                                                                                      |
-| stackNormalize | `boolean`                              | No       | `false`      | When `true` and `groupMode="stacked"`, normalises stacked values to 100% so bars represent proportions rather than absolutes. Appends `%` to value labels unless `valueFormat` is provided.                                                                                   |
-| scrollable     | `boolean`                              | No       | `false`      | When `true`, wraps the chart in a horizontally-scrollable container. Use with `minBandWidth` to keep bars readable at small container widths.                                                                                                                                 |
-| minBandWidth   | `number`                               | No       | `48`         | Minimum pixel width per category band when `scrollable` is `true`. The inner chart width expands until each band is at least this wide.                                                                                                                                       |
-| tooltipSnippet | `Snippet<[BarChartDataPoint, number]>` | No       | `-`          | Custom tooltip content. Receives the hovered data point and its index. Replaces the default tooltip.                                                                                                                                                                          |
-| empty          | `Snippet`                              | No       | `-`          | Content rendered when `data` is empty. When omitted, nothing renders for empty data.                                                                                                                                                                                          |
-| renderOverlay  | `Snippet<[BarChartRenderContext]>`     | No       | `-`          | Escape-hatch snippet rendered inside the SVG transform group after all bars. Use for custom overlays, annotations, or drop-off indicators in SVG coordinate space. Receives `{ innerWidth, innerHeight, margin }`.                                                            |
-| testId         | `string`                               | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                                                                                                                                                                       |
-| classes        | `string`                               | No       | `-`          | CSS class string applied to the top-level element. Useful for theming via class-scoped CSS variable overrides.                                                                                                                                                                |
+| Prop                  | Type                                   | Required | Default       | Description                                                                                                                                                                                                                                                                   |
+| --------------------- | -------------------------------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data                  | `BarChartDataPoint[]`                  | No       | `-`           | Array of `{label, value, range?, color?}` for a single series. Provide either `data` or `series`. Each data point maps to one bar. `range` enables floating/range bars (`[low, high]`). `color` accepts a plain color string, a pattern fill, or a gradient fill (`BarFill`). |
+| series                | `BarChartSeries[]`                     | No       | `-`           | Array of `{name, data, color?}` for multi-series charts. When provided, overrides `data`. `color` accepts a plain color string, a pattern fill, or a gradient fill (`BarFill`).                                                                                               |
+| groupMode             | `'grouped' \| 'stacked'`               | No       | `'grouped'`   | Layout mode for multi-series. `grouped` places bars side-by-side; `stacked` stacks them.                                                                                                                                                                                      |
+| orientation           | `'vertical' \| 'horizontal'`           | No       | `'vertical'`  | Bar orientation.                                                                                                                                                                                                                                                              |
+| showValues            | `boolean`                              | No       | `false`       | Whether to render the numeric value as a text label at the end of each bar. Disabled in stacked mode.                                                                                                                                                                         |
+| showGridlines         | `boolean`                              | No       | `true`        | Whether to show dashed gridlines across the value axis.                                                                                                                                                                                                                       |
+| showXAxis             | `boolean`                              | No       | `true`        | Whether to render the X axis (ticks, labels, axis line).                                                                                                                                                                                                                      |
+| showYAxis             | `boolean`                              | No       | `true`        | Whether to render the Y axis.                                                                                                                                                                                                                                                 |
+| showLegend            | `boolean`                              | No       | `false`       | Whether to render the legend above the chart. Only applies when `series` is provided.                                                                                                                                                                                         |
+| barPadding            | `number`                               | No       | `0.2`         | Space between bars as a fraction of bar width (0 = no gaps, 0.5 = half-width gaps).                                                                                                                                                                                          |
+| barRadius             | `number`                               | No       | `4`           | Corner radius of each bar in pixels.                                                                                                                                                                                                                                          |
+| aspectRatio           | `number`                               | No       | `16/9`        | Width-to-height ratio for the chart.                                                                                                                                                                                                                                          |
+| xAxisLabel            | `string`                               | No       | `-`           | Text label shown below the X axis.                                                                                                                                                                                                                                            |
+| yAxisLabel            | `string`                               | No       | `-`           | Text label shown beside the Y axis (rotated 90°).                                                                                                                                                                                                                             |
+| yDomain               | `[number, number]`                     | No       | auto          | Fixed `[min, max]` for the value axis.                                                                                                                                                                                                                                        |
+| valueFormat           | `(value: number) => string`            | No       | abbreviated   | Formatter for bar values. Default abbreviates with K/M/B suffixes.                                                                                                                                                                                                            |
+| stackNormalize        | `boolean`                              | No       | `false`       | Normalises stacked values to 100%. Applies only when `groupMode="stacked"`. Appends `%` to value labels unless `valueFormat` is supplied.                                                                                                                                    |
+| scrollable            | `boolean`                              | No       | `false`       | Wraps the chart in a horizontally-scrollable container. Use with `minBandWidth` to keep bars readable.                                                                                                                                                                        |
+| minBandWidth          | `number`                               | No       | `48`          | Minimum pixel width per category band when `scrollable` is `true`.                                                                                                                                                                                                            |
+| onChartReady          | `(api: ChartHighlightAPI) => void`     | No       | `-`           | Called once on mount with an imperative highlight handle. Use `api.highlight(index)` to emphasise a bar; `api.highlight(null)` clears. `api.getCategories()` returns the ordered label list. `api.type` is always `'bar-chart'`.                                              |
+| highlightedIndex      | `number \| null`                       | No       | `null`        | Declarative highlight: the bar at this zero-based index is shown at full opacity; all others are dimmed. Overrides any index set via `onChartReady`. Set to `null` to show all bars normally.                                                                                 |
+| normaliseToFirstPoint | `boolean`                              | No       | `false`       | When `true`, each series' values are expressed as a percentage of that series' own first data point (baseline = 100). Series whose first point is zero are left unchanged.                                                                                                    |
+| topN                  | `number`                               | No       | `-`           | Keep only the top `topN` bars by value (descending). The remaining bars are summed into one overflow bar labelled by `overflowLabel`. Has no effect when the chart already has `topN` or fewer bars.                                                                          |
+| overflowLabel         | `string`                               | No       | `"Other"`     | Label for the aggregated overflow bar produced by `topN`. Has no effect when `topN` is not set.                                                                                                                                                                               |
+| hideBarGraphics       | `boolean`                              | No       | `false`       | When `true`, bar rectangles are not drawn. Axis labels, gridlines, and the legend remain visible.                                                                                                                                                                             |
+| tooltipSnippet        | `Snippet<[BarChartDataPoint, number]>` | No       | `-`           | Custom tooltip content. Receives the hovered data point and its index. Replaces the default tooltip.                                                                                                                                                                          |
+| empty                 | `Snippet`                              | No       | `-`           | Content rendered when `data` is empty.                                                                                                                                                                                                                                        |
+| renderOverlay         | `Snippet<[BarChartRenderContext]>`     | No       | `-`           | Escape-hatch snippet rendered inside the SVG transform group after all bars. Receives `{ innerWidth, innerHeight, margin }`.                                                                                                                                                  |
+| testId                | `string`                               | No       | `-`           | Value for the `data-pw` attribute on the chart container.                                                                                                                                                                                                                     |
+| classes               | `string`                               | No       | `-`           | CSS class string applied to the top-level element.                                                                                                                                                                                                                            |
 
 ## Events
 
@@ -124,49 +190,86 @@ A responsive SVG bar chart for comparing categorical values. Supports vertical a
 
 Override these custom properties to theme the component.
 
-| Variable                        | Default                     | CSS Property     | Description                                                                                                                           |
-| ------------------------------- | --------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `--chart-background`            | `transparent`               | background       | Background color of the chart container.                                                                                              |
-| `--chart-font-family`           | `inherit`                   | font-family      | Font family for all chart text.                                                                                                       |
-| `--chart-transition-duration`   | `0.2s`                      | transition       | Duration of hover transitions.                                                                                                        |
-| `--chart-axis-color`            | `#666`                      | stroke, fill     | Color of axis lines, tick marks, and tick labels.                                                                                     |
-| `--chart-axis-stroke-width`     | `1`                         | stroke-width     | Width of axis lines and tick marks.                                                                                                   |
-| `--chart-axis-font-size`        | `11px`                      | font-size        | Font size of tick labels.                                                                                                             |
-| `--chart-axis-label-color`      | `#333`                      | fill             | Color of axis labels (xAxisLabel, yAxisLabel).                                                                                        |
-| `--chart-axis-label-font-size`  | `12px`                      | font-size        | Font size of axis labels.                                                                                                             |
-| `--chart-gridline-color`        | `#e0e0e0`                   | stroke           | Color of gridlines.                                                                                                                   |
-| `--chart-gridline-opacity`      | `0.5`                       | stroke-opacity   | Opacity of gridlines.                                                                                                                 |
-| `--chart-gridline-dash`         | `4 4`                       | stroke-dasharray | Dash pattern for gridlines.                                                                                                           |
-| `--chart-tooltip-background`    | `rgba(0,0,0,0.85)`          | background       | Background of default tooltip.                                                                                                        |
-| `--chart-tooltip-color`         | `#fff`                      | color            | Text color of default tooltip.                                                                                                        |
-| `--chart-tooltip-font-size`     | `12px`                      | font-size        | Font size of tooltip content.                                                                                                         |
-| `--chart-tooltip-padding`       | `8px 12px`                  | padding          | Inner padding of tooltip.                                                                                                             |
-| `--chart-tooltip-border-radius` | `4px`                       | border-radius    | Border radius of tooltip.                                                                                                             |
-| `--chart-tooltip-shadow`        | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Shadow on the tooltip.                                                                                                                |
-| `--chart-legend-gap`            | `16px`                      | gap              | Space between legend items.                                                                                                           |
-| `--chart-legend-font-size`      | `12px`                      | font-size        | Font size of legend labels.                                                                                                           |
-| `--chart-legend-swatch-size`    | `12px`                      | width, height    | Size of color swatches in the legend.                                                                                                 |
-| `--chart-legend-color`          | `#333`                      | color            | Color of legend text.                                                                                                                 |
-| `--chart-empty-padding`         | `32px 24px`                 | padding          | Padding around the empty state content.                                                                                               |
-| `--chart-empty-color`           | `#9ca3af`                   | color            | Text color of empty state default.                                                                                                    |
-| `--barchart-bar-hover-opacity`  | `1`                         | opacity          | Opacity of the hovered bar.                                                                                                           |
-| `--barchart-bar-dimmed-opacity` | `0.3`                       | opacity          | Opacity of non-hovered bars when hovering.                                                                                            |
-| `--barchart-value-color`        | `#333`                      | fill             | Color of value labels.                                                                                                                |
-| `--barchart-value-font-size`    | `11px`                      | font-size        | Font size of value labels.                                                                                                            |
-| `--barchart-scroll-area-height` | `auto`                      | height           | Fixed height of the scroll area when `scrollable` is `true`. Useful to constrain tall charts while still allowing horizontal panning. |
+| Variable                           | Default                     | CSS Property     | Description                                                                                                                           |
+| ---------------------------------- | --------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `--chart-background`               | `transparent`               | background       | Background color of the chart container.                                                                                              |
+| `--chart-font-family`              | `inherit`                   | font-family      | Font family for all chart text.                                                                                                       |
+| `--chart-transition-duration`      | `0.2s`                      | transition       | Duration of hover transitions.                                                                                                        |
+| `--chart-axis-color`               | `#666`                      | stroke, fill     | Color of axis lines, tick marks, and tick labels.                                                                                     |
+| `--chart-axis-stroke-width`        | `1`                         | stroke-width     | Width of axis lines and tick marks.                                                                                                   |
+| `--chart-axis-font-size`           | `11px`                      | font-size        | Font size of tick labels.                                                                                                             |
+| `--chart-axis-label-color`         | `#333`                      | fill             | Color of axis labels (xAxisLabel, yAxisLabel).                                                                                        |
+| `--chart-axis-label-font-size`     | `12px`                      | font-size        | Font size of axis labels.                                                                                                             |
+| `--chart-gridline-color`           | `#e0e0e0`                   | stroke           | Color of gridlines.                                                                                                                   |
+| `--chart-gridline-opacity`         | `0.5`                       | stroke-opacity   | Opacity of gridlines.                                                                                                                 |
+| `--chart-gridline-dash`            | `4 4`                       | stroke-dasharray | Dash pattern for gridlines.                                                                                                           |
+| `--chart-tooltip-background`       | `rgba(0,0,0,0.85)`          | background       | Background of default tooltip.                                                                                                        |
+| `--chart-tooltip-color`            | `#fff`                      | color            | Text color of default tooltip.                                                                                                        |
+| `--chart-tooltip-font-size`        | `12px`                      | font-size        | Font size of tooltip content.                                                                                                         |
+| `--chart-tooltip-padding`          | `8px 12px`                  | padding          | Inner padding of tooltip.                                                                                                             |
+| `--chart-tooltip-border-radius`    | `4px`                       | border-radius    | Border radius of tooltip.                                                                                                             |
+| `--chart-tooltip-shadow`           | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Shadow on the tooltip.                                                                                                                |
+| `--chart-legend-gap`               | `16px`                      | gap              | Space between legend items.                                                                                                           |
+| `--chart-legend-font-size`         | `12px`                      | font-size        | Font size of legend labels.                                                                                                           |
+| `--chart-legend-swatch-size`       | `12px`                      | width, height    | Size of color swatches in the legend.                                                                                                 |
+| `--chart-legend-color`             | `#333`                      | color            | Color of legend text.                                                                                                                 |
+| `--chart-empty-padding`            | `32px 24px`                 | padding          | Padding around the empty state content.                                                                                               |
+| `--chart-empty-color`              | `#9ca3af`                   | color            | Text color of empty state default.                                                                                                    |
+| `--barchart-bar-hover-opacity`     | `1`                         | opacity          | Opacity of the hovered bar.                                                                                                           |
+| `--barchart-bar-highlighted-opacity` | `1`                       | opacity          | Opacity of a bar emphasised via `highlightedIndex` or `onChartReady`.                                                                |
+| `--barchart-bar-dimmed-opacity`    | `0.3`                       | opacity          | Opacity of non-highlighted / non-hovered bars when a highlight is active.                                                            |
+| `--barchart-value-color`           | `#333`                      | fill             | Color of value labels.                                                                                                                |
+| `--barchart-value-font-size`       | `11px`                      | font-size        | Font size of value labels.                                                                                                            |
+| `--barchart-scroll-area-height`    | `auto`                      | height           | Fixed height of the scroll area when `scrollable` is `true`.                                                                         |
 
 ## Type Reference
 
 ```typescript
+import type { ChartHighlightAPI } from '@juspay/svelte-ui-components';
+
+type ChartHighlightAPI = {
+  highlight: (index: number | null) => void;
+  getCategories: () => string[];
+  type: 'bar-chart' | 'line-chart' | 'donut-chart';
+};
+
 type BarChartDataPoint = {
   label: string;
   value: number;
-  color?: string;
+  range?: [number, number];
+  color?: BarFill;
 };
 
 type BarChartSeries = {
   name: string;
   data: BarChartDataPoint[];
-  color?: string;
+  color?: BarFill;
 };
+```
+
+## Web Component
+
+```html
+<script type="module" src="svelte-ui-components.js"></script>
+
+<sui-bar-chart
+  aspect-ratio="2"
+  show-values
+  top-n="5"
+  overflow-label="Other"
+  test-id="revenue-chart"
+></sui-bar-chart>
+
+<script>
+  const chart = document.querySelector('sui-bar-chart');
+  chart.data = [
+    { label: 'Jan', value: 4200 },
+    { label: 'Feb', value: 3800 },
+    { label: 'Mar', value: 5100 }
+  ];
+  // Imperative highlight via onChartReady
+  chart.onChartReady = (api) => {
+    api.highlight(1); // highlight Feb
+  };
+</script>
 ```

--- a/docs/DeltaIndicator.md
+++ b/docs/DeltaIndicator.md
@@ -1,0 +1,120 @@
+# DeltaIndicator
+
+A compact inline indicator that conveys change direction and magnitude using a directional arrow and formatted text. Positive values are rendered in green, negative in red, and values within the neutral threshold in muted gray. Supports inverted color semantics for lower-is-better metrics (e.g. bounce rate, RTO), an optional arrow-hide mode for text-only display, a configurable neutral threshold, and a custom format function for full control over the displayed text.
+
+## Usage
+
+```svelte
+<script>
+  import { DeltaIndicator } from '@juspay/svelte-ui-components';
+</script>
+
+<DeltaIndicator value={12.5} />
+```
+
+### Negative and Neutral
+
+```svelte
+<DeltaIndicator value={-7.3} />
+<DeltaIndicator value={0} />
+```
+
+### Neutral Threshold
+
+Values whose absolute magnitude is at or below `neutralThreshold` are treated as neutral and rendered in the muted color without an arrow.
+
+```svelte
+<!-- 0.4 is within ±0.5 — treated as neutral -->
+<DeltaIndicator value={0.4} neutralThreshold={0.5} />
+```
+
+### Inverted Colors
+
+Use `invertColors` for lower-is-better metrics where a decrease is "good" (green) and an increase is "bad" (red).
+
+```svelte
+<!-- Bounce rate dropped 5.2% — good, renders green -->
+<DeltaIndicator value={-5.2} invertColors />
+
+<!-- Bounce rate rose 3.8% — bad, renders red -->
+<DeltaIndicator value={3.8} invertColors />
+```
+
+### Hide Arrow
+
+```svelte
+<DeltaIndicator value={18} hideArrow />
+```
+
+### Custom Format
+
+Pass a `format` function `(value: number) => string` to control the displayed text. The raw (signed) value is passed; use `Math.abs` inside if you want to suppress the sign.
+
+```svelte
+<script>
+  const currencyFormat = (v: number) => `${v >= 0 ? '+' : '-'}$${Math.abs(v).toFixed(2)}`;
+</script>
+
+<DeltaIndicator value={42.5} format={currencyFormat} />
+```
+
+### Theming with Classes
+
+Define a class in your CSS that sets DeltaIndicator CSS variables and pass it via `classes`:
+
+```css
+/* app.css */
+.delta-large {
+  --delta-indicator-font-size: 18px;
+  --delta-indicator-arrow-size: 14px;
+  --delta-indicator-gap: 5px;
+}
+```
+
+```svelte
+<DeltaIndicator value={9.1} classes="delta-large" />
+```
+
+## Props
+
+| Prop             | Type                       | Required | Default                        | Description                                                                                                                                       |
+| ---------------- | -------------------------- | -------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| value            | `number`                   | Yes      | `-`                            | The change amount. Its sign determines direction: positive → up, negative → down. When the absolute value is ≤ `neutralThreshold`, direction is neutral. |
+| format           | `(value: number) => string` | No       | `v => Math.round(Math.abs(v)) + '%'` | Custom formatter for the displayed text. Receives the raw signed value. Default shows the rounded absolute value followed by a percent sign.      |
+| invertColors     | `boolean`                  | No       | `false`                        | Swaps the up/down color tone for lower-is-better metrics. When `true`, an upward change renders in red and a downward change renders in green.    |
+| hideArrow        | `boolean`                  | No       | `false`                        | Hides the directional triangle arrow, rendering only the formatted text string.                                                                   |
+| neutralThreshold | `number`                   | No       | `0`                            | Absolute values at or below this threshold are classified as neutral (muted color, no arrow). Useful for suppressing noise on near-zero changes.  |
+| testId           | `string`                   | No       | `-`                            | Value for the `data-pw` attribute on the root element, used for end-to-end testing selectors.                                                    |
+| classes          | `string`                   | No       | `-`                            | CSS class string applied to the root element. Useful for theming via class-scoped CSS variable overrides.                                        |
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                           | Default    | CSS Property | Description                                                                 |
+| ---------------------------------- | ---------- | ------------ | --------------------------------------------------------------------------- |
+| `--delta-indicator-gap`            | `2px`      | gap          | Space between the arrow icon and the text label.                            |
+| `--delta-indicator-font-size`      | `13px`     | font-size    | Font size of the indicator text.                                            |
+| `--delta-indicator-font-weight`    | `600`      | font-weight  | Font weight of the indicator text.                                          |
+| `--delta-indicator-positive-color` | `#1a9d6f`  | color        | Color used when the tone is positive (value up, or value down + invertColors). |
+| `--delta-indicator-negative-color` | `#e5484d`  | color        | Color used when the tone is negative (value down, or value up + invertColors). |
+| `--delta-indicator-neutral-color`  | `#8a8a8a`  | color        | Color used when the value is within the neutral threshold.                  |
+| `--delta-indicator-arrow-size`     | `9px`      | width, height | Size of the directional triangle arrow SVG.                               |
+
+## Web Component
+
+Tag: `<sui-delta-indicator>`
+
+```html
+<sui-delta-indicator value="12.5"></sui-delta-indicator>
+<sui-delta-indicator value="-7.3" invert-colors></sui-delta-indicator>
+<sui-delta-indicator value="18" hide-arrow></sui-delta-indicator>
+<sui-delta-indicator value="0.4" neutral-threshold="0.5"></sui-delta-indicator>
+```
+
+Passing a custom `format` function via the web component requires setting the property programmatically:
+
+```js
+const el = document.querySelector('sui-delta-indicator');
+el.format = (v) => `${v >= 0 ? '+' : ''}${v.toFixed(1)} bps`;
+```

--- a/docs/DualAxisBarChart.md
+++ b/docs/DualAxisBarChart.md
@@ -1,0 +1,208 @@
+# DualAxisBarChart
+
+A pure-SVG dual-axis chart with two completely independent Y-axes — left (`yAxisIndex: 0`) and right (`yAxisIndex: 1`) — sharing one categorical X-axis. Each series independently declares its axis and render type (`'column'` or `'line'`), making it ideal for comparing metrics at very different scales (e.g. absolute revenue vs. percentage CTR) within the same chart. Built entirely with the shared `_chart` primitives (ChartContainer, Axis, ChartTooltip, Legend, scales) — zero external dependencies.
+
+## Usage
+
+```svelte
+<script>
+  import { DualAxisBarChart } from '@juspay/svelte-ui-components';
+
+  const categories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+
+  const series = [
+    {
+      name: 'Revenue ($)',
+      data: [42000, 38500, 51200, 46800, 58300, 62100],
+      yAxisIndex: 0,
+      type: 'column',
+      color: '#4e79a7'
+    },
+    {
+      name: 'CTR (%)',
+      data: [3.2, 2.8, 4.1, 3.7, 4.8, 5.2],
+      yAxisIndex: 1,
+      type: 'line',
+      color: '#f28e2b'
+    }
+  ];
+</script>
+
+<DualAxisBarChart
+  {categories}
+  {series}
+  leftAxis={{ title: 'Revenue ($)', color: '#4e79a7' }}
+  rightAxis={{ title: 'CTR (%)', color: '#f28e2b', valueFormat: (v) => `${v.toFixed(1)}%` }}
+/>
+```
+
+### Two Column Series on Different Axes
+
+```svelte
+<DualAxisBarChart
+  {categories}
+  series={[
+    { name: 'Orders', data: [120, 98, 143, 131, 165, 182], yAxisIndex: 0, type: 'column' },
+    { name: 'AOV ($)', data: [350, 393, 358, 357, 353, 341], yAxisIndex: 1, type: 'column' }
+  ]}
+  leftAxis={{ title: 'Orders' }}
+  rightAxis={{ title: 'AOV ($)', valueFormat: (v) => `$${v.toFixed(0)}` }}
+/>
+```
+
+### Custom Tooltip
+
+```svelte
+<DualAxisBarChart {categories} {series}>
+  {#snippet tooltipSnippet(ctx)}
+    <div style="background:#222; color:#fff; padding:8px 12px; border-radius:6px;">
+      <strong>{ctx.category}</strong>
+      {#each ctx.points as pt}
+        <div style="display:flex; gap:8px; align-items:center;">
+          <span style="background:{pt.color}; width:8px; height:8px; border-radius:2px;"></span>
+          {pt.name}: <strong>{pt.value}</strong>
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+</DualAxisBarChart>
+```
+
+### Click Handler
+
+```svelte
+<DualAxisBarChart
+  {categories}
+  {series}
+  onbarclick={(event) => {
+    console.log('clicked category', event.context.category);
+    console.log('all points', event.context.points);
+  }}
+/>
+```
+
+## Props
+
+| Prop            | Type                                          | Required | Default  | Description                                                                                                                                                     |
+| --------------- | --------------------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| categories      | `string[]`                                    | Yes      | —        | Ordered category labels for the shared X-axis (e.g. `['Jan', 'Feb', 'Mar']`). All series `data` arrays must have the same length as `categories`.              |
+| series          | `DualAxisSeries[]`                            | Yes      | —        | Array of series descriptors. Each series declares `yAxisIndex` (0=left, 1=right), `data` values, an optional render `type`, and an optional `color`.            |
+| leftAxis        | `DualAxisConfig`                              | No       | `{}`     | Configuration for the left (primary) Y-axis. Accepts `title`, `color`, and `valueFormat`.                                                                      |
+| rightAxis       | `DualAxisConfig`                              | No       | `{}`     | Configuration for the right (secondary) Y-axis. Accepts `title`, `color`, and `valueFormat`.                                                                   |
+| showGridlines   | `boolean`                                     | No       | `true`   | Whether to render dashed horizontal gridlines from the left-axis ticks.                                                                                         |
+| showLegend      | `boolean`                                     | No       | `true`   | Whether to render the shared series legend above the chart.                                                                                                     |
+| barRadius       | `number`                                      | No       | `3`      | Corner radius of column/bar shapes in pixels.                                                                                                                   |
+| barPadding      | `number`                                      | No       | `0.25`   | Padding between category bands as a fraction of band width (0–1).                                                                                               |
+| aspectRatio     | `number`                                      | No       | `16/9`   | Width-to-height ratio for the chart. Passed to ChartContainer's ResizeObserver sizing.                                                                          |
+| tooltipSnippet  | `Snippet<[DualAxisTooltipContext]>`            | No       | —        | Custom tooltip content rendered on hover. Receives a `DualAxisTooltipContext` with the hovered category and all series values. Replaces the default tooltip.    |
+| testId          | `string`                                      | No       | —        | Value for the `data-pw` attribute on the root element for test targeting.                                                                                       |
+| classes         | `string`                                      | No       | —        | Extra CSS class string on the root `<div>`. Useful for applying scoped CSS variable overrides.                                                                  |
+
+## Events
+
+| Event      | Type                                                                                             | Description                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| onbarclick | `(event: { categoryIndex: number; context: DualAxisTooltipContext }) => void`                    | Fires when the user clicks anywhere within a category column. Provides the index and full series context. |
+
+## Type Reference
+
+```typescript
+type DualAxisSeries = {
+  /** Display name shown in legend and tooltip. */
+  name: string;
+  /** Numeric values — one per category. */
+  data: number[];
+  /** Which Y-axis: 0 = left, 1 = right. */
+  yAxisIndex: 0 | 1;
+  /** Optional CSS color. Falls back to the default palette. */
+  color?: string;
+  /**
+   * Render type for this series.
+   * 'column' — vertical bars (default).
+   * 'line'   — line with dots drawn above the column layer.
+   */
+  type?: 'column' | 'line';
+};
+
+type DualAxisConfig = {
+  /** Label rendered above the axis line. */
+  title?: string;
+  /** CSS color for the axis title text. */
+  color?: string;
+  /** Custom tick formatter. Receives a raw number, returns display string. */
+  valueFormat?: (value: number) => string;
+};
+
+type DualAxisTooltipContext = {
+  /** The hovered category label. */
+  category: string;
+  /** Zero-based index of the hovered category. */
+  categoryIndex: number;
+  /** All series values for this category. */
+  points: Array<{
+    name: string;
+    value: number;
+    color: string;
+    yAxisIndex: 0 | 1;
+    type: 'column' | 'line';
+  }>;
+};
+```
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                              | Default                     | CSS Property     | Description                                               |
+| ------------------------------------- | --------------------------- | ---------------- | --------------------------------------------------------- |
+| `--chart-background`                  | `transparent`               | background       | Background color of the chart container.                  |
+| `--chart-font-family`                 | `inherit`                   | font-family      | Font family for all chart text.                           |
+| `--chart-transition-duration`         | `0.2s`                      | transition       | Duration of hover/opacity transitions.                    |
+| `--chart-axis-color`                  | `#666`                      | stroke, fill     | Color of axis lines, tick marks, and tick labels.         |
+| `--chart-axis-stroke-width`           | `1`                         | stroke-width     | Width of axis lines and tick marks.                       |
+| `--chart-axis-font-size`              | `11px`                      | font-size        | Font size of axis tick labels.                            |
+| `--chart-axis-label-color`            | `#333`                      | fill             | Color of axis title text.                                 |
+| `--chart-axis-label-font-size`        | `11px`                      | font-size        | Font size of axis title labels.                           |
+| `--chart-gridline-color`              | `#e0e0e0`                   | stroke           | Color of horizontal gridlines.                            |
+| `--chart-gridline-opacity`            | `0.5`                       | stroke-opacity   | Opacity of gridlines.                                     |
+| `--chart-gridline-dash`               | `4 4`                       | stroke-dasharray | Dash pattern for gridlines.                               |
+| `--chart-tooltip-background`          | `rgba(0,0,0,0.85)`          | background       | Background of the default tooltip.                        |
+| `--chart-tooltip-color`               | `#fff`                      | color            | Text color of the default tooltip.                        |
+| `--chart-tooltip-font-size`           | `12px`                      | font-size        | Font size of tooltip content.                             |
+| `--chart-tooltip-padding`             | `8px 12px`                  | padding          | Inner padding of the default tooltip.                     |
+| `--chart-tooltip-border-radius`       | `4px`                       | border-radius    | Border radius of the default tooltip.                     |
+| `--chart-tooltip-shadow`              | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Box shadow on the default tooltip.                        |
+| `--chart-legend-gap`                  | `16px`                      | gap              | Space between legend items.                               |
+| `--chart-legend-font-size`            | `12px`                      | font-size        | Font size of legend labels.                               |
+| `--chart-legend-swatch-size`          | `12px`                      | width, height    | Size of color swatches in the legend.                     |
+| `--chart-legend-color`                | `#333`                      | color            | Color of legend text.                                     |
+| `--dual-axis-bar-hover-opacity`       | `1`                         | opacity          | Opacity of bars in the hovered category.                  |
+| `--dual-axis-bar-dimmed-opacity`      | `0.3`                       | opacity          | Opacity of bars outside the hovered category.             |
+| `--dual-axis-line-stroke-width`       | `2`                         | stroke-width     | Stroke width of line series paths.                        |
+| `--dual-axis-dot-stroke`              | `#fff`                      | stroke           | Stroke color around line series dots.                     |
+| `--dual-axis-dot-stroke-width`        | `1.5`                       | stroke-width     | Stroke width of line series dots.                         |
+| `--dual-axis-guideline-color`         | `#aaa`                      | stroke           | Color of the vertical hover guideline.                    |
+| `--dual-axis-guideline-width`         | `1`                         | stroke-width     | Width of the vertical hover guideline.                    |
+| `--dual-axis-guideline-dash`          | `4 3`                       | stroke-dasharray | Dash pattern of the vertical hover guideline.             |
+| `--chart-empty-padding`               | `32px 24px`                 | padding          | Padding around the empty-state message.                   |
+| `--chart-empty-color`                 | `#9ca3af`                   | color            | Text color of the empty-state message.                    |
+
+## Web Component
+
+```html
+<sui-dual-axis-bar-chart
+  test-id="my-chart"
+  show-gridlines="true"
+  show-legend="true"
+></sui-dual-axis-bar-chart>
+<script>
+  const chart = document.querySelector('sui-dual-axis-bar-chart');
+  chart.categories = ['Jan', 'Feb', 'Mar'];
+  chart.series = [
+    { name: 'Revenue', data: [100, 200, 150], yAxisIndex: 0, type: 'column' },
+    { name: 'CTR', data: [3.2, 4.1, 3.7], yAxisIndex: 1, type: 'line' }
+  ];
+  chart.leftAxis = { title: 'Revenue ($)' };
+  chart.rightAxis = { title: 'CTR (%)', valueFormat: (v) => `${v.toFixed(1)}%` };
+</script>
+```

--- a/docs/FunnelChart.md
+++ b/docs/FunnelChart.md
@@ -1,0 +1,155 @@
+# FunnelChart
+
+A horizontal funnel chart built entirely from pure SVG — no external charting library required. Each stage renders as a rectangle whose height is proportional to its value relative to the maximum stage, and consecutive stages are joined by trapezoidal connector polygons that visually convey the drop-off between steps. Supports per-stage color overrides, custom value-and-percentage labels, hover expansion, click/hover events, and full CSS-variable theming.
+
+## Usage
+
+```svelte
+<script>
+  import { FunnelChart } from '@juspay/svelte-ui-components';
+
+  const stages = [
+    { category: 'Visit', value: 12000 },
+    { category: 'Product View', value: 8400 },
+    { category: 'Add to Cart', value: 4200 },
+    { category: 'Checkout', value: 2100 },
+    { category: 'Purchase', value: 980 }
+  ];
+</script>
+
+<FunnelChart data={stages} />
+```
+
+### Custom Stage Colors
+
+```svelte
+<FunnelChart
+  data={stages}
+  stageColors={['#8EE3F6', '#79E2E9', '#82DEE4', '#87E3D3', '#78CDBE']}
+  connectorColor="#BDFFFB"
+/>
+```
+
+### Custom Value Format
+
+```svelte
+<FunnelChart
+  data={stages}
+  valueFormat={(value) => value.toLocaleString()}
+/>
+```
+
+### Hide Value Labels
+
+```svelte
+<FunnelChart data={stages} showValueLabels={false} />
+```
+
+### Wider Connectors
+
+```svelte
+<FunnelChart data={stages} slopeWidth={24} />
+```
+
+### Disable Hover Expansion
+
+```svelte
+<FunnelChart data={stages} onHoverExpand={0} />
+```
+
+### Events
+
+```svelte
+<FunnelChart
+  data={stages}
+  onstageclick={({ index, stage }) => console.log('clicked', stage.category, index)}
+  onstagehover={(event) => console.log('hovered', event?.stage.category ?? 'none')}
+/>
+```
+
+### Empty State
+
+```svelte
+<FunnelChart data={[]}>
+  {#snippet empty()}
+    <p>No funnel data available.</p>
+  {/snippet}
+</FunnelChart>
+```
+
+## Props
+
+| Prop            | Type                                              | Required | Default                               | Description                                                                                                                                       |
+| --------------- | ------------------------------------------------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data            | `FunnelStage[]`                                   | Yes      | –                                     | Ordered array of `{ category, value }` stage objects. Stages are rendered left-to-right; the tallest bar corresponds to the maximum value.         |
+| stageColors     | `string[]`                                        | No       | chart palette                         | Fill color for each stage bar, index-matched to `data`. Unspecified entries fall back to the shared chart palette.                                 |
+| connectorColor  | `string`                                          | No       | `#BDFFFB`                             | Fill color for the trapezoidal connector shapes between consecutive stages.                                                                        |
+| slopeWidth      | `number`                                          | No       | `10`                                  | Horizontal width (SVG units) of each slope connector. Larger values produce steeper visual drops.                                                  |
+| onHoverExpand   | `number`                                          | No       | `10`                                  | Extra vertical pixels added symmetrically to the hovered stage bar. Set to `0` to disable.                                                        |
+| showValueLabels | `boolean`                                         | No       | `true`                                | Whether to render the value and percentage label centred inside each stage bar.                                                                    |
+| valueFormat     | `(value: number, max: number) => string`          | No       | `"<value>  \|  <pct>%"`              | Custom formatter for in-bar labels. Receives the stage value and the maximum value across all stages.                                              |
+| aspectRatio     | `number`                                          | No       | `16 / 9`                              | Width-to-height ratio passed to `ChartContainer`. Controls the chart's height relative to its container width.                                     |
+| testId          | `string`                                          | No       | –                                     | Value for the `data-pw` attribute on the chart root element.                                                                                      |
+| classes         | `string`                                          | No       | –                                     | CSS class string applied to the chart root element. Useful for scoping CSS-variable overrides.                                                     |
+| empty           | `Snippet`                                         | No       | –                                     | Content rendered when `data` is empty or all values are zero.                                                                                     |
+
+## Events
+
+| Event        | Type                                                                   | Description                                                                 |
+| ------------ | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| onstageclick | `(event: { index: number; stage: FunnelStage }) => void`               | Fires when the user clicks a stage bar. Receives the index and stage data.  |
+| onstagehover | `(event: { index: number; stage: FunnelStage } \| null) => void`       | Fires on stage hover and leave. Receives `null` when the pointer leaves.    |
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                               | Default                     | CSS Property     | Description                                                   |
+| -------------------------------------- | --------------------------- | ---------------- | ------------------------------------------------------------- |
+| `--chart-background`                   | `transparent`               | background       | Background color of the chart container.                      |
+| `--chart-font-family`                  | `inherit`                   | font-family      | Font family for all chart text.                               |
+| `--chart-transition-duration`          | `0.2s`                      | transition       | Duration of hover and expand transitions.                     |
+| `--chart-tooltip-background`           | `rgba(0,0,0,0.85)`          | background       | Background of the default tooltip.                            |
+| `--chart-tooltip-color`                | `#fff`                      | color            | Text color of the default tooltip.                            |
+| `--chart-tooltip-font-size`            | `12px`                      | font-size        | Font size of tooltip content.                                 |
+| `--chart-tooltip-padding`              | `8px 12px`                  | padding          | Inner padding of the tooltip.                                 |
+| `--chart-tooltip-border-radius`        | `4px`                       | border-radius    | Border radius of the tooltip.                                 |
+| `--chart-tooltip-shadow`               | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Shadow on the tooltip.                                        |
+| `--chart-empty-padding`                | `32px 24px`                 | padding          | Padding around the empty state content.                       |
+| `--chart-empty-color`                  | `#9ca3af`                   | color            | Text color of the empty state.                                |
+| `--funnel-chart-connector-color`       | `#BDFFFB`                   | fill             | Default fill for trapezoidal connector shapes.                |
+| `--funnel-chart-label-color`           | `#666`                      | fill             | Color of the category labels above each stage bar.            |
+| `--funnel-chart-label-font-size`       | `11px`                      | font-size        | Font size of category labels.                                 |
+| `--funnel-chart-value-color`           | `#fff`                      | fill             | Color of the value/percentage labels inside bars.             |
+| `--funnel-chart-value-font-size`       | `11px`                      | font-size        | Font size of in-bar value labels.                             |
+| `--funnel-chart-bar-hover-opacity`     | `1`                         | opacity          | Opacity of the hovered stage bar.                             |
+| `--funnel-chart-bar-dimmed-opacity`    | `0.35`                      | opacity          | Opacity of non-hovered bars when another stage is hovered.    |
+
+## Type Reference
+
+```typescript
+type FunnelStage = {
+  value: number;
+  category: string;
+};
+```
+
+## Web Component
+
+```html
+<sui-funnel-chart></sui-funnel-chart>
+
+<script>
+  const chart = document.querySelector('sui-funnel-chart');
+  chart.data = [
+    { category: 'Visit', value: 12000 },
+    { category: 'Cart', value: 4200 },
+    { category: 'Purchase', value: 980 }
+  ];
+  chart.stageColors = ['#4e79a7', '#f28e2b', '#59a14f'];
+  chart.showValueLabels = true;
+  chart.addEventListener('onstageclick', (e) => console.log(e.detail));
+</script>
+```
+
+All props are exposed as web component properties. Array and object props (`data`, `stageColors`, `valueFormat`, `onstageclick`, `onstagehover`) must be set via JavaScript property assignment, not HTML attributes.

--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -1,6 +1,6 @@
 # LineChart
 
-A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series, five curve interpolations (linear, monotone, spline, step, natural), gradient fill under the line, an overlay hover tracker that finds the nearest point even when dots are hidden, crosshair vertical line, data point labels, legend, and custom tooltips.
+A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series, five curve interpolations (linear, monotone, spline, step, natural), gradient fill under the line, a `showArea` mode with per-gradient custom colours, an `xAxisCategories` prop that replaces numeric x indices with string labels, an imperative highlight API exposed via `onChartReady` for external orchestration (e.g. voice narration sync), a declarative `highlightedIndex` prop, an overlay hover tracker that finds the nearest point even when dots are hidden, crosshair vertical line, data point labels, legend, and custom tooltips. Zero external dependencies — built from pure SVG with CSS custom property theming.
 
 ## Usage
 
@@ -32,15 +32,11 @@ A responsive SVG line chart for visualizing trends over continuous data. Support
   const series = [
     {
       name: 'Product A',
-      data: [
-        /* ... */
-      ]
+      data: [/* ... */]
     },
     {
       name: 'Product B',
-      data: [
-        /* ... */
-      ]
+      data: [/* ... */]
     }
   ];
 </script>
@@ -61,6 +57,82 @@ A responsive SVG line chart for visualizing trends over continuous data. Support
 <!-- horizontal-then-vertical steps -->
 <LineChart {series} curve="natural" />
 <!-- smooth natural cubic spline -->
+```
+
+### xAxisCategories — String Category Labels
+
+Replace the raw numeric x values on the X axis with human-readable category names. The array is parallel to the x indices (index 0 maps to `x=1`, index 1 maps to `x=2`, and so on).
+
+```svelte
+<script>
+  const monthSeries = [
+    {
+      name: 'Revenue',
+      data: [
+        { x: 1, y: 30 },
+        { x: 2, y: 45 },
+        { x: 3, y: 38 }
+      ]
+    }
+  ];
+  const months = ['Jan', 'Feb', 'Mar'];
+</script>
+
+<LineChart series={monthSeries} xAxisCategories={months} />
+```
+
+Category labels also appear in the default tooltip title instead of the raw numeric `x` value.
+
+### showArea — Filled Area Under the Line
+
+Fill the area below each line with a vertical gradient. By default the gradient is derived from the series colour (opaque at the top, transparent at the bottom). Supply `areaGradient` to use fully custom from/to colour stops.
+
+```svelte
+<!-- Default: uses series colour -->
+<LineChart {series} showArea />
+
+<!-- Custom gradient colours -->
+<LineChart
+  {series}
+  showArea
+  areaGradient={{ from: 'rgba(99,102,241,0.5)', to: 'rgba(99,102,241,0)' }}
+/>
+```
+
+### Highlight Hook — onChartReady
+
+Receive a `ChartHighlightAPI` after mount to drive point highlighting from an external orchestrator (e.g. animated step-through, voice narration sync, keyboard navigation):
+
+```svelte
+<script>
+  import type { ChartHighlightAPI } from '@juspay/svelte-ui-components';
+
+  let api;
+
+  const onChartReady = (chartApi) => {
+    api = chartApi;
+  };
+
+  // Later, to highlight the 3rd point:
+  api?.highlight(2);
+
+  // To clear:
+  api?.highlight(null);
+
+  // To read back the category labels:
+  const labels = api?.getCategories(); // e.g. ['Jan', 'Feb', 'Mar', ...]
+</script>
+
+<LineChart {series} xAxisCategories={months} {onChartReady} />
+```
+
+### highlightedIndex — Declarative Prop
+
+Highlight a point without a callback. Set `highlightedIndex` to a zero-based point index. The chart enlarges that dot, draws the crosshair, and dims all other dots. Set to `null` to clear.
+
+```svelte
+<!-- Highlight the 6th point (index 5) -->
+<LineChart {series} highlightedIndex={5} />
 ```
 
 ### Data Labels
@@ -92,52 +164,69 @@ Hovering anywhere over the plot area finds the nearest point and shows a crossha
 </LineChart>
 ```
 
+### Empty State
+
+```svelte
+<LineChart series={[]}>
+  {#snippet empty()}
+    <p>No data available.</p>
+  {/snippet}
+</LineChart>
+```
+
 ## Props
 
-| Prop           | Type                                                        | Required | Default      | Description                                                                                                               |
-| -------------- | ----------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| series         | `LineChartSeries[]`                                         | Yes      | `-`          | Array of `{name, data, color?}`. Each series renders as a separate line.                                                  |
-| curve          | `'linear' \| 'monotone' \| 'spline' \| 'step' \| 'natural'` | No       | `'monotone'` | Interpolation between points. `'spline'` is an alias for `'monotone'`.                                                    |
-| gradientFill   | `boolean`                                                   | No       | `false`      | When true, renders a gradient fill under each line fading from `fillOpacity+0.3` at the top to transparent at the bottom. |
-| fillOpacity    | `number`                                                    | No       | `0.3`        | Base opacity of the gradient fill (0–1). Only used when `gradientFill` is true. Hovered series gets `+0.2` boost.         |
-| showDots       | `boolean`                                                   | No       | `true`       | Whether to render dots at each data point. Hover still works via overlay when `false`.                                    |
-| showValues     | `boolean`                                                   | No       | `false`      | Whether to render text labels with the y-value at each data point.                                                        |
-| dotRadius      | `number`                                                    | No       | `4`          | Radius of data point dots in pixels. Hovered dot is 1.5× this.                                                            |
-| strokeWidth    | `number`                                                    | No       | `2`          | Width of line strokes in pixels.                                                                                          |
-| showGridlines  | `boolean`                                                   | No       | `true`       | Whether to show dashed gridlines across the Y axis.                                                                       |
-| showXAxis      | `boolean`                                                   | No       | `true`       | Whether to render the X axis.                                                                                             |
-| showYAxis      | `boolean`                                                   | No       | `true`       | Whether to render the Y axis.                                                                                             |
-| showLegend     | `boolean`                                                   | No       | `false`      | Whether to render the legend. Only shown when there are multiple series.                                                  |
-| xDomain        | `[number, number]`                                          | No       | auto         | Fixed `[min, max]` for the X axis.                                                                                        |
-| yDomain        | `[number, number]`                                          | No       | auto         | Fixed `[min, max]` for the Y axis.                                                                                        |
-| xAxisLabel     | `string`                                                    | No       | `-`          | Text label below the X axis.                                                                                              |
-| yAxisLabel     | `string`                                                    | No       | `-`          | Text label beside the Y axis (rotated).                                                                                   |
-| xTickFormat    | `(value: number \| string) => string`                       | No       | abbreviated  | Formatter for X axis tick labels.                                                                                         |
-| yTickFormat    | `(value: number \| string) => string`                       | No       | abbreviated  | Formatter for Y axis tick labels.                                                                                         |
-| aspectRatio    | `number`                                                    | No       | `16/9`       | Width-to-height ratio.                                                                                                    |
-| tooltipSnippet | `Snippet<[LineChartTooltipContext]>`                        | No       | `-`          | Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}` with values for all series at the hovered X.           |
-| empty          | `Snippet`                                                   | No       | `-`          | Content rendered when all series are empty.                                                                               |
-| testId         | `string`                                                    | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                   |
-| classes        | `string`                                                    | No       | `-`          | CSS class string applied to the top-level element.                                                                        |
+| Prop              | Type                                                         | Required | Default      | Description                                                                                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------ | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| series            | `LineChartSeries[]`                                          | Yes      | `-`          | Array of `{name, data, color?}`. Each series renders as a separate line.                                                                                                                                                            |
+| curve             | `'linear' \| 'monotone' \| 'spline' \| 'step' \| 'natural'` | No       | `'monotone'` | Interpolation between points. `'spline'` is an alias for `'monotone'`.                                                                                                                                                              |
+| gradientFill      | `boolean`                                                    | No       | `false`      | Legacy gradient fill: renders a per-series gradient using the series colour, from `fillOpacity+0.3` at top to transparent. Superseded by `showArea` + `areaGradient` for new usage.                                                 |
+| fillOpacity       | `number`                                                     | No       | `0.3`        | Base opacity of the `gradientFill` area (0–1). Hovered series gets `+0.2` boost.                                                                                                                                                    |
+| showArea          | `boolean`                                                    | No       | `false`      | Fill the area under each line. Uses `areaGradient` colours when provided; otherwise derives a vertical gradient from the series colour (0.35 opacity at top, transparent at bottom).                                                |
+| areaGradient      | `{ from: string; to: string }`                               | No       | `-`          | Custom CSS colour stops for the `showArea` fill. `from` is the colour at the top (near the line), `to` is the colour at the baseline. Any valid CSS colour string is accepted.                                                      |
+| showDots          | `boolean`                                                    | No       | `true`       | Whether to render dots at each data point. Hover still works via overlay when `false`.                                                                                                                                              |
+| showValues        | `boolean`                                                    | No       | `false`      | Whether to render text labels with the y-value at each data point.                                                                                                                                                                  |
+| dotRadius         | `number`                                                     | No       | `4`          | Radius of data point dots in pixels. Hovered or highlighted dot is 1.5× this.                                                                                                                                                       |
+| strokeWidth       | `number`                                                     | No       | `2`          | Width of line strokes in pixels.                                                                                                                                                                                                    |
+| showGridlines     | `boolean`                                                    | No       | `true`       | Whether to show dashed gridlines across the Y axis.                                                                                                                                                                                 |
+| showXAxis         | `boolean`                                                    | No       | `true`       | Whether to render the X axis.                                                                                                                                                                                                       |
+| showYAxis         | `boolean`                                                    | No       | `true`       | Whether to render the Y axis.                                                                                                                                                                                                       |
+| showLegend        | `boolean`                                                    | No       | `false`      | Whether to render the legend. Only shown when there are multiple series.                                                                                                                                                            |
+| xDomain           | `[number, number]`                                           | No       | auto         | Fixed `[min, max]` for the X axis.                                                                                                                                                                                                  |
+| yDomain           | `[number, number]`                                           | No       | auto         | Fixed `[min, max]` for the Y axis.                                                                                                                                                                                                  |
+| xAxisLabel        | `string`                                                     | No       | `-`          | Text label below the X axis.                                                                                                                                                                                                        |
+| yAxisLabel        | `string`                                                     | No       | `-`          | Text label beside the Y axis (rotated).                                                                                                                                                                                             |
+| xAxisCategories   | `string[]`                                                   | No       | `-`          | String category labels, one per x-index (parallel array). Index 0 maps to `x=1`, index 1 to `x=2`, and so on. When provided, these labels replace raw numeric x values on tick labels, the tooltip title, and `getCategories()`. |
+| xTickFormat       | `(value: number \| string) => string`                        | No       | abbreviated  | Formatter for X axis tick labels. When provided, overrides the `xAxisCategories` tick formatter.                                                                                                                                    |
+| yTickFormat       | `(value: number \| string) => string`                        | No       | abbreviated  | Formatter for Y axis tick labels.                                                                                                                                                                                                   |
+| aspectRatio       | `number`                                                     | No       | `16/9`       | Width-to-height ratio.                                                                                                                                                                                                              |
+| highlightedIndex  | `number \| null`                                             | No       | `null`       | Zero-based point index to highlight declaratively. Enlarges the dot at that index, draws the crosshair, and dims all other dots. Set `null` to clear.                                                                              |
+| tooltipSnippet    | `Snippet<[LineChartTooltipContext]>`                         | No       | `-`          | Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}` with values for all series at the hovered X.                                                                                                                    |
+| empty             | `Snippet`                                                    | No       | `-`          | Content rendered when all series are empty.                                                                                                                                                                                         |
+| testId            | `string`                                                     | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                                                                                                                             |
+| classes           | `string`                                                     | No       | `-`          | CSS class string applied to the top-level element.                                                                                                                                                                                  |
 
 ## Events
 
-| Event        | Type                                                                                              | Description                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| onpointclick | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint }) => void`         | Fires when the plot area is clicked with a hovered point.         |
-| onpointhover | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint } \| null) => void` | Fires when hover moves to a new point or leaves. `null` on leave. |
+| Event        | Type                                                                                              | Description                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| onpointclick | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint }) => void`         | Fires when the plot area is clicked with a hovered point.                                                               |
+| onpointhover | `(event: { seriesIndex: number; pointIndex: number; point: LineChartDataPoint } \| null) => void` | Fires when hover moves to a new point or leaves the chart. `null` on leave.                                             |
+| onChartReady | `(api: ChartHighlightAPI) => void`                                                                | Called once after mount. Provides a `ChartHighlightAPI` for imperative `highlight(index\|null)` and `getCategories()`. |
 
 ## CSS Variables
 
 In addition to the shared `--chart-*` variables (see BarChart docs), LineChart exposes:
 
-| Variable                       | Default | CSS Property     | Description                                  |
-| ------------------------------ | ------- | ---------------- | -------------------------------------------- |
-| `--linechart-dimmed-opacity`   | `0.2`   | opacity          | Opacity of non-hovered series when hovering. |
-| `--linechart-hover-line-color` | `#ccc`  | stroke           | Color of the vertical crosshair line.        |
-| `--linechart-hover-line-dash`  | `4 4`   | stroke-dasharray | Dash pattern of the crosshair.               |
-| `--linechart-value-color`      | `#333`  | fill             | Color of point value labels.                 |
-| `--linechart-value-font-size`  | `11px`  | font-size        | Font size of point value labels.             |
+| Variable                            | Default | CSS Property     | Description                                                        |
+| ----------------------------------- | ------- | ---------------- | ------------------------------------------------------------------ |
+| `--linechart-dimmed-opacity`        | `0.2`   | opacity          | Opacity of non-hovered / non-highlighted series/points.            |
+| `--linechart-hover-line-color`      | `#ccc`  | stroke           | Color of the vertical crosshair line (hover and highlight).        |
+| `--linechart-hover-line-dash`       | `4 4`   | stroke-dasharray | Dash pattern of the crosshair.                                     |
+| `--linechart-value-color`           | `#333`  | fill             | Color of point value labels.                                       |
+| `--linechart-value-font-size`       | `11px`  | font-size        | Font size of point value labels.                                   |
+| `--linechart-highlight-ring-color`  | `#fff`  | stroke           | Ring (outline) stroke colour of an actively highlighted dot.       |
+| `--linechart-highlight-ring-width`  | `2.5`   | stroke-width     | Ring stroke width of an actively highlighted dot.                  |
 
 ## Type Reference
 
@@ -158,4 +247,32 @@ type LineChartTooltipContext = {
   x: number;
   points: Array<{ name: string; y: number; color: string; label?: string }>;
 };
+
+type LineChartAreaGradient = {
+  /** Colour at the top of the gradient (closest to the line). */
+  from: string;
+  /** Colour at the bottom of the gradient (at the baseline). */
+  to: string;
+};
+
+// From @juspay/svelte-ui-components — also used by BarChart, DonutChart
+type ChartHighlightAPI = {
+  highlight: (index: number | null) => void;
+  getCategories: () => string[];
+  type: 'bar-chart' | 'line-chart' | 'donut-chart';
+};
 ```
+
+## Web Component
+
+```html
+<sui-line-chart
+  series='[{"name":"Revenue","data":[{"x":1,"y":30},{"x":2,"y":45}]}]'
+  show-area="true"
+  show-dots="true"
+  show-legend="false"
+  test-id="my-line-chart"
+></sui-line-chart>
+```
+
+Object/array props (`series`, `xDomain`, `yDomain`, `xAxisCategories`, `areaGradient`, callback props) must be set via JavaScript property assignment on the element, not as HTML attributes.

--- a/docs/PieChart.md
+++ b/docs/PieChart.md
@@ -1,6 +1,6 @@
 # PieChart
 
-A responsive SVG pie/donut chart with slice hover highlighting, custom labels, legend, and donut center content. When `innerRadius` is set, renders as a donut with optional content in the center hole via the `center` snippet. Supports a semi-circle (half-donut) layout via `semiCircle`, a tabular value legend via `legendShowValues`, and configurable percentage decimal places via `percentDecimals`.
+A responsive SVG pie/donut chart with slice hover highlighting, programmatic highlight control, an optional delta-change badge, custom labels, legend, and donut center content. When `innerRadius` is set, renders as a donut with optional content in the center hole via the `center` snippet. Supports a semi-circle (half-donut) layout via `semiCircle`, a tabular value legend via `legendShowValues`, and configurable percentage decimal places via `percentDecimals`. The `onChartReady` callback delivers an imperative `ChartHighlightAPI` so external orchestrators (e.g. voice narration, dashboards) can drive slice highlights without touching component state; the `highlightedIndex` prop provides the same capability declaratively. A `changePercentage` prop renders a positioned `DeltaIndicator` badge at the top-right corner of the chart container, with `changeInvertColors` for lower-is-better metrics.
 
 ## Usage
 
@@ -72,6 +72,49 @@ Use `percentDecimals` to control decimal places in the percentage column and on-
 <PieChart {data} showLegend legendShowValues percentDecimals={2} />
 ```
 
+### Delta Badge
+
+Render a `DeltaIndicator` badge anchored to the top-right corner. Positive values appear green ↑, negative appear red ↓ by default. Use `changeInvertColors` for lower-is-better metrics (e.g. RTO rate, bounce rate).
+
+```svelte
+<!-- Revenue up 12.5% -->
+<PieChart {data} changePercentage={12.5} />
+
+<!-- RTO rate down 8% — good, so show green ↓ -->
+<PieChart {data} changePercentage={-8} changeInvertColors />
+```
+
+### Programmatic Highlight — Declarative
+
+Highlight a specific slice index via the `highlightedIndex` prop. The highlighted slice scales out; all others dim. Pass `null` to clear.
+
+```svelte
+<script>
+  let highlighted = $state(0); // highlight Chrome
+</script>
+
+<PieChart {data} innerRadius={0.6} highlightedIndex={highlighted} />
+```
+
+### Programmatic Highlight — Imperative API
+
+Use `onChartReady` to receive a `ChartHighlightAPI` handle. Call `api.highlight(index)` / `api.highlight(null)` from external logic (voice narration, keyboard controls, dashboard orchestration).
+
+```svelte
+<script>
+  import type { ChartHighlightAPI } from '@juspay/svelte-ui-components';
+
+  let chartApi: ChartHighlightAPI | null = $state(null);
+</script>
+
+<PieChart {data} innerRadius={0.6} onChartReady={(api) => { chartApi = api; }} />
+
+<button onclick={() => chartApi?.highlight(0)}>Highlight Chrome</button>
+<button onclick={() => chartApi?.highlight(null)}>Clear</button>
+```
+
+The `type` field on the returned API is always `'donut-chart'`, regardless of whether `innerRadius` is set.
+
 ### Custom Tooltip
 
 ```svelte
@@ -86,26 +129,30 @@ Use `percentDecimals` to control decimal places in the percentage column and on-
 
 ## Props
 
-| Prop             | Type                               | Required | Default      | Description                                                                                                |
-| ---------------- | ---------------------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
-| data             | `PieChartSlice[]`                  | Yes      | `-`          | Array of `{label, value, color?}`. Each item becomes one slice. Slice angle is proportional to value.      |
-| innerRadius      | `number`                           | No       | `0`          | Inner radius as a fraction of outer radius (0-1). `0` renders a pie; `>0` renders a donut.                 |
-| padAngle         | `number`                           | No       | `0.02`       | Angular gap between slices in radians.                                                                     |
-| showLabels       | `boolean`                          | No       | `false`      | Whether to render slice labels (either inside or outside depending on `labelPosition`).                    |
-| showValues       | `boolean`                          | No       | `false`      | Whether to render the slice percentage as a label.                                                         |
-| labelPosition    | `'inside' \| 'outside'`            | No       | `'outside'`  | Where to render slice labels.                                                                              |
-| showLegend       | `boolean`                          | No       | `false`      | Whether to render a legend above the chart.                                                                |
-| startAngle       | `number`                           | No       | `-Math.PI/2` | Starting angle in radians. Default starts at 12 o'clock position.                                          |
-| aspectRatio      | `number`                           | No       | `1`          | Width-to-height ratio. `1` produces a circular container.                                                  |
-| valueFormat      | `(value: number) => string`        | No       | abbreviated  | Formatter for slice values in the default tooltip.                                                         |
-| tooltipSnippet   | `Snippet<[PieChartSlice, number]>` | No       | `-`          | Custom tooltip content. Receives the hovered slice and its index.                                          |
-| center           | `Snippet`                          | No       | `-`          | Content rendered inside the donut hole (only when `innerRadius > 0`). Rendered via SVG `foreignObject`.    |
-| empty            | `Snippet`                          | No       | `-`          | Content rendered when `data` is empty or all values are zero.                                              |
-| semiCircle       | `boolean`                          | No       | `false`      | Render as a semi-circle (half-pie/donut). Arc spans the top 180°. Aspect ratio defaults to 2:1.            |
-| legendShowValues | `boolean`                          | No       | `false`      | When `showLegend` is also true, renders a tabular legend with formatted values and percentages per slice.  |
-| percentDecimals  | `number`                           | No       | `0`          | Decimal places used for percentage formatting in on-arc labels (`showValues`) and the legend value column. |
-| testId           | `string`                           | No       | `-`          | Value for the data-pw attribute on the chart container.                                                    |
-| classes          | `string`                           | No       | `-`          | CSS class string applied to the top-level element.                                                         |
+| Prop               | Type                               | Required | Default      | Description                                                                                                                                                                              |
+| ------------------ | ---------------------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data               | `PieChartSlice[]`                  | Yes      | `-`          | Array of `{label, value, color?}`. Each item becomes one slice. Slice angle is proportional to value.                                                                                   |
+| innerRadius        | `number`                           | No       | `0`          | Inner radius as a fraction of outer radius (0-1). `0` renders a pie; `>0` renders a donut.                                                                                              |
+| padAngle           | `number`                           | No       | `0.02`       | Angular gap between slices in radians.                                                                                                                                                   |
+| showLabels         | `boolean`                          | No       | `false`      | Whether to render slice labels (either inside or outside depending on `labelPosition`).                                                                                                  |
+| showValues         | `boolean`                          | No       | `false`      | Whether to render the slice percentage as a label.                                                                                                                                       |
+| labelPosition      | `'inside' \| 'outside'`            | No       | `'outside'`  | Where to render slice labels.                                                                                                                                                            |
+| showLegend         | `boolean`                          | No       | `false`      | Whether to render a legend above the chart.                                                                                                                                              |
+| startAngle         | `number`                           | No       | `-Math.PI/2` | Starting angle in radians. Default starts at 12 o'clock position.                                                                                                                       |
+| aspectRatio        | `number`                           | No       | `1`          | Width-to-height ratio. `1` produces a circular container.                                                                                                                                |
+| valueFormat        | `(value: number) => string`        | No       | abbreviated  | Formatter for slice values in the default tooltip.                                                                                                                                       |
+| tooltipSnippet     | `Snippet<[PieChartSlice, number]>` | No       | `-`          | Custom tooltip content. Receives the hovered slice and its index.                                                                                                                        |
+| center             | `Snippet`                          | No       | `-`          | Content rendered inside the donut hole (only when `innerRadius > 0`). Rendered via SVG `foreignObject`.                                                                                 |
+| empty              | `Snippet`                          | No       | `-`          | Content rendered when `data` is empty or all values are zero.                                                                                                                            |
+| semiCircle         | `boolean`                          | No       | `false`      | Render as a semi-circle (half-pie/donut). Arc spans the top 180°. Aspect ratio defaults to 2:1.                                                                                         |
+| legendShowValues   | `boolean`                          | No       | `false`      | When `showLegend` is also true, renders a tabular legend with formatted values and percentages per slice.                                                                                |
+| percentDecimals    | `number`                           | No       | `0`          | Decimal places used for percentage formatting in on-arc labels (`showValues`) and the legend value column.                                                                               |
+| onChartReady       | `(api: ChartHighlightAPI) => void` | No       | `-`          | Called once on mount with the imperative highlight API. Use `api.highlight(index)` to highlight a slice and `api.highlight(null)` to clear. `api.type` is always `'donut-chart'`.       |
+| highlightedIndex   | `number \| null`                   | No       | `null`       | Declarative highlight: the index of the slice to highlight. The highlighted slice scales out and all others dim. Pass `null` or omit to clear. Mouse hover takes priority when active.   |
+| changePercentage   | `number`                           | No       | `-`          | When provided, renders a `DeltaIndicator` badge at the top-right of the chart container showing the percentage change. Positive values appear green ↑, negative appear red ↓ by default. |
+| changeInvertColors | `boolean`                          | No       | `false`      | Swap the up/down colors on the delta badge for lower-is-better metrics (e.g. RTO rate, bounce rate).                                                                                    |
+| testId             | `string`                           | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                                                                                  |
+| classes            | `string`                           | No       | `-`          | CSS class string applied to the top-level element.                                                                                                                                       |
 
 ## Events
 
@@ -122,11 +169,13 @@ In addition to the shared `--chart-*` variables (see BarChart docs), PieChart ex
 | ----------------------------------- | ------------ | ------------- | ---------------------------------------------------------------------------------------------------- |
 | `--piechart-stroke-color`           | `#fff`       | stroke        | Color of the stroke between slices.                                                                  |
 | `--piechart-stroke-width`           | `2`          | stroke-width  | Width of the stroke between slices.                                                                  |
-| `--piechart-hover-scale`            | `1.05`       | transform     | Scale factor applied to the hovered slice.                                                           |
-| `--piechart-dimmed-opacity`         | `0.3`        | opacity       | Opacity of non-hovered slices when hovering.                                                         |
+| `--piechart-hover-scale`            | `1.05`       | transform     | Scale factor applied to the highlighted (hovered or programmatic) slice.                             |
+| `--piechart-dimmed-opacity`         | `0.3`        | opacity       | Opacity of non-highlighted slices when any slice is active.                                          |
 | `--piechart-label-color`            | `#333`       | fill          | Color of slice labels.                                                                               |
 | `--piechart-label-font-size`        | `12px`       | font-size     | Font size of slice labels.                                                                           |
 | `--piechart-semi-aspect-ratio`      | `2`          | —             | Aspect ratio (width÷height) used when `semiCircle` is true and `aspectRatio` prop is not set.        |
+| `--piechart-delta-top`              | `8px`        | top           | Top offset of the delta badge overlay.                                                               |
+| `--piechart-delta-right`            | `8px`        | right         | Right offset of the delta badge overlay.                                                             |
 | `--piechart-legend-gap`             | `8px`        | gap           | Row gap in the `legendShowValues` table.                                                             |
 | `--piechart-legend-padding`         | `12px 0 0 0` | padding       | Padding on the `legendShowValues` container.                                                         |
 | `--piechart-legend-label-min-width` | `120px`      | min-width     | Minimum width of the label column in the `legendShowValues` table; aligns value columns across rows. |
@@ -135,6 +184,27 @@ In addition to the shared `--chart-*` variables (see BarChart docs), PieChart ex
 | `--piechart-legend-value-color`     | `#333`       | color         | Text color of the value column in the `legendShowValues` table.                                      |
 | `--piechart-legend-row-gap`         | `6px`        | gap           | Inline gap between swatch, label, and value within each legend row.                                  |
 | `--piechart-legend-swatch-radius`   | `2px`        | border-radius | Border radius of the color swatch in each legend row.                                                |
+
+The delta badge is themeable via the `DeltaIndicator` CSS variables (e.g. `--delta-indicator-positive-color`, `--delta-indicator-negative-color`, `--delta-indicator-font-size`).
+
+## Type Reference
+
+```typescript
+import type { ChartHighlightAPI } from '@juspay/svelte-ui-components';
+
+type PieChartSlice = {
+  label: string;
+  value: number;
+  color?: string;
+};
+
+// Returned by onChartReady:
+type ChartHighlightAPI = {
+  highlight: (index: number | null) => void;
+  getCategories: () => string[];
+  type: 'donut-chart'; // always 'donut-chart' for PieChart
+};
+```
 
 ## Utility: formatNumberIndian
 
@@ -150,12 +220,10 @@ In addition to the shared `--chart-*` variables (see BarChart docs), PieChart ex
 
 Thresholds: ≥ 1 Cr (10 million) → `"1.5Cr"`, ≥ 1 L (100 thousand) → `"2.3L"`, ≥ 1 K (1 thousand) → `"4.7K"`, otherwise `toLocaleString('en-IN')`.
 
-## Type Reference
+## Web Component
 
-```typescript
-type PieChartSlice = {
-  label: string;
-  value: number;
-  color?: string;
-};
+```html
+<sui-pie-chart></sui-pie-chart>
 ```
+
+All scalar props map to kebab-case attributes (`inner-radius`, `semi-circle`, `show-labels`, `show-values`, `label-position`, `show-legend`, `start-angle`, `aspect-ratio`, `legend-show-values`, `percent-decimals`, `highlighted-index`, `change-percentage`, `change-invert-colors`, `test-id`). Object and function props (`data`, `valueFormat`, `onChartReady`, `onsliceclick`, `onslicehover`, etc.) must be set via JavaScript property assignment.

--- a/docs/SankeyChart.md
+++ b/docs/SankeyChart.md
@@ -1,6 +1,6 @@
 # SankeyChart
 
-A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Link widths are proportional to flow values. Hovering highlights all connected nodes and dims unrelated ones.
+A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Link widths are proportional to flow values. Hovering highlights all connected nodes and dims unrelated ones (opt-out via `disableDimOnHover`). Supports a configurable minimum link/node thickness (`minLinkWidth`) so tiny flows remain visible, and a horizontal label offset (`dataLabelOffsetX`) for fine-grained spacing between node bars and their text labels.
 
 ## Usage
 
@@ -61,6 +61,30 @@ A responsive SVG Sankey diagram for visualizing flows between nodes. Automatical
 <SankeyChart {nodes} {links} nodeColorResolver={resolveColor} />
 ```
 
+### Minimum Link Width — keep tiny flows visible
+
+Use `minLinkWidth` to ensure flows with very small values still render as a visible band rather than collapsing to a sub-pixel line. Particularly useful for dense payment-flow diagrams where failure rates are small fractions of the total.
+
+```svelte
+<SankeyChart {nodes} {links} minLinkWidth={3} />
+```
+
+### Data Label Offset — breathing room between nodes and labels
+
+`dataLabelOffsetX` shifts every node label further away from (positive) or closer to (negative) its node bar. Lighthouse uses `30` for dense diagrams.
+
+```svelte
+<SankeyChart {nodes} {links} dataLabelOffsetX={30} />
+```
+
+### Disable Dim on Hover — all nodes stay at full opacity
+
+When you want the overall flow structure to remain fully readable while the user inspects one node, set `disableDimOnHover`. All nodes and links stay at their normal opacity regardless of hover state.
+
+```svelte
+<SankeyChart {nodes} {links} disableDimOnHover />
+```
+
 ### Custom Tooltip
 
 ```svelte
@@ -79,25 +103,38 @@ A responsive SVG Sankey diagram for visualizing flows between nodes. Automatical
 </SankeyChart>
 ```
 
+### Empty State
+
+```svelte
+<SankeyChart nodes={[]} links={[]}>
+  {#snippet empty()}
+    <p>No flow data available.</p>
+  {/snippet}
+</SankeyChart>
+```
+
 ## Props
 
-| Prop              | Type                                                    | Required | Default     | Description                                                                                                                                                                                                                                                                                             |
-| ----------------- | ------------------------------------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| nodes             | `SankeyNode[]`                                          | Yes      | `-`         | Array of `{id, label?, color?}`. Each node becomes a vertical bar.                                                                                                                                                                                                                                      |
-| links             | `SankeyLink[]`                                          | Yes      | `-`         | Array of `{source, target, value, color?}`. Each link becomes a curved band between nodes.                                                                                                                                                                                                              |
-| nodeWidth         | `number`                                                | No       | `16`        | Width of each node bar in pixels.                                                                                                                                                                                                                                                                       |
-| nodePadding       | `number`                                                | No       | `8`         | Vertical space between nodes in the same column.                                                                                                                                                                                                                                                        |
-| iterations        | `number`                                                | No       | `6`         | Number of relaxation passes to minimize link crossings. Higher = better layout but slower.                                                                                                                                                                                                              |
-| showValues        | `boolean`                                               | No       | `false`     | Whether to append the total flow value to each node label.                                                                                                                                                                                                                                              |
-| showLabels        | `boolean`                                               | No       | `true`      | Whether to render node labels.                                                                                                                                                                                                                                                                          |
-| aspectRatio       | `number`                                                | No       | `16/9`      | Width-to-height ratio.                                                                                                                                                                                                                                                                                  |
-| valueFormat       | `(value: number) => string`                             | No       | abbreviated | Formatter for flow values.                                                                                                                                                                                                                                                                              |
-| tooltipSnippet    | `Snippet<[SankeyTooltipContext]>`                       | No       | `-`         | Custom tooltip. Receives `{type: 'node', node, value}` on node hover, or `{type: 'link', link, sourceLabel, targetLabel, percentage}` on link hover. `sourceLabel`/`targetLabel` are pre-resolved human-readable names; `percentage` is the link's share of the source node's total flow (0–100, 2 dp). |
-| empty             | `Snippet`                                               | No       | `-`         | Content rendered when `nodes` is empty.                                                                                                                                                                                                                                                                 |
-| testId            | `string`                                                | No       | `-`         | Value for the data-pw attribute on the chart container.                                                                                                                                                                                                                                                 |
-| classes           | `string`                                                | No       | `-`         | CSS class string applied to the top-level element.                                                                                                                                                                                                                                                      |
-| columnLabels      | `string[]`                                              | No       | `-`         | Labels rendered above each column (index 0 = first column). Positioned above the chart area, centered on the column midpoint.                                                                                                                                                                           |
-| nodeColorResolver | `(id: string, label: string \| null) => string \| null` | No       | `-`         | Called for each node and also for link strokes (links inherit the source node's resolved colour). Return a CSS colour string to override the default palette, or `null` to fall through. `label` is `null` when the node has no label.                                                                  |
+| Prop               | Type                                                    | Required | Default     | Description                                                                                                                                                                                                                                                                                             |
+| ------------------ | ------------------------------------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| nodes              | `SankeyNode[]`                                          | Yes      | `-`         | Array of `{id, label?, color?}`. Each node becomes a vertical bar.                                                                                                                                                                                                                                      |
+| links              | `SankeyLink[]`                                          | Yes      | `-`         | Array of `{source, target, value, color?}`. Each link becomes a curved band between nodes.                                                                                                                                                                                                              |
+| nodeWidth          | `number`                                                | No       | `16`        | Width of each node bar in pixels.                                                                                                                                                                                                                                                                       |
+| nodePadding        | `number`                                                | No       | `8`         | Vertical space between nodes in the same column.                                                                                                                                                                                                                                                        |
+| iterations         | `number`                                                | No       | `6`         | Number of relaxation passes to minimize link crossings. Higher = better layout but slower.                                                                                                                                                                                                              |
+| showValues         | `boolean`                                               | No       | `false`     | Whether to append the total flow value to each node label.                                                                                                                                                                                                                                              |
+| showLabels         | `boolean`                                               | No       | `true`      | Whether to render node labels.                                                                                                                                                                                                                                                                          |
+| aspectRatio        | `number`                                                | No       | `16/9`      | Width-to-height ratio.                                                                                                                                                                                                                                                                                  |
+| valueFormat        | `(value: number) => string`                             | No       | abbreviated | Formatter for flow values.                                                                                                                                                                                                                                                                              |
+| tooltipSnippet     | `Snippet<[SankeyTooltipContext]>`                       | No       | `-`         | Custom tooltip. Receives `{type: 'node', node, value}` on node hover, or `{type: 'link', link, sourceLabel, targetLabel, percentage}` on link hover. `sourceLabel`/`targetLabel` are pre-resolved human-readable names; `percentage` is the link's share of the source node's total flow (0–100, 2 dp). |
+| empty              | `Snippet`                                               | No       | `-`         | Content rendered when `nodes` is empty.                                                                                                                                                                                                                                                                 |
+| testId             | `string`                                                | No       | `-`         | Value for the data-pw attribute on the chart container.                                                                                                                                                                                                                                                 |
+| classes            | `string`                                                | No       | `-`         | CSS class string applied to the top-level element.                                                                                                                                                                                                                                                      |
+| columnLabels       | `string[]`                                              | No       | `-`         | Labels rendered above each column (index 0 = first column). Positioned above the chart area, centered on the column midpoint.                                                                                                                                                                           |
+| nodeColorResolver  | `(id: string, label: string \| null) => string \| null` | No       | `-`         | Called for each node and also for link strokes (links inherit the source node's resolved colour). Return a CSS colour string to override the default palette, or `null` to fall through. `label` is `null` when the node has no label.                                                                  |
+| minLinkWidth       | `number`                                                | No       | `1`         | Minimum rendered thickness (px) for any link or node bar. Tiny flows that would otherwise collapse to sub-pixel widths remain at this thickness so they stay visually discoverable. Lighthouse uses `2`–`3` for dense payment-flow diagrams.                                                            |
+| dataLabelOffsetX   | `number`                                                | No       | `0`         | Horizontal offset in pixels applied to every node data-label, relative to the default position. Positive values push the label further away from the node bar; negative values pull it closer. Lighthouse uses `30` to create breathing room in dense diagrams.                                         |
+| disableDimOnHover  | `boolean`                                               | No       | `false`     | When `true`, hovering a node does not dim unrelated nodes — all nodes and links remain at full opacity. Useful for dense diagrams where the standard dim effect makes the overall flow structure hard to read.                                                                                           |
 
 ## Events
 
@@ -114,7 +151,7 @@ In addition to the shared `--chart-*` variables (see BarChart docs), SankeyChart
 
 | Variable                       | Default | CSS Property | Description                                          |
 | ------------------------------ | ------- | ------------ | ---------------------------------------------------- |
-| `--sankey-dimmed-opacity`      | `0.15`  | opacity      | Opacity of non-connected nodes/labels when hovering. |
+| `--sankey-dimmed-opacity`      | `0.15`  | opacity      | Opacity of non-connected nodes/labels when hovering. Has no effect when `disableDimOnHover` is `true`. |
 | `--sankey-label-color`         | `#333`  | fill         | Color of node labels.                                |
 | `--sankey-label-font-size`     | `12px`  | font-size    | Font size of node labels.                            |
 | `--sankey-col-label-color`     | `#666`  | fill         | Color of column header labels (`columnLabels` prop). |

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -25,7 +25,7 @@
   },
   {
     "name": "BarChart",
-    "description": "A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal orientations, single or multi-series data (grouped/stacked), value labels, custom colors per data point, hover tooltips, and click events. Zero external dependencies \u2014 built from pure SVG with CSS custom property theming."
+    "description": "A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal orientations, single or multi-series data (grouped/stacked), value labels, custom colors per data point, hover tooltips, click events, declarative and imperative bar highlighting via highlightedIndex and onChartReady, first-point normalisation for cross-series relative growth comparison, top-N clipping with overflow aggregation into a configurable label, and a graphics-free mode that renders axes and legend without bar rectangles. Zero external dependencies \u2014 built from pure SVG with CSS custom property theming."
   },
   {
     "name": "Book",
@@ -113,7 +113,7 @@
   },
   {
     "name": "IframeViewer",
-    "description": "A security-conscious iframe embed. Renders an `<iframe>` for the given `src` and forwards `postMessage` events to `onMessage` only when the message origin is in `allowedOrigins` and the source is the embedded iframe window — an empty list (the default) processes nothing, so it is secure by default. Themeable size/border via CSS variables; ships a `sui-iframe-viewer` web component."
+    "description": "A security-conscious iframe embed. Renders an `<iframe>` for the given `src` and forwards `postMessage` events to `onMessage` only when the message origin is in `allowedOrigins` and the source is the embedded iframe window \u2014 an empty list (the default) processes nothing, so it is secure by default. Themeable size/border via CSS variables; ships a `sui-iframe-viewer` web component."
   },
   {
     "name": "Img",
@@ -133,7 +133,7 @@
   },
   {
     "name": "LineChart",
-    "description": "A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series, four curve interpolations (linear, monotone, step, natural), an overlay hover tracker that finds the nearest point even when dots are hidden, crosshair vertical line, data point labels, legend, and custom tooltips."
+    "description": "A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series, five curve interpolations (linear, monotone, spline, step, natural), gradient fill under the line, a showArea mode that fills the area under each line with a fully-customisable vertical gradient via areaGradient, an xAxisCategories prop that maps string labels to the numeric x indices so callers can use named categories on the axis and in tooltips, an onChartReady callback that hands back a ChartHighlightAPI for imperative point highlighting from external orchestrators (e.g. voice narration sync, step-through animations), a declarative highlightedIndex prop for controlled highlight state, an overlay hover tracker that finds the nearest point even when dots are hidden, crosshair vertical line, data point labels, legend, and custom tooltip snippets. Zero external dependencies \u2014 built from pure SVG with CSS custom property theming."
   },
   {
     "name": "ListItem",
@@ -173,7 +173,7 @@
   },
   {
     "name": "PieChart",
-    "description": "A responsive SVG pie/donut chart with slice hover highlighting, custom labels, legend, and donut center content. When `innerRadius` is set, renders as a donut with optional content in the center hole via the `center` snippet."
+    "description": "A responsive SVG pie/donut chart with slice hover highlighting, programmatic highlight control, an optional delta-change badge, custom labels, legend, and donut center content. When innerRadius is set, renders as a donut with optional content in the center hole via the center snippet. Supports a semi-circle (half-donut) layout via semiCircle, a tabular value legend via legendShowValues, and configurable percentage decimal places via percentDecimals. The onChartReady callback delivers an imperative ChartHighlightAPI (type: 'donut-chart') so external orchestrators can drive slice highlights without touching component state; the highlightedIndex prop provides the same capability declaratively, with mouse hover always taking priority. A changePercentage prop renders a positioned DeltaIndicator badge at the top-right corner of the chart container, with changeInvertColors for lower-is-better metrics like RTO rate or bounce rate."
   },
   {
     "name": "Pill",
@@ -193,7 +193,7 @@
   },
   {
     "name": "SankeyChart",
-    "description": "A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Link widths are proportional to flow values. Hovering highlights all connected nodes and dims unrelated ones."
+    "description": "A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Link widths are proportional to flow values. Hovering highlights all connected nodes and dims unrelated ones (opt-out via disableDimOnHover). Supports a configurable minimum link/node thickness (minLinkWidth) so tiny flows remain visible at any scale, and a horizontal label offset (dataLabelOffsetX) for fine-grained spacing between node bars and their text labels."
   },
   {
     "name": "LottiePlayer",
@@ -274,5 +274,17 @@
   {
     "name": "Tooltip",
     "description": "A hover-triggered tooltip that displays text content above, below, left, or right of its trigger element. Supports configurable position, delay, and styling via CSS variables."
+  },
+  {
+    "name": "DeltaIndicator",
+    "description": "A compact inline indicator that conveys change direction and magnitude using a directional arrow and formatted text. Positive values render in green, negative in red, and values within the neutral threshold in muted gray. Supports inverted color semantics for lower-is-better metrics (e.g. bounce rate, RTO), an optional arrow-hide mode for text-only display, a configurable neutral threshold, and a custom format function for full control over the displayed text."
+  },
+  {
+    "name": "DualAxisBarChart",
+    "description": "A pure-SVG dual-axis chart with two completely independent Y-axes \u2014 left (yAxisIndex 0) and right (yAxisIndex 1) \u2014 sharing one categorical X-axis. Each series independently declares its axis and render type (column or line), making it ideal for comparing metrics at very different scales such as absolute revenue versus percentage CTR. Hover highlights the entire category column with a vertical guideline, and the shared tooltip displays all series values formatted by their respective axis formatters. Built from the shared _chart primitives (ChartContainer, Axis, ChartTooltip, Legend, scales, paths) with full CSS custom property theming and zero external dependencies."
+  },
+  {
+    "name": "FunnelChart",
+    "description": "A horizontal funnel chart built entirely from pure SVG, with no external charting library dependency. Renders sequential stages as rectangles whose height is proportional to each stage's value relative to the maximum, joined by trapezoidal connector polygons that visually convey drop-off between steps. Supports per-stage color overrides, a custom value-and-percentage label formatter, configurable slope connector width, hover-expansion animation, click and hover events, an empty-state snippet, and full CSS-variable theming through the shared chart token system."
   }
 ]

--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type {
     BarChartProperties,
     BarChartRenderContext,
@@ -6,6 +7,7 @@
     BarFillGradient,
     BarFillPattern
   } from './properties';
+  import type { ChartHighlightAPI } from '../_chart/highlight';
   import ChartContainer from '$lib/_chart/ChartContainer.svelte';
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
@@ -62,6 +64,12 @@
     tooltipSnippet,
     empty,
     renderOverlay,
+    onChartReady,
+    highlightedIndex = null,
+    normaliseToFirstPoint = false,
+    topN,
+    overflowLabel = 'Other',
+    hideBarGraphics = false,
     onbarclick,
     onbarhover,
     testId,
@@ -76,6 +84,24 @@
   let hovered = $state<{ si: number; pi: number } | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+  /** Internal tracking for the imperative highlight API (onChartReady). */
+  let apiHighlightedIndex = $state<number | null>(null);
+
+  // ── onMount: emit ChartHighlightAPI via onChartReady ──────────
+
+  onMount(() => {
+    if (typeof onChartReady !== 'function') {
+      return;
+    }
+    const api: ChartHighlightAPI = {
+      highlight: (index) => {
+        apiHighlightedIndex = index;
+      },
+      getCategories: () => labels,
+      type: 'bar-chart'
+    };
+    onChartReady(api);
+  });
 
   // ── Layout ─────────────────────────────────────────────────────
 
@@ -84,12 +110,90 @@
   let dims = $derived(computeChartDimensions(chartWidth, chartHeight));
 
   let isMulti = $derived(Array.isArray(series) && series.length > 0);
-  let resolvedSeries = $derived(isMulti ? series! : [{ name: '', data: data ?? [] }]);
+
+  // ── Raw resolved series (before transformations) ──────────────
+
+  let rawSeries = $derived(isMulti ? series! : [{ name: '', data: data ?? [] }]);
+
+  // ── normaliseToFirstPoint transformation ──────────────────────
+
+  /**
+   * When normaliseToFirstPoint is true, each value is expressed as a
+   * percentage of the series' first data point's value (baseline = 100).
+   * Series whose first point is zero are left unchanged to avoid division
+   * by zero.
+   */
+  let normalisedSeries = $derived.by(() => {
+    if (!normaliseToFirstPoint) {
+      return rawSeries;
+    }
+    return rawSeries.map((s) => {
+      const baseline = s.data[0]?.value ?? 0;
+      if (baseline === 0) {
+        return s;
+      }
+      return {
+        ...s,
+        data: s.data.map((d) => ({
+          ...d,
+          value: (d.value / baseline) * 100
+        }))
+      };
+    });
+  });
+
+  // ── topN transformation ────────────────────────────────────────
+
+  /**
+   * Clips to the top N bars (by first-series value, descending) and aggregates
+   * the rest into a single overflow bar. Operates on each series in parallel so
+   * the same category ordering is preserved across series.
+   * Only applies in non-multi or single-series mode (groupMode-agnostic:
+   * works by reordering labels, not by touching multi-series stacking).
+   */
+  let resolvedSeries = $derived.by(() => {
+    if (topN == null || normalisedSeries.length === 0) {
+      return normalisedSeries;
+    }
+    const firstSeriesData = normalisedSeries[0]?.data ?? [];
+    if (firstSeriesData.length <= topN) {
+      return normalisedSeries;
+    }
+    // Sort indices by first-series value descending
+    const sortedIndices = firstSeriesData
+      .map((d, i) => ({ value: d.value, i }))
+      .sort((a, b) => b.value - a.value)
+      .map((item) => item.i);
+
+    const topIndices = new Set(sortedIndices.slice(0, topN));
+
+    return normalisedSeries.map((s) => {
+      const topData = s.data.filter((_, idx) => topIndices.has(idx));
+      const overflowValue = s.data
+        .filter((_, idx) => !topIndices.has(idx))
+        .reduce((sum, d) => sum + d.value, 0);
+      return {
+        ...s,
+        data: [...topData, { label: overflowLabel, value: overflowValue }]
+      };
+    });
+  });
 
   let labels = $derived.by(() => {
     const first = resolvedSeries[0]?.data ?? [];
     return first.map((d) => d.label);
   });
+
+  // ── Effective highlighted index: merge declarative + imperative ─
+
+  /**
+   * The declarative `highlightedIndex` prop takes precedence when explicitly
+   * set (non-null). The imperative API writes to `apiHighlightedIndex`.
+   * When both are null the chart renders normally (no dimming).
+   */
+  let effectiveHighlightedIndex = $derived(
+    highlightedIndex != null ? highlightedIndex : apiHighlightedIndex
+  );
 
   let isNormalized = $derived(stackNormalize && isMulti && groupMode === 'stacked');
 
@@ -606,53 +710,61 @@
               </g>
             {/if}
 
-            {#each bars as bar, i (i)}
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              {#if isStackedMode && barRadius > 0}
-                <path
-                  class="bar"
-                  class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
-                  class:dimmed={hovered !== null &&
-                    (hovered.si !== bar.si || hovered.pi !== bar.pi)}
-                  d={stackedBarPath(bar)}
-                  fill={barFillAttr(bar)}
-                  aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
-                  onmouseenter={(e) => handleEnter(e, bar)}
-                  onmousemove={trackMouse}
-                  onmouseleave={handleLeave}
-                  onclick={() => handleClick(bar)}
-                />
-              {:else}
-                <rect
-                  class="bar"
-                  class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
-                  class:dimmed={hovered !== null &&
-                    (hovered.si !== bar.si || hovered.pi !== bar.pi)}
-                  x={bar.x}
-                  y={bar.y}
-                  width={bar.width}
-                  height={bar.height}
-                  rx={barRadius}
-                  ry={barRadius}
-                  fill={barFillAttr(bar)}
-                  aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
-                  onmouseenter={(e) => handleEnter(e, bar)}
-                  onmousemove={trackMouse}
-                  onmouseleave={handleLeave}
-                  onclick={() => handleClick(bar)}
-                />
-              {/if}
-              {#if showValues && !isStackedMode}
-                <text
-                  class="bar-value"
-                  x={isVertical ? bar.x + bar.width / 2 : bar.x + bar.width + 4}
-                  y={isVertical ? bar.y - 4 : bar.y + bar.height / 2}
-                  text-anchor={isVertical ? 'middle' : 'start'}
-                  dominant-baseline={isVertical ? 'auto' : 'middle'}>{getDisplayValue(bar)}</text
-                >
-              {/if}
-            {/each}
+            {#if !hideBarGraphics}
+              {#each bars as bar, i (i)}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                {#if isStackedMode && barRadius > 0}
+                  <path
+                    class="bar"
+                    class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
+                    class:highlighted={effectiveHighlightedIndex !== null &&
+                      effectiveHighlightedIndex === bar.pi}
+                    class:dimmed={(hovered !== null &&
+                      (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
+                      (effectiveHighlightedIndex !== null && effectiveHighlightedIndex !== bar.pi)}
+                    d={stackedBarPath(bar)}
+                    fill={barFillAttr(bar)}
+                    aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
+                    onmouseenter={(e) => handleEnter(e, bar)}
+                    onmousemove={trackMouse}
+                    onmouseleave={handleLeave}
+                    onclick={() => handleClick(bar)}
+                  />
+                {:else}
+                  <rect
+                    class="bar"
+                    class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
+                    class:highlighted={effectiveHighlightedIndex !== null &&
+                      effectiveHighlightedIndex === bar.pi}
+                    class:dimmed={(hovered !== null &&
+                      (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
+                      (effectiveHighlightedIndex !== null && effectiveHighlightedIndex !== bar.pi)}
+                    x={bar.x}
+                    y={bar.y}
+                    width={bar.width}
+                    height={bar.height}
+                    rx={barRadius}
+                    ry={barRadius}
+                    fill={barFillAttr(bar)}
+                    aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
+                    onmouseenter={(e) => handleEnter(e, bar)}
+                    onmousemove={trackMouse}
+                    onmouseleave={handleLeave}
+                    onclick={() => handleClick(bar)}
+                  />
+                {/if}
+                {#if showValues && !isStackedMode}
+                  <text
+                    class="bar-value"
+                    x={isVertical ? bar.x + bar.width / 2 : bar.x + bar.width + 4}
+                    y={isVertical ? bar.y - 4 : bar.y + bar.height / 2}
+                    text-anchor={isVertical ? 'middle' : 'start'}
+                    dominant-baseline={isVertical ? 'auto' : 'middle'}>{getDisplayValue(bar)}</text
+                  >
+                {/if}
+              {/each}
+            {/if}
 
             <!-- A1-4: renderOverlay escape hatch — rendered after all bars -->
             {#if typeof renderOverlay === 'function'}
@@ -690,6 +802,9 @@
   }
   .bar.hovered {
     opacity: var(--barchart-bar-hover-opacity, 1);
+  }
+  .bar.highlighted {
+    opacity: var(--barchart-bar-highlighted-opacity, 1);
   }
   .bar.dimmed {
     opacity: var(--barchart-bar-dimmed-opacity, 0.3);

--- a/src/lib/BarChart/properties.ts
+++ b/src/lib/BarChart/properties.ts
@@ -1,4 +1,5 @@
 import type { Snippet } from 'svelte';
+import type { ChartHighlightAPI } from '../_chart/highlight';
 
 // ── Fill types (A1-2 pattern, A1-3 gradient) ──────────────────
 
@@ -124,6 +125,46 @@ export type OptionalBarChartProperties = {
    * live in SVG coordinate space.
    */
   renderOverlay?: Snippet<[BarChartRenderContext]>;
+  /**
+   * Called once on mount with an imperative `ChartHighlightAPI` handle.
+   * Use `api.highlight(index)` to emphasise a specific bar (by its zero-based
+   * position within the category axis) and dim all others. Pass `null` to clear.
+   * The `type` field on the handle is always `'bar-chart'`.
+   */
+  onChartReady?: (api: ChartHighlightAPI) => void;
+  /**
+   * Declarative complement to `onChartReady`. When set to a non-null number the
+   * bar at that zero-based category index is highlighted (full opacity) and the
+   * remaining bars are dimmed. Set to `null` or omit to show all bars normally.
+   */
+  highlightedIndex?: number | null;
+  /**
+   * When `true`, each series' values are expressed as a percentage of that
+   * series' own first data point. A value equal to the baseline renders as 100,
+   * a value twice the baseline as 200, and so on. Useful for comparing relative
+   * growth across series that start at very different absolute levels.
+   * Has no effect on series that have no data or whose first point is zero.
+   */
+  normaliseToFirstPoint?: boolean;
+  /**
+   * When set, only the top `topN` bars (by descending value) are shown
+   * individually. The remaining bars are aggregated into a single bar whose
+   * value is the sum of all omitted bars and whose label is `overflowLabel`
+   * (default `"Other"`). Has no effect when the data has `topN` or fewer bars.
+   * In multi-series mode the ranking is based on the first series.
+   */
+  topN?: number;
+  /**
+   * Label for the aggregated overflow bar produced by `topN`. Defaults to
+   * `"Other"`. Has no effect when `topN` is not set.
+   */
+  overflowLabel?: string;
+  /**
+   * When `true`, bar rectangles are not rendered. Only the axis labels, gridlines,
+   * and legend remain visible. Useful for building legend-only or label-only
+   * thumbnails alongside a full chart.
+   */
+  hideBarGraphics?: boolean;
   testId?: string;
   classes?: string;
 };

--- a/src/lib/DeltaIndicator/DeltaIndicator.svelte
+++ b/src/lib/DeltaIndicator/DeltaIndicator.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { DeltaIndicatorProperties, DeltaDirection } from './properties';
+
+  let {
+    value,
+    format,
+    invertColors = false,
+    hideArrow = false,
+    neutralThreshold = 0,
+    testId,
+    classes
+  }: DeltaIndicatorProperties = $props();
+
+  const defaultFormat = (input: number): string => `${Math.round(Math.abs(input))}%`;
+
+  // A negative threshold would invert the neutral band and misclassify direction, so
+  // clamp it to a non-negative value before the comparison math.
+  const safeNeutralThreshold = $derived(Math.max(0, neutralThreshold));
+
+  let direction = $derived<DeltaDirection>(
+    value > safeNeutralThreshold ? 'up' : value < -safeNeutralThreshold ? 'down' : 'neutral'
+  );
+
+  // Tone drives the color. 'up' reads as positive by default; invertColors flips
+  // the positive/negative tone for lower-is-better metrics. Neutral is always muted.
+  let tone = $derived(
+    direction === 'neutral'
+      ? 'neutral'
+      : (direction === 'up') !== invertColors
+        ? 'positive'
+        : 'negative'
+  );
+
+  let text = $derived((format ?? defaultFormat)(value));
+</script>
+
+<span
+  class="delta-indicator delta-{tone} {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+>
+  {#if !hideArrow && direction !== 'neutral'}
+    <span class="delta-indicator-arrow delta-arrow-{direction}" aria-hidden="true">
+      <svg viewBox="0 0 10 10"><path d="M5 1 L9 8 L1 8 Z" /></svg>
+    </span>
+  {/if}
+  <span class="delta-indicator-text">{text}</span>
+</span>
+
+<style>
+  .delta-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--delta-indicator-gap, 2px);
+    font-size: var(--delta-indicator-font-size, 13px);
+    font-weight: var(--delta-indicator-font-weight, 600);
+    line-height: 1;
+  }
+
+  .delta-positive {
+    color: var(--delta-indicator-positive-color, #1a9d6f);
+  }
+
+  .delta-negative {
+    color: var(--delta-indicator-negative-color, #e5484d);
+  }
+
+  .delta-neutral {
+    color: var(--delta-indicator-neutral-color, #8a8a8a);
+  }
+
+  .delta-indicator-arrow {
+    display: inline-flex;
+    width: var(--delta-indicator-arrow-size, 9px);
+    height: var(--delta-indicator-arrow-size, 9px);
+    flex-shrink: 0;
+  }
+
+  .delta-indicator-arrow svg {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+  }
+
+  .delta-arrow-down {
+    transform: rotate(180deg);
+  }
+</style>

--- a/src/lib/DeltaIndicator/properties.ts
+++ b/src/lib/DeltaIndicator/properties.ts
@@ -1,0 +1,30 @@
+export type DeltaIndicatorProperties = MandatoryDeltaIndicatorProperties &
+  OptionalDeltaIndicatorProperties;
+
+export type DeltaDirection = 'up' | 'down' | 'neutral';
+
+export type MandatoryDeltaIndicatorProperties = {
+  /** The change amount; its sign selects the up / down / neutral direction. */
+  value: number;
+};
+
+export type OptionalDeltaIndicatorProperties = {
+  /**
+   * Formats the displayed text from the raw value. Default renders the rounded
+   * absolute value followed by a percent sign (e.g. `12%`).
+   */
+  format?: (value: number) => string;
+  /**
+   * Swap the up/down colors for lower-is-better metrics (e.g. bounce rate, RTO),
+   * where a decrease is "good" (positive tone) and an increase is "bad".
+   */
+  invertColors?: boolean;
+  /** Hide the directional arrow, showing only the formatted text. */
+  hideArrow?: boolean;
+  /** Absolute values at or below this are treated as `neutral` (default 0). */
+  neutralThreshold?: number;
+  /** Test selector applied as the `data-pw` attribute. */
+  testId?: string;
+  /** Additional CSS classes for theming. */
+  classes?: string;
+};

--- a/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
+++ b/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
@@ -1,0 +1,521 @@
+<script lang="ts">
+  import type {
+    DualAxisBarChartProperties,
+    DualAxisSeries,
+    DualAxisTooltipContext
+  } from './properties';
+  import ChartContainer from '$lib/_chart/ChartContainer.svelte';
+  import Axis from '$lib/_chart/Axis.svelte';
+  import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
+  import Legend from '$lib/_chart/Legend.svelte';
+  import { createBandScale, createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
+  import { computeChartDimensions } from '$lib/_chart/geometry';
+  import { getColor } from '$lib/_chart/colors';
+  import { formatNumber } from '$lib/_chart/format';
+  import { roundedRectPath, linePath } from '$lib/_chart/paths';
+  import type { LegendItem, TooltipData, LinearScale, BandScale, Point } from '$lib/_chart/types';
+
+  // ── Per-instance uid for SVG <defs> ids ────────────────────────
+  const uid = Math.random().toString(36).slice(2, 9);
+
+  // ── Props ──────────────────────────────────────────────────────
+
+  let {
+    categories,
+    series,
+    leftAxis = {},
+    rightAxis = {},
+    showGridlines = true,
+    showLegend = true,
+    barRadius = 3,
+    barPadding = 0.25,
+    aspectRatio = 16 / 9,
+    tooltipSnippet,
+    onbarclick,
+    testId,
+    classes
+  }: DualAxisBarChartProperties = $props();
+
+  // ── State ──────────────────────────────────────────────────────
+
+  let containerEl: HTMLDivElement | null = $state(null);
+  let chartWidth = $state(0);
+  let chartHeight = $state(0);
+  let hoveredCategoryIndex = $state<number | null>(null);
+  let mouseX = $state(0);
+  let mouseY = $state(0);
+
+  // ── Formatters ─────────────────────────────────────────────────
+
+  const leftFormat = $derived(leftAxis.valueFormat ?? formatNumber);
+  const rightFormat = $derived(rightAxis.valueFormat ?? formatNumber);
+
+  // ── Layout — wider right margin to accommodate right-axis labels ─
+
+  const dims = $derived(
+    computeChartDimensions(chartWidth, chartHeight, { top: 24, right: 56, bottom: 40, left: 56 })
+  );
+
+  // ── Scales ─────────────────────────────────────────────────────
+
+  const catScale: BandScale = $derived(
+    createBandScale(categories, [0, dims.innerWidth], barPadding)
+  );
+
+  /**
+   * Computes the [min, max] domain for all series mapped to the given axis index,
+   * then applies nice rounding. Returns [0, 1] for empty series.
+   */
+  const axisDomain = (axisIndex: 0 | 1): [number, number] => {
+    const axisSeries = series.filter((s) => s.yAxisIndex === axisIndex);
+    if (axisSeries.length === 0) {
+      return [0, 1];
+    }
+    const allValues = axisSeries.flatMap((s) => s.data);
+    if (allValues.length === 0) {
+      return [0, 1];
+    }
+    return niceLinearDomain(Math.min(0, ...allValues), Math.max(0, ...allValues));
+  };
+
+  const leftDomain: [number, number] = $derived(axisDomain(0));
+  const rightDomain: [number, number] = $derived(axisDomain(1));
+
+  const leftScale: LinearScale = $derived(createLinearScale(leftDomain, [dims.innerHeight, 0]));
+  const rightScale: LinearScale = $derived(createLinearScale(rightDomain, [dims.innerHeight, 0]));
+
+  // ── Series color resolution ────────────────────────────────────
+
+  const resolvedColor = (s: DualAxisSeries, si: number): string => s.color ?? getColor(si);
+
+  // ── Column/bar geometry ────────────────────────────────────────
+
+  /**
+   * Groups series by axis so we can compute per-axis sub-band widths.
+   * Within an axis group, series are ordered by their original index.
+   */
+  type AxisSeriesEntry = { series: DualAxisSeries; seriesIndex: number };
+
+  const leftAxisSeries: AxisSeriesEntry[] = $derived(
+    series
+      .map((s, si) => ({ series: s, seriesIndex: si }))
+      .filter((entry) => entry.series.yAxisIndex === 0 && entry.series.type !== 'line')
+  );
+
+  const rightAxisSeries: AxisSeriesEntry[] = $derived(
+    series
+      .map((s, si) => ({ series: s, seriesIndex: si }))
+      .filter((entry) => entry.series.yAxisIndex === 1 && entry.series.type !== 'line')
+  );
+
+  const columnSeriesEntries: AxisSeriesEntry[] = $derived([...leftAxisSeries, ...rightAxisSeries]);
+
+  /**
+   * Total number of column/bar series that share the category band.
+   * Line series float above and are not counted.
+   */
+  const columnCount: number = $derived(columnSeriesEntries.length);
+
+  type BarShape = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    color: string;
+    seriesIndex: number;
+    categoryIndex: number;
+    value: number;
+    path: string;
+  };
+
+  const bars: BarShape[] = $derived.by(() => {
+    if (dims.innerWidth <= 0 || dims.innerHeight <= 0) {
+      return [];
+    }
+    const result: BarShape[] = [];
+    const subBandWidth = columnCount > 0 ? catScale.bandwidth / columnCount : catScale.bandwidth;
+    const barW = Math.max(1, subBandWidth * 0.88);
+    const barGap = (subBandWidth - barW) / 2;
+
+    columnSeriesEntries.forEach((entry, subIndex) => {
+      const scale = entry.series.yAxisIndex === 0 ? leftScale : rightScale;
+      const color = resolvedColor(entry.series, entry.seriesIndex);
+      const zeroY = scale(0);
+
+      entry.series.data.forEach((value, catIdx) => {
+        // A series longer than `categories` would index past the band scale and
+        // emit NaN geometry; skip the surplus points defensively.
+        if (catIdx >= categories.length) {
+          return;
+        }
+        const bandStart = catScale(categories[catIdx]);
+        const barX = bandStart + subIndex * subBandWidth + barGap;
+        const valueY = scale(value);
+        const barY = value >= 0 ? valueY : zeroY;
+        const barHeight = Math.max(2, Math.abs(valueY - zeroY));
+
+        const path = roundedRectPath(barX, barY, barW, barHeight, barRadius, barRadius, 0, 0);
+
+        result.push({
+          x: barX,
+          y: barY,
+          width: barW,
+          height: barHeight,
+          color,
+          seriesIndex: entry.seriesIndex,
+          categoryIndex: catIdx,
+          value,
+          path
+        });
+      });
+    });
+
+    return result;
+  });
+
+  // ── Line series geometry ───────────────────────────────────────
+
+  type LineSeries = {
+    points: Point[];
+    color: string;
+    seriesIndex: number;
+  };
+
+  const lineSeriesData: LineSeries[] = $derived.by(() => {
+    if (dims.innerWidth <= 0 || dims.innerHeight <= 0) {
+      return [];
+    }
+    return series
+      .map((s, si) => ({ series: s, seriesIndex: si }))
+      .filter((entry) => entry.series.type === 'line')
+      .map((entry) => {
+        const scale = entry.series.yAxisIndex === 0 ? leftScale : rightScale;
+        const color = resolvedColor(entry.series, entry.seriesIndex);
+        const points: Point[] = [];
+        entry.series.data.forEach((value, catIdx) => {
+          // Mirror the bar guard: drop points past the category band to avoid NaN geometry.
+          if (catIdx >= categories.length) {
+            return;
+          }
+          points.push({
+            x: catScale(categories[catIdx]) + catScale.bandwidth / 2,
+            y: scale(value)
+          });
+        });
+        return { points, color, seriesIndex: entry.seriesIndex };
+      });
+  });
+
+  // ── Legend items ───────────────────────────────────────────────
+
+  const legendItems: LegendItem[] = $derived(
+    series.map((s, si) => ({ label: s.name, color: resolvedColor(s, si) }))
+  );
+
+  // ── Tooltip ────────────────────────────────────────────────────
+
+  const buildTooltipContext = (catIdx: number): DualAxisTooltipContext => ({
+    category: categories[catIdx],
+    categoryIndex: catIdx,
+    points: series.map((s, si) => ({
+      name: s.name,
+      value: s.data[catIdx] ?? 0,
+      color: resolvedColor(s, si),
+      yAxisIndex: s.yAxisIndex,
+      type: s.type ?? 'column'
+    }))
+  });
+
+  const tooltipData: TooltipData | null = $derived.by(() => {
+    if (hoveredCategoryIndex === null) {
+      return null;
+    }
+    const catIdx = hoveredCategoryIndex;
+    const category = categories[catIdx];
+    const items = series.map((s, si) => {
+      const fmt = s.yAxisIndex === 0 ? leftFormat : rightFormat;
+      return {
+        label: s.name,
+        value: fmt(s.data[catIdx] ?? 0),
+        color: resolvedColor(s, si)
+      };
+    });
+    return { title: category, items };
+  });
+
+  // ── Axis tick formatters ───────────────────────────────────────
+
+  const leftTickFormat = (tick: number | string): string =>
+    leftFormat(typeof tick === 'string' ? parseFloat(tick) : tick);
+
+  const rightTickFormat = (tick: number | string): string =>
+    rightFormat(typeof tick === 'string' ? parseFloat(tick) : tick);
+
+  // ── Hover target rectangles ────────────────────────────────────
+
+  /**
+   * Full-height invisible rectangles, one per category, used as hover targets.
+   * This is simpler and more reliable than per-bar hit testing and matches the
+   * Highcharts shared-tooltip UX where hovering anywhere in a column highlights
+   * the entire category.
+   */
+  type HoverRect = { x: number; width: number; catIdx: number };
+
+  const hoverRects: HoverRect[] = $derived(
+    categories.map((_, catIdx) => ({
+      x: catScale(categories[catIdx]),
+      width: catScale.bandwidth,
+      catIdx
+    }))
+  );
+
+  // ── Interactions ───────────────────────────────────────────────
+
+  const trackMouse = (event: MouseEvent) => {
+    if (containerEl === null) {
+      return;
+    }
+    const rect = containerEl.getBoundingClientRect();
+    mouseX = event.clientX - rect.left;
+    mouseY = event.clientY - rect.top;
+  };
+
+  const handleCategoryEnter = (event: MouseEvent, catIdx: number) => {
+    hoveredCategoryIndex = catIdx;
+    trackMouse(event);
+  };
+
+  const handleCategoryLeave = () => {
+    hoveredCategoryIndex = null;
+  };
+
+  const handleCategoryClick = (catIdx: number) => {
+    if (typeof onbarclick !== 'function') {
+      return;
+    }
+    onbarclick({ categoryIndex: catIdx, context: buildTooltipContext(catIdx) });
+  };
+
+  // ── Empty state ────────────────────────────────────────────────
+
+  const isEmpty = $derived(
+    series.length === 0 || categories.length === 0 || series.every((s) => s.data.length === 0)
+  );
+</script>
+
+<div
+  class="dual-axis-bar-chart {classes ?? ''}"
+  bind:this={containerEl}
+  data-pw={typeof testId === 'string' ? testId : null}
+>
+  {#if !isEmpty}
+    {#if showLegend}
+      <Legend items={legendItems} position="top" />
+    {/if}
+
+    <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
+      <g transform="translate({dims.margin.left}, {dims.margin.top})">
+        <!-- Left Y-axis (index 0) -->
+        <Axis
+          orientation="left"
+          scale={leftScale}
+          {showGridlines}
+          gridlineLength={dims.innerWidth}
+          tickFormat={leftTickFormat}
+          classes={leftAxis.color ? `axis-left-colored` : ''}
+        />
+
+        <!-- Right Y-axis (index 1) — positioned at innerWidth -->
+        <g transform="translate({dims.innerWidth}, 0)">
+          <Axis
+            orientation="right"
+            scale={rightScale}
+            showGridlines={false}
+            tickFormat={rightTickFormat}
+            classes={rightAxis.color ? `axis-right-colored` : ''}
+          />
+        </g>
+
+        <!-- X-axis at bottom -->
+        <g transform="translate(0, {dims.innerHeight})">
+          <Axis orientation="bottom" scale={catScale} showGridlines={false} />
+        </g>
+
+        <!-- Axis titles -->
+        {#if leftAxis.title}
+          <text
+            class="axis-title axis-title-left"
+            transform="translate({-dims.margin.left + 12}, {dims.innerHeight / 2}) rotate(-90)"
+            text-anchor="middle"
+            style={leftAxis.color ? `fill: ${leftAxis.color}` : ''}
+          >
+            {leftAxis.title}
+          </text>
+        {/if}
+        {#if rightAxis.title}
+          <text
+            class="axis-title axis-title-right"
+            transform="translate({dims.innerWidth + dims.margin.right - 12}, {dims.innerHeight /
+              2}) rotate(90)"
+            text-anchor="middle"
+            style={rightAxis.color ? `fill: ${rightAxis.color}` : ''}
+          >
+            {rightAxis.title}
+          </text>
+        {/if}
+
+        <!-- Column/bar shapes -->
+        {#each bars as bar, barIdx (barIdx)}
+          <path
+            class="bar-shape"
+            class:bar-hovered={hoveredCategoryIndex === bar.categoryIndex}
+            class:bar-dimmed={hoveredCategoryIndex !== null &&
+              hoveredCategoryIndex !== bar.categoryIndex}
+            d={bar.path}
+            fill={bar.color}
+            aria-label="{categories[bar.categoryIndex]}: {bar.value}"
+            role="img"
+          />
+        {/each}
+
+        <!-- Line series drawn above columns -->
+        {#each lineSeriesData as ls, lsi (lsi)}
+          {#if ls.points.length >= 2}
+            <path
+              class="line-series"
+              d={linePath(ls.points, 'monotone')}
+              stroke={ls.color}
+              fill="none"
+            />
+          {/if}
+          <!-- Line dots -->
+          {#each ls.points as pt, ptIdx (ptIdx)}
+            <circle
+              class="line-dot"
+              class:dot-hovered={hoveredCategoryIndex === ptIdx}
+              class:dot-dimmed={hoveredCategoryIndex !== null && hoveredCategoryIndex !== ptIdx}
+              cx={pt.x}
+              cy={pt.y}
+              r={hoveredCategoryIndex === ptIdx ? 6 : 4}
+              fill={ls.color}
+              stroke="var(--dual-axis-dot-stroke, #fff)"
+              stroke-width="var(--dual-axis-dot-stroke-width, 1.5)"
+              aria-label="{categories[ptIdx]}: {series[ls.seriesIndex]?.data[ptIdx] ?? 0}"
+              role="img"
+            />
+          {/each}
+        {/each}
+
+        <!-- Invisible per-category hover targets (full inner height) -->
+        {#each hoverRects as hr (hr.catIdx)}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <rect
+            class="hover-target"
+            x={hr.x}
+            y={0}
+            width={hr.width}
+            height={dims.innerHeight}
+            fill="transparent"
+            data-category-index={hr.catIdx}
+            onmouseenter={(event) => handleCategoryEnter(event, hr.catIdx)}
+            onmousemove={trackMouse}
+            onmouseleave={handleCategoryLeave}
+            onclick={() => handleCategoryClick(hr.catIdx)}
+          />
+        {/each}
+
+        <!-- Hover vertical guideline -->
+        {#if hoveredCategoryIndex !== null}
+          {@const guideX = catScale(categories[hoveredCategoryIndex]) + catScale.bandwidth / 2}
+          <line class="hover-guideline" x1={guideX} x2={guideX} y1={0} y2={dims.innerHeight} />
+        {/if}
+      </g>
+
+      <!-- SVG defs id namespace anchor (keeps uid live in reactive graph) -->
+      <defs>
+        <marker id="{uid}-anchor" />
+      </defs>
+    </ChartContainer>
+
+    <!-- Tooltip -->
+    {#if typeof tooltipSnippet === 'function' && hoveredCategoryIndex !== null}
+      <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
+        {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
+      </div>
+    {:else}
+      <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
+    {/if}
+  {:else}
+    <div class="chart-empty">No data available.</div>
+  {/if}
+</div>
+
+<style>
+  .dual-axis-bar-chart {
+    width: 100%;
+    position: relative;
+  }
+
+  .bar-shape {
+    transition: opacity var(--chart-transition-duration, 0.2s) ease;
+    cursor: pointer;
+  }
+
+  .bar-hovered {
+    opacity: var(--dual-axis-bar-hover-opacity, 1);
+  }
+
+  .bar-dimmed {
+    opacity: var(--dual-axis-bar-dimmed-opacity, 0.3);
+  }
+
+  .line-series {
+    stroke-width: var(--dual-axis-line-stroke-width, 2);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+  }
+
+  .line-dot {
+    transition:
+      r var(--chart-transition-duration, 0.2s) ease,
+      opacity var(--chart-transition-duration, 0.2s) ease;
+    cursor: pointer;
+  }
+
+  .dot-dimmed {
+    opacity: var(--dual-axis-bar-dimmed-opacity, 0.3);
+  }
+
+  .hover-target {
+    cursor: pointer;
+  }
+
+  .hover-guideline {
+    stroke: var(--dual-axis-guideline-color, #aaa);
+    stroke-width: var(--dual-axis-guideline-width, 1);
+    stroke-dasharray: var(--dual-axis-guideline-dash, 4 3);
+    pointer-events: none;
+    opacity: 0.6;
+  }
+
+  .axis-title {
+    fill: var(--chart-axis-label-color, #333);
+    font-size: var(--chart-axis-label-font-size, 11px);
+    font-family: var(--chart-font-family, inherit);
+    font-weight: 500;
+  }
+
+  .chart-tooltip-slot {
+    position: absolute;
+    z-index: 10;
+    pointer-events: none;
+  }
+
+  .chart-empty {
+    padding: var(--chart-empty-padding, 32px 24px);
+    color: var(--chart-empty-color, #9ca3af);
+    text-align: center;
+  }
+</style>

--- a/src/lib/DualAxisBarChart/properties.ts
+++ b/src/lib/DualAxisBarChart/properties.ts
@@ -1,0 +1,122 @@
+import type { Snippet } from 'svelte';
+
+// ── Axis config ───────────────────────────────────────────────
+
+/**
+ * Configuration for one of the two independent Y-axes.
+ */
+export type DualAxisConfig = {
+  /** Optional label rendered above the axis line. */
+  title?: string;
+  /**
+   * Color applied to axis title text and, by default, to tick labels on this side.
+   * Accepts any CSS color string.
+   */
+  color?: string;
+  /** Custom tick formatter. Receives a raw number and returns the display string. */
+  valueFormat?: (value: number) => string;
+};
+
+// ── Series ────────────────────────────────────────────────────
+
+/**
+ * A single data series in the dual-axis chart.
+ * Each series is mapped to either the left (0) or right (1) Y-axis.
+ */
+export type DualAxisSeries = {
+  /** Display name shown in the legend and tooltip. */
+  name: string;
+  /**
+   * Numeric values — one per category. The array length must match `categories`.
+   */
+  data: number[];
+  /**
+   * Which Y-axis this series uses.
+   * `0` = left axis, `1` = right axis.
+   */
+  yAxisIndex: 0 | 1;
+  /** Optional CSS color for the series bars/line. Falls back to the default palette. */
+  color?: string;
+  /**
+   * Render type for this individual series.
+   * `'column'` — vertical bars (default).
+   * `'line'`   — line with optional dots drawn over the column layer.
+   */
+  type?: 'column' | 'line';
+};
+
+// ── Tooltip context ───────────────────────────────────────────
+
+/**
+ * Data passed to `tooltipSnippet` when the user hovers a category.
+ */
+export type DualAxisTooltipContext = {
+  /** The hovered category label. */
+  category: string;
+  /** Zero-based index of the hovered category. */
+  categoryIndex: number;
+  /**
+   * All series values for this category, in series order.
+   * Each entry mirrors the corresponding `DualAxisSeries` plus the resolved value.
+   */
+  points: Array<{
+    name: string;
+    value: number;
+    color: string;
+    yAxisIndex: 0 | 1;
+    type: 'column' | 'line';
+  }>;
+};
+
+// ── Component properties ──────────────────────────────────────
+
+export type DualAxisBarChartProperties = MandatoryDualAxisBarChartProperties &
+  OptionalDualAxisBarChartProperties &
+  DualAxisBarChartEventProperties;
+
+export type MandatoryDualAxisBarChartProperties = {
+  /** Ordered category labels for the shared X-axis (e.g. `['Jan', 'Feb', 'Mar']`). */
+  categories: string[];
+  /**
+   * Array of series descriptors. Each series declares a `yAxisIndex` (0=left, 1=right),
+   * the numeric `data` values, and an optional render `type`.
+   */
+  series: DualAxisSeries[];
+};
+
+export type OptionalDualAxisBarChartProperties = {
+  /** Configuration for the left (primary) Y-axis. */
+  leftAxis?: DualAxisConfig;
+  /** Configuration for the right (secondary) Y-axis. */
+  rightAxis?: DualAxisConfig;
+  /** Whether to render dashed gridlines from the left-axis ticks. Default `true`. */
+  showGridlines?: boolean;
+  /** Whether to render the shared legend below the chart. Default `true`. */
+  showLegend?: boolean;
+  /** Corner radius on column/bar shapes in pixels. Default `3`. */
+  barRadius?: number;
+  /** Padding between category bands as a fraction of band width (0–1). Default `0.25`. */
+  barPadding?: number;
+  /**
+   * Width-to-height ratio for the chart area.
+   * Passed to `ChartContainer`'s ResizeObserver sizing. Default `16/9`.
+   */
+  aspectRatio?: number;
+  /**
+   * Custom tooltip content. Receives a `DualAxisTooltipContext` and replaces the
+   * default multi-series tooltip.
+   */
+  tooltipSnippet?: Snippet<[DualAxisTooltipContext]>;
+  /** Value set on `data-pw` for test targeting. */
+  testId?: string;
+  /** Extra CSS class string on the root `<div>`. */
+  classes?: string;
+};
+
+export type DualAxisBarChartEventProperties = {
+  /**
+   * Fires when the user clicks a bar or line-dot.
+   * Receives the category index and the full tooltip context for that category.
+   */
+  onbarclick?: (event: { categoryIndex: number; context: DualAxisTooltipContext }) => void;
+};

--- a/src/lib/FunnelChart/FunnelChart.svelte
+++ b/src/lib/FunnelChart/FunnelChart.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+  import type { FunnelChartProperties, FunnelStage } from './properties';
+  import ChartContainer from '$lib/_chart/ChartContainer.svelte';
+  import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
+  import { getColor } from '$lib/_chart/colors';
+  import { formatNumber, formatPercent } from '$lib/_chart/format';
+
+  // ── Props ──────────────────────────────────────────────────────
+
+  let {
+    data,
+    stageColors,
+    connectorColor = 'var(--funnel-chart-connector-color, #BDFFFB)',
+    slopeWidth = 10,
+    onHoverExpand = 10,
+    showValueLabels = true,
+    valueFormat,
+    aspectRatio = 16 / 9,
+    testId,
+    classes,
+    empty,
+    onstageclick,
+    onstagehover
+  }: FunnelChartProperties = $props();
+
+  // ── State ──────────────────────────────────────────────────────
+
+  let containerEl: HTMLDivElement | null = $state(null);
+  let chartWidth = $state(0);
+  let chartHeight = $state(0);
+  let hoveredIndex = $state<number | null>(null);
+  let mouseX = $state(0);
+  let mouseY = $state(0);
+
+  // ── Derived geometry ───────────────────────────────────────────
+
+  const MARGIN_TOP = 32;
+  const MARGIN_RIGHT = 8;
+  const MARGIN_BOTTOM = 8;
+  const MARGIN_LEFT = 8;
+  const LABEL_AREA_HEIGHT = 24;
+
+  let innerWidth = $derived(Math.max(0, chartWidth - MARGIN_LEFT - MARGIN_RIGHT));
+  let innerHeight = $derived(Math.max(0, chartHeight - MARGIN_TOP - MARGIN_BOTTOM));
+
+  let maxValue = $derived.by(() => {
+    if (data.length === 0) {
+      return 1;
+    }
+    let max = 0;
+    for (const stage of data) {
+      if (stage.value > max) {
+        max = stage.value;
+      }
+    }
+    return max === 0 ? 1 : max;
+  });
+
+  // The documented contract treats an all-zero dataset as empty (it would otherwise
+  // render meaningless min-height bars), so fold that into the empty check.
+  let isEmpty = $derived(data.length === 0 || data.every((stage) => stage.value === 0));
+
+  /**
+   * Computes the total horizontal space consumed by slope connectors.
+   * There are (data.length - 1) connectors, each slopeWidth wide.
+   */
+  let totalSlopeSpace = $derived(Math.max(0, data.length - 1) * slopeWidth);
+
+  /**
+   * Width of each stage bar column in SVG user units.
+   * All stages share the same column width; the visual narrowing comes from the bar
+   * height being proportional to value/max, not from the column width.
+   */
+  let stageColumnWidth = $derived(
+    data.length === 0 ? 0 : Math.max(1, (innerWidth - totalSlopeSpace) / data.length)
+  );
+
+  /** Available height for the bars themselves (below the category labels). */
+  let barAreaHeight = $derived(Math.max(0, innerHeight - LABEL_AREA_HEIGHT));
+
+  /**
+   * Resolve the fill color for a stage. Uses explicitly-provided `stageColors` array
+   * first, falls back to the shared chart palette via `getColor`.
+   */
+  function resolveStageColor(index: number): string {
+    const explicit = stageColors?.[index];
+    if (typeof explicit === 'string' && explicit.length > 0) {
+      return explicit;
+    }
+    return getColor(index);
+  }
+
+  /**
+   * Compute the SVG x-offset for the left edge of a stage column (including slope offsets
+   * for preceding connectors). Each connector occupies `slopeWidth` units horizontally so
+   * consecutive stage rectangles do not overlap.
+   */
+  function stageX(index: number): number {
+    return index * (stageColumnWidth + slopeWidth);
+  }
+
+  /**
+   * Bar height for a given stage value, proportional to value/maxValue.
+   * Clamped to at least 2px so zero-value stages remain visible.
+   */
+  function barHeight(stageValue: number, expandPixels: number = 0): number {
+    return Math.max(2, (stageValue / maxValue) * barAreaHeight + expandPixels);
+  }
+
+  /**
+   * Vertical y-offset that centres the bar vertically within the bar area.
+   * `expandPixels` is added symmetrically (half-top, half-bottom) on hover.
+   */
+  function barY(stageValue: number, expandPixels: number = 0): number {
+    const h = barHeight(stageValue, expandPixels);
+    return LABEL_AREA_HEIGHT + (barAreaHeight - h) / 2;
+  }
+
+  /**
+   * Build an SVG polygon `points` string for the trapezoidal connector between stage
+   * `index` and `index + 1`. The trapezoid fills the slopeWidth gap between two adjacent
+   * bars, matching the top and bottom edges of both bars.
+   */
+  function connectorPoints(index: number): string {
+    const currentStage = data[index] ?? null;
+    const nextStage = data[index + 1] ?? null;
+    if (currentStage === null || nextStage === null) {
+      return '';
+    }
+
+    const expandCurrent = hoveredIndex === index ? onHoverExpand : 0;
+    const expandNext = hoveredIndex === index + 1 ? onHoverExpand : 0;
+
+    const x1 = stageX(index) + stageColumnWidth;
+    const y1Top = barY(currentStage.value, expandCurrent);
+    const y1Bot = y1Top + barHeight(currentStage.value, expandCurrent);
+
+    const x2 = stageX(index + 1);
+    const y2Top = barY(nextStage.value, expandNext);
+    const y2Bot = y2Top + barHeight(nextStage.value, expandNext);
+
+    return `${x1},${y1Top} ${x1},${y1Bot} ${x2},${y2Bot} ${x2},${y2Top}`;
+  }
+
+  /**
+   * Format the in-bar label. Uses a consumer-supplied `valueFormat` when provided,
+   * otherwise renders `"<value> | <pct>%"`.
+   */
+  function formatLabel(stage: FunnelStage): string {
+    if (typeof valueFormat === 'function') {
+      return valueFormat(stage.value, maxValue);
+    }
+    const pct = formatPercent(stage.value, maxValue);
+    return `${formatNumber(stage.value)}  |  ${pct}`;
+  }
+
+  // ── Tooltip ────────────────────────────────────────────────────
+
+  let tooltipData = $derived.by(() => {
+    if (hoveredIndex === null) {
+      return null;
+    }
+    const stage = data[hoveredIndex] ?? null;
+    if (stage === null) {
+      return null;
+    }
+    return {
+      title: stage.category,
+      items: [
+        {
+          label: stage.category,
+          value: formatLabel(stage),
+          color: resolveStageColor(hoveredIndex)
+        }
+      ]
+    };
+  });
+
+  // ── Interaction ────────────────────────────────────────────────
+
+  function trackMouse(event: MouseEvent) {
+    if (containerEl === null) {
+      return;
+    }
+    const rect = containerEl.getBoundingClientRect();
+    mouseX = event.clientX - rect.left;
+    mouseY = event.clientY - rect.top;
+  }
+
+  function handleEnter(event: MouseEvent, index: number) {
+    hoveredIndex = index;
+    trackMouse(event);
+    const stage = data[index] ?? null;
+    if (stage !== null) {
+      onstagehover?.({ index, stage });
+    }
+  }
+
+  function handleLeave() {
+    hoveredIndex = null;
+    onstagehover?.(null);
+  }
+
+  function handleClick(index: number) {
+    const stage = data[index] ?? null;
+    if (stage !== null) {
+      onstageclick?.({ index, stage });
+    }
+  }
+</script>
+
+<div
+  class="funnel-chart {classes ?? ''}"
+  bind:this={containerEl}
+  data-pw={typeof testId === 'string' ? testId : null}
+>
+  {#if isEmpty && typeof empty === 'function'}
+    <div class="chart-empty">{@render empty()}</div>
+  {:else}
+    <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
+      <g transform="translate({MARGIN_LEFT}, {MARGIN_TOP})">
+        <!-- Stage bars and category labels -->
+        {#each data as stage, index (index)}
+          {@const expand = hoveredIndex === index ? onHoverExpand : 0}
+          {@const bh = barHeight(stage.value, expand)}
+          {@const by = barY(stage.value, expand)}
+          {@const bx = stageX(index)}
+          {@const color = resolveStageColor(index)}
+          {@const labelX = bx + stageColumnWidth / 2}
+
+          <!-- Category label above the bar -->
+          <text
+            class="funnel-category-label"
+            x={labelX}
+            y={LABEL_AREA_HEIGHT - 6}
+            text-anchor="middle"
+            dominant-baseline="auto">{stage.category}</text
+          >
+
+          <!-- Stage bar -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <rect
+            class="funnel-bar"
+            class:funnel-bar-hovered={hoveredIndex === index}
+            class:funnel-bar-dimmed={hoveredIndex !== null && hoveredIndex !== index}
+            x={bx}
+            y={by}
+            width={stageColumnWidth}
+            height={bh}
+            fill={color}
+            rx={2}
+            aria-label="{stage.category}: {formatLabel(stage)}"
+            onmouseenter={(event) => handleEnter(event, index)}
+            onmousemove={trackMouse}
+            onmouseleave={handleLeave}
+            onclick={() => handleClick(index)}
+          />
+
+          <!-- Value label centred inside the bar -->
+          {#if showValueLabels}
+            <text
+              class="funnel-value-label"
+              x={labelX}
+              y={by + bh / 2}
+              text-anchor="middle"
+              dominant-baseline="middle"
+              pointer-events="none">{formatLabel(stage)}</text
+            >
+          {/if}
+        {/each}
+
+        <!-- Trapezoidal connectors between stages -->
+        {#each data as _stage, index (index)}
+          {#if index < data.length - 1}
+            <polygon
+              class="funnel-connector"
+              points={connectorPoints(index)}
+              fill={connectorColor}
+              pointer-events="none"
+            />
+          {/if}
+        {/each}
+      </g>
+    </ChartContainer>
+
+    <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
+  {/if}
+</div>
+
+<style>
+  .funnel-chart {
+    width: 100%;
+    position: relative;
+  }
+
+  .funnel-category-label {
+    fill: var(--funnel-chart-label-color, #666);
+    font-size: var(--funnel-chart-label-font-size, 11px);
+    font-family: var(--chart-font-family, inherit);
+    pointer-events: none;
+  }
+
+  .funnel-bar {
+    transition:
+      opacity var(--chart-transition-duration, 0.2s) ease,
+      y var(--chart-transition-duration, 0.2s) ease,
+      height var(--chart-transition-duration, 0.2s) ease;
+    cursor: pointer;
+  }
+
+  .funnel-bar-hovered {
+    opacity: var(--funnel-chart-bar-hover-opacity, 1);
+  }
+
+  .funnel-bar-dimmed {
+    opacity: var(--funnel-chart-bar-dimmed-opacity, 0.35);
+  }
+
+  .funnel-value-label {
+    fill: var(--funnel-chart-value-color, #fff);
+    font-size: var(--funnel-chart-value-font-size, 11px);
+    font-family: var(--chart-font-family, inherit);
+  }
+
+  .funnel-connector {
+    transition: d var(--chart-transition-duration, 0.2s) ease;
+  }
+
+  .chart-empty {
+    padding: var(--chart-empty-padding, 32px 24px);
+    color: var(--chart-empty-color, #9ca3af);
+    text-align: center;
+  }
+</style>

--- a/src/lib/FunnelChart/properties.ts
+++ b/src/lib/FunnelChart/properties.ts
@@ -1,0 +1,74 @@
+import type { Snippet } from 'svelte';
+
+// ── Data shape ────────────────────────────────────────────────
+
+export type FunnelStage = {
+  /** Numeric value for this stage. Used to compute bar heights and percentages. */
+  value: number;
+  /** Human-readable label displayed above the stage bar. */
+  category: string;
+};
+
+// ── Component property types ──────────────────────────────────
+
+export type FunnelChartProperties = MandatoryFunnelChartProperties &
+  OptionalFunnelChartProperties &
+  FunnelChartEventProperties;
+
+export type MandatoryFunnelChartProperties = {
+  /** Ordered list of funnel stages. The first stage is the widest; each subsequent stage narrows proportionally. */
+  data: FunnelStage[];
+};
+
+export type OptionalFunnelChartProperties = {
+  /**
+   * Fill color for each stage bar. Index-matched to `data`.
+   * Cycles via the shared chart palette for any stages without an explicit entry.
+   */
+  stageColors?: string[];
+  /**
+   * Fill color for the trapezoidal connector polygons drawn between consecutive stages.
+   * Defaults to a light-teal shared palette neutral.
+   */
+  connectorColor?: string;
+  /**
+   * Horizontal width (in SVG user units relative to total inner width) of each
+   * trapezoidal slope connector. Larger values produce steeper visual drops between stages.
+   * Default is `10`.
+   */
+  slopeWidth?: number;
+  /**
+   * Extra vertical pixels added symmetrically to the hovered stage bar (half on each edge).
+   * Set to `0` to disable hover expansion. Default is `10`.
+   */
+  onHoverExpand?: number;
+  /**
+   * When `true`, renders the value and percentage label centred inside each stage bar.
+   * Default is `true`.
+   */
+  showValueLabels?: boolean;
+  /**
+   * Custom formatter for the value portion of the in-bar label.
+   * Receives the stage value and the maximum value across all stages.
+   * The default renders `"<value> | <pct>%"`.
+   */
+  valueFormat?: (value: number, max: number) => string;
+  /**
+   * Width-to-height ratio for the chart area.
+   * Passed directly to `ChartContainer`. Default is `16 / 9`.
+   */
+  aspectRatio?: number;
+  /** Value for the `data-pw` attribute on the chart root element. */
+  testId?: string;
+  /** CSS class string applied to the chart root element. Useful for CSS-variable theming. */
+  classes?: string;
+  /** Content rendered when `data` is empty or all values are zero. */
+  empty?: Snippet;
+};
+
+export type FunnelChartEventProperties = {
+  /** Fires when the user clicks a stage bar. Receives the stage index and its data. */
+  onstageclick?: (event: { index: number; stage: FunnelStage }) => void;
+  /** Fires when the user hovers over or leaves a stage bar. `null` on leave. */
+  onstagehover?: (event: { index: number; stage: FunnelStage } | null) => void;
+};

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { LineChartProperties, LineChartTooltipContext } from './properties';
+  import type { ChartHighlightAPI } from '$lib/_chart/highlight';
   import { onMount } from 'svelte';
   import ChartContainer from '$lib/_chart/ChartContainer.svelte';
   import Axis from '$lib/_chart/Axis.svelte';
@@ -25,6 +26,8 @@
     curve = 'monotone',
     gradientFill = false,
     fillOpacity = 0.3,
+    showArea = false,
+    areaGradient,
     showDots = true,
     showValues = false,
     dotRadius = 4,
@@ -37,11 +40,14 @@
     yDomain,
     xAxisLabel,
     yAxisLabel,
+    xAxisCategories,
     xTickFormat,
     yTickFormat,
     aspectRatio = 16 / 9,
     tooltipSnippet,
     empty,
+    highlightedIndex = null,
+    onChartReady,
     onpointclick,
     onpointhover,
     testId,
@@ -54,11 +60,42 @@
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hovered = $state<{ si: number; pi: number } | null>(null);
+  // internalHighlight holds the index driven by the ChartHighlightAPI.highlight() call.
+  // The effective highlighted index merges this with the prop-driven highlightedIndex.
+  let internalHighlight = $state<number | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
 
+  // Effective highlighted index: the declarative prop takes precedence when it is a non-null
+  // number; otherwise the imperative API value (internalHighlight) is used. This lets callers
+  // mix both approaches — e.g. default to null so the API drives highlights, then override with
+  // a specific prop value when a controlled index is needed.
+  let effectiveHighlight = $derived(
+    typeof highlightedIndex === 'number' ? highlightedIndex : internalHighlight
+  );
+
   onMount(() => {
     uid = Math.random().toString(36).slice(2, 9);
+
+    const api: ChartHighlightAPI = {
+      type: 'line-chart',
+      highlight: (index) => {
+        internalHighlight = index;
+      },
+      getCategories: () => {
+        if (xAxisCategories && xAxisCategories.length > 0) {
+          return xAxisCategories;
+        }
+        // Fall back to the x-values of the longest series as string labels.
+        const reference = series.reduce(
+          (longest, s) => (s.data.length > longest.data.length ? s : longest),
+          series[0] ?? { data: [] }
+        );
+        return reference.data.map((d) => String(d.x));
+      }
+    };
+
+    onChartReady?.(api);
   });
 
   // ── Layout ─────────────────────────────────────────────────────
@@ -108,6 +145,23 @@
     series.map((s, i) => ({ label: s.name, color: s.color ?? getColor(i) }))
   );
 
+  // ── Category tick formatter ────────────────────────────────────
+
+  // When xAxisCategories is supplied we build a formatter that maps the numeric
+  // x-value (1-based index used in the data) to the corresponding category label.
+  let resolvedXTickFormat = $derived.by(() => {
+    if (xAxisCategories && xAxisCategories.length > 0) {
+      const categories = xAxisCategories;
+      return (value: number | string): string => {
+        const numericValue = typeof value === 'string' ? parseFloat(value) : value;
+        // x values are 1-based indices; category array is 0-based.
+        const categoryIndex = Math.round(numericValue) - 1;
+        return categories[categoryIndex] ?? String(value);
+      };
+    }
+    return xTickFormat;
+  });
+
   // ── Tooltip ────────────────────────────────────────────────────
 
   let hoveredPoint = $derived(
@@ -117,6 +171,24 @@
   let hoverLineX = $derived(
     hovered === null ? null : (lines[hovered.si]?.points[hovered.pi]?.x ?? null)
   );
+
+  // When a highlight index is active (imperative or prop), show the vertical
+  // crosshair at that point even without a mouse hover.
+  let highlightLineX = $derived.by<number | null>(() => {
+    if (effectiveHighlight === null) {
+      return null;
+    }
+    // Use the first series that has a point at this index.
+    for (const line of lines) {
+      const point = line.points[effectiveHighlight];
+      if (point) {
+        return point.x;
+      }
+    }
+    return null;
+  });
+
+  let activeLineX = $derived(hoverLineX ?? highlightLineX);
 
   let tooltipContext = $derived.by<LineChartTooltipContext | null>(() => {
     if (hovered === null || hoveredPoint === null) {
@@ -140,8 +212,11 @@
     if (tooltipContext === null) {
       return null;
     }
+    const xLabel = resolvedXTickFormat
+      ? resolvedXTickFormat(tooltipContext.x)
+      : `x: ${formatNumber(tooltipContext.x)}`;
     return {
-      title: xTickFormat ? xTickFormat(tooltipContext.x) : `x: ${formatNumber(tooltipContext.x)}`,
+      title: xLabel,
       items: tooltipContext.points.map((p) => ({
         label: p.name,
         value: formatNumber(p.y),
@@ -150,18 +225,51 @@
     };
   });
 
+  // ── Highlight dim logic ────────────────────────────────────────
+
+  // A point index is "dimmed" when the highlight system is active (hover or
+  // imperative highlight) and the point is not the active one.
+  const isDotDimmed = (si: number, pi: number): boolean => {
+    // Hover interaction takes precedence over imperative highlight.
+    if (hovered !== null) {
+      return hovered.si !== si || hovered.pi !== pi;
+    }
+    if (effectiveHighlight !== null) {
+      return pi !== effectiveHighlight;
+    }
+    return false;
+  };
+
+  const isLineDimmed = (si: number): boolean => {
+    if (hovered !== null) {
+      return hovered.si !== si;
+    }
+    // When only a point index is highlighted (no series index), dim no lines.
+    return false;
+  };
+
+  const isHighlightedDot = (si: number, pi: number): boolean => {
+    if (hovered !== null) {
+      return hovered.si === si && hovered.pi === pi;
+    }
+    if (effectiveHighlight !== null) {
+      return pi === effectiveHighlight;
+    }
+    return false;
+  };
+
   // ── Interactions ───────────────────────────────────────────────
 
-  function trackMouse(e: MouseEvent) {
+  const trackMouse = (e: MouseEvent): void => {
     if (containerEl === null) {
       return;
     }
     const rect = containerEl.getBoundingClientRect();
     mouseX = e.clientX - rect.left;
     mouseY = e.clientY - rect.top;
-  }
+  };
 
-  function findNearest(plotX: number, plotY: number): { si: number; pi: number } | null {
+  const findNearest = (plotX: number, plotY: number): { si: number; pi: number } | null => {
     if (series.length === 0) {
       return null;
     }
@@ -196,9 +304,9 @@
       }
     }
     return { si: nearestSi, pi: nearestPi };
-  }
+  };
 
-  function handleOverlayMove(e: MouseEvent) {
+  const handleOverlayMove = (e: MouseEvent): void => {
     trackMouse(e);
     const plotX = mouseX - dims.margin.left;
     const plotY = mouseY - dims.margin.top;
@@ -212,16 +320,16 @@
       const point = series[next.si].data[next.pi];
       onpointhover?.({ seriesIndex: next.si, pointIndex: next.pi, point });
     }
-  }
+  };
 
-  function handleLeave() {
+  const handleLeave = (): void => {
     if (hovered !== null) {
       hovered = null;
       onpointhover?.(null);
     }
-  }
+  };
 
-  function handleClick() {
+  const handleClick = (): void => {
     if (hovered === null) {
       return;
     }
@@ -229,7 +337,7 @@
     if (point) {
       onpointclick?.({ seriesIndex: hovered.si, pointIndex: hovered.pi, point });
     }
-  }
+  };
 </script>
 
 <div
@@ -245,31 +353,54 @@
     {/if}
 
     <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
-      {#if gradientFill}
+      {#if gradientFill || showArea}
         <defs>
           {#each lines as line, si (si)}
-            <linearGradient
-              id="line-grad-{uid}-{si}"
-              x1="0"
-              y1="0"
-              x2="0"
-              y2={dims.innerHeight}
-              gradientUnits="userSpaceOnUse"
-            >
-              <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
-                   anchor at the top that fades to transparent at the bottom. This intentionally
-                   exceeds the base fillOpacity so that gradient-fill areas appear more vivid
-                   than a flat solid-fill at fillOpacity alone. -->
-              <stop
-                offset="0%"
-                stop-color={line.color}
-                stop-opacity={Math.min(
-                  (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
-                  1
-                )}
-              />
-              <stop offset="100%" stop-color={line.color} stop-opacity={0} />
-            </linearGradient>
+            {#if gradientFill}
+              <linearGradient
+                id="line-grad-{uid}-{si}"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2={dims.innerHeight}
+                gradientUnits="userSpaceOnUse"
+              >
+                <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
+                     anchor at the top that fades to transparent at the bottom. This intentionally
+                     exceeds the base fillOpacity so that gradient-fill areas appear more vivid
+                     than a flat solid-fill at fillOpacity alone. -->
+                <stop
+                  offset="0%"
+                  stop-color={line.color}
+                  stop-opacity={Math.min(
+                    (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
+                    1
+                  )}
+                />
+                <stop offset="100%" stop-color={line.color} stop-opacity={0} />
+              </linearGradient>
+            {/if}
+            {#if showArea}
+              <linearGradient
+                id="line-area-{uid}-{si}"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2={dims.innerHeight}
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop
+                  offset="0%"
+                  stop-color={areaGradient ? areaGradient.from : line.color}
+                  stop-opacity={areaGradient ? 1 : 0.35}
+                />
+                <stop
+                  offset="100%"
+                  stop-color={areaGradient ? areaGradient.to : line.color}
+                  stop-opacity={areaGradient ? 1 : 0}
+                />
+              </linearGradient>
+            {/if}
           {/each}
         </defs>
       {/if}
@@ -286,12 +417,24 @@
         {/if}
         {#if showXAxis}
           <g transform="translate(0, {dims.innerHeight})">
-            <Axis orientation="bottom" scale={xScale} label={xAxisLabel} tickFormat={xTickFormat} />
+            <Axis
+              orientation="bottom"
+              scale={xScale}
+              label={xAxisLabel}
+              tickFormat={resolvedXTickFormat}
+            />
           </g>
         {/if}
 
         {#each lines as line, si (si)}
-          {#if gradientFill}
+          {#if showArea}
+            <path
+              class="line-area-fill"
+              class:dimmed={isLineDimmed(si)}
+              d={line.areaD}
+              fill="url(#line-area-{uid}-{si})"
+            />
+          {:else if gradientFill}
             <path
               class="line-area-fill"
               class:dimmed={hovered !== null && hovered.si !== si}
@@ -301,7 +444,7 @@
           {/if}
           <path
             class="line-path"
-            class:dimmed={hovered !== null && hovered.si !== si}
+            class:dimmed={isLineDimmed(si)}
             d={line.path}
             stroke={line.color}
             stroke-width={strokeWidth}
@@ -310,7 +453,7 @@
           {#if line.points.length === 1 && !showDots}
             <circle
               class="single-point"
-              class:dimmed={hovered !== null && hovered.si !== si}
+              class:dimmed={isLineDimmed(si)}
               cx={line.points[0].x}
               cy={line.points[0].y}
               r={dotRadius * 1.5}
@@ -321,10 +464,11 @@
             {#each line.points as point, pi (pi)}
               <circle
                 class="dot"
-                class:dimmed={hovered !== null && hovered.si !== si}
+                class:dimmed={isDotDimmed(si, pi)}
+                class:highlighted={isHighlightedDot(si, pi)}
                 cx={point.x}
                 cy={point.y}
-                r={hovered?.si === si && hovered?.pi === pi ? dotRadius * 1.5 : dotRadius}
+                r={isHighlightedDot(si, pi) ? dotRadius * 1.5 : dotRadius}
                 fill={line.color}
               />
             {/each}
@@ -342,8 +486,8 @@
           {/if}
         {/each}
 
-        {#if hoverLineX !== null}
-          <line class="hover-line" x1={hoverLineX} x2={hoverLineX} y1={0} y2={dims.innerHeight} />
+        {#if activeLineX !== null}
+          <line class="hover-line" x1={activeLineX} x2={activeLineX} y1={0} y2={dims.innerHeight} />
         {/if}
 
         <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -411,6 +555,10 @@
   }
   .dot.dimmed {
     opacity: var(--linechart-dimmed-opacity, 0.2);
+  }
+  .dot.highlighted {
+    stroke: var(--linechart-highlight-ring-color, #fff);
+    stroke-width: var(--linechart-highlight-ring-width, 2.5);
   }
   .point-value {
     fill: var(--linechart-value-color, #333);

--- a/src/lib/LineChart/properties.ts
+++ b/src/lib/LineChart/properties.ts
@@ -1,5 +1,6 @@
 import type { Snippet } from 'svelte';
 import type { CurveType } from '$lib/_chart/types';
+import type { ChartHighlightAPI } from '$lib/_chart/highlight';
 
 export type LineChartDataPoint = {
   x: number;
@@ -18,37 +19,100 @@ export type LineChartTooltipContext = {
   points: Array<{ name: string; y: number; color: string; label?: string }>;
 };
 
+/**
+ * Colours used for the vertical gradient fill rendered under the line when
+ * `showArea` is true. Both values accept any valid CSS colour string.
+ */
+export type LineChartAreaGradient = {
+  /** Colour at the top of the gradient (closest to the line). */
+  from: string;
+  /** Colour at the bottom of the gradient (at the baseline). */
+  to: string;
+};
+
 export type LineChartProperties = MandatoryLineChartProperties &
   OptionalLineChartProperties &
   LineChartEventProperties;
 
 export type MandatoryLineChartProperties = {
+  /** Array of `{name, data, color?}`. Each series renders as a separate line. */
   series: LineChartSeries[];
 };
 
 export type OptionalLineChartProperties = {
+  /** Interpolation between points. `'spline'` is an alias for `'monotone'`. */
   curve?: CurveType;
+  /**
+   * When true, renders a gradient fill under each line using the series colour,
+   * fading from `fillOpacity+0.3` at the top to transparent at the bottom.
+   * For per-series custom gradient colours use `showArea` + `areaGradient` instead.
+   */
   gradientFill?: boolean;
+  /** Base opacity of the gradient fill (0–1). Only used when `gradientFill` is true. */
   fillOpacity?: number;
+  /**
+   * When true, renders a solid filled area under each line. The fill colour is
+   * taken from `areaGradient` when provided, otherwise falls back to a
+   * transparent-to-series-colour vertical gradient.
+   */
+  showArea?: boolean;
+  /**
+   * Custom colours for the filled area rendered when `showArea` is true.
+   * Applies the same gradient to every series; supply a per-series colour via
+   * each series' own `color` field if distinct fills are needed.
+   */
+  areaGradient?: LineChartAreaGradient;
+  /** Whether to render dots at each data point. Hover still works via overlay when `false`. */
   showDots?: boolean;
+  /** Whether to render text labels with the y-value at each data point. */
   showValues?: boolean;
+  /** Radius of data point dots in pixels. Hovered or highlighted dot is 1.5× this. */
   dotRadius?: number;
+  /** Width of line strokes in pixels. */
   strokeWidth?: number;
+  /** Whether to show dashed gridlines across the Y axis. */
   showGridlines?: boolean;
+  /** Whether to render the X axis. */
   showXAxis?: boolean;
+  /** Whether to render the Y axis. */
   showYAxis?: boolean;
+  /** Whether to render the legend. Only shown when there are multiple series. */
   showLegend?: boolean;
+  /** Fixed `[min, max]` for the X axis. When omitted the domain is derived from data. */
   xDomain?: [number, number];
+  /** Fixed `[min, max]` for the Y axis. When omitted the domain is derived from data. */
   yDomain?: [number, number];
+  /** Text label below the X axis. */
   xAxisLabel?: string;
+  /** Text label beside the Y axis (rotated). */
   yAxisLabel?: string;
+  /**
+   * String category labels, one per unique x-index (parallel array to the
+   * numeric x values used in `series[n].data`). When provided these labels
+   * replace the raw numeric x values in the X-axis tick labels and tooltips.
+   * Index 0 maps to x=1, index 1 maps to x=2, and so on.
+   */
+  xAxisCategories?: string[];
+  /** Formatter for X axis tick labels. */
   xTickFormat?: (value: number | string) => string;
+  /** Formatter for Y axis tick labels. */
   yTickFormat?: (value: number | string) => string;
+  /** Width-to-height ratio for the chart. */
   aspectRatio?: number;
+  /** Custom tooltip. Receives `{x, points: [{name, y, color, label?}]}`. */
   tooltipSnippet?: Snippet<[LineChartTooltipContext]>;
+  /** Content rendered when all series are empty. */
   empty?: Snippet;
+  /** Value for the data-pw attribute on the chart container. */
   testId?: string;
+  /** CSS class string applied to the top-level element. */
   classes?: string;
+  /**
+   * Zero-based point index to highlight imperatively. When set, the marker at
+   * that index is emphasised and all others are dimmed. Pass `null` to clear.
+   * Use `onChartReady` for the imperative API equivalent.
+   */
+  highlightedIndex?: number | null;
 };
 
 export type LineChartEventProperties = {
@@ -64,4 +128,10 @@ export type LineChartEventProperties = {
       point: LineChartDataPoint;
     } | null
   ) => void;
+  /**
+   * Called once after the chart mounts, handing back a `ChartHighlightAPI`
+   * so an external orchestrator (e.g. voice narration sync) can drive point
+   * highlighting without knowledge of the chart's internal state.
+   */
+  onChartReady?: (api: ChartHighlightAPI) => void;
 };

--- a/src/lib/PieChart/PieChart.svelte
+++ b/src/lib/PieChart/PieChart.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { PieChartProperties } from './properties';
   import ChartContainer from '$lib/_chart/ChartContainer.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
+  import DeltaIndicator from '../DeltaIndicator/DeltaIndicator.svelte';
   import { arcPath } from '$lib/_chart/paths';
   import { computePieLayout } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
@@ -31,7 +33,11 @@
     classes,
     semiCircle = false,
     legendShowValues = false,
-    percentDecimals = 0
+    percentDecimals = 0,
+    onChartReady,
+    highlightedIndex = null,
+    changePercentage,
+    changeInvertColors = false
   }: PieChartProperties = $props();
 
   // ── State ──────────────────────────────────────────────────────
@@ -40,30 +46,39 @@
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hoveredIndex = $state<number | null>(null);
+  let programmaticIndex = $state<number | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
 
-  // Aspect ratio read from --piechart-semi-aspect-ratio CSS variable.
-  // Uses $effect so it re-reads whenever containerEl binds or semiCircle changes
-  // (e.g. media-query theme switch), not just on initial mount.
+  // ── Highlight API ──────────────────────────────────────────────
+
+  // Aspect ratio read from the --piechart-semi-aspect-ratio CSS variable on mount.
   let semiAspectRatioCssVar = $state(2);
 
-  // eslint-disable-next-line no-restricted-syntax
-  $effect(() => {
-    // Track semiCircle and containerEl so the effect re-runs when either changes.
-    void semiCircle;
-    void containerEl;
-    if (typeof window === 'undefined' || containerEl === null) {
-      return;
-    }
-    const rawValue = getComputedStyle(containerEl)
-      .getPropertyValue('--piechart-semi-aspect-ratio')
-      .trim();
-    const parsed = parseFloat(rawValue);
-    if (!Number.isNaN(parsed) && parsed > 0) {
-      semiAspectRatioCssVar = parsed;
+  onMount(() => {
+    onChartReady?.({
+      highlight: (index) => {
+        programmaticIndex = index;
+      },
+      getCategories: () => data.map((d) => d.label),
+      type: 'donut-chart'
+    });
+
+    if (typeof window !== 'undefined' && containerEl !== null) {
+      const rawValue = getComputedStyle(containerEl)
+        .getPropertyValue('--piechart-semi-aspect-ratio')
+        .trim();
+      const parsed = parseFloat(rawValue);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        semiAspectRatioCssVar = parsed;
+      }
     }
   });
+
+  // ── Active index ───────────────────────────────────────────────
+  // Precedence: mouse hover > declarative highlightedIndex prop > imperative API.
+
+  let activeIndex = $derived<number | null>(hoveredIndex ?? highlightedIndex ?? programmaticIndex);
 
   // ── Layout ─────────────────────────────────────────────────────
 
@@ -146,6 +161,10 @@
 
   // ── Tooltip ────────────────────────────────────────────────────
 
+  // Tooltip visibility tracks hover only. activeIndex also covers declarative/imperative
+  // highlights, but those arrive without mouse coordinates, so a tooltip driven by them
+  // would render at the top-left (mouseX/mouseY still 0). Highlight styling uses
+  // activeIndex; the tooltip stays gated on hoveredIndex.
   let tooltipData = $derived.by(() => {
     if (hoveredIndex === null || !slices[hoveredIndex]) {
       return null;
@@ -209,8 +228,8 @@
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <path
             class="slice"
-            class:hovered={hoveredIndex === slice.index}
-            class:dimmed={hoveredIndex !== null && hoveredIndex !== slice.index}
+            class:hovered={activeIndex === slice.index}
+            class:dimmed={activeIndex !== null && activeIndex !== slice.index}
             d={slice.path}
             fill={slice.color}
             aria-label="{slice.label}: {format(slice.value)}"
@@ -249,6 +268,12 @@
         {/if}
       </g>
     </ChartContainer>
+
+    {#if typeof changePercentage === 'number'}
+      <div class="pie-delta-badge">
+        <DeltaIndicator value={changePercentage} invertColors={changeInvertColors} />
+      </div>
+    {/if}
 
     {#if showLegend && legendShowValues}
       <ul class="pie-legend-values">
@@ -311,6 +336,13 @@
     align-items: center;
     justify-content: center;
     text-align: center;
+  }
+  .pie-delta-badge {
+    position: absolute;
+    top: var(--piechart-delta-top, 8px);
+    right: var(--piechart-delta-right, 8px);
+    z-index: 2;
+    pointer-events: none;
   }
   .chart-tooltip-slot {
     position: absolute;

--- a/src/lib/PieChart/properties.ts
+++ b/src/lib/PieChart/properties.ts
@@ -1,4 +1,5 @@
 import type { Snippet } from 'svelte';
+import type { ChartHighlightAPI } from '../_chart/highlight';
 
 export type PieChartSlice = {
   label: string;
@@ -32,6 +33,31 @@ export type OptionalPieChartProperties = {
   semiCircle?: boolean;
   legendShowValues?: boolean;
   percentDecimals?: number;
+  /**
+   * Called once on mount with the imperative highlight API. Pass the returned
+   * object to an external orchestrator (e.g. voice narration) so it can drive
+   * slice highlighting without touching internal state. The `type` field is
+   * always `'donut-chart'` regardless of whether `innerRadius` is set.
+   */
+  onChartReady?: (api: ChartHighlightAPI) => void;
+  /**
+   * Index of the slice to highlight programmatically. The highlighted slice
+   * scales out and all others dim, exactly as if the user were hovering it.
+   * Pass `null` (or omit the prop) to clear all highlights.
+   */
+  highlightedIndex?: number | null;
+  /**
+   * When provided, renders a `DeltaIndicator` badge anchored to the top-right
+   * corner of the chart container. Positive values show green ↑, negative
+   * values show red ↓ (unless `changeInvertColors` is `true`).
+   */
+  changePercentage?: number;
+  /**
+   * Swap the up/down colors on the delta badge for lower-is-better metrics
+   * (e.g. RTO rate, bounce rate). Has no effect when `changePercentage` is
+   * not provided.
+   */
+  changeInvertColors?: boolean;
 };
 
 export type PieChartEventProperties = {

--- a/src/lib/SankeyChart/SankeyChart.svelte
+++ b/src/lib/SankeyChart/SankeyChart.svelte
@@ -28,7 +28,10 @@
     testId,
     classes,
     columnLabels,
-    nodeColorResolver
+    nodeColorResolver,
+    minLinkWidth = 1,
+    dataLabelOffsetX = 0,
+    disableDimOnHover = false
   }: SankeyChartProperties = $props();
 
   // ── State ──────────────────────────────────────────────────────
@@ -54,7 +57,8 @@
       Math.max(0, chartHeight - MARGIN * 2),
       nodeWidth,
       nodePadding,
-      iterations
+      iterations,
+      minLinkWidth
     )
   );
 
@@ -98,6 +102,9 @@
   };
 
   let connectedNodes = $derived.by(() => {
+    if (disableDimOnHover) {
+      return null;
+    }
     if (hoveredNode !== null) {
       const connected = new SvelteSet<string>([hoveredNode]);
       for (const l of links) {
@@ -285,7 +292,8 @@
 
         {#each layout.links as link, i (i)}
           {@const highlighted = isLinkHighlighted(link.source, link.target)}
-          {@const dimmed = (hoveredNode !== null || hoveredLink !== null) && !highlighted}
+          {@const dimmed =
+            !disableDimOnHover && (hoveredNode !== null || hoveredLink !== null) && !highlighted}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <path
@@ -293,7 +301,7 @@
             d={link.path}
             fill="none"
             stroke={link.color ?? nodeColorMap.get(link.source) ?? getColor(0)}
-            stroke-width={Math.max(1, link.width)}
+            stroke-width={Math.max(minLinkWidth, link.width)}
             stroke-opacity={highlighted ? 0.7 : dimmed ? 0.08 : 0.4}
             onmouseenter={(e) => handleLinkEnter(e, link.source, link.target)}
             onmousemove={trackMouse}
@@ -326,7 +334,9 @@
             <text
               class="sankey-label"
               class:node-dimmed={dimmed}
-              x={node.column === 0 ? node.x - 6 : node.x + node.width + 6}
+              x={node.column === 0
+                ? node.x - 6 - dataLabelOffsetX
+                : node.x + node.width + 6 + dataLabelOffsetX}
               y={node.y + node.height / 2}
               text-anchor={node.column === 0 ? 'end' : 'start'}
               dominant-baseline="middle"

--- a/src/lib/SankeyChart/properties.ts
+++ b/src/lib/SankeyChart/properties.ts
@@ -63,6 +63,25 @@ export type OptionalSankeyChartProperties = {
    * through to the default palette colour.
    */
   nodeColorResolver?: (id: string, label: string | null) => string | null;
+  /**
+   * Minimum rendered thickness (px) for any link or node bar. Tiny flows that would otherwise
+   * collapse to sub-pixel widths remain at this thickness so they stay visually discoverable.
+   * Defaults to `1`. Lighthouse uses `2` for dense payment-flow diagrams.
+   */
+  minLinkWidth?: number;
+  /**
+   * Horizontal offset in pixels applied to every node data-label, relative to the default
+   * position (left of first-column nodes, right of all other nodes). Positive values push
+   * the label further away from the node; negative values pull it closer. Lighthouse uses
+   * `30` to create breathing room between the node bar and its label.
+   */
+  dataLabelOffsetX?: number;
+  /**
+   * When `true`, hovering a node does **not** dim unrelated nodes — all nodes and links
+   * remain at full opacity. Useful for dense diagrams where the dimming effect makes it hard
+   * to read the overall structure. Defaults to `false` (standard dim-on-hover behaviour).
+   */
+  disableDimOnHover?: boolean;
 };
 
 export type SankeyChartEventProperties = {

--- a/src/lib/_chart/geometry.ts
+++ b/src/lib/_chart/geometry.ts
@@ -73,7 +73,8 @@ export function computeSankeyLayout(
   height: number,
   nodeWidth: number = 16,
   nodePadding: number = 8,
-  iterations: number = 6
+  iterations: number = 6,
+  minLinkWidth: number = 1
 ): { nodes: ComputedSankeyNode[]; links: ComputedSankeyLink[] } {
   if (nodes.length === 0) {
     return { nodes: [], links: [] };
@@ -144,9 +145,10 @@ export function computeSankeyLayout(
       const val = nodeValues.get(id) ?? 0;
       const h =
         totalValue > 0 ? (val / totalValue) * availableHeight : availableHeight / ids.length;
+      const renderedH = Math.max(minLinkWidth, h);
       nodeY.set(id, y);
-      nodeH.set(id, Math.max(1, h));
-      y += h + nodePadding;
+      nodeH.set(id, renderedH);
+      y += renderedH + nodePadding;
     }
   }
 
@@ -206,7 +208,7 @@ export function computeSankeyLayout(
     const targetNode = nodeById.get(l.target);
     const sVal = nodeValues.get(l.source) ?? 1;
     const sourceH = nodeH.get(l.source) ?? 0;
-    const linkWidth = Math.max(1, (l.value / Math.max(sVal, 1)) * sourceH);
+    const linkWidth = Math.max(minLinkWidth, (l.value / Math.max(sVal, 1)) * sourceH);
 
     const sx = (sourceNode?.x ?? 0) + nodeWidth;
     const sy = (sourceOffsets.get(l.source) ?? 0) + linkWidth / 2;

--- a/src/lib/_chart/highlight.ts
+++ b/src/lib/_chart/highlight.ts
@@ -1,0 +1,16 @@
+export type ChartHighlightType = 'bar-chart' | 'line-chart' | 'donut-chart';
+
+/**
+ * The imperative interface a chart hands back through `onChartReady`, so an
+ * external orchestrator (e.g. voice narration sync) can drive point highlighting
+ * without knowing the chart's internal rendering. Replaces the legacy pattern of
+ * reaching into a charting-library instance stored on the DOM node.
+ */
+export type ChartHighlightAPI = {
+  /** Highlight the data point at this zero-based index; pass `null` to clear. */
+  highlight: (index: number | null) => void;
+  /** The ordered category labels for this chart, for name-based lookup. */
+  getCategories: () => string[];
+  /** The chart kind, for consumers maintaining a registry of charts. */
+  type: ChartHighlightType;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -68,6 +68,9 @@ export { default as PieChart } from './PieChart/PieChart.svelte';
 export { default as SankeyChart } from './SankeyChart/SankeyChart.svelte';
 export { default as LottiePlayer } from './LottiePlayer/LottiePlayer.svelte';
 export { default as StatCard } from './StatCard/StatCard.svelte';
+export { default as DeltaIndicator } from './DeltaIndicator/DeltaIndicator.svelte';
+export { default as DualAxisBarChart } from './DualAxisBarChart/DualAxisBarChart.svelte';
+export { default as FunnelChart } from './FunnelChart/FunnelChart.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -133,6 +136,10 @@ export type * from './PieChart/properties';
 export type * from './SankeyChart/properties';
 export type * from './LottiePlayer/properties';
 export type * from './StatCard/properties';
+export type * from './DeltaIndicator/properties';
+export type * from './DualAxisBarChart/properties';
+export type * from './FunnelChart/properties';
+export type * from './_chart/highlight';
 
 export { validateInput } from './utils';
 export { formatNumberIndian } from './_chart/format';

--- a/src/routes/components/_nav.ts
+++ b/src/routes/components/_nav.ts
@@ -71,7 +71,8 @@ export const componentNav: NavGroup[] = [
       { name: 'IconStack', slug: 'icon-stack' },
       { name: 'Snippet', slug: 'snippet' },
       { name: 'RelativeTime', slug: 'relative-time' },
-      { name: 'EmptyState', slug: 'empty-state' }
+      { name: 'EmptyState', slug: 'empty-state' },
+      { name: 'DeltaIndicator', slug: 'delta-indicator' }
     ]
   },
   {
@@ -81,7 +82,9 @@ export const componentNav: NavGroup[] = [
       { name: 'AreaChart', slug: 'area-chart' },
       { name: 'BarChart', slug: 'bar-chart' },
       { name: 'PieChart', slug: 'pie-chart' },
-      { name: 'SankeyChart', slug: 'sankey-chart' }
+      { name: 'SankeyChart', slug: 'sankey-chart' },
+      { name: 'DualAxisBarChart', slug: 'dual-axis-bar-chart' },
+      { name: 'FunnelChart', slug: 'funnel-chart' }
     ]
   },
   {

--- a/src/routes/components/bar-chart/+page.svelte
+++ b/src/routes/components/bar-chart/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import BarChart from '$lib/BarChart/BarChart.svelte';
+  import type { ChartHighlightAPI } from '$lib/_chart/highlight';
 
   const monthlyRevenue = [
     { label: 'Jan', value: 4200 },
@@ -24,12 +25,86 @@
     { label: 'Sales', value: 31 },
     { label: 'Support', value: 15 }
   ];
+
+  // ── normaliseToFirstPoint demo ─────────────────────────────────
+
+  const growthSeries = [
+    {
+      name: 'Revenue',
+      data: [
+        { label: 'Q1', value: 1000 },
+        { label: 'Q2', value: 1400 },
+        { label: 'Q3', value: 1250 },
+        { label: 'Q4', value: 1800 }
+      ]
+    },
+    {
+      name: 'Users',
+      data: [
+        { label: 'Q1', value: 200 },
+        { label: 'Q2', value: 340 },
+        { label: 'Q3', value: 310 },
+        { label: 'Q4', value: 520 }
+      ]
+    }
+  ];
+
+  // ── topN + overflowLabel demo ──────────────────────────────────
+
+  const manyCategories = [
+    { label: 'Electronics', value: 9400 },
+    { label: 'Clothing', value: 7200 },
+    { label: 'Home & Garden', value: 5800 },
+    { label: 'Sports', value: 4100 },
+    { label: 'Toys', value: 3300 },
+    { label: 'Books', value: 2600 },
+    { label: 'Beauty', value: 2100 },
+    { label: 'Food', value: 1800 },
+    { label: 'Automotive', value: 1400 },
+    { label: 'Music', value: 900 }
+  ];
+
+  // ── hideBarGraphics demo ───────────────────────────────────────
+
+  const labelOnlyData = [
+    { label: 'Alpha', value: 75 },
+    { label: 'Beta', value: 50 },
+    { label: 'Gamma', value: 90 }
+  ];
+
+  // ── onChartReady + declarative highlightedIndex demo ──────────
+
+  let highlightApi: ChartHighlightAPI | null = $state(null);
+  let declarativeHighlight = $state<number | null>(null);
+  let apiHighlightStep = $state(0);
+
+  const handleChartReady = (api: ChartHighlightAPI) => {
+    highlightApi = api;
+  };
+
+  const cycleApiHighlight = () => {
+    if (highlightApi === null) {
+      return;
+    }
+    const categories = highlightApi.getCategories();
+    const nextStep = (apiHighlightStep + 1) % (categories.length + 1);
+    apiHighlightStep = nextStep;
+    highlightApi.highlight(nextStep < categories.length ? nextStep : null);
+  };
 </script>
 
 <div class="page-header">
   <span class="category-badge">Data Visualization</span>
   <h1>BarChart</h1>
 </div>
+
+<p class="intro">
+  A responsive SVG bar chart for comparing categorical values. Supports vertical and horizontal
+  orientations, single or multi-series data (grouped/stacked), value labels, custom fills, hover
+  tooltips, and click events. New capabilities include declarative and imperative bar highlighting,
+  first-point normalisation, top-N clipping with overflow aggregation, and a graphics-free
+  legend/label-only mode.
+</p>
 
 <h3>Basic</h3>
 <div class="demo-row">
@@ -50,3 +125,99 @@
 <div class="demo-row">
   <BarChart data={horizontalData} orientation="horizontal" />
 </div>
+
+<h3>Highlight — Declarative (<code>highlightedIndex</code>)</h3>
+<p>
+  Clicking a button below sets <code>highlightedIndex</code> directly. The highlighted bar stays at
+  full opacity while others dim. Set to <code>null</code> to clear.
+</p>
+<div class="demo-row">
+  <div class="demo-controls">
+    {#each monthlyRevenue as point, idx (idx)}
+      <button
+        class="demo-btn"
+        class:active={declarativeHighlight === idx}
+        onclick={() => {
+          declarativeHighlight = declarativeHighlight === idx ? null : idx;
+        }}
+      >
+        {point.label}
+      </button>
+    {/each}
+    <button
+      class="demo-btn"
+      onclick={() => {
+        declarativeHighlight = null;
+      }}
+    >
+      Clear
+    </button>
+  </div>
+  <BarChart data={monthlyRevenue} showValues highlightedIndex={declarativeHighlight} />
+</div>
+
+<h3>Highlight — Imperative (<code>onChartReady</code>)</h3>
+<p>
+  The chart fires <code>onChartReady</code> on mount with a <code>ChartHighlightAPI</code> handle.
+  Call <code>api.highlight(index)</code> externally (e.g. from a voice narrator or a sibling component).
+</p>
+<div class="demo-row">
+  <div class="demo-controls">
+    <button class="demo-btn" onclick={cycleApiHighlight}>
+      Cycle highlight (step {apiHighlightStep})
+    </button>
+  </div>
+  <BarChart data={monthlyRevenue} onChartReady={handleChartReady} />
+</div>
+
+<h3>Normalise to First Point (<code>normaliseToFirstPoint</code>)</h3>
+<p>
+  Each series' values are expressed as a percentage of its first data point (baseline = 100). This
+  makes relative growth comparable across series with very different starting magnitudes.
+</p>
+<div class="demo-row">
+  <BarChart series={growthSeries} groupMode="grouped" showLegend showValues normaliseToFirstPoint />
+</div>
+
+<h3>Top-N Clipping (<code>topN</code> + <code>overflowLabel</code>)</h3>
+<p>
+  Only the top 4 categories by value are shown individually. The remaining 6 are summed into a
+  single bar labelled "Other".
+</p>
+<div class="demo-row">
+  <BarChart data={manyCategories} topN={4} overflowLabel="Other" showValues />
+</div>
+
+<h3>Hide Bar Graphics (<code>hideBarGraphics</code>)</h3>
+<p>
+  Bar rectangles are not rendered. Axis labels, gridlines, and any legend remain visible. Useful for
+  legend-only or label-only companion views.
+</p>
+<div class="demo-row">
+  <BarChart data={labelOnlyData} hideBarGraphics showXAxis showYAxis showGridlines />
+</div>
+
+<style>
+  .intro {
+    max-width: 680px;
+    margin-bottom: 24px;
+  }
+  .demo-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .demo-btn {
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f5f5f5;
+    cursor: pointer;
+  }
+  .demo-btn.active {
+    background: #3b82f6;
+    color: #fff;
+    border-color: #2563eb;
+  }
+</style>

--- a/src/routes/components/breadcrumb/+page.svelte
+++ b/src/routes/components/breadcrumb/+page.svelte
@@ -1,24 +1,25 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import Breadcrumb from '$lib/Breadcrumb/Breadcrumb.svelte';
   import type { BreadcrumbItemData, BreadcrumbItemContext } from '$lib/Breadcrumb/properties';
 
   const basicItems: BreadcrumbItemData[] = [
-    { href: '/components/breadcrumb', label: 'Home' },
-    { href: '/components/breadcrumb', label: 'Products' },
+    { href: `${base}/components/breadcrumb`, label: 'Home' },
+    { href: `${base}/components/breadcrumb`, label: 'Products' },
     { href: '', label: 'Laptops' }
   ];
 
   const deepItems: BreadcrumbItemData[] = [
-    { href: '/components/breadcrumb', label: 'Home' },
-    { href: '/components/breadcrumb', label: 'Settings' },
-    { href: '/components/breadcrumb', label: 'Account' },
-    { href: '/components/breadcrumb', label: 'Security' },
+    { href: `${base}/components/breadcrumb`, label: 'Home' },
+    { href: `${base}/components/breadcrumb`, label: 'Settings' },
+    { href: `${base}/components/breadcrumb`, label: 'Account' },
+    { href: `${base}/components/breadcrumb`, label: 'Security' },
     { href: '', label: 'Two-Factor Auth' }
   ];
 
   const iconItems: BreadcrumbItemData[] = [
-    { href: '/components/breadcrumb', label: 'Home' },
-    { href: '/components/breadcrumb', label: 'Orders' },
+    { href: `${base}/components/breadcrumb`, label: 'Home' },
+    { href: `${base}/components/breadcrumb`, label: 'Orders' },
     { href: '', label: 'Order #1234' }
   ];
 </script>

--- a/src/routes/components/delta-indicator/+page.svelte
+++ b/src/routes/components/delta-indicator/+page.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import DeltaIndicator from '$lib/DeltaIndicator/DeltaIndicator.svelte';
+
+  const currencyFormat = (input: number): string => {
+    const sign = input >= 0 ? '+' : '-';
+    return `${sign}$${Math.abs(input).toFixed(2)}`;
+  };
+
+  const bpsFormat = (input: number): string => `${input > 0 ? '+' : ''}${input.toFixed(1)} bps`;
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Data Display</span>
+  <h1>DeltaIndicator</h1>
+</div>
+
+<p class="intro">
+  A compact inline indicator that conveys change direction and magnitude using a directional arrow
+  and formatted text. Positive values render in green, negative in red, and values within the
+  neutral threshold in muted gray.
+</p>
+
+<h3>Positive / Negative / Neutral</h3>
+<div class="demo-row">
+  <DeltaIndicator value={12.5} testId="positive-example" />
+  <DeltaIndicator value={-7.3} testId="negative-example" />
+  <DeltaIndicator value={0} testId="neutral-zero" />
+  <DeltaIndicator value={0.4} neutralThreshold={0.5} testId="neutral-threshold" />
+</div>
+
+<h3>Inverted Colors (lower-is-better metrics)</h3>
+<p class="state-display">e.g. bounce rate, RTO — a decrease is good, an increase is bad</p>
+<div class="demo-row">
+  <DeltaIndicator value={-5.2} invertColors testId="inverted-negative" />
+  <DeltaIndicator value={3.8} invertColors testId="inverted-positive" />
+  <DeltaIndicator value={0} invertColors testId="inverted-neutral" />
+</div>
+
+<h3>Hide Arrow</h3>
+<div class="demo-row">
+  <DeltaIndicator value={18} hideArrow testId="no-arrow-positive" />
+  <DeltaIndicator value={-4.5} hideArrow testId="no-arrow-negative" />
+  <DeltaIndicator value={0} hideArrow testId="no-arrow-neutral" />
+</div>
+
+<h3>Custom Format — Currency Delta</h3>
+<div class="demo-row">
+  <DeltaIndicator value={42.5} format={currencyFormat} testId="currency-positive" />
+  <DeltaIndicator value={-18.75} format={currencyFormat} testId="currency-negative" />
+</div>
+
+<h3>Custom Format — Basis Points</h3>
+<div class="demo-row">
+  <DeltaIndicator value={25} format={bpsFormat} testId="bps-positive" />
+  <DeltaIndicator value={-10} format={bpsFormat} testId="bps-negative" />
+</div>
+
+<h3>CSS Variable Theming</h3>
+<div class="demo-row">
+  <div class="themed-container">
+    <DeltaIndicator value={9.1} classes="delta-large" testId="themed-large" />
+    <DeltaIndicator value={-3.4} classes="delta-large" testId="themed-large-neg" />
+  </div>
+</div>
+
+<style>
+  .intro {
+    color: var(--doc-text-secondary);
+    margin-bottom: 24px;
+    max-width: 640px;
+  }
+
+  .themed-container {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+  }
+
+  :global(.delta-large) {
+    --delta-indicator-font-size: 18px;
+    --delta-indicator-arrow-size: 14px;
+    --delta-indicator-gap: 5px;
+    --delta-indicator-positive-color: #0d7f58;
+    --delta-indicator-negative-color: #c7373b;
+  }
+</style>

--- a/src/routes/components/dual-axis-bar-chart/+page.svelte
+++ b/src/routes/components/dual-axis-bar-chart/+page.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+  import DualAxisBarChart from '$lib/DualAxisBarChart/DualAxisBarChart.svelte';
+  import type { DualAxisTooltipContext } from '$lib/DualAxisBarChart/properties';
+
+  // ── Demo 1: Revenue (columns, left) + CTR (line, right) ────────
+
+  const monthlyCategories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+
+  const revenueCtrSeries = [
+    {
+      name: 'Revenue ($)',
+      data: [42000, 38500, 51200, 46800, 58300, 62100],
+      yAxisIndex: 0 as const,
+      type: 'column' as const,
+      color: '#4e79a7'
+    },
+    {
+      name: 'CTR (%)',
+      data: [3.2, 2.8, 4.1, 3.7, 4.8, 5.2],
+      yAxisIndex: 1 as const,
+      type: 'line' as const,
+      color: '#f28e2b'
+    }
+  ];
+
+  // ── Demo 2: Orders (columns, left) + Avg Order Value (columns, right) ──
+
+  const ordersSeries = [
+    {
+      name: 'Orders',
+      data: [120, 98, 143, 131, 165, 182],
+      yAxisIndex: 0 as const,
+      type: 'column' as const,
+      color: '#59a14f'
+    },
+    {
+      name: 'Avg Order Value ($)',
+      data: [350, 393, 358, 357, 353, 341],
+      yAxisIndex: 1 as const,
+      type: 'column' as const,
+      color: '#76b7b2'
+    }
+  ];
+
+  // ── Demo 3: Three series — two columns + one line ───────────────
+
+  const multiSeriesCategories = ['Q1', 'Q2', 'Q3', 'Q4'];
+
+  const threeSeriesData = [
+    {
+      name: 'Gross Sales ($)',
+      data: [120000, 145000, 138000, 172000],
+      yAxisIndex: 0 as const,
+      type: 'column' as const,
+      color: '#4e79a7'
+    },
+    {
+      name: 'Returns ($)',
+      data: [8400, 10150, 9660, 12040],
+      yAxisIndex: 0 as const,
+      type: 'column' as const,
+      color: '#e15759'
+    },
+    {
+      name: 'Return Rate (%)',
+      data: [7.0, 7.0, 7.0, 7.0],
+      yAxisIndex: 1 as const,
+      type: 'line' as const,
+      color: '#edc948'
+    }
+  ];
+
+  // ── Demo 4: Custom tooltip ──────────────────────────────────────
+
+  const customTooltipCategories = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+  const customTooltipSeries = [
+    {
+      name: 'Sessions',
+      data: [3200, 2800, 4100, 3700, 4900],
+      yAxisIndex: 0 as const,
+      type: 'column' as const,
+      color: '#b07aa1'
+    },
+    {
+      name: 'Bounce Rate (%)',
+      data: [42, 38, 35, 40, 33],
+      yAxisIndex: 1 as const,
+      type: 'line' as const,
+      color: '#ff9da7'
+    }
+  ];
+
+  let lastClickedCategory = $state<string | null>(null);
+
+  const handleBarClick = (event: { categoryIndex: number; context: DualAxisTooltipContext }) => {
+    lastClickedCategory = event.context.category;
+  };
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Data Visualization</span>
+  <h1>DualAxisBarChart</h1>
+</div>
+
+<p class="page-intro">
+  A pure-SVG dual-axis chart with two independent Y-axes (left and right) sharing one categorical
+  X-axis. Each series independently declares its axis (<code>yAxisIndex: 0 | 1</code>) and render
+  type (<code>'column'</code> or <code>'line'</code>). Ideal for comparing metrics at very different
+  scales — e.g. absolute counts vs. percentages.
+</p>
+
+<!-- Demo 1: Revenue + CTR -->
+<h3>Revenue (columns, left axis) + CTR (line, right axis)</h3>
+<div class="demo-row">
+  <DualAxisBarChart
+    categories={monthlyCategories}
+    series={revenueCtrSeries}
+    leftAxis={{ title: 'Revenue ($)', color: '#4e79a7' }}
+    rightAxis={{ title: 'CTR (%)', color: '#f28e2b', valueFormat: (v) => `${v.toFixed(1)}%` }}
+    testId="demo-revenue-ctr"
+  />
+</div>
+
+<!-- Demo 2: Two column series on different axes -->
+<h3>Orders (left) + Avg Order Value (right) — two column series</h3>
+<div class="demo-row">
+  <DualAxisBarChart
+    categories={monthlyCategories}
+    series={ordersSeries}
+    leftAxis={{ title: 'Orders' }}
+    rightAxis={{ title: 'AOV ($)', valueFormat: (v) => `$${v.toFixed(0)}` }}
+    showGridlines={true}
+    testId="demo-orders-aov"
+  />
+</div>
+
+<!-- Demo 3: Three series (two columns + one flat line) -->
+<h3>Three series — Gross Sales + Returns (columns, left) + Return Rate (line, right)</h3>
+<div class="demo-row">
+  <DualAxisBarChart
+    categories={multiSeriesCategories}
+    series={threeSeriesData}
+    leftAxis={{ title: 'Amount ($)' }}
+    rightAxis={{ title: 'Rate (%)', valueFormat: (v) => `${v.toFixed(1)}%` }}
+    barPadding={0.3}
+    testId="demo-three-series"
+  />
+</div>
+
+<!-- Demo 4: Custom tooltip + click handler -->
+<h3>Custom tooltip + click handler</h3>
+{#if lastClickedCategory !== null}
+  <p class="click-feedback">Last clicked: <strong>{lastClickedCategory}</strong></p>
+{/if}
+<div class="demo-row">
+  <DualAxisBarChart
+    categories={customTooltipCategories}
+    series={customTooltipSeries}
+    leftAxis={{ title: 'Sessions' }}
+    rightAxis={{ title: 'Bounce Rate (%)', valueFormat: (v) => `${v}%` }}
+    onbarclick={handleBarClick}
+    testId="demo-custom-tooltip"
+  >
+    {#snippet tooltipSnippet(ctx)}
+      <div class="custom-tooltip">
+        <div class="custom-tooltip-title">{ctx.category}</div>
+        {#each ctx.points as point, ptIdx (ptIdx)}
+          <div class="custom-tooltip-row">
+            <span class="custom-tooltip-swatch" style="background: {point.color}"></span>
+            <span class="custom-tooltip-label">{point.name}</span>
+            <span class="custom-tooltip-value">
+              {point.yAxisIndex === 1 ? `${point.value}%` : point.value.toLocaleString()}
+            </span>
+          </div>
+        {/each}
+      </div>
+    {/snippet}
+  </DualAxisBarChart>
+</div>
+
+<!-- Demo 5: No gridlines, no legend -->
+<h3>No gridlines, no legend</h3>
+<div class="demo-row">
+  <DualAxisBarChart
+    categories={monthlyCategories}
+    series={revenueCtrSeries}
+    leftAxis={{ title: 'Revenue' }}
+    rightAxis={{ title: 'CTR %', valueFormat: (v) => `${v.toFixed(1)}%` }}
+    showGridlines={false}
+    showLegend={false}
+    testId="demo-no-gridlines"
+  />
+</div>
+
+<style>
+  .page-intro {
+    margin-bottom: 24px;
+    color: #555;
+    max-width: 680px;
+  }
+
+  .demo-row {
+    margin-bottom: 40px;
+    max-width: 800px;
+  }
+
+  .click-feedback {
+    margin-bottom: 8px;
+    font-size: 14px;
+    color: #555;
+  }
+
+  .custom-tooltip {
+    background: rgba(20, 20, 30, 0.93);
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 6px;
+    font-size: 12px;
+    min-width: 160px;
+  }
+
+  .custom-tooltip-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    padding-bottom: 4px;
+  }
+
+  .custom-tooltip-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
+  }
+
+  .custom-tooltip-swatch {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .custom-tooltip-label {
+    opacity: 0.8;
+    flex: 1;
+  }
+
+  .custom-tooltip-value {
+    font-weight: 600;
+    white-space: nowrap;
+  }
+</style>

--- a/src/routes/components/funnel-chart/+page.svelte
+++ b/src/routes/components/funnel-chart/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import FunnelChart from '$lib/FunnelChart/FunnelChart.svelte';
+  import { formatNumber } from '$lib/_chart/format';
+
+  const checkoutFunnel = [
+    { category: 'Visit', value: 12000 },
+    { category: 'Product View', value: 8400 },
+    { category: 'Add to Cart', value: 4200 },
+    { category: 'Checkout', value: 2100 },
+    { category: 'Purchase', value: 980 }
+  ];
+
+  const conversionFunnel = [
+    { category: 'Awareness', value: 50000 },
+    { category: 'Interest', value: 32000 },
+    { category: 'Consideration', value: 18000 },
+    { category: 'Intent', value: 9500 },
+    { category: 'Purchase', value: 4200 }
+  ];
+
+  const tealColors = ['#8EE3F6C2', '#8EE3F6', '#79E2E9', '#82DEE4', '#87E3D3'];
+
+  const warmColors = ['#f28e2b', '#e15759', '#b07aa1', '#ff9da7', '#9c755f'];
+
+  let lastClickedStage = $state<string | null>(null);
+  let lastHoveredStage = $state<string | null>(null);
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Data Visualization</span>
+  <h1>FunnelChart</h1>
+</div>
+
+<p>
+  A horizontal funnel chart built entirely from pure SVG. Each stage bar height is proportional to
+  its value relative to the maximum stage, with trapezoidal connectors showing the transition
+  between stages.
+</p>
+
+<h3>Basic — E-commerce Checkout Funnel</h3>
+<div class="demo-row">
+  <FunnelChart data={checkoutFunnel} />
+</div>
+
+<h3>Custom Stage Colors</h3>
+<div class="demo-row">
+  <FunnelChart data={checkoutFunnel} stageColors={tealColors} connectorColor="#BDFFFB" />
+</div>
+
+<h3>Warm Palette</h3>
+<div class="demo-row">
+  <FunnelChart data={conversionFunnel} stageColors={warmColors} connectorColor="#f5cba7" />
+</div>
+
+<h3>Custom Value Format (show only value)</h3>
+<div class="demo-row">
+  <FunnelChart data={checkoutFunnel} valueFormat={(value) => formatNumber(value)} />
+</div>
+
+<h3>Without Value Labels</h3>
+<div class="demo-row">
+  <FunnelChart data={checkoutFunnel} showValueLabels={false} />
+</div>
+
+<h3>Wider Slope Connectors</h3>
+<div class="demo-row">
+  <FunnelChart data={checkoutFunnel} slopeWidth={24} />
+</div>
+
+<h3>No Hover Expansion</h3>
+<div class="demo-row">
+  <FunnelChart data={checkoutFunnel} onHoverExpand={0} />
+</div>
+
+<h3>Events</h3>
+<div class="demo-row">
+  <FunnelChart
+    data={checkoutFunnel}
+    onstageclick={({ stage }) => {
+      lastClickedStage = stage.category;
+    }}
+    onstagehover={(event) => {
+      lastHoveredStage = event?.stage.category ?? null;
+    }}
+  />
+  {#if lastClickedStage}
+    <p class="event-log">Last clicked: <strong>{lastClickedStage}</strong></p>
+  {/if}
+  {#if lastHoveredStage}
+    <p class="event-log">Hovering: <strong>{lastHoveredStage}</strong></p>
+  {/if}
+</div>
+
+<h3>Empty State</h3>
+<div class="demo-row">
+  <FunnelChart data={[]}>
+    {#snippet empty()}
+      <p>No funnel data available.</p>
+    {/snippet}
+  </FunnelChart>
+</div>
+
+<h3>Custom Aspect Ratio (4:3)</h3>
+<div class="demo-row">
+  <FunnelChart data={conversionFunnel} aspectRatio={4 / 3} />
+</div>
+
+<style>
+  .event-log {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #555;
+  }
+</style>

--- a/src/routes/components/line-chart/+page.svelte
+++ b/src/routes/components/line-chart/+page.svelte
@@ -1,5 +1,21 @@
 <script lang="ts">
   import LineChart from '$lib/LineChart/LineChart.svelte';
+  import type { ChartHighlightAPI } from '$lib/_chart/highlight';
+
+  const monthLabels = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec'
+  ];
 
   const singleSeries = [
     {
@@ -56,12 +72,67 @@
       ]
     }
   ];
+
+  // ── Highlight hook demo ────────────────────────────────────────
+
+  let highlightApi: ChartHighlightAPI | null = $state(null);
+  let activeHighlightIndex = $state<number | null>(null);
+
+  const onChartReady = (api: ChartHighlightAPI): void => {
+    highlightApi = api;
+  };
+
+  const setHighlight = (index: number | null): void => {
+    activeHighlightIndex = index;
+    highlightApi?.highlight(index);
+  };
+
+  // ── xAxisCategories demo ───────────────────────────────────────
+
+  const weekSeries = [
+    {
+      name: 'Sessions',
+      data: [
+        { x: 1, y: 1200 },
+        { x: 2, y: 980 },
+        { x: 3, y: 1450 },
+        { x: 4, y: 1700 },
+        { x: 5, y: 1350 },
+        { x: 6, y: 900 },
+        { x: 7, y: 750 }
+      ]
+    }
+  ];
+  const dayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+  // ── showArea demo ──────────────────────────────────────────────
+
+  const areaSeries = [
+    {
+      name: 'Conversions',
+      color: '#6366f1',
+      data: [
+        { x: 1, y: 14 },
+        { x: 2, y: 22 },
+        { x: 3, y: 18 },
+        { x: 4, y: 31 },
+        { x: 5, y: 27 },
+        { x: 6, y: 40 }
+      ]
+    }
+  ];
 </script>
 
 <div class="page-header">
   <span class="category-badge">Data Visualization</span>
   <h1>LineChart</h1>
 </div>
+
+<p>
+  A responsive SVG line chart for visualizing trends over continuous data. Supports multiple series,
+  five curve interpolations, gradient fill, categorical x-axis labels, filled area with custom
+  gradient, and an imperative highlight API for external orchestration.
+</p>
 
 <h3>Single Series</h3>
 <div class="demo-row">
@@ -82,3 +153,113 @@
 <div class="demo-row">
   <LineChart series={singleSeries} curve="step" />
 </div>
+
+<h3>xAxisCategories — month labels</h3>
+<p>
+  Pass string category labels via <code>xAxisCategories</code>. The labels are mapped by index to
+  the numeric x values used in the data (x=1 → index 0, x=2 → index 1, …).
+</p>
+<div class="demo-row">
+  <LineChart series={singleSeries} xAxisCategories={monthLabels} />
+</div>
+
+<h3>xAxisCategories — weekday labels</h3>
+<div class="demo-row">
+  <LineChart series={weekSeries} xAxisCategories={dayLabels} showDots />
+</div>
+
+<h3>showArea — default gradient (series colour)</h3>
+<p>
+  Set <code>showArea</code> to fill the area under the line with a vertical gradient derived from the
+  series colour.
+</p>
+<div class="demo-row">
+  <LineChart series={areaSeries} showArea />
+</div>
+
+<h3>showArea + areaGradient — custom colours</h3>
+<p>
+  Provide <code>areaGradient</code> with <code>from</code> and <code>to</code> colour stops to use a fully
+  custom vertical gradient fill.
+</p>
+<div class="demo-row">
+  <LineChart
+    series={areaSeries}
+    showArea
+    areaGradient={{ from: 'rgba(99,102,241,0.5)', to: 'rgba(99,102,241,0)' }}
+  />
+</div>
+
+<h3>showArea + xAxisCategories</h3>
+<div class="demo-row">
+  <LineChart
+    series={areaSeries}
+    showArea
+    areaGradient={{ from: 'rgba(99,102,241,0.4)', to: 'rgba(99,102,241,0)' }}
+    xAxisCategories={['Q1', 'Q2', 'Q3', 'Q4', 'Q5', 'Q6']}
+  />
+</div>
+
+<h3>Highlight Hook — onChartReady + imperative API</h3>
+<p>
+  Use <code>onChartReady</code> to receive a <code>ChartHighlightAPI</code> with a
+  <code>highlight(index)</code> method. The buttons below drive the chart externally, simulating a voice-narration
+  or step-through orchestrator.
+</p>
+<div class="demo-row">
+  <LineChart series={singleSeries} xAxisCategories={monthLabels} {onChartReady} showDots />
+</div>
+<div class="highlight-controls">
+  {#each monthLabels as label, i (i)}
+    <button
+      class="highlight-btn"
+      class:active={activeHighlightIndex === i}
+      onclick={() => setHighlight(activeHighlightIndex === i ? null : i)}
+    >
+      {label}
+    </button>
+  {/each}
+  <button class="highlight-btn clear-btn" onclick={() => setHighlight(null)}>Clear</button>
+</div>
+
+<h3>highlightedIndex — declarative prop</h3>
+<p>
+  Use the <code>highlightedIndex</code> prop to highlight a point declaratively (no callback needed).
+  The chart dims all other points and draws the crosshair at the highlighted index.
+</p>
+<div class="demo-row">
+  <LineChart series={singleSeries} xAxisCategories={monthLabels} highlightedIndex={5} showDots />
+</div>
+
+<h3>Legacy gradientFill (backward-compatible)</h3>
+<div class="demo-row">
+  <LineChart series={singleSeries} gradientFill />
+</div>
+
+<style>
+  .highlight-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .highlight-btn {
+    padding: 4px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    background: #f9fafb;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .highlight-btn.active {
+    background: #6366f1;
+    color: #fff;
+    border-color: #6366f1;
+  }
+  .clear-btn {
+    margin-left: 8px;
+    background: #fee2e2;
+    border-color: #fca5a5;
+    color: #b91c1c;
+  }
+</style>

--- a/src/routes/components/pie-chart/+page.svelte
+++ b/src/routes/components/pie-chart/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import PieChart from '$lib/PieChart/PieChart.svelte';
+  import type { ChartHighlightAPI } from '$lib/_chart/highlight';
 
   const marketShare = [
     { label: 'Chrome', value: 65 },
@@ -16,6 +17,18 @@
     { label: 'Utilities', value: 200, color: '#76b7b2' },
     { label: 'Entertainment', value: 150, color: '#59a14f' }
   ];
+
+  // ── Highlight hook demo ────────────────────────────────────────
+  let chartApi: ChartHighlightAPI | null = $state(null);
+  let highlightedSlice = $state<number | null>(null);
+
+  const handleChartReady = (api: ChartHighlightAPI) => {
+    chartApi = api;
+  };
+
+  const highlightSlice = (index: number | null) => {
+    highlightedSlice = index;
+  };
 </script>
 
 <div class="page-header">
@@ -42,3 +55,77 @@
 <div class="demo-row" style="max-width: 400px;">
   <PieChart data={expenses} innerRadius={0.5} showLegend />
 </div>
+
+<h3>Delta Badge — positive change</h3>
+<div class="demo-row" style="max-width: 400px;">
+  <PieChart data={marketShare} innerRadius={0.6} changePercentage={12.5} />
+</div>
+
+<h3>Delta Badge — negative change (inverted colors for lower-is-better metric)</h3>
+<div class="demo-row" style="max-width: 400px;">
+  <PieChart data={expenses} changePercentage={-8.3} changeInvertColors />
+</div>
+
+<h3>Highlight Hook — declarative (highlightedIndex prop)</h3>
+<div class="demo-row" style="max-width: 400px;">
+  <div class="demo-controls">
+    {#each marketShare as slice, i (i)}
+      <button
+        class="demo-btn"
+        class:active={highlightedSlice === i}
+        onclick={() => highlightSlice(highlightedSlice === i ? null : i)}
+      >
+        {slice.label}
+      </button>
+    {/each}
+    <button class="demo-btn" onclick={() => highlightSlice(null)}>Clear</button>
+  </div>
+  <PieChart data={marketShare} innerRadius={0.55} highlightedIndex={highlightedSlice} />
+</div>
+
+<h3>Highlight Hook — imperative (onChartReady API)</h3>
+<div class="demo-row" style="max-width: 400px;">
+  <div class="demo-controls">
+    {#each marketShare as slice, i (i)}
+      <button class="demo-btn" onclick={() => chartApi?.highlight(i)}>
+        {slice.label}
+      </button>
+    {/each}
+    <button class="demo-btn" onclick={() => chartApi?.highlight(null)}>Clear</button>
+  </div>
+  <PieChart data={marketShare} innerRadius={0.55} onChartReady={handleChartReady} />
+</div>
+
+<h3>Delta Badge + Highlight combined</h3>
+<div class="demo-row" style="max-width: 400px;">
+  <PieChart
+    data={expenses}
+    innerRadius={0.6}
+    showLegend
+    legendShowValues
+    changePercentage={5.2}
+    highlightedIndex={0}
+  />
+</div>
+
+<style>
+  .demo-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .demo-btn {
+    padding: 4px 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    background: #f9fafb;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .demo-btn.active {
+    background: #3b82f6;
+    color: #fff;
+    border-color: #3b82f6;
+  }
+</style>

--- a/src/routes/components/sankey-chart/+page.svelte
+++ b/src/routes/components/sankey-chart/+page.svelte
@@ -44,6 +44,28 @@
     { source: 'docs', target: 'signup', value: 15 },
     { source: 'docs', target: 'bounce', value: 10 }
   ];
+
+  // Dense payment flow — tiny values would collapse without minLinkWidth
+  const paymentNodes = [
+    { id: 'card', label: 'Card', color: '#6366f1' },
+    { id: 'upi', label: 'UPI', color: '#22c55e' },
+    { id: 'wallet', label: 'Wallet', color: '#f59e0b' },
+    { id: 'success', label: 'Success', color: '#10b981' },
+    { id: 'pending', label: 'Pending', color: '#f97316' },
+    { id: 'failed', label: 'Failed', color: '#ef4444' }
+  ];
+
+  const paymentLinks = [
+    { source: 'card', target: 'success', value: 820 },
+    { source: 'card', target: 'pending', value: 5 },
+    { source: 'card', target: 'failed', value: 3 },
+    { source: 'upi', target: 'success', value: 940 },
+    { source: 'upi', target: 'pending', value: 2 },
+    { source: 'upi', target: 'failed', value: 1 },
+    { source: 'wallet', target: 'success', value: 310 },
+    { source: 'wallet', target: 'pending', value: 4 },
+    { source: 'wallet', target: 'failed', value: 2 }
+  ];
 </script>
 
 <div class="page-header">
@@ -64,4 +86,34 @@
 <h3>Website Traffic Flow</h3>
 <div class="demo-row">
   <SankeyChart nodes={trafficNodes} links={trafficLinks} />
+</div>
+
+<h3>dataLabelOffsetX — Extra breathing room between nodes and labels (offset: 30px)</h3>
+<div class="demo-row">
+  <SankeyChart nodes={simpleNodes} links={simpleLinks} dataLabelOffsetX={30} />
+</div>
+
+<h3>
+  minLinkWidth — Tiny flows stay visible (minLinkWidth: 3, payment data with near-zero failure
+  rates)
+</h3>
+<div class="demo-row">
+  <SankeyChart nodes={paymentNodes} links={paymentLinks} minLinkWidth={3} showValues />
+</div>
+
+<h3>disableDimOnHover — All nodes stay at full opacity when hovering</h3>
+<div class="demo-row">
+  <SankeyChart nodes={trafficNodes} links={trafficLinks} disableDimOnHover />
+</div>
+
+<h3>Combined — minLinkWidth + dataLabelOffsetX + disableDimOnHover</h3>
+<div class="demo-row">
+  <SankeyChart
+    nodes={paymentNodes}
+    links={paymentLinks}
+    minLinkWidth={3}
+    dataLabelOffsetX={30}
+    disableDimOnHover
+    showValues
+  />
 </div>

--- a/src/wc/components/DeltaIndicator.wc.svelte
+++ b/src/wc/components/DeltaIndicator.wc.svelte
@@ -1,0 +1,22 @@
+<svelte:options
+  customElement={{
+    tag: 'sui-delta-indicator',
+    shadow: 'open',
+    props: {
+      value: { type: 'Number' },
+      invertColors: { type: 'Boolean', attribute: 'invert-colors' },
+      hideArrow: { type: 'Boolean', attribute: 'hide-arrow' },
+      neutralThreshold: { type: 'Number', attribute: 'neutral-threshold' },
+      format: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' },
+      classes: { type: 'String' }
+    }
+  }}
+/>
+
+<script lang="ts">
+  import DeltaIndicator from '$lib/DeltaIndicator/DeltaIndicator.svelte';
+  let props = $props();
+</script>
+
+<DeltaIndicator {...props} />

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -56,3 +56,4 @@ import './components/Tooltip.wc.svelte';
 import './components/DateRangePicker.wc.svelte';
 import './components/LottiePlayer.wc.svelte';
 import './components/StatCard.wc.svelte';
+import './components/DeltaIndicator.wc.svelte';


### PR DESCRIPTION
## Chart system: unify voice + non-voice charts and close the dashboard-chart gaps

This adds the chart primitives a consuming dashboard (Lighthouse) needs to retire its bespoke Highcharts/D3 chart layer and unify **voice-synced and regular charts on one pure-SVG implementation**, plus removes the most-duplicated chart patterns.

### New components
- **DeltaIndicator** — inline directional trend badge (arrow + colored %); `invertColors` for lower-is-better metrics (RTO/bounce), custom `format`, neutral threshold. (Consolidates a trend-badge pattern duplicated ~9× in the consumer.)
- **DualAxisBarChart** — two fully independent Y-axes sharing one categorical X-axis; each series declares its axis (`0`/`1`) and render type (`column`/`line`/`bar`). Built on the shared `_chart` primitives.
- **FunnelChart** — pure-SVG horizontal funnel with trapezoidal drop-off connectors, hover expansion, value+percentage labels (replaces a D3 implementation).

### Extensions (all backward-compatible)
- **Highlight hook** on **BarChart / LineChart / PieChart** — `onChartReady(api)` returning the shared **`ChartHighlightAPI`** (`highlight(index | null)`, `getCategories()`, `type`) plus a declarative `highlightedIndex`. This lets an external orchestrator (e.g. AI voice-narration sync) drive point/slice highlighting **without storing a charting-library instance on the DOM** — the key that unifies voice + non-voice charts.
- **BarChart**: `normaliseToFirstPoint`, `topN` + `overflowLabel`, `hideBarGraphics`.
- **LineChart**: `xAxisCategories` (string-category X-axis), `showArea` + `areaGradient`.
- **PieChart**: `changePercentage` delta badge (rendered via `DeltaIndicator`), `changeInvertColors`.
- **SankeyChart**: `minLinkWidth`, `dataLabelOffsetX`, `disableDimOnHover`.

### Notes
- No new `SingleStatCard` — the existing **`StatCard`** already covers that use case; consumer callsites fold onto it.
- Charts remain **not** exposed as web components (consistent with existing Bar/Line/Pie/Sankey/Area); only `DeltaIndicator` ships a `sui-delta-indicator` wrapper.

### Validation
`pnpm run check` (0 errors), `pnpm run lint` (strict: no `as`, no bare `undefined` — clean), `pnpm run build` (svelte-package + publint clean). A demo route was added under `/components` for each new/extended component and all render correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new chart components: Delta Indicator, Dual-Axis Bar Chart, and Funnel Chart.
  * Expanded chart interactions with programmatic and declarative highlighting across bar, line, and pie charts.
  * Added new chart options like area fills, x-axis category labels, top-N clipping, normalization, delta badges, and Sankey layout controls.

* **Bug Fixes**
  * Improved chart hover, highlight, and dimming behavior for more consistent interactions.

* **Documentation**
  * Updated and added component docs, examples, and web component usage guidance for the new chart features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update (`e8b8298`):** Addressed all CodeRabbit review threads (Sankey clamp, dropped unimplemented `'bar'` type, DeltaIndicator threshold clamp + kebab-case WC attributes, DualAxis length guards, FunnelChart all-zero empty state, PieChart hover-gated tooltip) and fixed the GitHub Pages prerender failure (breadcrumb demo links now use the `$app/paths` base). `BASE_PATH=/svelte-ui-components pnpm run build` → exit 0, 0 prerender errors.