### PR TITLE
feat(Combobox): add multi-select, create, action & limit

### DIFF
--- a/docs/Combobox.md
+++ b/docs/Combobox.md
@@ -2,6 +2,8 @@
 
 A text input with an attached dropdown list that filters options as the user types. Built on the library's Input component internally, so it inherits Input's validation, text transformers, and formatting capabilities via the `inputProperties` pass-through. Implements the WAI-ARIA combobox pattern with full keyboard navigation (ArrowUp/Down to highlight, Enter to select, Escape to close, Tab to close and move focus). The dropdown opens on focus or typing and closes on outside click, Escape, or item selection. Supports disabled items, custom item rendering via a Snippet, custom filter logic, a custom empty-state Snippet, input prefix/suffix slots, dropdown header/footer slots, and bindable `value`, `inputValue`, `open`, and `highlightedIndex` state.
 
+It also supports **multi-select** (`multiple`): picks become removable pills inside the control, tracked via a bindable `selected` array, with optional inline **create** (`allowCreate`), a **selection limit** (`maxSelected`), and a persistent custom **action** row.
+
 ## Usage
 
 ```svelte
@@ -18,6 +20,49 @@ A text input with an attached dropdown list that filters options as the user typ
 </script>
 
 <Combobox items={fruits} bind:value={selected} placeholder="Search fruits..." />
+```
+
+### Multi-select (pills)
+
+Set `multiple` and bind a `selected` string array. Picked options render as removable pills; `Backspace` on an empty input removes the last pill.
+
+```svelte
+<script>
+  let picked = $state([]);
+</script>
+
+<Combobox items={fruits} multiple bind:selected={picked} placeholder="Pick fruits…" />
+```
+
+### Multi-select with create
+
+`allowCreate` offers a "Create …" row when the typed value has no match. Use `oncreate` to persist the new option into your own `items` list.
+
+```svelte
+<Combobox
+  items={tagItems}
+  multiple
+  allowCreate
+  bind:selected={tags}
+  oncreate={(value) => (tagItems = [...tagItems, { id: value, label: value }])}
+/>
+```
+
+### Selection limit
+
+```svelte
+<Combobox items={fruits} multiple maxSelected={3} bind:selected={picked} />
+```
+
+### Custom action row
+
+```svelte
+<Combobox
+  items={fruits}
+  multiple
+  bind:selected={picked}
+  action={{ label: 'Manage…', onClick: openManager }}
+/>
 ```
 
 ### With Custom Item Rendering
@@ -212,6 +257,13 @@ Pass Input props via `inputProperties` to enable validation, text formatting, an
 | inputProperties  | `OptionalInputProperties`                                   | No       | `-`              | Pass-through props for the internal Input component. Use for validation (`validators`, `validationPattern`, `inProgressPattern`), text formatting (`textTransformers`, `textViewPresentation`), `dataType`, `maxLength`, `minLength`, `useTextArea`, `label`, `onErrorMessage`, `infoMessage`, etc. See Input component docs for the full list. |
 | inputEventProperties | `InputEventProperties`                                  | No       | `-`              | Pass-through event handlers for the internal Input component. Use for `onPaste`, `onStateChange`, `onClick`, etc. Note: `onInput`, `onFocus`, `onBlur`, and `onKeyDown` are managed by Combobox and forwarded — use Combobox's own events for these. |
 | filterFn         | `(item: ComboboxItem, query: string) => boolean`            | No       | case-insensitive `includes` | Custom filter function called for each item when `inputValue` is non-empty. Return `true` to include the item. Use for startsWith, fuzzy matching, or server-side filtering (always return `true` and update `items` externally). |
+| multiple         | `boolean`                                                   | No       | `false`          | Enable multi-select: picked options become removable pills inside the control, and selection is tracked in `selected` instead of `value`.                             |
+| selected         | `string[]`                                                  | No       | `[]`             | Bindable. Array of selected item `id`s (multi-select mode). Use `bind:selected`.                                                                                       |
+| maxSelected      | `number`                                                    | No       | `-`              | Cap the number of selections (multi-select). At the limit, option/create rows are hidden and a limit message is shown.                                                 |
+| maxSelectedText  | `string`                                                    | No       | `'You can select up to {n}.'` | Message shown in the dropdown once `maxSelected` is reached.                                                                                          |
+| allowCreate      | `boolean`                                                   | No       | `false`          | Show a "Create …" row when the query has no exact match. Fires `oncreate`; in multi-select the value is also added to `selected`.                                      |
+| createLabel      | `(query: string) => string`                                 | No       | `Create "{query}"` | Builds the create-row label from the current query.                                                                                                                 |
+| action           | `ComboboxAction`                                            | No       | `-`              | A persistent custom action row at the foot of the dropdown: `{ label, onClick, keepOpen? }`.                                                                           |
 
 ## Snippets
 
