### PR TITLE
feat: add showSelectAll to Select (multi-select select-all + indeterminate)

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -15,6 +15,8 @@
     disabled = false,
     bottomContent,
     optionIndicator,
+    showSelectAll = false,
+    selectAllLabel = 'Select all',
     triggerSummary,
     testId,
     itemTestId,
@@ -51,6 +53,31 @@
     searchable && query.length > 0
       ? items.filter((item) => item.label.toLowerCase().includes(query.toLowerCase()))
       : items
+  );
+
+  type SelectRow = { kind: 'select-all' } | { kind: 'item'; item: SelectItem };
+
+  let selectAllVisible: boolean = $derived(multiple && showSelectAll && filteredItems.length > 0);
+
+  let selectedFilteredCount: number = $derived(
+    filteredItems.filter((item) => value.includes(item.id)).length
+  );
+  let allFilteredSelected: boolean = $derived(
+    filteredItems.length > 0 && selectedFilteredCount === filteredItems.length
+  );
+  let selectAllIndeterminate: boolean = $derived(
+    selectedFilteredCount > 0 && selectedFilteredCount < filteredItems.length
+  );
+
+  // Unified, keyboard-navigable row list: the optional "select all" row shares the same
+  // highlightedIndex space as the options, so arrow-key navigation needs no special casing.
+  let optionRows: SelectRow[] = $derived(
+    selectAllVisible
+      ? [
+          { kind: 'select-all' },
+          ...filteredItems.map((item): SelectRow => ({ kind: 'item', item }))
+        ]
+      : filteredItems.map((item): SelectRow => ({ kind: 'item', item }))
   );
 
   let displayText = $derived.by(() => {
@@ -111,19 +138,36 @@
     onchange?.(value);
   }
 
-  function selectHighlighted(): void {
-    if (highlightedIndex < 0 || highlightedIndex >= filteredItems.length) {
+  function toggleSelectAll(): void {
+    if (disabled) {
       return;
     }
-    const item = filteredItems.at(highlightedIndex);
-    if (typeof item === 'object' && item !== null) {
-      selectItem(item.id);
+    if (allFilteredSelected) {
+      value = value.filter((id) => !filteredItems.some((item) => item.id === id));
+    } else {
+      value = [...new Set([...value, ...filteredItems.map((item) => item.id)])];
+    }
+    onchange?.(value);
+  }
+
+  function selectHighlighted(): void {
+    if (highlightedIndex < 0 || highlightedIndex >= optionRows.length) {
+      return;
+    }
+    const row = optionRows.at(highlightedIndex);
+    if (typeof row !== 'object' || row === null) {
+      return;
+    }
+    if (row.kind === 'select-all') {
+      toggleSelectAll();
+    } else {
+      selectItem(row.item.id);
     }
   }
 
   async function moveHighlight(delta: number): Promise<void> {
     const next = highlightedIndex + delta;
-    if (next < 0 || next >= filteredItems.length) {
+    if (next < 0 || next >= optionRows.length) {
       return;
     }
     highlightedIndex = next;
@@ -355,44 +399,88 @@
       {#if filteredItems.length === 0}
         <div class="select-empty">No results</div>
       {:else}
-        {#each filteredItems as item, index (item.id)}
-          <div
-            class="select-option"
-            class:multi={multiple}
-            class:selected={value.includes(item.id)}
-            class:highlighted={index === highlightedIndex}
-            role="option"
-            id={`${listboxId}-option-${index}`}
-            aria-selected={value.includes(item.id)}
-            tabindex="-1"
-            {...typeof item.testId === 'string'
-              ? { 'data-pw': item.testId }
-              : typeof itemTestId === 'string'
-                ? { 'data-pw': `${itemTestId}-${item.id}` }
-                : typeof testId === 'string'
-                  ? { 'data-pw': `${testId}-${item.id}` }
-                  : {}}
-            onclick={() => selectItem(item.id)}
-            onmouseenter={() => (highlightedIndex = index)}
-          >
-            {#if multiple}
+        {#each optionRows as row, index (row.kind === 'select-all' ? 'select-all' : row.item.id)}
+          {#if row.kind === 'select-all'}
+            <div
+              class="select-option select-all"
+              class:multi={multiple}
+              class:selected={allFilteredSelected}
+              class:highlighted={index === highlightedIndex}
+              role="option"
+              id={`${listboxId}-option-${index}`}
+              aria-selected={allFilteredSelected}
+              aria-label={selectAllIndeterminate
+                ? `${selectAllLabel}, ${selectedFilteredCount} of ${filteredItems.length} selected`
+                : selectAllLabel}
+              tabindex="-1"
+              {...typeof testId === 'string' ? { 'data-pw': `${testId}-select-all` } : {}}
+              onclick={toggleSelectAll}
+              onmouseenter={() => (highlightedIndex = index)}
+            >
               {#if typeof optionIndicator === 'function'}
-                {@render optionIndicator({ checked: value.includes(item.id) })}
+                {@render optionIndicator({
+                  checked: allFilteredSelected,
+                  indeterminate: selectAllIndeterminate
+                })}
               {:else}
                 <span
                   class="select-option-indicator"
-                  class:checked={value.includes(item.id)}
+                  class:checked={allFilteredSelected}
+                  class:indeterminate={selectAllIndeterminate}
                   aria-hidden="true"
                 >
-                  {#if value.includes(item.id)}
+                  {#if allFilteredSelected}
                     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                     <span class="select-option-check">{@html checkmarkSvg}</span>
+                  {:else if selectAllIndeterminate}
+                    <span class="select-option-dash"></span>
                   {/if}
                 </span>
               {/if}
-            {/if}
-            {item.label}
-          </div>
+              {selectAllLabel}
+            </div>
+          {:else}
+            <div
+              class="select-option"
+              class:multi={multiple}
+              class:selected={value.includes(row.item.id)}
+              class:highlighted={index === highlightedIndex}
+              role="option"
+              id={`${listboxId}-option-${index}`}
+              aria-selected={value.includes(row.item.id)}
+              tabindex="-1"
+              {...typeof row.item.testId === 'string'
+                ? { 'data-pw': row.item.testId }
+                : typeof itemTestId === 'string'
+                  ? { 'data-pw': `${itemTestId}-${row.item.id}` }
+                  : typeof testId === 'string'
+                    ? { 'data-pw': `${testId}-${row.item.id}` }
+                    : {}}
+              onclick={() => selectItem(row.item.id)}
+              onmouseenter={() => (highlightedIndex = index)}
+            >
+              {#if multiple}
+                {#if typeof optionIndicator === 'function'}
+                  {@render optionIndicator({
+                    checked: value.includes(row.item.id),
+                    indeterminate: false
+                  })}
+                {:else}
+                  <span
+                    class="select-option-indicator"
+                    class:checked={value.includes(row.item.id)}
+                    aria-hidden="true"
+                  >
+                    {#if value.includes(row.item.id)}
+                      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                      <span class="select-option-check">{@html checkmarkSvg}</span>
+                    {/if}
+                  </span>
+                {/if}
+              {/if}
+              {row.item.label}
+            </div>
+          {/if}
         {/each}
       {/if}
       {#if typeof bottomContent === 'function'}
@@ -596,6 +684,23 @@
   .select-option-check :global(svg) {
     width: 100%;
     height: 100%;
+  }
+
+  .select-option-indicator.indeterminate {
+    background-color: var(--select-option-indicator-checked-background, #2196f3);
+    border-color: var(--select-option-indicator-checked-border-color, #2196f3);
+  }
+
+  .select-option-dash {
+    width: var(--select-option-indicator-dash-size, 10px);
+    height: var(--select-option-indicator-dash-thickness, 2px);
+    border-radius: 1px;
+    background-color: var(--select-option-indicator-dash-color, #ffffff);
+  }
+
+  .select-option.select-all {
+    border-bottom: var(--select-all-border, none);
+    font-weight: var(--select-all-font-weight, inherit);
   }
 
   .select-empty {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -25,14 +25,25 @@ export type OptionalSelectProperties = {
   disabled?: boolean;
   bottomContent?: Snippet;
   /**
-   * Snippet for rendering a custom multi-select option indicator, receiving `{ checked }`.
-   * When omitted, multiple-mode options render a design-system checkbox box (bordered square
-   * that fills and shows a checkmark when selected), themeable via the `--select-option-indicator-*`
-   * CSS variables: `-size` (18px), `-border`, `-border-radius`, `-background`,
-   * `-checked-background`, `-checked-border-color`, `-check-size`, `-check-color`. Provide this
-   * snippet to fully replace the indicator (e.g. to restore the legacy ☑/☐ glyph).
+   * Snippet for rendering a custom multi-select option indicator, receiving `{ checked, indeterminate }`.
+   * `indeterminate` is `true` only for the `showSelectAll` row when some — but not all — listed options
+   * are selected; it is always `false` for individual option rows. When omitted, multiple-mode options
+   * render a design-system checkbox box (bordered
+   * square that fills and shows a checkmark when selected, or a centred dash when indeterminate),
+   * themeable via the `--select-option-indicator-*` CSS variables: `-size` (18px), `-border`,
+   * `-border-radius`, `-background`, `-checked-background`, `-checked-border-color`, `-check-size`,
+   * `-check-color`, `-dash-size`, `-dash-thickness`, `-dash-color`. Provide this snippet to fully
+   * replace the indicator (e.g. to restore the legacy ☑/☐ glyph).
    */
-  optionIndicator?: Snippet<[{ checked: boolean }]>;
+  optionIndicator?: Snippet<[{ checked: boolean; indeterminate?: boolean }]>;
+  /**
+   * Multiple mode only. When `true`, renders a "Select all" row at the top of the dropdown that
+   * toggles every currently-listed (search-filtered) option. The row shows an indeterminate
+   * indicator when only some of the listed options are selected. No effect outside `multiple` mode.
+   */
+  showSelectAll?: boolean;
+  /** Label for the `showSelectAll` row. Defaults to `'Select all'`. */
+  selectAllLabel?: string;
   testId?: string;
   /** Fallback per-option test id prefix. Each option emits `data-pw="{itemTestId}-{id}"` when its own `item.testId` is not set. */
   itemTestId?: string;

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -41,6 +41,8 @@
   let searchValue: string[] = $state([]);
   let multiValue: string[] = $state([]);
   let multiSearchValue: string[] = $state([]);
+  let selectAllValue: string[] = $state([]);
+  let selectAllSearchValue: string[] = $state([]);
   let stringItemsValue: string[] = $state([]);
   let bottomContentValue: string[] = $state([]);
   let customIndicatorValue: string[] = $state([]);
@@ -105,6 +107,48 @@
   />
   {#if multiSearchValue.length > 0}
     <p class="demo-info">Selected IDs: {multiSearchValue.join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Multi select + select all</h3>
+<p>
+  Pass <code>showSelectAll</code> in <code>multiple</code> mode to render a "Select all" row at the top
+  of the dropdown. It toggles every listed option and shows an indeterminate (dash) indicator when only
+  some are selected.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Select
+    items={fruits}
+    multiple
+    showSelectAll
+    bind:value={selectAllValue}
+    placeholder="Pick fruits"
+    testId="select-all-demo"
+  />
+  {#if selectAllValue.length > 0}
+    <p class="demo-info">Selected IDs: {selectAllValue.join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Multi select + select all + searchable</h3>
+<p>
+  With <code>searchable</code>, "Select all" toggles only the currently-filtered options, and a
+  custom
+  <code>selectAllLabel</code> can be supplied.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Select
+    items={languages}
+    multiple
+    showSelectAll
+    searchable
+    selectAllLabel="Select all (visible)"
+    bind:value={selectAllSearchValue}
+    placeholder="Search languages..."
+    testId="select-all-search-demo"
+  />
+  {#if selectAllSearchValue.length > 0}
+    <p class="demo-info">Selected IDs: {selectAllSearchValue.join(', ')}</p>
   {/if}
 </div>
 

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -14,6 +14,8 @@
       classes: { type: 'String' },
       open: { type: 'Boolean', reflect: true },
       dropdownAlign: { type: 'String', attribute: 'dropdown-align' },
+      showSelectAll: { type: 'Boolean', attribute: 'show-select-all', reflect: true },
+      selectAllLabel: { type: 'String', attribute: 'select-all-label' },
       onchange: { type: 'Object' },
       leftIcon: { type: 'String', attribute: 'left-icon', reflect: true },
       leftIconTestId: { type: 'String', attribute: 'left-icon-test-id' }

--- a/tests/select-select-all.test.ts
+++ b/tests/select-select-all.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the `showSelectAll` multi-select feature: the synthetic "select all" row,
+// toggle-all / deselect-all, the indeterminate (dash) state + its accessible label,
+// keyboard reachability, and search-scoped selection.
+test.describe('Select — select all (multi-select)', () => {
+  test('renders a select-all row that selects and deselects every option', async ({ page }) => {
+    await page.goto('/components/select');
+
+    const select = page.locator('[data-pw="select-all-demo"]');
+    await expect(select).toBeVisible();
+    await select.getByRole('combobox').click();
+
+    const listbox = select.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+
+    const selectAll = listbox.locator('[data-pw="select-all-demo-select-all"]');
+    await expect(selectAll).toBeVisible();
+    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(0);
+
+    // Select all -> the select-all box and every option box are checked.
+    await selectAll.click();
+    await expect(selectAll.locator('.select-option-indicator.checked')).toHaveCount(1);
+    await expect(
+      listbox.locator('[data-pw="select-all-demo-apple"] .select-option-indicator.checked')
+    ).toHaveCount(1);
+    await expect(
+      listbox.locator('[data-pw="select-all-demo-grape"] .select-option-indicator.checked')
+    ).toHaveCount(1);
+
+    // Toggle again -> nothing is checked.
+    await selectAll.click();
+    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(0);
+  });
+
+  test('shows an indeterminate dash and accessible state when only some are selected', async ({
+    page
+  }) => {
+    await page.goto('/components/select');
+
+    const select = page.locator('[data-pw="select-all-demo"]');
+    await select.getByRole('combobox').click();
+    const listbox = select.getByRole('listbox');
+    const selectAll = listbox.locator('[data-pw="select-all-demo-select-all"]');
+
+    await listbox.locator('[data-pw="select-all-demo-apple"]').click();
+
+    const indicator = selectAll.locator('.select-option-indicator');
+    await expect(indicator).toHaveClass(/indeterminate/);
+    await expect(indicator).not.toHaveClass(/checked/);
+    await expect(selectAll.locator('.select-option-dash')).toHaveCount(1);
+    // Partial state is exposed to assistive tech via the row's accessible name.
+    await expect(selectAll).toHaveAttribute('aria-label', /of 7 selected/);
+  });
+
+  test('keyboard navigation reaches the select-all row', async ({ page }) => {
+    await page.goto('/components/select');
+
+    const select = page.locator('[data-pw="select-all-demo"]');
+    await select.getByRole('combobox').focus();
+    await page.keyboard.press('ArrowDown'); // open
+    const listbox = select.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+
+    await page.keyboard.press('ArrowDown'); // highlight the first row (select-all)
+    const selectAll = listbox.locator('[data-pw="select-all-demo-select-all"]');
+    await expect(selectAll).toHaveClass(/highlighted/);
+
+    await page.keyboard.press('Enter'); // toggle the highlighted select-all row
+    await expect(selectAll.locator('.select-option-indicator.checked')).toHaveCount(1);
+  });
+
+  test('searchable: select-all toggles only the filtered options', async ({ page }) => {
+    await page.goto('/components/select');
+
+    const select = page.locator('[data-pw="select-all-search-demo"]');
+    await expect(select).toBeVisible();
+
+    const search = select.locator('.select-search');
+    await search.click();
+    await search.fill('java'); // matches "JavaScript" and "Java"
+
+    const listbox = select.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+    // select-all row + the two filtered options
+    await expect(listbox.getByRole('option')).toHaveCount(3);
+
+    await listbox.locator('[data-pw="select-all-search-demo-select-all"]').click();
+    await expect(
+      listbox.locator('[data-pw="select-all-search-demo-js"] .select-option-indicator.checked')
+    ).toHaveCount(1);
+    await expect(
+      listbox.locator('[data-pw="select-all-search-demo-java"] .select-option-indicator.checked')
+    ).toHaveCount(1);
+
+    // A non-matching option (Python) was untouched.
+    await search.fill('');
+    await expect(
+      listbox.locator('[data-pw="select-all-search-demo-py"] .select-option-indicator.checked')
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What

Adds `showSelectAll` (+ `selectAllLabel`) to `Select` for multi-select. When `showSelectAll` is set in `multiple` mode, a **"Select all"** row renders at the top of the dropdown that toggles every currently-listed (search-filtered) option, with an **indeterminate** (dash) indicator when only some are selected.

- `showSelectAll?: boolean` — render the select-all row (multiple mode only; no-op otherwise).
- `selectAllLabel?: string` — label for the row (default `'Select all'`).
- `optionIndicator` snippet param extended to `{ checked, indeterminate? }` — **non-breaking**: existing snippets that destructure only `checked` are unaffected.
- New themeable vars: default indicator dash (`--select-option-indicator-dash-size` / `-dash-thickness` / `-dash-color`) and a row hook (`--select-all-border`, `--select-all-font-weight`).

Implemented via a unified `optionRows` model so the select-all row shares the same `highlightedIndex` space as the options — arrow-key navigation needed no special-casing. With `searchable`, "Select all" toggles only the filtered options.

## Why

Unblocks the Lighthouse `Dropdown → Select` migration: the project `Dropdown` has a select-all-with-indeterminate that the library lacked — the one true gap blocking the fold (apply-confirm is already composable via the existing `bottomContent`).

## Demo

`/components/select` → new **"Multi select + select all"** and **"Multi select + select all + searchable"** sections.

## Verified

- `pnpm run check` → 0 errors
- `pnpm run lint` (prettier + eslint, strict) → clean
- `pnpm run build` → packages clean (publint: only the pre-existing repo-url suggestion)
- Live on the demo route: partial selection → indeterminate dash; "Select all" → all 8 selected (checkmark); toggle again → cleared (verified via DOM state probe + screenshot).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Select all” row for multi-select dropdowns, with a customizable label.
  * “Select all” now supports checked/indeterminate/unselected states and works with keyboard and mouse selection.
  * In searchable mode, “Select all” applies only to the currently filtered options.
* **Documentation**
  * Updated examples and guidance to demonstrate select-all behavior for both searchable and non-searchable multi-selects.
* **Tests**
  * Added coverage for select-all toggling, indeterminate/ARIA state, keyboard navigation, and filtered behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->