### PR TITLE
feat: extend StatCard (rows/breakdown/checkbox/slots) + add ProportionBar

### DIFF
--- a/docs/ProportionBar.md
+++ b/docs/ProportionBar.md
@@ -1,0 +1,128 @@
+# ProportionBar
+
+A horizontal stacked bar that visualises how a total is distributed across labelled segments. Renders proportional coloured bands in an SVG track with a default colour palette (overridable per segment) and an optional legend listing each segment's label and formatted value. Each band's width is derived from its `value` relative to the sum of all segments; negative and non-finite values are sanitized to zero so the rendered widths always stay within 0–100%. When the legend is hidden the SVG exposes the full breakdown as its accessible name (`role="img"` + `aria-label`), so screen-reader users still get the data. All visual properties are controlled via CSS custom properties.
+
+## Usage
+
+```svelte
+<script>
+  import { ProportionBar } from '@juspay/svelte-ui-components';
+
+  const segments = [
+    { label: 'UPI', value: 4820 },
+    { label: 'Cards', value: 2150 },
+    { label: 'Wallets', value: 870 },
+    { label: 'NetBanking', value: 560 },
+    { label: 'COD', value: 210 }
+  ];
+</script>
+
+<ProportionBar {segments} />
+```
+
+### Custom Segment Colours
+
+Omit `color` to fall back to the default palette, or set it per segment.
+
+```svelte
+<ProportionBar
+  segments={[
+    { label: 'Delivered', value: 7200, color: '#22c55e' },
+    { label: 'In Transit', value: 1800, color: '#f59e0b' },
+    { label: 'Cancelled', value: 540, color: '#ef4444' }
+  ]}
+/>
+```
+
+### Custom Value Format
+
+Pass `valueFormat` `(value, percent) => string` to control the legend value column.
+
+```svelte
+<script>
+  const currencyFormat = (value, percent) => `₹${(value / 100).toFixed(1)}L (${Math.round(percent)}%)`;
+</script>
+
+<ProportionBar segments={revenueSegments} valueFormat={currencyFormat} trackHeight="14px" />
+```
+
+### Without a Legend
+
+When `showLegend={false}`, the legend list is removed and the SVG itself carries the full breakdown as its accessible name.
+
+```svelte
+<ProportionBar segments={paymentSegments} showLegend={false} />
+```
+
+### Themed Bar
+
+```svelte
+<div class="brand-bar">
+  <ProportionBar segments={orderStatusSegments} trackHeight="6px" />
+</div>
+
+<style>
+  .brand-bar {
+    --proportion-bar-track-bg: #f3f4f6;
+    --proportion-bar-track-border-radius: 2px;
+    --proportion-bar-legend-label-color: #374151;
+    --proportion-bar-legend-value-color: #111827;
+  }
+</style>
+```
+
+## Props
+
+| Prop        | Type                                       | Required | Default | Description                                                                                                       |
+| ----------- | ------------------------------------------ | -------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| segments    | `ProportionBarSegment[]`                   | Yes      | `-`     | Segments whose values define the proportions. Each is `{ label: string; value: number; color?: string }`.       |
+| showLegend  | `boolean`                                  | No       | `true`  | Whether to render the legend list below the bar.                                                                |
+| valueFormat | `(value: number, percent: number) => string` | No    | `-`     | Custom formatter for the legend value column. Defaults to `"N (X%)"`.                                            |
+| trackHeight | `string`                                   | No       | `-`     | Height of the bar track (e.g. `"8px"`). Also settable via `--proportion-bar-track-height`.                       |
+| testId      | `string`                                   | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                      |
+| classes     | `string`                                   | No       | `-`     | Extra CSS class names appended to the root element. Useful for theming via CSS-variable overrides.              |
+
+### ProportionBarSegment
+
+| Field | Type     | Required | Description                                                       |
+| ----- | -------- | -------- | ----------------------------------------------------------------- |
+| label | `string` | Yes      | Display label for the segment.                                    |
+| value | `number` | Yes      | Absolute value used to compute the proportion. Negative / non-finite values are treated as zero. |
+| color | `string` | No       | Override fill colour. Falls back to the default palette by index. |
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                                    | Default   | CSS Property  | Description                                  |
+| ------------------------------------------- | --------- | ------------- | -------------------------------------------- |
+| `--proportion-bar-gap`                      | `10px`    | gap           | Vertical gap between the track and legend.   |
+| `--proportion-bar-width`                    | `100%`    | width         | Width of the component.                      |
+| `--proportion-bar-track-height`             | `10px`    | height        | Height of the bar track.                     |
+| `--proportion-bar-track-border-radius`      | `4px`     | border-radius | Corner radius of the track.                  |
+| `--proportion-bar-track-bg`                 | `#f0f0f0` | background    | Background of the empty track.               |
+| `--proportion-bar-legend-gap`               | `6px`     | gap           | Vertical gap between legend items.           |
+| `--proportion-bar-legend-item-gap`          | `8px`     | gap           | Horizontal gap within a legend item.         |
+| `--proportion-bar-swatch-size`              | `10px`    | width/height  | Size of a legend colour swatch.              |
+| `--proportion-bar-swatch-border-radius`     | `2px`     | border-radius | Corner radius of a legend swatch.            |
+| `--proportion-bar-legend-label-color`       | `#374151` | color         | Colour of legend labels.                     |
+| `--proportion-bar-legend-value-color`       | `#111827` | color         | Colour of legend values.                     |
+
+## Web Component
+
+Tag: `<sui-proportion-bar>`
+
+`segments` is an array and `valueFormat` is a function, so both are exposed as JS properties only (not HTML attributes):
+
+```html
+<sui-proportion-bar id="payments" track-height="12px"></sui-proportion-bar>
+
+<script>
+  const bar = document.querySelector('#payments');
+  bar.segments = [
+    { label: 'UPI', value: 4820 },
+    { label: 'Cards', value: 2150 }
+  ];
+  bar.valueFormat = (value, percent) => `${value} (${percent}%)`;
+</script>
+```

--- a/docs/StatCard.md
+++ b/docs/StatCard.md
@@ -1,6 +1,6 @@
 # StatCard
 
-A compact metric display card for dashboards. Shows a title label, a prominent value, an optional delta badge (with automatic positive/negative colour inference from the leading sign character), an optional subtitle, a footer snippet, and an optional custom value snippet for advanced rendering. All visual properties are controlled via CSS custom properties. When `onclick` is provided the root element becomes an accessible button (`role="button"`, `tabindex="0"`, Enter/Space keyboard support) without any API change for existing consumers that omit the prop.
+A compact metric display card for dashboards. Shows a title label, a prominent value, an optional delta badge (with automatic positive/negative colour inference from the leading sign character), an optional subtitle, a footer snippet, and an optional custom value snippet for advanced rendering. For richer dashboards it also supports a multi-row layout (`rows`) with per-row deltas, tooltips, and a breakdown grid, plus a header that can carry a title tooltip, a checkbox, and arbitrary right-aligned content. All visual properties are controlled via CSS custom properties. When `onclick` is provided the root element becomes an accessible button (`role="button"`, `tabindex="0"`, Enter/Space keyboard support) without any API change for existing consumers that omit the prop.
 
 ## Usage
 