@@ -225,6 +277,8 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | inputSuffix    | `Snippet`                          | Content rendered after the input inside the input wrapper (e.g., a clear button, spinner, or chevron). Sits inside the border/focus ring.                                                   |
 | dropdownHeader | `Snippet`                          | Content rendered at the top of the dropdown, before the options list (e.g., a category label or pinned items).                                                                              |
 | dropdownFooter | `Snippet`                          | Content rendered at the bottom of the dropdown, after the options list (e.g., a "Show all results" link or action buttons).                                                                 |
+| pillSnippet    | `Snippet<[string, () => void, boolean]>` | Multi-select: custom pill renderer; receives `(value, remove, disabled)`. Defaults to the library `Pill`.                                                                             |
+| actionIcon     | `Snippet`                          | Custom leading icon for the persistent `action` row.                                                                                                                                        |
 
 ## Events
 
@@ -237,6 +291,10 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | onkeydown | `(event: KeyboardEvent) => void` | Fires when a key is pressed in the input, before the component's built-in handling. Call `event.preventDefault()` to suppress the default behavior for that key.   |
 | onfocus   | `(event: FocusEvent) => void`    | Fires when the input element gains focus.                                                                                                                          |
 | onblur    | `(event: FocusEvent) => void`    | Fires when the input element loses focus.                                                                                                                          |
+| onchange  | `(selected: string[]) => void`   | Multi-select: fires whenever the selection changes (add, remove, or create).                                                                                       |
+| onadd     | `(value: string) => void`        | Multi-select: fires when a value is added.                                                                                                                          |
+| onremove  | `(value: string) => void`        | Multi-select: fires when a value is removed.                                                                                                                        |
+| oncreate  | `(value: string) => void`        | Fires when the create row is chosen, with the trimmed query.                                                                                                        |
 
 ## CSS Variables
 
