### PR TITLE
fix(StatCard): render subtitle alongside rows

### DIFF
--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -198,10 +198,10 @@
         </div>
       {/if}
     </div>
+  {/if}
 
-    {#if typeof subtitle === 'string' && subtitle.length > 0}
-      <div class="statcard-subtitle">{subtitle}</div>
-    {/if}
+  {#if typeof subtitle === 'string' && subtitle.length > 0}
+    <div class="statcard-subtitle">{subtitle}</div>
   {/if}
 
   {#if children}

--- a/src/routes/components/stat-card/+page.svelte
+++ b/src/routes/components/stat-card/+page.svelte
@@ -161,6 +161,20 @@
   <StatCard title="Conversion Metrics" rows={conversionRow} testId="with-breakdown" />
 </div>
 
+<h3>Multi-Row With Subtitle</h3>
+<p class="intro" style="margin-bottom: 12px;">
+  The subtitle (e.g. a date-comparison label) renders below the metric rows. It must not be
+  suppressed when <code>rows</code> are present.
+</p>
+<div class="demo-row">
+  <StatCard
+    title="Revenue Overview"
+    rows={checkoutRows}
+    subtitle="Today vs Yesterday"
+    testId="rows-with-subtitle"
+  />
+</div>
+
 <h3>With Custom Children (ProportionBar)</h3>
 <div class="demo-row">
   <StatCard title="Payment Methods" value="8,610 orders" testId="with-children">

--- a/tests/stat-card.test.ts
+++ b/tests/stat-card.test.ts
@@ -78,4 +78,23 @@ test.describe('StatCard', () => {
     await card.locator('.statcard-value').click();
     await expect(clickCount).toHaveText('1');
   });
+
+  test('renders the subtitle below metric rows', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    // Regression: the subtitle block previously lived inside the no-rows {:else}
+    // branch, so a card given both `rows` and `subtitle` silently dropped the
+    // subtitle (e.g. the "Today vs Yesterday" comparison label).
+    const card = page.locator('[data-pw="rows-with-subtitle"]');
+    await expect(card.locator('.statcard-row')).toHaveCount(3);
+    await expect(card.locator('.statcard-subtitle')).toHaveText('Today vs Yesterday');
+  });
+
+  test('still renders the subtitle for a single-value card', async ({ page }) => {
+    await page.goto('/components/stat-card');
+
+    const card = page.locator('[data-pw="with-subtitle"]');
+    await expect(card.locator('.statcard-row')).toHaveCount(0);
+    await expect(card.locator('.statcard-subtitle')).toHaveText('vs last 30 days');
+  });
 });


### PR DESCRIPTION
## Problem

`StatCard` only renders its `subtitle` inside the `{:else}` (no-rows) branch of `{#if hasRows && rows}`. A card given **both** `rows` and `subtitle` silently drops the subtitle.

This is a real consumer regression: analytics metric cards always pass `rows` (the PREPAID/COD/% breakdown) **and** a `subtitle` (the date-range comparison label, e.g. "Today vs Yesterday"). After migrating to the library `StatCard`, that comparison label disappeared entirely, leaving an empty spacing gap under every metric card.

```svelte
{#if hasRows && rows}
  <div class="statcard-rows">…</div>
{:else}
  …value / delta…
  {#if subtitle}<div class="statcard-subtitle">{subtitle}</div>{/if}   <!-- unreachable when rows exist -->
{/if}
```

## Fix

Hoist the `subtitle` block out of the `{:else}` branch so it renders after the rows/value section in **both** cases. No new prop, token, or CSS — the `subtitle` prop, the `.statcard-subtitle` styles, and the type were already correct; only the template placement was wrong.

```svelte
{#if hasRows && rows}
  <div class="statcard-rows">…</div>
{:else}
  …value / delta…
{/if}

{#if subtitle}<div class="statcard-subtitle">{subtitle}</div>{/if}
```

The flex-column card layout (`gap: var(--statcard-gap)`) naturally spaces the subtitle below the rows section.

## Proof

Added a demo (`Multi-Row With Subtitle`, `data-pw="rows-with-subtitle"`) and two Playwright tests in `tests/stat-card.test.ts`:

- `renders the subtitle below metric rows` — asserts a card with 3 rows **and** a subtitle shows `.statcard-subtitle`. **Fails on the current code, passes after the fix.**
- `still renders the subtitle for a single-value card` — guards the existing no-rows path.

| | Result |
|---|---|
| Before fix (component reverted, test kept) | `renders the subtitle below metric rows` ❌ FAILS |
| After fix | **9/9 passed** (incl. both new tests) |

`prettier --check` ✓, `eslint` ✓, `svelte-check` introduces no new errors (the 2 pre-existing `LottiePlayer`/`lottie-web` module errors are unrelated).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new StatCard example showing multi-row content with a subtitle.
  * Improved StatCard rendering so subtitles appear correctly alongside row-based content.

* **Bug Fixes**
  * Fixed an issue where subtitles could be skipped in certain StatCard layouts.
  * Ensured subtitle text displays consistently for both multi-row and single-value cards.

* **Tests**
  * Added end-to-end coverage for subtitle display in StatCard scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->