### PR TITLE
feat(Input): add textarea ergonomics (rows, auto-resize, resize, counter)

### DIFF
--- a/docs/Input.md
+++ b/docs/Input.md
@@ -1,6 +1,6 @@
 # Input
 
-A text input field with built-in validation for email, phone (tel), password, and text patterns. Validates automatically using `validationPattern` and `inProgressPattern` RegExp props, plus optional custom validator functions. Shows error messages when validation fails and info messages below the input. For `tel` dataType, automatically strips non-digit characters and enforces `maxLength`. Supports text transformers that modify the raw input value and view presentation transformers that format the displayed value (e.g., adding spaces to a card number). The validation state (`Valid` / `InProgress` / `Invalid`) is computed reactively and reported via `onStateChange`. Can render as a `<textarea>` when `useTextArea` is true.
+A text input field with built-in validation for email, phone (tel), password, and text patterns. Validates automatically using `validationPattern` and `inProgressPattern` RegExp props, plus optional custom validator functions. Shows error messages when validation fails and info messages below the input. For `tel` dataType, automatically strips non-digit characters and enforces `maxLength`. Supports text transformers that modify the raw input value and view presentation transformers that format the displayed value (e.g., adding spaces to a card number). The validation state (`Valid` / `InProgress` / `Invalid`) is computed reactively and reported via `onStateChange`. Can render as a `<textarea>` when `useTextArea` is true, with multi-line options: `rows`, auto-resize (`autoResize` / `minRows` / `maxRows`), a `resize` handle, and a `showCount` character counter.
 
 ## Usage
 
@@ -10,6 +10,30 @@ A text input field with built-in validation for email, phone (tel), password, an
 </script>
 
 <Input value={'...'} />