@@ -307,6 +365,16 @@ type ComboboxItem = {
 ```
 
 To pass extra data (icons, descriptions, etc.), extend the type: `type MyItem = ComboboxItem & { icon: string }` and cast inside `itemSnippet`.
+
+### ComboboxAction
+
+```typescript
+type ComboboxAction = {
+  label: string;
+  onClick: () => void;
+  keepOpen?: boolean; // keep the dropdown open after the action runs (default false)
+};
+```
 
 ## Internal Dependencies
 

--- a/docs/Select.md
+++ b/docs/Select.md
@@ -100,6 +100,7 @@ Pass an image URL (or inline data URI) via `leftIcon` to render a leading icon a
 | hierarchy      | `SelectHierarchy`          | No       | `'default'` | Visual hierarchy of the trigger. `'ghost'` renders a transparent, borderless trigger — useful when the Select is embedded in a toolbar or header where a full bordered input would be visually heavy. |
 | leftIcon       | `string`                   | No       | -           | Image src (URL or data URI) for an icon rendered at the left of the trigger. Size is controlled by `--select-left-icon-size` (default 16px).                                                          |
 | leftIconTestId | `string`                   | No       | -           | `data-pw` test id forwarded to the leading icon element for end-to-end testing selectors.                                                                                                             |
+| showSelectedTick | `boolean`                | No       | `false`     | Single-select only. When `true`, the selected option shows a checkmark at its right edge. No effect in `multiple` mode. Themeable via `--select-option-tick-size` / `--select-option-tick-color`.     |
 
 ## Snippets
 

--- a/src/lib/Combobox/Combobox.svelte
+++ b/src/lib/Combobox/Combobox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import Input from '../Input/Input.svelte';
+  import Pill from '../Pill/Pill.svelte';
   import type { ComboboxItem, ComboboxProperties } from './properties';
 
   function defaultFilter(item: ComboboxItem, query: string): boolean {
@@ -29,13 +30,27 @@
     inputSuffix,
     dropdownHeader,
     dropdownFooter,
+    // multi-select + create/action
+    multiple = false,
+    selected = $bindable([]),
+    maxSelected,
+    maxSelectedText,
+    pillSnippet,
+    allowCreate = false,
+    createLabel = (query: string) => `Create "${query}"`,
+    action,
+    actionIcon,
     onselect,
     oninput,
     onopen,
     onclose,
     onkeydown,
     onfocus,
-    onblur
+    onblur,
+    onchange,
+    onadd,
+    onremove,
+    oncreate
   }: ComboboxProperties = $props();
 
   let containerEl: HTMLDivElement | null = $state(null);
@@ -45,19 +60,62 @@
     return inputRef?.getInputRef() ?? null;
   }
 
+  function focusInput(): void {
+    inputRef?.getInputRef()?.focus();
+  }
+
   const listboxId = `combobox-listbox-${Math.random().toString(36).slice(2, 9)}`;
 
+  let selectedSet = $derived(new Set(selected));
+  let trimmedQuery = $derived(inputValue.trim());
+
   let filteredItems: ComboboxItem[] = $derived(
-    inputValue.length > 0 ? items.filter((item) => filterFn(item, inputValue)) : items
+    items.filter((item) => {
+      if (multiple && selectedSet.has(item.id)) {
+        return false;
+      }
+      return inputValue.length > 0 ? filterFn(item, inputValue) : true;
+    })
   );
 
   let selectableItems: ComboboxItem[] = $derived(
     filteredItems.filter((item) => item.disabled !== true)
   );
 
+  let exactMatch: ComboboxItem | undefined = $derived(
+    items.find((item) => item.label.toLowerCase() === trimmedQuery.toLowerCase())
+  );
+
+  let atLimit = $derived(
+    multiple && typeof maxSelected === 'number' && selected.length >= maxSelected
+  );
+
+  let limitText = $derived(
+    maxSelectedText ??
+      (typeof maxSelected === 'number'
+        ? `You can select up to ${maxSelected}.`
+        : 'Selection limit reached.')
+  );
+
+  let showCreate = $derived(
+    allowCreate &&
+      !atLimit &&
+      trimmedQuery !== '' &&
+      exactMatch === undefined &&
+      !(multiple && selectedSet.has(trimmedQuery))
+  );
+
+  // Navigable rows: selectable options (hidden at the limit) → create → action.
+  let navItemCount = $derived(atLimit ? 0 : selectableItems.length);
+  let createNavIndex = $derived(showCreate ? navItemCount : -1);
+  let actionNavIndex = $derived(action ? navItemCount + (showCreate ? 1 : 0) : -1);
+  let navCount = $derived(navItemCount + (showCreate ? 1 : 0) + (action ? 1 : 0));
+
   let highlightedOptionId: string | null = $derived(
     highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : null
   );
+
+  const labelOf = (id: string): string => items.find((item) => item.id === id)?.label ?? id;
 
   function openDropdown() {
     if (disabled || open) {
@@ -77,14 +135,101 @@
     onclose?.();
   }
 
+  function emitChange(): void {
+    onchange?.([...selected]);
+  }
+
+  function addValue(id: string): void {
+    if (atLimit || selectedSet.has(id)) {
+      return;
+    }
+    selected = [...selected, id];
+    inputValue = '';
+    highlightedIndex = -1;
+    onadd?.(id);
+    emitChange();
+    focusInput();
+  }
+
+  function removeValue(id: string): void {
+    if (!selectedSet.has(id)) {
+      return;
+    }
+    selected = selected.filter((current) => current !== id);
+    onremove?.(id);
+    emitChange();
+  }
+
   function selectItem(item: ComboboxItem) {
     if (item.disabled === true) {
       return;
     }
+    onselect?.(item);
+    if (multiple) {
+      addValue(item.id);
+      return;
+    }
     value = item.id;
     inputValue = item.label;
-    onselect?.(item);
     closeDropdown();
+  }
+
+  function create(): void {
+    const created = trimmedQuery;
+    if (created === '') {
+      return;
+    }
+    oncreate?.(created);
+    if (multiple) {
+      addValue(created);
+      return;
+    }
+    value = created;
+    inputValue = created;
+    closeDropdown();
+  }
+
+  function runAction(): void {
+    action?.onClick();
+    if (!action?.keepOpen) {
+      closeDropdown();
+    }
+  }
+
+  async function moveHighlight(delta: number): Promise<void> {
+    if (navCount === 0) {
+      return;
+    }
+    let next = highlightedIndex + delta;
+    if (next < 0) {
+      next = navCount - 1;
+    } else if (next >= navCount) {
+      next = 0;
+    }
+    highlightedIndex = next;
+    await tick();
+    if (containerEl !== null) {
+      const el = containerEl.querySelector('.combobox-option.highlighted');
+      if (el instanceof HTMLElement && typeof el.scrollIntoView === 'function') {
+        el.scrollIntoView({ block: 'nearest' });
+      }
+    }
+  }
+
+  function selectHighlighted() {
+    if (highlightedIndex < 0 || highlightedIndex >= navCount) {
+      return;
+    }
+    if (highlightedIndex < navItemCount) {
+      const item = selectableItems.at(highlightedIndex);
+      if (item) {
+        selectItem(item);
+      }
+    } else if (highlightedIndex === createNavIndex) {
+      create();
+    } else if (highlightedIndex === actionNavIndex) {
+      runAction();
+    }
   }
 
   function getFilteredSelectableIndex(item: ComboboxItem): number {
@@ -100,40 +245,10 @@
     return -1;
   }
 
-  async function moveHighlight(delta: number): Promise<void> {
-    if (selectableItems.length === 0) {
-      return;
-    }
-    let next = highlightedIndex + delta;
-    if (next < 0) {
-      next = selectableItems.length - 1;
-    } else if (next >= selectableItems.length) {
-      next = 0;
-    }
-    highlightedIndex = next;
-    await tick();
-    if (containerEl !== null) {
-      const el = containerEl.querySelector('.combobox-option.highlighted');
-      if (el instanceof HTMLElement && typeof el.scrollIntoView === 'function') {
-        el.scrollIntoView({ block: 'nearest' });
-      }
-    }
-  }
-
-  function selectHighlighted() {
-    if (highlightedIndex < 0 || highlightedIndex >= selectableItems.length) {
-      return;
-    }
-    const item = selectableItems.at(highlightedIndex);
-    if (typeof item === 'object' && item !== null) {
-      selectItem(item);
-    }
-  }
-
-  function handleInput(val: string, _event: Event) {
+  function handleInput(val: string, event: Event) {
     inputValue = val;
     oninput?.(val);
-    inputEventProperties?.onInput?.(val, _event);
+    inputEventProperties?.onInput?.(val, event);
     if (!open) {
       openDropdown();
     }
@@ -167,6 +282,17 @@
         if (open && highlightedIndex >= 0) {
           event.preventDefault();
           selectHighlighted();
+        } else if (exactMatch && !(multiple && selectedSet.has(exactMatch.id))) {
+          event.preventDefault();
+          selectItem(exactMatch);
+        } else if (showCreate) {
+          event.preventDefault();
+          create();
+        }
+        break;
+      case 'Backspace':
+        if (multiple && inputValue === '' && selected.length > 0) {
+          removeValue(selected[selected.length - 1]);
         }
         break;
       case 'Escape':
@@ -194,6 +320,13 @@
     inputEventProperties?.onBlur?.(event);
   }
 
+  function handleControlClick() {
+    if (multiple && !disabled) {
+      focusInput();
+      openDropdown();
+    }
+  }
+
   function handleClickOutside(event: Event) {
     if (
       event.target instanceof Node &&
@@ -213,16 +346,26 @@
 </script>
 
 <div class="combobox {classes ?? ''}" class:disabled bind:this={containerEl} data-pw={testId}>
-  <div class="combobox-input-wrapper">
+  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+  <div class="combobox-input-wrapper" class:multiple onclick={handleControlClick}>
     {#if typeof inputPrefix === 'function'}
       <div class="combobox-input-prefix">{@render inputPrefix()}</div>
+    {/if}
+    {#if multiple}
+      {#each selected as id (id)}
+        {#if typeof pillSnippet === 'function'}
+          {@render pillSnippet(id, () => !disabled && removeValue(id), disabled)}
+        {:else}
+          <Pill text={labelOf(id)} dismissible {disabled} ondismiss={() => removeValue(id)} />
+        {/if}
+      {/each}
     {/if}
     <div class="combobox-input">
       <Input
         {...inputProperties}
         bind:value={inputValue}
         bind:this={inputRef}
-        {placeholder}
+        placeholder={multiple && selected.length > 0 ? '' : placeholder}
         {name}
         disable={disabled}
         autoComplete="off"
@@ -249,7 +392,10 @@
       {#if typeof dropdownHeader === 'function'}
         <div class="combobox-dropdown-header">{@render dropdownHeader()}</div>
       {/if}
-      {#if filteredItems.length === 0}
+
+      {#if atLimit}
+        <div class="combobox-limit" role="alert">{limitText}</div>
+      {:else if filteredItems.length === 0 && !showCreate && !action}
         {#if typeof emptySnippet === 'function'}
           {@render emptySnippet()}
         {:else}
@@ -263,11 +409,11 @@
           <div
             class="combobox-option"
             class:highlighted={isHighlighted}
-            class:selected={item.id === value}
+            class:selected={!multiple && item.id === value}
             class:combobox-option-disabled={item.disabled === true}
             role="option"
             id={`${listboxId}-option-${selectableIndex}`}
-            aria-selected={item.id === value}
+            aria-selected={!multiple && item.id === value}
             aria-disabled={item.disabled === true ? 'true' : null}
             tabindex="-1"
             onclick={() => selectItem(item)}
@@ -286,6 +432,56 @@
           </div>
         {/each}
       {/if}
+
+      {#if showCreate}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <div
+          class="combobox-option combobox-create"
+          class:highlighted={highlightedIndex === createNavIndex}
+          class:with-divider={navItemCount > 0}
+          role="option"
+          id={`${listboxId}-option-${createNavIndex}`}
+          aria-selected="false"
+          tabindex="-1"
+          onclick={() => create()}
+          onmouseenter={() => (highlightedIndex = createNavIndex)}
+          data-pw={typeof testId === 'string' ? `${testId}-create` : null}
+        >
+          <span class="combobox-create-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" width="14" height="14" fill="none">
+              <path
+                d="M10 4v12M4 10h12"
+                stroke="currentColor"
+                stroke-width="1.7"
+                stroke-linecap="round"
+              />
+            </svg>
+          </span>
+          {createLabel(trimmedQuery)}
+        </div>
+      {/if}
+
+      {#if action}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <div
+          class="combobox-option combobox-action"
+          class:highlighted={highlightedIndex === actionNavIndex}
+          class:with-divider={navItemCount > 0 || showCreate}
+          role="option"
+          id={`${listboxId}-option-${actionNavIndex}`}
+          aria-selected="false"
+          tabindex="-1"
+          onclick={() => runAction()}
+          onmouseenter={() => (highlightedIndex = actionNavIndex)}
+          data-pw={typeof testId === 'string' ? `${testId}-action` : null}
+        >
+          {#if typeof actionIcon === 'function'}
+            <span class="combobox-action-icon" aria-hidden="true">{@render actionIcon()}</span>
+          {/if}
+          {action.label}
+        </div>
+      {/if}
+
       {#if typeof dropdownFooter === 'function'}
         <div class="combobox-dropdown-footer">{@render dropdownFooter()}</div>
       {/if}
@@ -315,6 +511,14 @@
     border: var(--combobox-input-border, 1px solid #cccccc);
     border-radius: var(--combobox-input-border-radius, var(--radius, 4px));
     transition: var(--combobox-input-transition, border-color 0.15s, box-shadow 0.15s);
+  }
+
+  /* Multi-select control: pills wrap above the typeahead input. */
+  .combobox-input-wrapper.multiple {
+    flex-wrap: wrap;
+    gap: var(--combobox-pill-gap, 4px);
+    padding: var(--combobox-multiple-padding, 4px 6px);
+    cursor: text;
   }
 
   .combobox-input-wrapper:hover {
@@ -357,6 +561,12 @@
     --input-radius: 0;
   }
 
+  .combobox-input-wrapper.multiple .combobox-input {
+    flex: 1 1 60px;
+    min-width: 60px;
+    --input-padding: var(--combobox-multiple-input-padding, 2px 4px);
+  }
+
   .combobox-input::placeholder {
     color: var(--combobox-placeholder-color, #999999);
   }
@@ -378,6 +588,9 @@
   }
 
   .combobox-option {
+    display: flex;
+    align-items: center;
+    gap: var(--combobox-option-gap, 8px);
     padding: var(--combobox-option-padding, 8px 12px);
     color: var(--combobox-option-color, #333333);
     font-size: var(--combobox-option-font-size, inherit);
@@ -412,6 +625,41 @@
     opacity: var(--combobox-option-disabled-opacity, 0.4);
     cursor: var(--combobox-option-disabled-cursor, not-allowed);
     pointer-events: none;
+  }
+
+  .combobox-create {
+    color: var(--combobox-create-color, #2563eb);
+  }
+
+  .combobox-action {
+    color: var(--combobox-action-color, #374151);
+  }
+
+  .combobox-option.with-divider {
+    border-top: var(--combobox-divider, 1px solid #e5e7eb);
+  }
+
+  .combobox-create-icon,
+  .combobox-action-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .combobox-action-icon :global(svg) {
+    width: 14px;
+    height: 14px;
+  }
+
+  .combobox-limit {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: var(--combobox-limit-padding, 8px 12px);
+    font-size: var(--combobox-limit-font-size, 13px);
+    font-weight: 500;
+    color: var(--combobox-limit-color, #b45309);
+    background: var(--combobox-limit-background, #fffbeb);
   }
 
   .combobox-dropdown-header {

--- a/src/lib/Combobox/properties.ts
+++ b/src/lib/Combobox/properties.ts
@@ -7,6 +7,14 @@ export type ComboboxItem = {
   disabled?: boolean;
 };
 
+/** A persistent custom action row rendered at the foot of the dropdown. */
+export type ComboboxAction = {
+  label: string;
+  onClick: () => void;
+  /** Keep the dropdown open after the action runs. Defaults to `false`. */
+  keepOpen?: boolean;
+};
+
 export type ComboboxProperties = MandatoryComboboxProperties &
   OptionalComboboxProperties &
   ComboboxEventProperties;
@@ -36,6 +44,31 @@ export type OptionalComboboxProperties = {
   inputSuffix?: Snippet;
   dropdownHeader?: Snippet;
   dropdownFooter?: Snippet;
+
+  // ── Multi-select (pill typeahead) ─────────────────────────────────────────
+  /** Enable multi-select: picked options become removable pills inside the control. */
+  multiple?: boolean;
+  /** Bindable array of selected ids (multi-select mode). */
+  selected?: string[];
+  /** Cap the number of selections (multi-select mode). */
+  maxSelected?: number;
+  /**
+   * Message shown in the dropdown once `maxSelected` is reached (option/create rows are hidden).
+   * Defaults to "You can select up to {maxSelected}.".
+   */
+  maxSelectedText?: string;
+  /** Custom pill renderer; receives `(value, remove, disabled)`. */
+  pillSnippet?: Snippet<[string, () => void, boolean]>;
+
+  // ── Create + custom action rows ───────────────────────────────────────────
+  /** Show a "Create …" row when the query has no exact match. Default `false`. */
+  allowCreate?: boolean;
+  /** Build the create-row label from the current query. */
+  createLabel?: (query: string) => string;
+  /** A persistent custom action row shown at the foot of the dropdown. */
+  action?: ComboboxAction;
+  /** Custom leading icon for the persistent action row. */
+  actionIcon?: Snippet;
 };
 
 export type ComboboxEventProperties = {
@@ -46,4 +79,12 @@ export type ComboboxEventProperties = {
   onkeydown?: (event: KeyboardEvent) => void;
   onfocus?: (event: FocusEvent) => void;
   onblur?: (event: FocusEvent) => void;
+  /** Multi-select: fires whenever the selection changes (add, remove, or create). */
+  onchange?: (selected: string[]) => void;
+  /** Multi-select: fires when a value is added. */
+  onadd?: (value: string) => void;
+  /** Multi-select: fires when a value is removed. */
+  onremove?: (value: string) => void;
+  /** Fires when the create row is chosen, with the trimmed query. */
+  oncreate?: (value: string) => void;
 };

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -17,6 +17,7 @@
     optionIndicator,
     showSelectAll = false,
     selectAllLabel = 'Select all',
+    showSelectedTick = false,
     triggerSummary,
     testId,
     itemTestId,
@@ -443,6 +444,7 @@
             <div
               class="select-option"
               class:multi={multiple}
+              class:tickable={showSelectedTick && !multiple}
               class:selected={value.includes(row.item.id)}
               class:highlighted={index === highlightedIndex}
               role="option"
@@ -478,7 +480,11 @@
                   </span>
                 {/if}
               {/if}
-              {row.item.label}
+              <span class="select-option-label">{row.item.label}</span>
+              {#if showSelectedTick && !multiple && value.includes(row.item.id)}
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                <span class="select-option-tick" aria-hidden="true">{@html checkmarkSvg}</span>
+              {/if}
             </div>
           {/if}
         {/each}
@@ -739,5 +745,32 @@
     border-color: var(--select-ghost-trigger-open-border-color, transparent);
     background: var(--select-ghost-trigger-open-background, rgba(0, 0, 0, 0.06));
     box-shadow: none;
+  }
+
+  /* Single-select right-edge tick (showSelectedTick) */
+  .select-option.tickable {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .select-option.tickable .select-option-label {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .select-option-tick {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: var(--select-option-tick-size, 16px);
+    height: var(--select-option-tick-size, 16px);
+    color: var(--select-option-tick-color, #2563eb);
+  }
+
+  .select-option-tick :global(svg) {
+    width: 100%;
+    height: 100%;
   }
 </style>

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -44,6 +44,13 @@ export type OptionalSelectProperties = {
   showSelectAll?: boolean;
   /** Label for the `showSelectAll` row. Defaults to `'Select all'`. */
   selectAllLabel?: string;
+  /**
+   * Single-select only: when `true`, the currently selected option shows a
+   * checkmark at its right edge. No effect in `multiple` mode (which already
+   * renders a checkbox indicator). Themeable via `--select-option-tick-size`
+   * and `--select-option-tick-color`. Defaults to `false`.
+   */
+  showSelectedTick?: boolean;
   testId?: string;
   /** Fallback per-option test id prefix. Each option emits `data-pw="{itemTestId}-{id}"` when its own `item.testId` is not set. */
   itemTestId?: string;

--- a/src/routes/components/combobox/+page.svelte
+++ b/src/routes/components/combobox/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Combobox from '$lib/Combobox/Combobox.svelte';
+  import type { ComboboxItem } from '$lib/Combobox/properties';
 
   const fruits = [
     { id: 'apple', label: 'Apple' },
@@ -13,6 +14,23 @@
 
   let selected = $state('');
   let inputText = $state('');
+
+  // multi-select
+  let picked = $state<string[]>([]);
+
+  // multi-select + create (tags). Keep a mutable item list so created tags persist.
+  let tagItems = $state<ComboboxItem[]>([
+    { id: 'frontend', label: 'frontend' },
+    { id: 'backend', label: 'backend' },
+    { id: 'design', label: 'design' }
+  ]);
+  let tags = $state<string[]>([]);
+
+  // multi-select + limit
+  let limited = $state<string[]>([]);
+
+  // multi-select + custom action
+  let withAction = $state<string[]>([]);
 </script>
 
 <div class="page-header">
@@ -20,6 +38,7 @@
   <h1>Combobox</h1>
 </div>
 
+<h3>Single select</h3>
 <div class="demo-row" style="max-width: 320px;">
   <Combobox
     items={fruits}
@@ -27,7 +46,72 @@
     bind:inputValue={inputText}
     placeholder="Search fruits..."
   />
-  <p style="font-size: 13px; color: #666; margin-top: 8px;">
-    Selected: {selected || 'none'} | Input: {inputText || 'empty'}
-  </p>
+  <p class="demo-info">Selected: {selected || 'none'} | Input: {inputText || 'empty'}</p>
 </div>
+
+<h3>Multi select (pills)</h3>
+<p>Set <code>multiple</code> with a bindable <code>selected</code> array. Picks become removable pills.</p>
+<div class="demo-row" style="max-width: 420px;">
+  <Combobox items={fruits} multiple bind:selected={picked} placeholder="Pick fruits…" />
+  {#if picked.length > 0}
+    <p class="demo-info">Selected: {picked.join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Multi select + create</h3>
+<p>
+  With <code>allowCreate</code>, typing a value with no match offers a "Create …" row. Use
+  <code>oncreate</code> to persist it into your own list.
+</p>
+<div class="demo-row" style="max-width: 420px;">
+  <Combobox
+    items={tagItems}
+    multiple
+    allowCreate
+    bind:selected={tags}
+    placeholder="Add tags…"
+    oncreate={(value) => {
+      if (!tagItems.some((item) => item.id === value)) {
+        tagItems = [...tagItems, { id: value, label: value }];
+      }
+    }}
+  />
+  {#if tags.length > 0}
+    <p class="demo-info">Tags: {tags.join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Multi select + limit</h3>
+<p>Cap selections with <code>maxSelected</code>; the dropdown shows a limit message once reached.</p>
+<div class="demo-row" style="max-width: 420px;">
+  <Combobox
+    items={fruits}
+    multiple
+    maxSelected={3}
+    bind:selected={limited}
+    placeholder="Pick up to 3…"
+  />
+  {#if limited.length > 0}
+    <p class="demo-info">{limited.length}/3 selected</p>
+  {/if}
+</div>
+
+<h3>Multi select + custom action</h3>
+<p>Pass an <code>action</code> for a persistent row at the foot of the dropdown.</p>
+<div class="demo-row" style="max-width: 420px;">
+  <Combobox
+    items={fruits}
+    multiple
+    bind:selected={withAction}
+    placeholder="Pick fruits…"
+    action={{ label: 'Manage fruits…', onClick: () => alert('Manage clicked') }}
+  />
+</div>
+
+<style>
+  .demo-info {
+    font-size: 13px;
+    color: #666;
+    margin-top: 8px;
+  }
+</style>

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -38,6 +38,7 @@
   const statusOptions: string[] = ['Active', 'Inactive', 'Pending', 'Archived'];
 
   let singleValue: string[] = $state([]);
+  let singleTickValue: string[] = $state([]);
   let searchValue: string[] = $state([]);
   let multiValue: string[] = $state([]);
   let multiSearchValue: string[] = $state([]);
@@ -71,6 +72,14 @@
   <Select items={fruits} bind:value={singleValue} placeholder="Choose a fruit" />
   {#if singleValue.length > 0}
     <p class="demo-info">Selected ID: {singleValue.at(0)}</p>
+  {/if}
+</div>
+
+<h3>Single select with selected tick</h3>
+<div class="demo-row" style="max-width: 300px;">
+  <Select items={fruits} bind:value={singleTickValue} placeholder="Choose a fruit" showSelectedTick />
+  {#if singleTickValue.length > 0}
+    <p class="demo-info">Selected ID: {singleTickValue.at(0)}</p>
   {/if}
 </div>
 


### PR DESCRIPTION

<img width="301" height="256" alt="image" src="https://github.com/user-attachments/assets/b66035f9-c2d2-418d-80fd-62d5312edad7" />

https://github.com/user-attachments/assets/50abc257-82da-471b-b3ff-36b0e3a030c2

## Summary

Adds multi-select (pill typeahead) to the existing **`Combobox`** — **instead of
shipping a separate `MultiCombobox` component** (which this branch originally
proposed). Per maintainer guidance, the capabilities are folded into the
component that already does single-select typeahead, so consumers have one
combobox rather than two overlapping ones.

## What's added (all opt-in; single-select unchanged)

- **`multiple`** — picked options become removable pills inside the control,
  tracked via a bindable **`selected: string[]`**; `Backspace` on an empty input
  removes the last pill.
- **`allowCreate`** / `createLabel` / **`oncreate`** — inline "Create …" row when
  the query has no exact match.
- **`action`** / `actionIcon` — a persistent custom row at the foot of the dropdown.
- **`maxSelected`** / `maxSelectedText` — selection cap with a limit message.
- Events: `onadd` / `onremove` / `onchange`; `pillSnippet` for custom pills.
- Unified, keyboard-navigable row model (options → create → action).

## Backward compatibility

Fully additive — pills/create/action/limit are all opt-in, so existing
single-select `Combobox` usage is unchanged.

## Note

This supersedes the original "add a standalone MultiCombobox" approach in this
branch — that component has been removed and the work folded into `Combobox`.
This branch also still carries the earlier Select select-all / selected-tick
changes.

## Verification

- `npm run check` — 0 errors
- Demo verified at `/components/combobox` (multi-select, create, limit, action)
