### PR TITLE
fix: input field width in input button component

### DIFF
--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -132,7 +132,7 @@
     --input-focus-border: none;
     --input-box-shadow: none;
     --input-margin: none;
-    --input-width: fit-content;
+    --input-width: 100%;
     font-size: var(--input-font-size, 16px) !important;
     font-weight: var(--input-button-font-weight, 500);
     margin: var(--input-button-margin);


### PR DESCRIPTION
Fixed the input field width inside the Input Button component

Before: 
<img width="545" height="86" alt="Screenshot 2026-06-25 at 8 30 36 AM" src="https://github.com/user-attachments/assets/d6cf73c0-1cc2-4833-b1bc-7ba23d521643" />


After: 
<img width="547" height="84" alt="Screenshot 2026-06-25 at 8 29 21 AM" src="https://github.com/user-attachments/assets/08f0197d-14d6-4ff6-98e1-d9f951edb8b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the input button component so its input now stretches to the full available width, improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->