@@ -94,6 +94,82 @@ Delta colour is inferred from the leading character: `+` → green (`--statcard-
 />
 ```
 
+### Multi-Row Layout
+
+Pass `rows` to render several metrics stacked and divider-separated. Each row carries its own heading, a numeric `change` (rendered with `DeltaIndicator`, with `invertChangeColors` for lower-is-better metrics), an optional tooltip, and optional `additionalContent`.
+
+```svelte
+<StatCard
+  title="Revenue Overview"
+  rows={[
+    { heading: 'Gross Revenue', value: '₹12.4Cr', change: 8.2 },
+    { heading: 'Net Revenue', value: '₹10.9Cr', change: 5.7, additionalContent: 'after RTO' },
+    { heading: 'RTO Rate', value: '12.1%', change: -2.3, invertChangeColors: true }
+  ]}
+/>
+```
+
+### Breakdown Grid
+
+A row can carry a `breakdown` array, rendered as a labelled grid beneath the row value.
+
+```svelte
+<StatCard
+  title="Conversion Metrics"
+  rows={[
+    {
+      heading: 'Checkout Conversion',
+      value: '68.4%',
+      change: 3.1,
+      breakdownHeading: 'By Device',
+      breakdown: [
+        { label: 'Mobile', value: '71.2%', change: 4.0 },
+        { label: 'Desktop', value: '63.8%', change: 1.5 }
+      ]
+    }
+  ]}
+/>
+```
+
+### Title Tooltip
+
+```svelte
+<StatCard
+  title="Net Revenue"
+  value="₹10.9Cr"
+  delta="+5.7%"
+  tooltip={{ text: 'Revenue after returns and RTO deductions', position: 'top' }}
+/>
+```
+
+### Header Checkbox
+
+The header renders even without a title. `onCheckboxChange` fires with the new checked state; drive `checkbox.checked` from your own state for a controlled checkbox. On an interactive card (`onclick` set), toggling the checkbox does not fire the card action.
+
+```svelte
+<script>
+  let withReturns = $state(false);
+</script>
+
+<StatCard
+  title="Include Returns"
+  value={withReturns ? '₹12.4Cr' : '₹10.9Cr'}
+  checkbox={{ text: 'With returns', checked: withReturns }}
+  onCheckboxChange={(checked) => (withReturns = checked)}
+/>
+```
+
+### Header-Right Content & Children
+
+```svelte
+<StatCard title="Payment Methods" value="8,610 orders">
+  {#snippet headerRight()}
+    <a href="/payments">Details →</a>
+  {/snippet}
+  <ProportionBar segments={paymentSegments} trackHeight="8px" />
+</StatCard>
+```
+
 ## Props
 
 | Prop          | Type                          | Required | Default | Description                                                                                                                                           |
@@ -105,6 +181,12 @@ Delta colour is inferred from the leading character: `+` → green (`--statcard-
 | subtitle      | `string`                      | No       | `-`     | Secondary label rendered below the value row.                                                                                                         |
 | footer        | `Snippet`                     | No       | `-`     | Snippet rendered in the card footer area, separated by a border-top line.                                                                             |
 | valueSnippet  | `Snippet`                     | No       | `-`     | Replaces the string `value` with a custom snippet for advanced value rendering.                                                                       |
+| rows          | `StatCardRow[]`               | No       | `-`     | Multiple metric rows. When set, replaces the single value/delta row with a divider-separated column. Each row supports `heading`, `change`, `invertChangeColors`, `tooltip`, `additionalContent`, `breakdownHeading`, and a `breakdown` grid. |
+| tooltip       | `StatCardTooltip`             | No       | `-`     | Tooltip shown on the card title — `{ text, position?, testId? }`.                                                                                     |
+| checkbox      | `{ text: string; checked?: boolean }` | No | `-` | Renders a checkbox next to the title. The header is shown even when `title` is omitted. Pair with `onCheckboxChange` for a controlled checkbox.       |
+| headerRight   | `Snippet`                     | No       | `-`     | Snippet rendered at the right edge of the header row.                                                                                                 |
+| children      | `Snippet`                     | No       | `-`     | Default slot rendered inside the card body, after any rows (e.g. an embedded `ProportionBar`).                                                        |
+| onCheckboxChange | `(checked: boolean) => void` | No     | `-`     | Fires with the new checked state when the header checkbox is toggled.                                                                                 |
 | classes       | `string`                      | No       | `-`     | Extra CSS class names appended to the root element. Useful for theming — define classes with CSS variable overrides and pass them to create variants. |
 | testId        | `string`                      | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                                                            |
 | onclick       | `(event: MouseEvent) => void` | No       | `-`     | Click handler. When provided, the card root becomes interactive: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler.        |
@@ -114,6 +196,7 @@ Delta colour is inferred from the leading character: `+` → green (`--statcard-
 | Event   | Type                          | Description                                                                                                                                          |
 | ------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | onclick | `(event: MouseEvent) => void` | Fires when the card is clicked. When provided, the card gains `role="button"`, `tabindex="0"`, and keyboard support (Enter/Space). No-op if omitted. |
+| onCheckboxChange | `(checked: boolean) => void` | Fires with the new checked state when the header checkbox is toggled. Interaction is stopped from propagating to the card's click action. |
 
 ## CSS Variables
 
@@ -159,6 +242,17 @@ Override these custom properties to theme the component.
 | `--statcard-footer-margin-top`    | `8px`                    | margin-top     | Top margin of the footer section.                                            |
 | `--statcard-footer-padding-top`   | `8px`                    | padding-top    | Top padding of the footer section (space between border and content).        |
 | `--statcard-footer-border-top`    | `1px solid #e5e7eb`      | border-top     | Top border line separating the footer from the card body.                    |
+| `--statcard-header-gap`           | `8px`                    | gap            | Gap between the header-left group and the header-right content.               |
+| `--statcard-header-left-gap`      | `8px`                    | gap            | Gap between the title, checkbox, and other header-left items.                 |
+| `--statcard-rows-gap`             | `0px`                    | gap            | Gap between metric rows in the multi-row layout.                              |
+| `--statcard-row-gap`              | `4px`                    | gap            | Vertical gap between a row's heading, value line, and breakdown.              |
+| `--statcard-row-divider-height`   | `1px`                    | height         | Thickness of the line between rows.                                           |
+| `--statcard-row-divider-color`    | `#e5e7eb`                | background     | Colour of the row divider line.                                              |
+| `--statcard-row-divider-margin`   | `8px 0`                  | margin         | Spacing around the row divider line.                                          |
+| `--statcard-row-heading-color`    | `#6b7280`                | color          | Colour of a row heading.                                                      |
+| `--statcard-breakdown-col-min`    | `100px`                  | grid-template  | Minimum column width of the breakdown grid (auto-fill).                       |
+| `--statcard-breakdown-gap`        | `8px`                    | gap            | Gap between breakdown items.                                                  |
+| `--statcard-children-margin-top`  | `4px`                    | margin-top     | Top margin of the `children` slot content.                                    |
 
 ## Web Component
 
@@ -171,4 +265,19 @@ Tag: `<sui-stat-card>`
   delta="+12.5%"
   subtitle="vs last month"
 ></sui-stat-card>
+```
+
+Complex props (`rows`, `tooltip`, `checkbox`, `onCheckboxChange`) are functions/objects/arrays and so are exposed as JS properties only (not HTML attributes); the `headerRight` and `children` snippets map to the `header-right` named slot and the default slot respectively:
+
+```html
+<sui-stat-card id="revenue" title="Revenue Overview">
+  <a slot="header-right" href="/payments">Details →</a>
+</sui-stat-card>
+
+<script>
+  document.querySelector('#revenue').rows = [
+    { heading: 'Gross Revenue', value: '₹12.4Cr', change: 8.2 },
+    { heading: 'Net Revenue', value: '₹10.9Cr', change: 5.7 }
+  ];
+</script>
 ```

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -184,6 +184,10 @@
     "description": "A horizontal progress bar that fills from left to right based on a percentage value. Supports configurable width, height, colors, border radius, and an animated transition on value changes."
   },
   {
+    "name": "ProportionBar",
+    "description": "A horizontal stacked bar that visualizes how a total is distributed across labelled segments. Renders proportional coloured bands in an SVG track with a palette fallback and an optional legend listing each segment's label and formatted value. Negative and non-finite segment values are sanitized to zero so widths stay within 0–100%. When the legend is hidden the SVG exposes the full breakdown as its accessible name. Supports a custom value formatter, configurable track height, and CSS-variable theming."
+  },
+  {
     "name": "Radio",
     "description": "A styled radio button input with a custom circular indicator. Supports checked state binding, disabled state, and configurable size and colors via CSS variables."
   },
@@ -233,7 +237,7 @@
   },
   {
     "name": "StatCard",
-    "description": "A compact metric display card for dashboards. Shows a title label, a prominent value, an optional delta badge (with automatic positive/negative colour inference from the leading sign character), an optional subtitle, and a footer snippet. When onclick is provided, the card becomes an accessible interactive button (role=button, tabindex=0, Enter/Space keyboard support). All visual properties are CSS-var driven."
+    "description": "A compact metric display card for dashboards. Shows a title label, a prominent value, an optional delta badge (with automatic positive/negative colour inference from the leading sign character), an optional subtitle, and a footer snippet. Also supports a multi-row layout with per-row deltas, tooltips, and a breakdown grid, plus a header that can carry a title tooltip, a checkbox, and right-aligned content, and a default children slot for embedding content such as a ProportionBar. When onclick is provided, the card becomes an accessible interactive button (role=button, tabindex=0, Enter/Space keyboard support). All visual properties are CSS-var driven."
   },
   {
     "name": "Status",

--- a/src/lib/ProportionBar/ProportionBar.svelte
+++ b/src/lib/ProportionBar/ProportionBar.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  /**
+   * ProportionBar — a horizontal stacked bar that visualises how a total is
+   * distributed across labelled segments. Renders proportional coloured bands in
+   * an SVG track with an optional legend. Each band's width is derived from its
+   * `value` relative to the sum of all segments; non-finite or negative values
+   * are treated as zero so the rendered widths always stay within 0–100%.
+   *
+   * @example
+   * ```svelte
+   * <ProportionBar
+   *   segments={[
+   *     { label: 'UPI', value: 480 },
+   *     { label: 'Cards', value: 220 }
+   *   ]}
+   * />
+   * ```
+   *
+   * @see docs/ProportionBar.md
+   */
+  import type { ProportionBarProperties, ProportionBarSegment } from './properties';
+
+  const DEFAULT_PALETTE = ['#8F49DE', '#FFC533', '#62D5C0', '#FF74CD', '#D1E7FF'];
+
+  let {
+    segments,
+    showLegend = true,
+    valueFormat,
+    trackHeight,
+    testId,
+    classes
+  }: ProportionBarProperties = $props();
+
+  const resolveColor = (segment: ProportionBarSegment, index: number): string => {
+    if (typeof segment.color === 'string' && segment.color.length > 0) {
+      return segment.color;
+    }
+    return DEFAULT_PALETTE[index % DEFAULT_PALETTE.length];
+  };
+
+  /** Reject negative or non-finite values so derived percentages stay within 0–100. */
+  const sanitizeValue = (value: number): number =>
+    Number.isFinite(value) && value > 0 ? value : 0;
+
+  const total = $derived(segments.reduce((sum, segment) => sum + sanitizeValue(segment.value), 0));
+
+  const computedSegments = $derived(
+    segments.map((segment, segmentIndex) => {
+      const safeValue = sanitizeValue(segment.value);
+      const percent = total > 0 ? (safeValue / total) * 100 : 0;
+      return {
+        label: segment.label,
+        value: safeValue,
+        percent,
+        color: resolveColor(segment, segmentIndex)
+      };
+    })
+  );
+
+  const defaultFormat = (absoluteValue: number, percent: number): string =>
+    `${absoluteValue.toLocaleString()} (${Math.round(percent)}%)`;
+
+  const formatValue = (absoluteValue: number, percent: number): string =>
+    (valueFormat ?? defaultFormat)(absoluteValue, percent);
+
+  /**
+   * Comma-joined "label: value (percent)" summary. Used as the SVG's accessible
+   * name when the legend is hidden, so screen-reader users still get the full
+   * breakdown even though the bands themselves are presentational.
+   */
+  const ariaSummary = $derived(
+    computedSegments
+      .map(
+        (computedSegment) =>
+          `${computedSegment.label}: ${formatValue(computedSegment.value, computedSegment.percent)}`
+      )
+      .join(', ')
+  );
+
+  /** Cumulative x offsets for SVG rect positions. */
+  const rectSegments = $derived(
+    computedSegments.reduce<{ x: number; width: number; color: string }[]>(
+      (acc, computedSegment) => {
+        const previousX = acc.length > 0 ? acc[acc.length - 1].x + acc[acc.length - 1].width : 0;
+        acc.push({ x: previousX, width: computedSegment.percent, color: computedSegment.color });
+        return acc;
+      },
+      []
+    )
+  );
+
+  const trackHeightStyle = $derived(
+    typeof trackHeight === 'string' && trackHeight.length > 0
+      ? `--proportion-bar-track-height: ${trackHeight};`
+      : ''
+  );
+</script>
+
+<div
+  class="proportion-bar {classes ?? ''}"
+  style={trackHeightStyle}
+  data-pw={typeof testId === 'string' ? testId : null}
+>
+  <div class="proportion-bar-track">
+    <svg
+      viewBox="0 0 100 10"
+      preserveAspectRatio="none"
+      class="proportion-bar-svg"
+      role={showLegend ? null : 'img'}
+      aria-hidden={showLegend ? 'true' : null}
+      aria-label={showLegend ? null : ariaSummary}
+    >
+      {#each rectSegments as rectSegment, rectIndex (rectIndex)}
+        <rect
+          x={rectSegment.x}
+          y={0}
+          width={rectSegment.width}
+          height={10}
+          fill={rectSegment.color}
+        >
+          <title
+            >{computedSegments[rectIndex].label}: {formatValue(
+              computedSegments[rectIndex].value,
+              computedSegments[rectIndex].percent
+            )}</title
+          >
+        </rect>
+      {/each}
+    </svg>
+  </div>
+
+  {#if showLegend}
+    <ul class="proportion-bar-legend" aria-label="Segment breakdown">
+      {#each computedSegments as computedSegment, legendIndex (legendIndex)}
+        <li class="proportion-bar-legend-item">
+          <span
+            class="proportion-bar-swatch"
+            style="background: {computedSegment.color};"
+            aria-hidden="true"
+          ></span>
+          <span class="proportion-bar-legend-label">{computedSegment.label}</span>
+          <span class="proportion-bar-legend-value">
+            {formatValue(computedSegment.value, computedSegment.percent)}
+          </span>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .proportion-bar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--proportion-bar-gap, 10px);
+    width: var(--proportion-bar-width, 100%);
+  }
+
+  .proportion-bar-track {
+    width: 100%;
+    height: var(--proportion-bar-track-height, 10px);
+    border-radius: var(--proportion-bar-track-border-radius, 4px);
+    overflow: hidden;
+    background: var(--proportion-bar-track-bg, #f0f0f0);
+  }
+
+  .proportion-bar-svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .proportion-bar-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--proportion-bar-legend-gap, 6px);
+  }
+
+  .proportion-bar-legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--proportion-bar-legend-item-gap, 8px);
+  }
+
+  .proportion-bar-swatch {
+    display: inline-block;
+    width: var(--proportion-bar-swatch-size, 10px);
+    height: var(--proportion-bar-swatch-size, 10px);
+    border-radius: var(--proportion-bar-swatch-border-radius, 2px);
+    flex-shrink: 0;
+  }
+
+  .proportion-bar-legend-label {
+    flex: 1;
+    font-size: var(--proportion-bar-legend-label-font-size, 13px);
+    font-weight: var(--proportion-bar-legend-label-font-weight, 400);
+    color: var(--proportion-bar-legend-label-color, #374151);
+    line-height: 1.4;
+  }
+
+  .proportion-bar-legend-value {
+    font-size: var(--proportion-bar-legend-value-font-size, 13px);
+    font-weight: var(--proportion-bar-legend-value-font-weight, 500);
+    color: var(--proportion-bar-legend-value-color, #111827);
+    line-height: 1.4;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/ProportionBar/properties.ts
+++ b/src/lib/ProportionBar/properties.ts
@@ -1,0 +1,38 @@
+export type ProportionBarSegment = {
+  /** Display label for this segment. */
+  label: string;
+  /** Absolute numeric value used to compute proportion. */
+  value: number;
+  /** Override fill color for this segment. Falls back to the default palette. */
+  color?: string;
+};
+
+export type ProportionBarProperties = MandatoryProportionBarProperties &
+  OptionalProportionBarProperties;
+
+export type MandatoryProportionBarProperties = {
+  /** Array of segments whose values define the proportions shown in the bar. */
+  segments: ProportionBarSegment[];
+};
+
+export type OptionalProportionBarProperties = {
+  /**
+   * Whether to render a legend list below the bar. Each legend item shows a
+   * colour swatch, the segment label, and the formatted value. Defaults to `true`.
+   */
+  showLegend?: boolean;
+  /**
+   * Custom formatter for the legend value column. Receives the absolute value and
+   * the computed percentage. Defaults to `"N (X%)"`.
+   */
+  valueFormat?: (value: number, percent: number) => string;
+  /**
+   * Height of the bar track (e.g. `"8px"`, `"12px"`). Also settable via the
+   * `--proportion-bar-track-height` CSS variable.
+   */
+  trackHeight?: string;
+  /** Test selector applied as the `data-pw` attribute on the root element. */
+  testId?: string;
+  /** Extra CSS class names appended to the root element. */
+  classes?: string;
+};

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import type { StatCardProperties } from './properties';
+  import DeltaIndicator from '../DeltaIndicator/DeltaIndicator.svelte';
+  import Tooltip from '../Tooltip/Tooltip.svelte';
+  import CheckListItem from '../CheckListItem/CheckListItem.svelte';
 
   let {
     title,
@@ -9,9 +12,15 @@
     subtitle,
     footer,
     valueSnippet,
+    rows,
+    tooltip,
+    checkbox,
+    headerRight,
+    children,
     testId,
     classes,
-    onclick
+    onclick,
+    onCheckboxChange
   }: StatCardProperties = $props();
 
   const isInteractive = $derived(typeof onclick === 'function');
@@ -34,6 +43,16 @@
   );
 
   const hasDelta = $derived(typeof delta === 'string' && delta.trim().length > 0);
+  const hasRows = $derived(Array.isArray(rows) && rows.length > 0);
+  const hasTitle = $derived(typeof title === 'string' && title.length > 0);
+
+  /**
+   * The header is rendered when ANY header content is present — not only a title.
+   * This keeps `checkbox` and `headerRight` visible on title-less cards.
+   */
+  const hasHeaderContent = $derived(
+    hasTitle || Boolean(checkbox) || typeof headerRight === 'function'
+  );
 
   const handleKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -44,6 +63,19 @@
         event.currentTarget.click();
       }
     }
+  };
+
+  const handleCheckboxChange = (checked: boolean): void => {
+    onCheckboxChange?.(checked);
+  };
+
+  /**
+   * Keep header checkbox interaction from bubbling to the card's click/keydown
+   * handler — otherwise toggling the checkbox on an interactive card would also
+   * fire its `onclick` action.
+   */
+  const stopHeaderInteraction = (event: Event): void => {
+    event.stopPropagation();
   };
 </script>
 
@@ -57,30 +89,122 @@
   onclick={isInteractive ? onclick : null}
   onkeydown={isInteractive ? handleKeydown : null}
 >
-  {#if typeof title === 'string' && title.length > 0}
-    <div class="statcard-title">{title}</div>
+  {#if hasHeaderContent}
+    <div class="statcard-header">
+      <div class="statcard-header-left">
+        {#if hasTitle}
+          {#if tooltip}
+            <Tooltip
+              text={tooltip.text}
+              position={tooltip.position ?? 'top'}
+              testId={tooltip.testId}
+            >
+              <div class="statcard-title statcard-title-tooltip">{title}</div>
+            </Tooltip>
+          {:else}
+            <div class="statcard-title">{title}</div>
+          {/if}
+        {/if}
+        {#if checkbox}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="statcard-header-checkbox"
+            onclick={stopHeaderInteraction}
+            onkeydown={stopHeaderInteraction}
+          >
+            <CheckListItem
+              text={checkbox.text}
+              checked={checkbox.checked ?? false}
+              onclick={handleCheckboxChange}
+            />
+          </div>
+        {/if}
+      </div>
+      {#if headerRight}
+        <div class="statcard-header-right">{@render headerRight()}</div>
+      {/if}
+    </div>
   {/if}
 
-  <div class="statcard-value-row">
-    {#if typeof valueSnippet === 'function'}
-      <div class="statcard-value">{@render valueSnippet()}</div>
-    {:else if typeof value === 'string' && value.length > 0}
-      <div class="statcard-value">{value}</div>
-    {/if}
+  {#if hasRows && rows}
+    <div class="statcard-rows">
+      {#each rows as row, rowIndex (rowIndex)}
+        {#if rowIndex > 0}
+          <div class="statcard-row-divider"></div>
+        {/if}
+        <div class="statcard-row" data-pw={typeof row.testId === 'string' ? row.testId : null}>
+          {#if typeof row.heading === 'string' && row.heading.length > 0}
+            <div class="statcard-row-heading-wrap">
+              {#if row.tooltip}
+                <Tooltip
+                  text={row.tooltip.text}
+                  position={row.tooltip.position ?? 'top'}
+                  testId={row.tooltip.testId}
+                >
+                  <div class="statcard-row-heading statcard-row-heading-tooltip">{row.heading}</div>
+                </Tooltip>
+              {:else}
+                <div class="statcard-row-heading">{row.heading}</div>
+              {/if}
+            </div>
+          {/if}
+          <div class="statcard-row-value-line">
+            <div class="statcard-value">{row.value}</div>
+            {#if typeof row.change === 'number'}
+              <DeltaIndicator value={row.change} invertColors={row.invertChangeColors ?? false} />
+            {/if}
+            {#if typeof row.additionalContent === 'string' && row.additionalContent.length > 0}
+              <div class="statcard-row-additional">{row.additionalContent}</div>
+            {/if}
+          </div>
+          {#if Array.isArray(row.breakdown) && row.breakdown.length > 0}
+            {#if typeof row.breakdownHeading === 'string' && row.breakdownHeading.length > 0}
+              <div class="statcard-breakdown-heading">{row.breakdownHeading}</div>
+            {/if}
+            <div class="statcard-breakdown-grid">
+              {#each row.breakdown as breakdownItem, breakdownIndex (breakdownIndex)}
+                <div class="statcard-breakdown-item">
+                  <div class="statcard-breakdown-label">{breakdownItem.label}</div>
+                  <div class="statcard-breakdown-value">{breakdownItem.value}</div>
+                  {#if typeof breakdownItem.change === 'number'}
+                    <DeltaIndicator
+                      value={breakdownItem.change}
+                      invertColors={breakdownItem.invertChangeColors ?? false}
+                    />
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <div class="statcard-value-row">
+      {#if typeof valueSnippet === 'function'}
+        <div class="statcard-value">{@render valueSnippet()}</div>
+      {:else if typeof value === 'string' && value.length > 0}
+        <div class="statcard-value">{value}</div>
+      {/if}
 
-    {#if hasDelta}
-      <div
-        class="statcard-delta"
-        class:statcard-delta-positive={resolvedDeltaPositive === true}
-        class:statcard-delta-negative={resolvedDeltaPositive === false}
-      >
-        {delta}
-      </div>
-    {/if}
-  </div>
+      {#if hasDelta}
+        <div
+          class="statcard-delta"
+          class:statcard-delta-positive={resolvedDeltaPositive === true}
+          class:statcard-delta-negative={resolvedDeltaPositive === false}
+        >
+          {delta}
+        </div>
+      {/if}
+    </div>
 
-  {#if typeof subtitle === 'string' && subtitle.length > 0}
-    <div class="statcard-subtitle">{subtitle}</div>
+    {#if typeof subtitle === 'string' && subtitle.length > 0}
+      <div class="statcard-subtitle">{subtitle}</div>
+    {/if}
+  {/if}
+
+  {#if children}
+    <div class="statcard-children">{@render children()}</div>
   {/if}
 
   {#if typeof footer === 'function'}
@@ -116,6 +240,33 @@
     outline-offset: var(--statcard-focus-outline-offset, 2px);
   }
 
+  .statcard-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--statcard-header-gap, 8px);
+  }
+
+  .statcard-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--statcard-header-left-gap, 8px);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .statcard-header-right {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  /* Transparent wrapper: keeps the checkbox in the event path (to stop bubbling to
+     the card action) without altering the header layout. */
+  .statcard-header-checkbox {
+    display: contents;
+  }
+
   .statcard-title {
     font-size: var(--statcard-title-font-size, 12px);
     font-weight: var(--statcard-title-font-weight, 500);
@@ -124,6 +275,12 @@
     white-space: var(--statcard-title-white-space, nowrap);
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .statcard-title-tooltip {
+    cursor: default;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
   }
 
   .statcard-value-row {
@@ -160,6 +317,98 @@
     font-weight: var(--statcard-subtitle-font-weight, 400);
     color: var(--statcard-subtitle-color, #9ca3af);
     line-height: var(--statcard-subtitle-line-height, 1.4);
+  }
+
+  /* Multi-row layout */
+  .statcard-rows {
+    display: flex;
+    flex-direction: column;
+    gap: var(--statcard-rows-gap, 0px);
+  }
+
+  .statcard-row-divider {
+    height: var(--statcard-row-divider-height, 1px);
+    background: var(--statcard-row-divider-color, #e5e7eb);
+    margin: var(--statcard-row-divider-margin, 8px 0);
+  }
+
+  .statcard-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--statcard-row-gap, 4px);
+  }
+
+  .statcard-row-heading-wrap {
+    display: flex;
+    align-items: center;
+  }
+
+  .statcard-row-heading {
+    font-size: var(--statcard-row-heading-font-size, 12px);
+    font-weight: var(--statcard-row-heading-font-weight, 500);
+    color: var(--statcard-row-heading-color, #6b7280);
+    line-height: var(--statcard-row-heading-line-height, 1.4);
+  }
+
+  .statcard-row-heading-tooltip {
+    cursor: default;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+  }
+
+  .statcard-row-value-line {
+    display: flex;
+    align-items: baseline;
+    gap: var(--statcard-row-value-gap, 8px);
+    flex-wrap: wrap;
+  }
+
+  .statcard-row-additional {
+    font-size: var(--statcard-row-additional-font-size, 12px);
+    font-weight: var(--statcard-row-additional-font-weight, 400);
+    color: var(--statcard-row-additional-color, #9ca3af);
+    line-height: 1.4;
+  }
+
+  /* Breakdown grid */
+  .statcard-breakdown-heading {
+    font-size: var(--statcard-breakdown-heading-font-size, 11px);
+    font-weight: var(--statcard-breakdown-heading-font-weight, 600);
+    color: var(--statcard-breakdown-heading-color, #6b7280);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin-top: var(--statcard-breakdown-heading-margin-top, 6px);
+  }
+
+  .statcard-breakdown-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--statcard-breakdown-col-min, 100px), 1fr));
+    gap: var(--statcard-breakdown-gap, 8px);
+    margin-top: var(--statcard-breakdown-margin-top, 4px);
+  }
+
+  .statcard-breakdown-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--statcard-breakdown-item-gap, 2px);
+  }
+
+  .statcard-breakdown-label {
+    font-size: var(--statcard-breakdown-label-font-size, 11px);
+    font-weight: var(--statcard-breakdown-label-font-weight, 400);
+    color: var(--statcard-breakdown-label-color, #9ca3af);
+    line-height: 1.4;
+  }
+
+  .statcard-breakdown-value {
+    font-size: var(--statcard-breakdown-value-font-size, 14px);
+    font-weight: var(--statcard-breakdown-value-font-weight, 600);
+    color: var(--statcard-breakdown-value-color, inherit);
+    line-height: 1.2;
+  }
+
+  .statcard-children {
+    margin-top: var(--statcard-children-margin-top, 4px);
   }
 
   .statcard-footer {

--- a/src/lib/StatCard/properties.ts
+++ b/src/lib/StatCard/properties.ts
@@ -4,6 +4,53 @@ export type StatCardProperties = OptionalStatCardProperties & StatCardEventPrope
 
 export type MandatoryStatCardProperties = Record<string, never>;
 
+export type StatCardTooltip = {
+  text: string;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  testId?: string;
+};
+
+export type StatCardBreakdownItem = {
+  label: string;
+  value: string;
+  change?: number;
+  invertChangeColors?: boolean;
+};
+
+/**
+ * A single metric row inside a multi-row StatCard.
+ *
+ * @example
+ * ```ts
+ * const row: StatCardRow = {
+ *   heading: 'Gross Revenue',
+ *   value: '₹12.4Cr',
+ *   change: 8.2,
+ *   tooltip: { text: 'Revenue before returns' }
+ * };
+ * ```
+ */
+export type StatCardRow = {
+  /** The metric value string for this row (e.g. "₹1.23Cr", "98.4%"). */
+  value: string;
+  /** Optional row-level heading label. */
+  heading?: string;
+  /** Numeric change for the delta indicator. */
+  change?: number;
+  /** Invert delta colors for lower-is-better metrics on this row. */
+  invertChangeColors?: boolean;
+  /** Additional descriptive text rendered after the delta. */
+  additionalContent?: string;
+  /** Tooltip shown on the row heading. */
+  tooltip?: StatCardTooltip;
+  /** Heading rendered above the breakdown grid. */
+  breakdownHeading?: string;
+  /** Breakdown items rendered in a grid below the row value. */
+  breakdown?: StatCardBreakdownItem[];
+  /** Test selector for the row root element. */
+  testId?: string;
+};
+
 export type OptionalStatCardProperties = {
   /** Card heading label. */
   title?: string;
@@ -19,6 +66,19 @@ export type OptionalStatCardProperties = {
   footer?: Snippet;
   /** Replaces the string `value` with a custom snippet for advanced value rendering. */
   valueSnippet?: Snippet;
+  /**
+   * Multiple metric rows. When provided, replaces the single value/delta row with
+   * a column of rows separated by dividers.
+   */
+  rows?: StatCardRow[];
+  /** Tooltip shown on the card title. */
+  tooltip?: StatCardTooltip;
+  /** Checkbox rendered next to the title. */
+  checkbox?: { text: string; checked?: boolean };
+  /** Snippet rendered at the right edge of the header row. */
+  headerRight?: Snippet;
+  /** Snippet rendered inside the card body, after any rows. */
+  children?: Snippet;
   /** Renders as `data-pw` on the root element for Playwright test selection. */
   testId?: string;
   /** Extra CSS class names appended to the root element. */
@@ -28,4 +88,6 @@ export type OptionalStatCardProperties = {
 export type StatCardEventProperties = {
   /** Makes the card interactive: adds `role="button"`, `tabindex=0`, and wires click/Enter/Space. */
   onclick?: (event: MouseEvent) => void;
+  /** Fired when the header checkbox changes. */
+  onCheckboxChange?: (checked: boolean) => void;
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -71,6 +71,7 @@ export { default as StatCard } from './StatCard/StatCard.svelte';
 export { default as DeltaIndicator } from './DeltaIndicator/DeltaIndicator.svelte';
 export { default as DualAxisBarChart } from './DualAxisBarChart/DualAxisBarChart.svelte';
 export { default as FunnelChart } from './FunnelChart/FunnelChart.svelte';
+export { default as ProportionBar } from './ProportionBar/ProportionBar.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -139,6 +140,7 @@ export type * from './StatCard/properties';
 export type * from './DeltaIndicator/properties';
 export type * from './DualAxisBarChart/properties';
 export type * from './FunnelChart/properties';
+export type * from './ProportionBar/properties';
 export type * from './_chart/highlight';
 
 export { validateInput } from './utils';

--- a/src/routes/components/_nav.ts
+++ b/src/routes/components/_nav.ts
@@ -78,6 +78,8 @@ export const componentNav: NavGroup[] = [
   {
     category: 'Data Visualization',
     items: [
+      { name: 'StatCard', slug: 'stat-card' },
+      { name: 'ProportionBar', slug: 'proportion-bar' },
       { name: 'LineChart', slug: 'line-chart' },
       { name: 'AreaChart', slug: 'area-chart' },
       { name: 'BarChart', slug: 'bar-chart' },

--- a/src/routes/components/proportion-bar/+page.svelte
+++ b/src/routes/components/proportion-bar/+page.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import ProportionBar from '$lib/ProportionBar/ProportionBar.svelte';
+
+  const paymentMethodSegments = [
+    { label: 'UPI', value: 4820 },
+    { label: 'Cards', value: 2150 },
+    { label: 'Wallets', value: 870 },
+    { label: 'NetBanking', value: 560 },
+    { label: 'COD', value: 210 }
+  ];
+
+  const orderStatusSegments = [
+    { label: 'Delivered', value: 7200, color: '#22c55e' },
+    { label: 'In Transit', value: 1800, color: '#f59e0b' },
+    { label: 'Cancelled', value: 540, color: '#ef4444' },
+    { label: 'RTO', value: 260, color: '#8b5cf6' }
+  ];
+
+  const currencyFormat = (absoluteValue: number, percent: number): string =>
+    `₹${(absoluteValue / 100).toFixed(1)}L (${Math.round(percent)}%)`;
+
+  const revenueSegments = [
+    { label: 'Breeze Checkout', value: 6800 },
+    { label: 'Direct', value: 2400 },
+    { label: 'Marketplace', value: 800 }
+  ];
+
+  // Negative and non-finite values are sanitized to zero so the rendered widths
+  // always stay within 0–100%.
+  const robustSegments = [
+    { label: 'Valid A', value: 600 },
+    { label: 'Negative (ignored)', value: -200 },
+    { label: 'Valid B', value: 400 },
+    { label: 'NaN (ignored)', value: Number.NaN }
+  ];
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Data Visualization</span>
+  <h1>ProportionBar</h1>
+</div>
+
+<p class="intro">
+  A horizontal bar that visualises how a total is distributed across segments. Renders an SVG track
+  with proportional coloured bands and an optional legend listing each segment with its label and
+  formatted value.
+</p>
+
+<h3>Payment Methods Distribution</h3>
+<div class="demo-row" style="flex-direction: column; align-items: stretch; max-width: 480px;">
+  <ProportionBar segments={paymentMethodSegments} testId="payment-methods-bar" />
+</div>
+
+<h3>Order Status Breakdown (custom colors)</h3>
+<div class="demo-row" style="flex-direction: column; align-items: stretch; max-width: 480px;">
+  <ProportionBar segments={orderStatusSegments} testId="order-status-bar" />
+</div>
+
+<h3>Revenue Channels — Custom Format & Track Height</h3>
+<p class="state-display">Formatted as lakhs; track height set to 14px</p>
+<div class="demo-row" style="flex-direction: column; align-items: stretch; max-width: 480px;">
+  <ProportionBar
+    segments={revenueSegments}
+    valueFormat={currencyFormat}
+    trackHeight="14px"
+    testId="revenue-bar"
+  />
+</div>
+
+<h3>No Legend</h3>
+<p class="state-display">
+  With the legend hidden, the SVG carries the full breakdown as its accessible name.
+</p>
+<div class="demo-row" style="max-width: 480px;">
+  <ProportionBar segments={paymentMethodSegments} showLegend={false} testId="no-legend-bar" />
+</div>
+
+<h3>Handles Invalid Values</h3>
+<p class="state-display">Negative and non-finite segment values are ignored (treated as zero).</p>
+<div class="demo-row" style="flex-direction: column; align-items: stretch; max-width: 480px;">
+  <ProportionBar segments={robustSegments} testId="robust-bar" />
+</div>
+
+<h3>CSS Variable Theming</h3>
+<div
+  class="demo-row themed-demo"
+  style="flex-direction: column; align-items: stretch; max-width: 480px;"
+>
+  <ProportionBar
+    segments={orderStatusSegments}
+    trackHeight="6px"
+    classes="proportion-themed"
+    testId="themed-bar"
+  />
+</div>
+
+<style>
+  .intro {
+    color: var(--doc-text-secondary);
+    margin-bottom: 24px;
+    max-width: 640px;
+  }
+
+  .themed-demo {
+    --proportion-bar-legend-label-color: var(--doc-text-primary);
+    --proportion-bar-legend-value-color: var(--doc-text-heading);
+    --proportion-bar-track-border-radius: 2px;
+  }
+</style>

--- a/src/routes/components/stat-card/+page.svelte
+++ b/src/routes/components/stat-card/+page.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import StatCard from '$lib/StatCard/StatCard.svelte';
+  import ProportionBar from '$lib/ProportionBar/ProportionBar.svelte';
+
+  let checkboxChecked = $state(false);
+  let headerlessChecked = $state(false);
+  let clickableChecked = $state(false);
+  let cardClicks = $state(0);
+
+  const checkoutRows = [
+    {
+      heading: 'Gross Revenue',
+      value: '₹12.4Cr',
+      change: 8.2,
+      tooltip: { text: 'Total revenue before returns and cancellations', position: 'top' as const }
+    },
+    {
+      heading: 'Net Revenue',
+      value: '₹10.9Cr',
+      change: 5.7,
+      additionalContent: 'after RTO'
+    },
+    {
+      heading: 'RTO Rate',
+      value: '12.1%',
+      change: -2.3,
+      invertChangeColors: true,
+      tooltip: { text: 'Return to Origin rate — lower is better' }
+    }
+  ];
+
+  const conversionRow = [
+    {
+      heading: 'Checkout Conversion',
+      value: '68.4%',
+      change: 3.1,
+      breakdownHeading: 'By Device',
+      breakdown: [
+        { label: 'Mobile', value: '71.2%', change: 4.0 },
+        { label: 'Desktop', value: '63.8%', change: 1.5 },
+        { label: 'Tablet', value: '58.1%', change: -0.8, invertChangeColors: false }
+      ]
+    }
+  ];
+
+  const paymentSegments = [
+    { label: 'UPI', value: 4820 },
+    { label: 'Cards', value: 2150 },
+    { label: 'Wallets', value: 870 }
+  ];
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Data Visualization</span>
+  <h1>StatCard</h1>
+</div>
+
+<p class="intro">
+  A flexible metric card for displaying KPIs. Supports a single value with a delta badge, or
+  multiple metric rows with per-row headings, tooltips, deltas, and breakdown grids. Additional
+  header slots allow tooltips, checkboxes, and custom right-aligned content.
+</p>
+
+<h3>Basic — Value + Delta</h3>
+<div class="demo-row" style="align-items: stretch;">
+  <StatCard title="Total Orders" value="8,610" delta="+12.5%" testId="basic-positive" />
+  <StatCard title="RTO Rate" value="11.8%" delta="-2.3%" testId="basic-negative" />
+  <StatCard title="Avg Order Value" value="₹1,240" delta="0%" testId="basic-neutral" />
+</div>
+
+<h3>With Subtitle</h3>
+<div class="demo-row">
+  <StatCard
+    title="Checkout Conversion"
+    value="68.4%"
+    delta="+3.1%"
+    subtitle="vs last 30 days"
+    testId="with-subtitle"
+  />
+</div>
+
+<h3>With Title Tooltip</h3>
+<div class="demo-row">
+  <StatCard
+    title="Net Revenue"
+    value="₹10.9Cr"
+    delta="+5.7%"
+    tooltip={{ text: 'Revenue after returns, cancellations, and RTO deductions', position: 'top' }}
+    testId="with-tooltip"
+  />
+</div>
+
+<h3>With Header Checkbox</h3>
+<div class="demo-row">
+  <StatCard
+    title="Include Returns"
+    value={checkboxChecked ? '₹12.4Cr' : '₹10.9Cr'}
+    delta={checkboxChecked ? '+8.2%' : '+5.7%'}
+    checkbox={{ text: 'With returns', checked: checkboxChecked }}
+    onCheckboxChange={(checked) => {
+      checkboxChecked = checked;
+    }}
+    testId="with-checkbox"
+  />
+</div>
+
+<h3>Header Without Title</h3>
+<p class="intro" style="margin-bottom: 12px;">
+  A checkbox-only header renders even when no title is set.
+</p>
+<div class="demo-row">
+  <StatCard
+    value="₹10.9Cr"
+    delta="+5.7%"
+    checkbox={{ text: 'Include returns', checked: headerlessChecked }}
+    onCheckboxChange={(checked) => {
+      headerlessChecked = checked;
+    }}
+    testId="headerless-card"
+  />
+</div>
+
+<h3>Clickable Card With Checkbox</h3>
+<p class="intro" style="margin-bottom: 12px;">
+  Toggling the checkbox does not trigger the card's click action. Card clicks: {cardClicks}
+</p>
+<div class="demo-row">
+  <StatCard
+    title="View Report"
+    value="68.4%"
+    delta="+3.1%"
+    checkbox={{ text: 'Live data', checked: clickableChecked }}
+    onCheckboxChange={(checked) => {
+      clickableChecked = checked;
+    }}
+    onclick={() => {
+      cardClicks += 1;
+    }}
+    testId="clickable-checkbox-card"
+  />
+  <span data-pw="card-click-count">{cardClicks}</span>
+</div>
+
+<h3>Multi-Row — Revenue Breakdown</h3>
+<div class="demo-row">
+  <StatCard title="Revenue Overview" rows={checkoutRows} testId="multi-row" />
+</div>
+
+<h3>Multi-Row with Breakdown Grid</h3>
+<div class="demo-row">
+  <StatCard title="Conversion Metrics" rows={conversionRow} testId="with-breakdown" />
+</div>
+
+<h3>With Custom Children (ProportionBar)</h3>
+<div class="demo-row">
+  <StatCard title="Payment Methods" value="8,610 orders" testId="with-children">
+    <ProportionBar segments={paymentSegments} trackHeight="8px" />
+  </StatCard>
+</div>
+
+<h3>Interactive (clickable)</h3>
+<div class="demo-row">
+  <StatCard
+    title="View Report"
+    value="68.4%"
+    delta="+3.1%"
+    onclick={() => alert('Card clicked!')}
+    testId="interactive-card"
+  />
+</div>
+
+<h3>With Footer Snippet</h3>
+<div class="demo-row">
+  <StatCard title="Total Orders" value="8,610" delta="+12.5%" testId="with-footer">
+    {#snippet footer()}
+      <div style="font-size: 12px; color: #6b7280;">Updated 5 minutes ago</div>
+    {/snippet}
+  </StatCard>
+</div>
+
+<style>
+  .intro {
+    color: var(--doc-text-secondary);
+    margin-bottom: 24px;
+    max-width: 640px;
+  }
+</style>

--- a/src/wc/components/ProportionBar.wc.svelte
+++ b/src/wc/components/ProportionBar.wc.svelte
@@ -1,0 +1,24 @@
+<svelte:options
+  customElement={{
+    tag: 'sui-proportion-bar',
+    shadow: 'open',
+    props: {
+      segments: { type: 'Object' },
+      showLegend: { type: 'Boolean', attribute: 'show-legend' },
+      // `valueFormat` is a function and cannot cross the HTML-attribute boundary,
+      // so it is exposed as a JS property only (no `attribute` mapping):
+      //   document.querySelector('sui-proportion-bar').valueFormat = (v, p) => `${v} (${p}%)`;
+      valueFormat: { type: 'Object' },
+      trackHeight: { type: 'String', attribute: 'track-height' },
+      testId: { type: 'String', attribute: 'test-id' },
+      classes: { type: 'String' }
+    }
+  }}
+/>
+
+<script lang="ts">
+  import ProportionBar from '$lib/ProportionBar/ProportionBar.svelte';
+  let props = $props();
+</script>
+
+<ProportionBar {...props} />

--- a/src/wc/components/StatCard.wc.svelte
+++ b/src/wc/components/StatCard.wc.svelte
@@ -8,6 +8,13 @@
       delta: { type: 'String', reflect: true },
       deltaPositive: { type: 'Boolean', attribute: 'delta-positive', reflect: true },
       subtitle: { type: 'String', reflect: true },
+      // Complex props (arrays / objects / functions) cannot cross the HTML-attribute
+      // boundary, so they are exposed as JS properties only:
+      //   document.querySelector('sui-stat-card').rows = [{ heading: 'Revenue', value: '₹1.2Cr', change: 8.2 }];
+      rows: { type: 'Object' },
+      tooltip: { type: 'Object' },
+      checkbox: { type: 'Object' },
+      onCheckboxChange: { type: 'Object' },
       classes: { type: 'String' },
       testId: { type: 'String', attribute: 'test-id' },
       onclick: { type: 'Object' }
@@ -21,10 +28,14 @@
 </script>
 
 <StatCard {...props}>
+  {#snippet headerRight()}
+    <slot name="header-right"></slot>
+  {/snippet}
   {#snippet footer()}
     <slot name="footer"></slot>
   {/snippet}
   {#snippet valueSnippet()}
     <slot name="value-snippet"></slot>
   {/snippet}
+  <slot></slot>
 </StatCard>

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -57,3 +57,4 @@ import './components/DateRangePicker.wc.svelte';
 import './components/LottiePlayer.wc.svelte';
 import './components/StatCard.wc.svelte';
 import './components/DeltaIndicator.wc.svelte';
+import './components/ProportionBar.wc.svelte';

--- a/tests/proportion-bar.test.ts
+++ b/tests/proportion-bar.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the ProportionBar: one rect + one legend item per segment, widths that
+// sum to the full track, the accessible SVG summary when the legend is hidden,
+// and sanitization of negative / non-finite segment values.
+test.describe('ProportionBar', () => {
+  test('renders one rect and one legend item per segment', async ({ page }) => {
+    await page.goto('/components/proportion-bar');
+
+    const bar = page.locator('[data-pw="payment-methods-bar"]');
+    await expect(bar).toBeVisible();
+    await expect(bar.locator('.proportion-bar-svg rect')).toHaveCount(5);
+    await expect(bar.locator('.proportion-bar-legend-item')).toHaveCount(5);
+  });
+
+  test('segment widths fill the whole track (~100%)', async ({ page }) => {
+    await page.goto('/components/proportion-bar');
+
+    const widths = await page
+      .locator('[data-pw="payment-methods-bar"] .proportion-bar-svg rect')
+      .evaluateAll((rects) => rects.map((rect) => Number(rect.getAttribute('width'))));
+    const total = widths.reduce((sum, width) => sum + width, 0);
+    expect(Math.round(total)).toBe(100);
+  });
+
+  test('exposes an accessible SVG summary when the legend is hidden', async ({ page }) => {
+    await page.goto('/components/proportion-bar');
+
+    const bar = page.locator('[data-pw="no-legend-bar"]');
+    await expect(bar.locator('.proportion-bar-legend')).toHaveCount(0);
+
+    const svg = bar.locator('.proportion-bar-svg');
+    await expect(svg).toHaveAttribute('role', 'img');
+    await expect(svg).toHaveAttribute('aria-label', /UPI/);
+  });
+
+  test('ignores negative and non-finite values (widths stay within 0–100)', async ({ page }) => {
+    await page.goto('/components/proportion-bar');
+
+    const rects = page.locator('[data-pw="robust-bar"] .proportion-bar-svg rect');
+    await expect(rects).toHaveCount(4);
+
+    const widths = await rects.evaluateAll((nodes) =>
+      nodes.map((node) => Number(node.getAttribute('width')))
+    );
+    for (const width of widths) {
+      expect(width).toBeGreaterThanOrEqual(0);
+      expect(width).toBeLessThanOrEqual(100);
+    }
+    // Only 600 and 400 are valid -> 60% and 40%; the negative and NaN bands are 0.
+    expect(Math.round(widths.reduce((sum, width) => sum + width, 0))).toBe(100);
+  });
+});

--- a/tests/stat-card.test.ts
+++ b/tests/stat-card.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the extended StatCard: backward-compatible single value, multi-row layout
+// with dividers + per-row deltas, the breakdown grid, a header that renders without
+// a title, the onCheckboxChange callback, and the guard that keeps checkbox
+// interaction from firing an interactive card's click action.
+test.describe('StatCard', () => {
+  test('renders a basic single value (backward compatible)', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="basic-positive"]');
+    await expect(card).toBeVisible();
+    await expect(card.locator('.statcard-value')).toHaveText('8,610');
+  });
+
+  test('multi-row card renders a row and a divider per metric', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="multi-row"]');
+    await expect(card.locator('.statcard-row')).toHaveCount(3);
+    await expect(card.locator('.statcard-row-divider')).toHaveCount(2);
+    await expect(card.locator('.delta-indicator')).toHaveCount(3);
+  });
+
+  test('breakdown grid renders one item per breakdown entry', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="with-breakdown"]');
+    await expect(card.locator('.statcard-breakdown-item')).toHaveCount(3);
+  });
+
+  test('renders the header even when no title is set', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="headerless-card"]');
+    await expect(card.locator('.statcard-header')).toHaveCount(1);
+    await expect(card.locator('.statcard-title')).toHaveCount(0);
+    await expect(card.getByRole('checkbox')).toBeVisible();
+  });
+
+  test('checkbox toggle fires onCheckboxChange', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="with-checkbox"]');
+    await expect(card.locator('.statcard-value')).toHaveText('₹10.9Cr');
+    await card.getByRole('checkbox').click();
+    await expect(card.locator('.statcard-value')).toHaveText('₹12.4Cr');
+  });
+
+  test('toggling the checkbox does not trigger the card action', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="clickable-checkbox-card"]');
+    const clickCount = page.locator('[data-pw="card-click-count"]');
+    await expect(clickCount).toHaveText('0');
+
+    // Checkbox toggles without firing the card's onclick.
+    await card.getByRole('checkbox').click();
+    await expect(card.locator('.box')).toHaveClass(/checked/);
+    await expect(clickCount).toHaveText('0');
+
+    // Clicking the card body still fires the action.
+    await card.locator('.statcard-value').click();
+    await expect(clickCount).toHaveText('1');
+  });
+});


### PR DESCRIPTION
## What

- **Extend the existing `StatCard` (fully backward-compatible)** with the richer features dashboards need:
  - `rows: StatCardRow[]` — **multi-row** values, each with an optional `heading`, a `change` rendered via the library **`DeltaIndicator`** (arrow + %), `additionalContent`, a per-row `tooltip`, and an optional **`breakdown` drill-down grid** (keyed metrics, each with its own value + delta).
  - Title `tooltip`, a `checkbox` (library **`CheckListItem`**), a `headerRight` snippet, and a **`children`** snippet (for embedding charts inside the card).
  - All existing props (`value`, `delta`, `deltaPositive`, `subtitle`, `footer`, `valueSnippet`, `onclick`) keep working unchanged — the single-value path is untouched.
- **New `ProportionBar` component** — a horizontal proportion bar (SVG segments summing to 100%, rounded track) with an optional legend; built-in 5-colour palette; themeable via `--proportion-bar-*`.

Composes existing library primitives (`DeltaIndicator`, `Tooltip`, `CheckListItem`) rather than reinventing them.

## Why

Unblocks the Lighthouse hold-and-fold: folding the project-owned `StatisticsCard` (**25 call-sites**), `SingleStatCard`, and `StackedBarChart` onto the library. The basic `StatCard` already covered the single-value case (`SingleStatCard`); these additions cover the rich analytics card; `ProportionBar` covers `StackedBarChart`.

## Demos

- `/components/stat-card` — new multi-row, breakdown drill-down, checkbox + `headerRight`, and `children` examples.
- `/components/proportion-bar` — with/without legend + custom colours.

## Verified

- `pnpm run check` → **0 errors** · `pnpm run lint` (prettier + eslint, strict) → **clean** · `pnpm run build` → **clean** (publint: only the pre-existing repo-url suggestion).
- Live on the demo route: 11 StatCards render (multi-row, breakdown grid, checkboxes, delta indicators all present); ProportionBar renders segments + legend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new proportion/stacked bar visualization with optional legend, custom formatting, theming, and web component support.
  * Expanded the stat card to support multi-row layouts, tooltips, checkboxes, header actions, breakdown details, and custom content.
  * Added demo pages and navigation entries for both components so they’re easy to explore in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->