### PR TITLE
feat: add rowsDirection to StatCard for horizontal section layout

### DIFF
--- a/docs/StatCard.md
+++ b/docs/StatCard.md
@@ -109,6 +109,22 @@ Pass `rows` to render several metrics stacked and divider-separated. Each row ca
 />
 ```
 
+### Horizontal Rows
+
+Set `rowsDirection="row"` to lay the sections side by side with vertical dividers (each section flexes to share the width equally) — useful for dashboard cards that show several related metrics in one row.
+
+```svelte
+<StatCard
+  title="Revenue Overview"
+  rowsDirection="row"
+  rows={[
+    { heading: 'Gross Revenue', value: '₹12.4Cr', change: 8.2 },
+    { heading: 'Net Revenue', value: '₹10.9Cr', change: 5.7 },
+    { heading: 'RTO Rate', value: '12.1%', change: -2.3, invertChangeColors: true }
+  ]}
+/>
+```
+
 ### Breakdown Grid
 
 A row can carry a `breakdown` array, rendered as a labelled grid beneath the row value.
@@ -182,6 +198,7 @@ The header renders even without a title. `onCheckboxChange` fires with the new c
 | footer        | `Snippet`                     | No       | `-`     | Snippet rendered in the card footer area, separated by a border-top line.                                                                             |
 | valueSnippet  | `Snippet`                     | No       | `-`     | Replaces the string `value` with a custom snippet for advanced value rendering.                                                                       |
 | rows          | `StatCardRow[]`               | No       | `-`     | Multiple metric rows. When set, replaces the single value/delta row with a divider-separated column. Each row supports `heading`, `change`, `invertChangeColors`, `tooltip`, `additionalContent`, `breakdownHeading`, and a `breakdown` grid. |
+| rowsDirection | `'column' \| 'row'`           | No       | `'column'` | Layout direction for `rows`. `'column'` stacks rows vertically with horizontal dividers; `'row'` lays the sections side by side with vertical dividers, each section flexing to share the width equally. |
 | tooltip       | `StatCardTooltip`             | No       | `-`     | Tooltip shown on the card title — `{ text, position?, testId? }`.                                                                                     |
 | checkbox      | `{ text: string; checked?: boolean }` | No | `-` | Renders a checkbox next to the title. The header is shown even when `title` is omitted. Pair with `onCheckboxChange` for a controlled checkbox.       |
 | headerRight   | `Snippet`                     | No       | `-`     | Snippet rendered at the right edge of the header row.                                                                                                 |
@@ -248,7 +265,8 @@ Override these custom properties to theme the component.
 | `--statcard-row-gap`              | `4px`                    | gap            | Vertical gap between a row's heading, value line, and breakdown.              |
 | `--statcard-row-divider-height`   | `1px`                    | height         | Thickness of the line between rows.                                           |
 | `--statcard-row-divider-color`    | `#e5e7eb`                | background     | Colour of the row divider line.                                              |
-| `--statcard-row-divider-margin`   | `8px 0`                  | margin         | Spacing around the row divider line.                                          |
+| `--statcard-row-divider-margin`   | `8px 0`                  | margin         | Spacing around the row divider line (vertical/column layout).                 |
+| `--statcard-row-divider-margin-horizontal` | `0 16px`        | margin         | Spacing around the vertical divider when `rowsDirection="row"`.               |
 | `--statcard-row-heading-color`    | `#6b7280`                | color          | Colour of a row heading.                                                      |
 | `--statcard-breakdown-col-min`    | `100px`                  | grid-template  | Minimum column width of the breakdown grid (auto-fill).                       |
 | `--statcard-breakdown-gap`        | `8px`                    | gap            | Gap between breakdown items.                                                  |

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -13,6 +13,7 @@
     footer,
     valueSnippet,
     rows,
+    rowsDirection = 'column',
     tooltip,
     checkbox,
     headerRight,
