### PR TITLE
BZ-4232: fix: reset end time on manual date selection

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -443,6 +443,10 @@
     draftEnd = event.rangeEnd;
     // A direct calendar click is not a preset selection.
     selectedPresetLabel = null;
+    if (showTimeSelection) {
+      startTimeDisplay = '12:00 AM';
+      endTimeDisplay = isSameDay(event.rangeEnd, now) ? formatTimeDisplay(now) : '11:59 PM';
+    }
   }
 
   function handleSingleSelect(event: { date: Date }): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date range selection so the time picker now refreshes correctly after choosing a range from the calendar.
  * When time selection is enabled, the start time resets to midnight and the end time updates to a sensible default based on the selected date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->