### PR TITLE
feat: add carousel test ids

### DIFF
--- a/src/lib/Carousel/Carousel.svelte
+++ b/src/lib/Carousel/Carousel.svelte
@@ -9,7 +9,10 @@
     showDots = false,
     isScrollableLast = false,
     onkeydown,
-    classes
+    classes,
+    testId,
+    dotsWrapperTestId,
+    dotTestId
   }: CarouselProperties = $props();
 
   let slidesDiv: HTMLDivElement | null = $state(null);
@@ -138,7 +141,10 @@
   });
 </script>
 
-<div class="carousel-container {classes ?? ''}">
+<div
+  class="carousel-container {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+>
   {#if views.length > 0}
     <div class="carousel" bind:this={carouselDiv}>
       <div class="slidesDiv" bind:this={slidesDiv}>
@@ -155,7 +161,10 @@
     </div>
   {/if}
   {#if showDots}
-    <div class="dots-wrapper">
+    <div
+      class="dots-wrapper"
+      data-pw={typeof dotsWrapperTestId === 'string' ? dotsWrapperTestId : null}
+    >
       <!-- eslint-disable-next-line -->
       {#each views as _, index}
         <div
@@ -163,6 +172,7 @@
           onclick={() => moveSlideToIndex(index)}
           {onkeydown}
           role="none"
+          data-pw={typeof dotTestId === 'string' ? `${dotTestId}-${index + 1}` : null}
         ></div>
       {/each}
     </div>

--- a/src/lib/Carousel/properties.ts
+++ b/src/lib/Carousel/properties.ts
@@ -18,6 +18,9 @@ export type OptionalCarouselProperties = {
   showDots?: boolean;
   isScrollableLast?: boolean;
   classes?: string;
+  testId?: string;
+  dotsWrapperTestId?: string;
+  dotTestId?: string;
 };
 
 export type CarouselEventProperties = {


### PR DESCRIPTION

- Adds `data-pw` support to the Carousel root container, dots wrapper, and individual dots.
- Adds dynamic dot test IDs using 1-based indexing