@@ -127,7 +128,7 @@
   {/if}
 
   {#if hasRows && rows}
-    <div class="statcard-rows">
+    <div class="statcard-rows" class:statcard-rows-horizontal={rowsDirection === 'row'}>
       {#each rows as row, rowIndex (rowIndex)}
         {#if rowIndex > 0}
           <div class="statcard-row-divider"></div>
@@ -330,6 +331,25 @@
     height: var(--statcard-row-divider-height, 1px);
     background: var(--statcard-row-divider-color, #e5e7eb);
     margin: var(--statcard-row-divider-margin, 8px 0);
+  }
+
+  /* Horizontal layout: lay the metric sections side by side with vertical
+     dividers. Each section flexes to share the available width equally. */
+  .statcard-rows-horizontal {
+    flex-direction: row;
+  }
+
+  .statcard-rows-horizontal .statcard-row {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .statcard-rows-horizontal .statcard-row-divider {
+    align-self: stretch;
+    flex-shrink: 0;
+    width: var(--statcard-row-divider-height, 1px);
+    height: auto;
+    margin: var(--statcard-row-divider-margin-horizontal, 0 16px);
   }
 
   .statcard-row {

--- a/src/lib/StatCard/properties.ts
+++ b/src/lib/StatCard/properties.ts
@@ -71,6 +71,12 @@ export type OptionalStatCardProperties = {
    * a column of rows separated by dividers.
    */
   rows?: StatCardRow[];
+  /**
+   * Layout direction for `rows`. `'column'` (default) stacks rows vertically with
+   * horizontal dividers; `'row'` lays the sections side by side with vertical
+   * dividers, each section flexing to share the width equally.
+   */
+  rowsDirection?: 'column' | 'row';
   /** Tooltip shown on the card title. */
   tooltip?: StatCardTooltip;
   /** Checkbox rendered next to the title. */

--- a/src/routes/components/stat-card/+page.svelte
+++ b/src/routes/components/stat-card/+page.svelte
@@ -146,6 +146,16 @@
   <StatCard title="Revenue Overview" rows={checkoutRows} testId="multi-row" />
 </div>
 
+<h3>Horizontal Rows (sections side by side)</h3>
+<div class="demo-row">
+  <StatCard
+    title="Revenue Overview"
+    rows={checkoutRows}
+    rowsDirection="row"
+    testId="horizontal-rows"
+  />
+</div>
+
 <h3>Multi-Row with Breakdown Grid</h3>
 <div class="demo-row">
   <StatCard title="Conversion Metrics" rows={conversionRow} testId="with-breakdown" />

--- a/src/wc/components/StatCard.wc.svelte
+++ b/src/wc/components/StatCard.wc.svelte
@@ -12,6 +12,7 @@
       // boundary, so they are exposed as JS properties only:
       //   document.querySelector('sui-stat-card').rows = [{ heading: 'Revenue', value: '₹1.2Cr', change: 8.2 }];
       rows: { type: 'Object' },
+      rowsDirection: { type: 'String', attribute: 'rows-direction' },
       tooltip: { type: 'Object' },
       checkbox: { type: 'Object' },
       onCheckboxChange: { type: 'Object' },

--- a/tests/stat-card.test.ts
+++ b/tests/stat-card.test.ts
@@ -22,6 +22,21 @@ test.describe('StatCard', () => {
     await expect(card.locator('.delta-indicator')).toHaveCount(3);
   });
 
+  test('horizontal rows lay the sections side by side', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const rowsContainer = page.locator('[data-pw="horizontal-rows"] .statcard-rows');
+    await expect(rowsContainer).toHaveClass(/statcard-rows-horizontal/);
+    await expect(rowsContainer).toHaveCSS('flex-direction', 'row');
+
+    // Sections sit side by side: every row shares the same vertical top.
+    const tops = await page
+      .locator('[data-pw="horizontal-rows"] .statcard-row')
+      .evaluateAll((rows) => rows.map((row) => Math.round(row.getBoundingClientRect().top)));
+    expect(tops.length).toBe(3);
+    expect(new Set(tops).size).toBe(1);
+  });
+
   test('breakdown grid renders one item per breakdown entry', async ({ page }) => {
     await page.goto('/components/stat-card');
 


### PR DESCRIPTION
## What
Adds `rowsDirection: 'column' | 'row'` to `StatCard`. Default `'column'` (backward compatible) stacks rows vertically with horizontal dividers; `'row'` lays the metric sections **side by side** with vertical dividers, each section `flex: 1` to share the width equally.

## Why
Unblocks folding Lighthouse's `StatisticsCard` onto the library `StatCard`. StatisticsCard lays its multi-section body horizontally on desktop — this was the last structural gap before that migration (its single-section + header + breakdown already map cleanly).

## Changes
- **`StatCard.svelte`** — `rowsDirection` prop + `.statcard-rows-horizontal` (flex-direction: row; sections `flex: 1; min-width: 0`; divider becomes vertical, reusing `--statcard-row-divider-height` as thickness, with `--statcard-row-divider-margin-horizontal`).
- **`properties.ts`** — typed `rowsDirection?: 'column' | 'row'`.
- **`StatCard.wc.svelte`** — web-component parity (`rows-direction` attribute).
- **Demo** — "Horizontal Rows" variant. **Docs** — prop row, usage example, new CSS var.
- **Test** — asserts `flex-direction: row` and that the sections share the same top (side by side).

## Proof of testing
- `check` **0 errors** · `check:wc` clean (only the pre-existing `LottiePlayer.wc.svelte` `$host` errors, unrelated) · lint clean · build clean.
- `tests/stat-card.test.ts` — **7/7 pass**, incl. the new _"horizontal rows lay the sections side by side"_.
- DOM at the real touch point `/components/stat-card`, **both light + dark**:
  `{ flexDirection: "row", sections: 3, dividers: 2, sectionTops: [<single value>] }` → 3 sections side by side, 2 vertical dividers, verified in both themes. (Both-theme screenshots captured locally.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for arranging StatCard rows side by side with a new horizontal layout option.
  * Exposed the new layout setting in both the component API and the custom element attribute.

* **Documentation**
  * Updated the StatCard docs with a horizontal rows example, prop details, and spacing guidance for vertical dividers.

* **Tests**
  * Added end-to-end coverage for the horizontal rows layout to verify alignment and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->