+```
+
+### Multi-line (textarea)
+
+Set `useTextArea` to render a `<textarea>`. It supports the same label/validation/error
+machinery as the single-line input, plus textarea-specific options: `rows`, `autoResize`
+(`minRows`/`maxRows`), a `resize` handle, and a `showCount` character counter.
+
+```svelte
+<script>
+  let notes = $state('');
+</script>
+
+<!-- Fixed height -->
+<Input bind:value={notes} useTextArea label="Notes" rows={4} />
+
+<!-- Auto-grow between 2 and 8 rows -->
+<Input bind:value={notes} useTextArea autoResize minRows={2} maxRows={8} />
+
+<!-- Character counter -->
+<Input bind:value={notes} useTextArea showCount maxLength={140} label="Bio" />
+
+<!-- User-resizable -->
+<Input bind:value={notes} useTextArea resize="vertical" />
 ```
 
 ## Props
@@ -33,6 +57,12 @@ A text input field with built-in validation for email, phone (tel), password, an
 | max                  | `number`                                                               | No       | `-`                 | Maximum value for numeric inputs (HTML max attribute). Only applies to `<input>`, not `<textarea>`.                                                                                                                           |
 | actionInput          | `boolean`                                                              | No       | `false`             | When true, hides the label, error message, and info message, and adjusts border-radius/shadow for seamless integration inside InputButton.                                                                                    |
 | useTextArea          | `boolean`                                                              | No       | `false`             | When true, renders a `<textarea>` instead of an `<input>`. Useful for multi-line text entry.                                                                                                                                  |
+| rows                 | `number`                                                               | No       | `-`                 | Initial visible rows for the textarea (only applies when `useTextArea`).                                                                                                                                                      |
+| autoResize           | `boolean`                                                              | No       | `false`             | When `useTextArea`, grows/shrinks the textarea to fit its content between `minRows` and `maxRows`; disables manual resizing while active.                                                                                      |
+| minRows              | `number`                                                               | No       | `rows`              | Lower bound (in rows) when `autoResize` is on.                                                                                                                                                                                |
+| maxRows              | `number`                                                               | No       | `-`                 | Upper bound (in rows) when `autoResize` is on; beyond this the textarea scrolls.                                                                                                                                              |
+| resize               | `'none' \| 'vertical' \| 'horizontal' \| 'both'`                       | No       | `'none'`            | Manual resize-handle behaviour for the textarea. Forced to `'none'` when `autoResize` is on.                                                                                                                                  |
+| showCount            | `boolean`                                                              | No       | `false`             | When `useTextArea`, shows a live `current / maxLength` character counter beneath the field.                                                                                                                                    |
 | autoComplete         | `HTMLInputAttributes['autocomplete']`                                  | No       | `'on'`              | The HTML autocomplete attribute value. Controls browser autofill behavior. Accepts any string for non-standard values (e.g., `'off'`, `'new-password'`).                                                                      |
 | name                 | `string`                                                               | No       | `''`                | The HTML name attribute for the input. Used for form submission and label association.                                                                                                                                        |
 | textTransformers     | `TextTransformer[]`                                                    | No       | `[]`                | Array of functions applied to the raw input value before digit extraction (tel mode only). Use for stripping country codes or formatting.                                                                                     |
@@ -126,6 +156,10 @@ Override these custom properties to theme the component.
 | `--input-info-msg-padding`          | `-`                                                    | padding          | Padding inside the info message.                                            |
 | `--input-placeholder-color`         | `-`                                                    | color            | Color of placeholder text.                                                  |
 | `--input-error-border`              | `1px solid var(--input-error-msg-text-color, #fa1405)` | border           | Border of the input when in error state.                                    |
+| `--input-char-count-size`           | `12px`                                                 | font-size        | Font size of the textarea character counter.                                |
+| `--input-char-count-color`          | `#98a2b3`                                               | color            | Color of the character counter.                                             |
+| `--input-char-count-limit-color`    | `#fa1405`                                               | color            | Counter color when the value reaches `maxLength`.                           |
+| `--input-char-count-margin`         | `4px 0 0`                                               | margin           | Margin around the character counter.                                        |
 
 ## Type Reference
 

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -47,7 +47,13 @@
     leftIconLabel = 'Leading action',
     rightIconLabel = 'Trailing action',
     mandatory = false,
-    forceError = false
+    forceError = false,
+    rows,
+    autoResize = false,
+    minRows,
+    maxRows,
+    resize = 'none',
+    showCount = false
   }: InputProperties = $props();
 
   export function focus() {
@@ -103,6 +109,38 @@
   const showError = $derived(showErrorMessage || forceError);
   const hasLeftIcon = $derived(typeof leftIcon === 'function');
   const hasRightIcon = $derived(typeof rightIcon === 'function');
+
+  const charCount = $derived(value?.length ?? 0);
+  const effectiveResize = $derived(autoResize ? 'none' : resize);
+
+  // Grow the textarea to fit its content between minRows and maxRows.
+  function adjustTextAreaHeight(): void {
+    const el = inputElement;
+    if (!el || !useTextArea || !autoResize) {
+      return;
+    }
+    el.style.height = 'auto';
+    const styles = window.getComputedStyle(el);
+    const lineHeight = parseFloat(styles.lineHeight) || 20;
+    const verticalPadding = parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
+    const border = parseFloat(styles.borderTopWidth) + parseFloat(styles.borderBottomWidth);
+    const lower = minRows ?? rows ?? 2;
+    const minHeight = lower * lineHeight + verticalPadding + border;
+    const maxHeight =
+      maxRows != null ? maxRows * lineHeight + verticalPadding + border : Number.POSITIVE_INFINITY;
+    const nextHeight = Math.min(Math.max(el.scrollHeight, minHeight), maxHeight);
+    el.style.height = `${nextHeight}px`;
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    // Re-run on every value change (and on mount) while auto-resize is enabled.
+    void value;
+    if (useTextArea && autoResize) {
+      adjustTextAreaHeight();
+    }
+  });
 
   function handleOnInput(event: Event) {
     if (inputElement === null) {
@@ -232,8 +270,11 @@
         onpaste={handleOnPaste}
         onclick={onClick}
         onkeydown={onKeyDown}
+        data-pw={testId}
         class:action-input={actionInput}
         style="--focus-border: {addFocusColor ? 1 : 0}px;"
+        style:resize={effectiveResize}
+        rows={rows ?? null}
         disabled={disable}
         bind:this={inputElement}
         maxlength={dataType === 'tel' ? null : maxLength}
@@ -319,6 +360,11 @@
   {#if infoMessage !== '' && !actionInput}
     <div class="info-message">
       {infoMessage}
+    </div>
+  {/if}
+  {#if useTextArea && showCount && !actionInput}
+    <div class="input-char-count" class:at-limit={charCount >= maxLength}>
+      {charCount}/{maxLength}
     </div>
   {/if}
 </div>
@@ -464,6 +510,18 @@
     color: var(--input-info-msg-text-color, #fa1405);
     margin: var(--input-info-msg-margin);
     padding: var(--input-info-msg-padding);
+  }
+
+  .input-char-count {
+    align-self: flex-end;
+    font-size: var(--input-char-count-size, 12px);
+    color: var(--input-char-count-color, #98a2b3);
+    margin: var(--input-char-count-margin, 4px 0 0);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .input-char-count.at-limit {
+    color: var(--input-char-count-limit-color, var(--input-error-msg-text-color, #fa1405));
   }
 
   ::placeholder {

--- a/src/lib/Input/properties.ts
+++ b/src/lib/Input/properties.ts
@@ -27,6 +27,24 @@ export type OptionalInputProperties = {
   max?: number;
   actionInput?: boolean;
   useTextArea?: boolean;
+  /** Initial visible rows for the textarea (only applies when `useTextArea`). */
+  rows?: number;
+  /**
+   * Grow/shrink the textarea to fit its content between `minRows` and `maxRows`
+   * (only when `useTextArea`). Disables manual resizing while active.
+   */
+  autoResize?: boolean;
+  /** Lower bound (in rows) when `autoResize` is on. Defaults to `rows`. */
+  minRows?: number;
+  /** Upper bound (in rows) when `autoResize` is on; beyond this the textarea scrolls. */
+  maxRows?: number;
+  /**
+   * Manual resize-handle behaviour for the textarea. Defaults to `'none'` (unchanged from
+   * before); forced to `'none'` when `autoResize` is on.
+   */
+  resize?: 'none' | 'vertical' | 'horizontal' | 'both';
+  /** Show a live `current / maxLength` character counter beneath the field. */
+  showCount?: boolean;
   autoComplete?: HTMLInputAttributes['autocomplete'];
   name?: string;
   textTransformers?: TextTransformer[];

--- a/src/routes/components/input/+page.svelte
+++ b/src/routes/components/input/+page.svelte
@@ -2,6 +2,10 @@
   import Input from '$lib/Input/Input.svelte';
 
   let inputValue = $state('');
+  let notes = $state('');
+  let autoGrow = $state('');
+  let bio = $state('');
+  let resizable = $state('');
 </script>
 
 <div class="page-header">
@@ -9,6 +13,53 @@
   <h1>Input</h1>
 </div>
 
+<h3>Basic</h3>
 <div class="demo-row" style="max-width: 400px;">
   <Input bind:value={inputValue} placeholder="Enter your name" label="Name" />
+</div>
+
+<h3>Multi-line (useTextArea)</h3>
+<p>
+  Set <code>useTextArea</code> to render a <code>&lt;textarea&gt;</code> instead of an
+  <code>&lt;input&gt;</code>. Use <code>rows</code> for the initial height.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input bind:value={notes} useTextArea label="Notes" placeholder="Add your notes" rows={4} />
+</div>
+
+<h3>Auto-resize</h3>
+<p>
+  With <code>autoResize</code> the textarea grows with its content between <code>minRows</code> and
+  <code>maxRows</code> (then scrolls).
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input
+    bind:value={autoGrow}
+    useTextArea
+    autoResize
+    minRows={2}
+    maxRows={8}
+    label="Description"
+    placeholder="Keep typing — the field grows…"
+  />
+</div>
+
+<h3>Character counter</h3>
+<p>Pass <code>showCount</code> with a <code>maxLength</code> to show a live counter.</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input
+    bind:value={bio}
+    useTextArea
+    showCount
+    maxLength={140}
+    label="Bio"
+    placeholder="Max 140 characters"
+    rows={3}
+  />
+</div>
+
+<h3>Manual resize</h3>
+<p>Control the resize handle with <code>resize</code> (default <code>'none'</code>).</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input bind:value={resizable} useTextArea resize="vertical" label="Comment" rows={3} />
 </div>

--- a/src/routes/components/input/+page.svelte
+++ b/src/routes/components/input/+page.svelte
@@ -6,6 +6,8 @@
   let autoGrow = $state('');
   let bio = $state('');
   let resizable = $state('');
+  let resizableX = $state('');
+  let resizableBoth = $state('');
 </script>
 
 <div class="page-header">
@@ -59,7 +61,24 @@
 </div>
 
 <h3>Manual resize</h3>
-<p>Control the resize handle with <code>resize</code> (default <code>'none'</code>).</p>
+<p>
+  Control the resize handle with <code>resize</code> (default <code>'none'</code>) —
+  <code>'vertical'</code>, <code>'horizontal'</code>, or <code>'both'</code>. Drag the corner/edge
+  of each field below.
+</p>
 <div class="demo-row" style="max-width: 400px;">
-  <Input bind:value={resizable} useTextArea resize="vertical" label="Comment" rows={3} />
+  <Input bind:value={resizable} useTextArea resize="vertical" label="Vertical" rows={3} />
 </div>
+<div class="demo-row resize-narrow">
+  <Input bind:value={resizableX} useTextArea resize="horizontal" label="Horizontal" rows={3} />
+</div>
+<div class="demo-row resize-narrow">
+  <Input bind:value={resizableBoth} useTextArea resize="both" label="Both" rows={3} />
+</div>
+
+<style>
+  /* Start narrower so horizontal/both resizing has room to grow as well as shrink. */
+  .resize-narrow :global(.input-container) {
+    --input-width: 240px;
+  }
+</style>


### PR DESCRIPTION

https://github.com/user-attachments/assets/f0d273fa-346d-4fc0-b600-3ee2dd90a212

## Summary

Adds multi-line ergonomics to the existing `Input` component's `useTextArea`
mode — **instead of shipping a separate `TextArea` component** (which this PR
originally proposed).

Per maintainer guidance, the goal is to build on what already exists rather than
add a parallel component: `Input` already renders a `<textarea>` when
`useTextArea` is set and already carries the label / validation / error-message /
`mandatory` / `maxLength` machinery. A standalone `TextArea` would have duplicated
all of that and given consumers two overlapping ways to do the same thing.

## What's added (textarea-only, all additive)

- **`rows`** — initial visible rows for the textarea.
- **`autoResize`** + **`minRows`** / **`maxRows`** — grow/shrink the field to fit
  its content between the bounds; beyond `maxRows` it scrolls.
- **`resize`** — manual resize-handle behaviour (`none` / `vertical` /
  `horizontal` / `both`); defaults to `'none'`, forced to `'none'` when
  `autoResize` is on.
- **`showCount`** — live `current / maxLength` character counter that turns the
  error color at the limit.
- New CSS variables: `--input-char-count-size` / `-color` / `-limit-color` /
  `-margin`.

## Backward compatibility

- Fully additive. The single-line `<input>` path is untouched, and existing
  `useTextArea` usage is unchanged (`resize` defaults to `'none'`, matching the
  prior hardcoded behaviour).

## What's included

- `src/lib/Input/Input.svelte`, `src/lib/Input/properties.ts`
- Updated `docs/Input.md` (Usage → "Multi-line (textarea)", Props, CSS Variables)
- Expanded demo route `src/routes/components/input/`

## Verification

- `npm run check` — 0 errors
- Demo verified at `/components/input` (fixed height, auto-resize, counter, manual resize)
