### PR TITLE
fix(KeyValue): satisfy lint to unblock the release pipeline

### DIFF
--- a/src/lib/KeyValue/KeyValue.svelte
+++ b/src/lib/KeyValue/KeyValue.svelte
@@ -15,9 +15,11 @@
   }: KeyValueProperties = $props();
 
   const isEmptyValue = (value: KeyValueItem['value']): boolean =>
-    value === null || value === undefined || (typeof value === 'string' && value.trim() === '');
+    value == null || (typeof value === 'string' && value.trim() === '');
 
-  let visibleItems = $derived(hideEmpty ? items.filter((item) => !isEmptyValue(item.value)) : items);
+  let visibleItems = $derived(
+    hideEmpty ? items.filter((item) => !isEmptyValue(item.value)) : items
+  );
 
   const displayValue = (item: KeyValueItem): string =>
     isEmptyValue(item.value) ? emptyText : String(item.value);

--- a/src/routes/components/key-value/+page.svelte
+++ b/src/routes/components/key-value/+page.svelte
@@ -54,8 +54,8 @@
   <h3>Sizes</h3>
   <p>
     Three typography presets — <code>sm</code> (14/12px), <code>md</code> (16/14px, default), and
-    <code>lg</code> (18/16px) — scale the text. The value sits 2px below the label so the key reads
-    as the primary element.
+    <code>lg</code> (18/16px) — scale the text. The value sits 2px below the label so the key reads as
+    the primary element.
   </p>
   <div class="demo-row size-row">
     <div>


### PR DESCRIPTION
## Problem
The **Release and Publish** workflow has failed on every `release` push for the last several merges (StatCard subtitle #341, design-parity, KeyValue) at the `pnpm lint` step — so no version has published since 2.80.1.

Two lint failures in the KeyValue component:
- **prettier**: `src/lib/KeyValue/KeyValue.svelte` + `src/routes/components/key-value/+page.svelte`
- **eslint** (`no-restricted-syntax`): `value === undefined` in `isEmptyValue`

## Fix
`prettier --write` the two files, and replace `value === null || value === undefined` with the idiomatic `value == null` (matches both null and undefined; behaviourally identical).

## Verification
`pnpm run lint` → **prettier clean + eslint clean** (previously failed). This unblocks publishing **2.80.2**, which carries the StatCard subtitle fix from #341.