### PR TITLE
feat(Button): add variant, size, icon-only, link & loading API

### DIFF
--- a/docs/Button.md
+++ b/docs/Button.md
@@ -1,6 +1,6 @@
 # Button
 
-An action button that supports two loader modes: a circular spinner overlay or a horizontal progress bar that fills over time. The button text supports HTML content. When `showLoader` is true with `loaderType='ProgressBar'`, clicking the button triggers a progress bar animation and prevents further clicks until complete. Includes icon and children snippet support for rendering custom content.
+An action button with a built-in variant and size system: four visual styles (`primary`, `secondary`, `ghost`, `destructive`), three sizes (`sm`/`md`/`lg`), plus `iconOnly` and `fullWidth` affordances. It can render as a styled link via `href`, exposes a `loading` state (spinner + `aria-busy`), and supports icon/children snippets. Every visual property remains overridable through `--button-*` CSS variables, so an explicit override or a `classes` recipe always wins over the variant default.
 
 ## Usage
 
@@ -10,6 +10,55 @@ An action button that supports two loader modes: a circular spinner overlay or a
 </script>
 
 <Button text="Submit" onclick={(e) => console.log('clicked', e)} />
+```
+
+### Variants
+
+```svelte
+<Button text="Primary" variant="primary" />
+<Button text="Secondary" variant="secondary" />
+<Button text="Ghost" variant="ghost" />
+<Button text="Destructive" variant="destructive" />
+```
+
+### Sizes
+
+```svelte
+<Button text="Small" size="sm" />
+<Button text="Medium" size="md" />
+<Button text="Large" size="lg" />
+```
+
+### Icon only
+
+Pair `iconOnly` with `ariaLabel` so the button has an accessible name.
+
+```svelte
+<Button iconOnly ariaLabel="Add">
+  {#snippet icon()}<PlusIcon />{/snippet}
+</Button>
+```
+
+### Full width
+
+```svelte
+<Button text="Continue" fullWidth />
+```
+
+### Loading
+
+`loading` shows the spinner, sets `aria-busy`, and disables the button (preferred over the legacy `showLoader`/`loaderType` pair).
+
+```svelte
+<Button text={saving ? 'Saving…' : 'Save'} loading={saving} onclick={save} />
+```
+
+### As a link
+
+With `href` the button renders as a styled `<a>`. A disabled link is rendered inert via `aria-disabled` and `tabindex="-1"`.
+
+```svelte
+<Button text="Open docs" href="/docs" target="_blank" variant="secondary" />
 ```
 
 ### With Icon
@@ -36,12 +85,21 @@ An action button that supports two loader modes: a circular spinner overlay or a
 
 | Prop            | Type                              | Required | Default    | Description                                                                                                                                                                                                                |
 | --------------- | --------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| text            | `string`                          | No       | `-`        | The button label text. Supports HTML content (rendered via `{@html}`).                                                                                                                                                     |
-| enable          | `boolean`                         | No       | `true`     | Whether the button is clickable. When false, the button appears dimmed and ignores clicks. Equivalent to the inverse of `disabled`.                                                                                        |
-| disabled        | `boolean`                         | No       | `false`    | Whether the button is disabled. When true, the button appears dimmed (opacity 0.4) and ignores clicks. Takes effect alongside `enable` — either being falsy disables the button.                                           |
-| showProgressBar | `boolean`                         | No       | `false`    | Bindable. When true, a horizontal progress bar overlay animates across the button. Set automatically when `showLoader=true` and `loaderType='ProgressBar'` after first click.                                              |
-| showLoader      | `boolean`                         | No       | `false`    | Whether to show a loading indicator. Combined with `loaderType` to determine the visual style.                                                                                                                             |
-| loaderType      | `'Circular' \| 'ProgressBar'`     | No       | `-`        | The type of loader to display when `showLoader` is true. `'Circular'` shows a spinning ring inside the button; `'ProgressBar'` shows a horizontal fill animation across the button.                                        |
+| text            | `string`                          | No       | `-`        | The button label text. Rendered as plain text by default; set `allowHtml` to render as HTML.                                                                                                                               |
+| variant         | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'` | No | `'primary'` | Visual style. Maps to the `--button-*` variables; an explicit `--button-color`/`classes` override wins over the variant default.                                                          |
+| size            | `'sm' \| 'md' \| 'lg'`            | No       | `'md'`     | Size preset controlling padding, height, and font size.                                                                                                                                                                    |
+| iconOnly        | `boolean`                         | No       | `false`    | Square padding for an icon-only button. Pair with `ariaLabel`.                                                                                                                                                             |
+| fullWidth       | `boolean`                         | No       | `false`    | Stretch the button to the full width of its container.                                                                                                                                                                     |
+| href            | `string`                          | No       | `-`        | Render the button as a styled `<a>`. `type` is ignored; a disabled link is made inert via `aria-disabled`/`tabindex="-1"`.                                                                                                  |
+| target          | `string`                          | No       | `-`        | Anchor target (only with `href`), e.g. `_blank`.                                                                                                                                                                           |
+| rel             | `string`                          | No       | `-`        | Anchor rel (only with `href`). Defaults to `noopener noreferrer` when `target="_blank"`.                                                                                                                                   |
+| loading         | `boolean`                         | No       | `false`    | Loading state: shows the spinner, sets `aria-busy`, and disables the button. Preferred over `showLoader`/`loaderType`.                                                                                                      |
+| allowHtml       | `boolean`                         | No       | `false`    | Render `text` as raw HTML. Only enable for trusted, non-user-derived markup.                                                                                                                                                |
+| enable          | `boolean`                         | No       | `true`     | **Deprecated** — use `disabled`. When false the button is disabled. Retained for backward compatibility.                                                                                                                    |
+| disabled        | `boolean`                         | No       | `false`    | Whether the button is disabled. When true, the button appears dimmed (opacity 0.4) and ignores clicks.                                                                                                                      |
+| showProgressBar | `boolean`                         | No       | `false`    | **Deprecated.** Bindable. When true, a horizontal progress bar overlay animates across the button. Set automatically when `showLoader=true` and `loaderType='ProgressBar'` after first click.                              |
+| showLoader      | `boolean`                         | No       | `false`    | **Deprecated** — prefer `loading`. Whether to show a loading indicator. Combined with `loaderType` to determine the visual style.                                                                                           |
+| loaderType      | `'Circular' \| 'ProgressBar'`     | No       | `-`        | **Deprecated** — used with `showLoader`. `'Circular'` shows a spinning ring inside the button; `'ProgressBar'` shows a horizontal fill animation across the button.                                                         |
 | type            | `'submit' \| 'reset' \| 'button'` | No       | `'button'` | The HTML button `type` attribute.                                                                                                                                                                                          |
 | testId          | `string`                          | No       | `-`        | Value for the `data-pw` attribute, used for end-to-end testing selectors.                                                                                                                                                  |
 | ariaLabel       | `string`                          | No       | `-`        | Accessible label for the button. Used when the button has only an icon and no visible text.                                                                                                                                |
@@ -90,7 +148,7 @@ Override these custom properties to theme the component.
 | `--button-height`                           | `fit-content`                  | height             | Height of the button.                                                                                                                                             |
 | `--button-padding`                          | `16px`                         | padding            | Inner padding of the button.                                                                                                                                      |
 | `--button-margin`                           | `-`                            | margin             | Outer margin of the button.                                                                                                                                       |
-| `--button-border-radius`                    | `0px`                          | border-radius      | Corner rounding of the button.                                                                                                                                    |
+| `--button-border-radius`                    | `var(--radius, 6px)`           | border-radius      | Corner rounding of the button.                                                                                                                                    |
 | `--cursor`                                  | `pointer`                      | cursor             | Cursor style on hover.                                                                                                                                            |
 | `--opacity`                                 | `1`                            | opacity            | Opacity of the button.                                                                                                                                            |
 | `--button-border`                           | `none`                         | border             | Border style of the button.                                                                                                                                       |
@@ -129,11 +187,25 @@ Override these custom properties to theme the component.
 
 Custom types used by this component's props and events:
 
+### ButtonVariant
+
+```typescript
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+```
+
+### ButtonSize
+
+```typescript
+type ButtonSize = 'sm' | 'md' | 'lg';
+```
+
 ### LoaderType
 
 ```typescript
 type LoaderType = 'Circular' | 'ProgressBar';
 ```
+
+> **Note:** the `variant`/`size` presets only set internal default values — they never override an explicit `--button-*` variable or a `classes` recipe. This is what keeps existing consumers (e.g. apps that already drive `--button-color` through their own utility classes) rendering unchanged.
 
 ## Internal Dependencies
 

--- a/docs/Button.md
+++ b/docs/Button.md
@@ -35,9 +35,16 @@ Pair `iconOnly` with `ariaLabel` so the button has an accessible name.
 
 ```svelte
 <Button iconOnly ariaLabel="Add">
-  {#snippet icon()}<PlusIcon />{/snippet}
+  {#snippet icon()}
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+      <line x1="8" y1="3" x2="8" y2="13" />
+      <line x1="3" y1="8" x2="13" y2="8" />
+    </svg>
+  {/snippet}
 </Button>
 ```
+
+> Use `stroke="currentColor"` (or `fill="currentColor"`) in the icon so it inherits the button's text color across variants.
 
 ### Full width
 

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -37,14 +37,17 @@
     classes
   }: ButtonProperties = $props();
 
-  let isLoading = $derived(loading || showLoader);
-  let isDisabled = $derived(disabled || !enable || isLoading);
-  // `loading` and the legacy Circular loaderType both render the spinner.
+  // `loading` and the legacy Circular loaderType both render the spinner and disable the button.
   let showCircularLoader = $derived(loading || (showLoader && loaderType === 'Circular'));
-  let resolvedRel = $derived(rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined));
+  // The legacy ProgressBar loader stays clickable until the first click starts the bar, then
+  // it disables (the documented flow). So it must NOT count toward "disabled" before it starts.
+  let isProgressBarLoader = $derived(showLoader && loaderType === 'ProgressBar');
+  let isBusy = $derived(showCircularLoader || showProgressBar);
+  let isDisabled = $derived(disabled || !enable || showCircularLoader || showProgressBar);
+  let resolvedRel = $derived(rel ?? (target === '_blank' ? 'noopener noreferrer' : null));
 
   function handleButtonClick(event: MouseEvent): void {
-    if (isDisabled || showProgressBar) {
+    if (isDisabled) {
       // Anchors have no native disabled state — block navigation/handler explicitly.
       if (href) {
         event.preventDefault();
@@ -52,7 +55,7 @@
       return;
     }
     onclick?.(event);
-    if (showLoader && loaderType === 'ProgressBar') {
+    if (isProgressBarLoader) {
       showProgressBar = true;
     }
   }
@@ -83,10 +86,10 @@
     aria-label={ariaLabel ?? null}
     aria-expanded={ariaExpanded ?? null}
     aria-selected={ariaSelected ?? null}
-    aria-busy={isLoading || null}
+    aria-busy={isBusy || null}
     type={href ? null : type}
     disabled={href ? null : isDisabled}
-    href={href ? (isDisabled ? undefined : href) : null}
+    href={href ? (isDisabled ? null : href) : null}
     target={href ? target : null}
     rel={href ? resolvedRel : null}
     aria-disabled={href && isDisabled ? 'true' : null}

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -4,10 +4,20 @@
 
   let {
     text,
+    variant = 'primary',
+    size = 'md',
+    iconOnly = false,
+    fullWidth = false,
+    href,
+    target,
+    rel,
+    loading = false,
+    allowHtml = false,
     enable = true,
     disabled = false,
     showLoader = false,
     loaderType,
+    showProgressBar = $bindable(false),
     type = 'button',
     testId,
     ariaLabel,
@@ -22,16 +32,23 @@
     onmouseleave,
     ontouchstart,
     ontouchend,
-    showProgressBar = $bindable(false),
     icon,
     children,
     classes
   }: ButtonProperties = $props();
 
-  let isDisabled = $derived(!enable || disabled || showLoader);
+  let isLoading = $derived(loading || showLoader);
+  let isDisabled = $derived(disabled || !enable || isLoading);
+  // `loading` and the legacy Circular loaderType both render the spinner.
+  let showCircularLoader = $derived(loading || (showLoader && loaderType === 'Circular'));
+  let resolvedRel = $derived(rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined));
 
   function handleButtonClick(event: MouseEvent): void {
-    if (showProgressBar) {
+    if (isDisabled || showProgressBar) {
+      // Anchors have no native disabled state — block navigation/handler explicitly.
+      if (href) {
+        event.preventDefault();
+      }
       return;
     }
     onclick?.(event);
@@ -41,11 +58,17 @@
   }
 </script>
 
-<div class="button-container {classes ?? ''}">
+<div
+  class="button-container variant-{variant} size-{size} {classes ?? ''}"
+  class:icon-only={iconOnly}
+  class:full-width={fullWidth}
+>
   {#if showProgressBar}
     <div class="button-progress-bar"></div>
   {/if}
-  <button
+  <svelte:element
+    this={href ? 'a' : 'button'}
+    class="button-el"
     class:disabled={isDisabled}
     onclick={handleButtonClick}
     {onkeydown}
@@ -55,28 +78,38 @@
     {onmouseleave}
     {ontouchstart}
     {ontouchend}
-    disabled={isDisabled}
-    {type}
     data-pw={testId}
-    aria-label={ariaLabel}
-    aria-expanded={ariaExpanded}
-    aria-selected={ariaSelected}
-    {role}
+    role={role ?? null}
+    aria-label={ariaLabel ?? null}
+    aria-expanded={ariaExpanded ?? null}
+    aria-selected={ariaSelected ?? null}
+    aria-busy={isLoading || null}
+    type={href ? null : type}
+    disabled={href ? null : isDisabled}
+    href={href ? (isDisabled ? undefined : href) : null}
+    target={href ? target : null}
+    rel={href ? resolvedRel : null}
+    aria-disabled={href && isDisabled ? 'true' : null}
+    tabindex={href && isDisabled ? -1 : null}
   >
-    {#if showLoader && loaderType === 'Circular'}
+    {#if showCircularLoader}
       <div class="button-loader"><Loader /></div>
     {/if}
     {#if typeof icon === 'function'}
       <div class="button-icon">{@render icon()}</div>
     {/if}
     {#if typeof text === 'string' && text.length > 0}
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-      <div class="button-text">{@html text}</div>
+      {#if allowHtml}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        <div class="button-text">{@html text}</div>
+      {:else}
+        <div class="button-text">{text}</div>
+      {/if}
     {/if}
     {#if typeof children === 'function'}
       {@render children()}
     {/if}
-  </button>
+  </svelte:element>
 </div>
 
 <style>
@@ -84,23 +117,92 @@
     position: relative;
     width: var(--button-width, fit-content);
   }
-  button {
+
+  /* ---- Variant defaults (set the internal --_btn-* layer; explicit --button-* always wins) ---- */
+  .variant-primary {
+    --_btn-color: #3a4550;
+    --_btn-text-color: #ffffff;
+    --_btn-border: none;
+  }
+
+  .variant-secondary {
+    --_btn-color: transparent;
+    --_btn-text-color: #3a4550;
+    --_btn-border: 1px solid #cbd5e1;
+    --_btn-hover-color: #f1f5f9;
+    --_btn-hover-text-color: #3a4550;
+    --_btn-hover-border: 1px solid #cbd5e1;
+  }
+
+  .variant-ghost {
+    --_btn-color: transparent;
+    --_btn-text-color: #3a4550;
+    --_btn-border: none;
+    --_btn-hover-color: #f1f5f9;
+    --_btn-hover-text-color: #3a4550;
+    --_btn-hover-border: none;
+  }
+
+  .variant-destructive {
+    --_btn-color: #e7000b;
+    --_btn-text-color: #ffffff;
+    --_btn-border: none;
+    --_btn-hover-color: #c10007;
+    --_btn-hover-text-color: #ffffff;
+    --_btn-hover-border: none;
+  }
+
+  /* ---- Size defaults (md reproduces the legacy 16px padding / 14px font) ---- */
+  .size-sm {
+    --_btn-padding: 8px 12px;
+    --_btn-font-size: 13px;
+  }
+
+  .size-md {
+    --_btn-padding: 16px;
+    --_btn-font-size: 14px;
+  }
+
+  .size-lg {
+    --_btn-padding: 20px 28px;
+    --_btn-font-size: 16px;
+  }
+
+  .icon-only {
+    --_btn-padding: 8px;
+  }
+
+  .icon-only.size-sm {
+    --_btn-padding: 6px;
+  }
+
+  .icon-only.size-lg {
+    --_btn-padding: 12px;
+  }
+
+  .full-width {
+    --button-width: 100%;
+  }
+
+  .button-el {
     max-height: var(--button-max-height);
     max-width: var(--button-max-width);
     min-width: var(--button-min-width);
     font-family: var(--button-font-family);
     font-weight: var(--button-font-weight, 500);
-    font-size: var(--button-font-size, 14px);
-    background-color: var(--button-color, #3a4550);
-    color: var(--button-text-color, white);
+    font-size: var(--button-font-size, var(--_btn-font-size, 14px));
+    background-color: var(--button-color, var(--_btn-color, #3a4550));
+    color: var(--button-text-color, var(--_btn-text-color, white));
     height: var(--button-height, fit-content);
-    padding: var(--button-padding, 16px);
+    padding: var(--button-padding, var(--_btn-padding, 16px));
     margin: var(--button-margin);
-    border-radius: var(--button-border-radius, var(--radius, 4px));
+    border-radius: var(--button-border-radius, var(--radius, 6px));
     width: var(--button-width, fit-content);
     cursor: var(--cursor, pointer);
     opacity: var(--opacity, 1);
-    border: var(--button-border, none);
+    border: var(--button-border, var(--_btn-border, none));
+    box-sizing: border-box;
+    text-decoration: none;
     display: flex;
     justify-content: var(--button-justify-content, center);
     align-items: center;
@@ -110,14 +212,16 @@
     box-shadow: var(--button-box-shadow, none);
   }
 
-  .disabled {
+  .button-el.disabled,
+  .button-el:disabled {
     cursor: var(--disabled-cursor, not-allowed);
     opacity: var(--disabled-opacity, 0.4);
-    color: var(--disabled-text-color, var(--button-text-color, white));
+    color: var(--disabled-text-color, var(--button-text-color, var(--_btn-text-color, white)));
     font-size: var(--disabled-font-size);
     font-weight: var(--disabled-font-weight);
-    border: var(--disabled-border);
-    background: var(--disabled-background-color, var(--button-color, #3a4550));
+    /* Preserve the variant border when disabled so secondary (bordered) stays distinct from ghost. */
+    border: var(--disabled-border, var(--button-border, var(--_btn-border, none)));
+    background: var(--disabled-background-color, var(--button-color, var(--_btn-color, #3a4550)));
     box-shadow: var(
       --button-disabled-box-shadow,
       var(--disabled-box-shadow, var(--button-box-shadow, none))
@@ -138,21 +242,30 @@
     display: var(--button-text-display);
   }
 
-  button:hover {
-    background: var(--button-hover-color, var(--button-color, #3a4550));
-    color: var(--button-hover-text-color, var(--button-text-color, white));
-    border: var(--button-hover-border, var(--button-border, none));
+  .button-el:hover:not(.disabled) {
+    background: var(
+      --button-hover-color,
+      var(--_btn-hover-color, var(--button-color, var(--_btn-color, #3a4550)))
+    );
+    color: var(
+      --button-hover-text-color,
+      var(--_btn-hover-text-color, var(--button-text-color, var(--_btn-text-color, white)))
+    );
+    border: var(
+      --button-hover-border,
+      var(--_btn-hover-border, var(--button-border, var(--_btn-border, none)))
+    );
     transform: var(--button-hover-transform);
     box-shadow: var(--button-hover-box-shadow, var(--button-box-shadow, none));
   }
 
-  button:active {
+  .button-el:active:not(.disabled) {
     transform: var(--button-active-transform);
-    background: var(--button-active-background, var(--button-color, #3a4550));
+    background: var(--button-active-background, var(--button-color, var(--_btn-color, #3a4550)));
     box-shadow: var(--button-active-box-shadow, var(--button-box-shadow, none));
   }
 
-  button:focus-visible {
+  .button-el:focus-visible {
     box-shadow: var(--button-focus-visible-box-shadow, var(--button-box-shadow, none));
   }
 

--- a/src/lib/Button/properties.ts
+++ b/src/lib/Button/properties.ts
@@ -2,14 +2,55 @@ import type { Snippet } from 'svelte';
 
 export type LoaderType = 'Circular' | 'ProgressBar';
 
+/** Visual style of the button. Maps to a built-in palette via `--button-*` variables. */
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+
+/** Size preset controlling padding/height/font-size. */
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
 export type ButtonProperties = OptionalButtonProperties & ButtonEventProperties;
 
 export type OptionalButtonProperties = {
   text?: string;
+  /**
+   * Visual style: `primary` (default, filled), `secondary` (outlined), `ghost`
+   * (transparent), `destructive` (danger). Each maps to the `--button-*` variables, so an
+   * explicit `--button-color` / `classes` override always wins over the variant default.
+   */
+  variant?: ButtonVariant;
+  /** Size preset: `sm` / `md` (default) / `lg`. Controls padding, height, and font size. */
+  size?: ButtonSize;
+  /** Square padding for an icon-only button. Pair with `ariaLabel` for accessibility. */
+  iconOnly?: boolean;
+  /** Stretch the button to the full width of its container. */
+  fullWidth?: boolean;
+  /**
+   * Render the button as an `<a>` styled identically. Use for button-styled links/navigation.
+   * When set, `type` is ignored; a disabled link is rendered inert via `aria-disabled`.
+   */
+  href?: string;
+  /** Anchor target (only with `href`), e.g. `_blank`. */
+  target?: string;
+  /** Anchor rel (only with `href`). Defaults to `noopener noreferrer` when `target="_blank"`. */
+  rel?: string;
+  /**
+   * Show a loading state: renders the circular loader, sets `aria-busy`, and disables the
+   * button. Preferred over the legacy `showLoader`/`loaderType` pair.
+   */
+  loading?: boolean;
+  /**
+   * Render the `text` as raw HTML. Defaults to `false` (safe plain-text rendering). Only enable
+   * for trusted, non-user-derived markup.
+   */
+  allowHtml?: boolean;
+  /** @deprecated Use `disabled` instead. Retained for backward compatibility. */
   enable?: boolean;
-  showProgressBar?: boolean;
+  /** @deprecated Prefer `loading`. Shows a loader; pair with `loaderType`. */
   showLoader?: boolean;
+  /** @deprecated Used with `showLoader`. `'Circular'` or `'ProgressBar'`. */
   loaderType?: LoaderType;
+  /** @deprecated Drives the progress-bar animation when `loaderType='ProgressBar'`. */
+  showProgressBar?: boolean;
   type?: 'submit' | 'reset' | 'button';
   testId?: string;
   icon?: Snippet;

--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
   import Button from '$lib/Button/Button.svelte';
+
+  let loadingDemo = $state(false);
+
+  const runLoading = () => {
+    loadingDemo = true;
+    setTimeout(() => (loadingDemo = false), 1600);
+  };
 </script>
 
 <div class="page-header">
@@ -7,8 +14,108 @@
   <h1>Button</h1>
 </div>
 
-<div class="demo-row">
-  <Button text="Primary" onclick={() => alert('Clicked!')} />
-  <Button text="Disabled" enable={false} />
-  <Button text="With Loader" showLoader loaderType="Circular" />
+<div class="btn-demos">
+  <h3>Variants</h3>
+  <div class="demo-row">
+    <Button text="Primary" variant="primary" />
+    <Button text="Secondary" variant="secondary" />
+    <Button text="Ghost" variant="ghost" />
+    <Button text="Destructive" variant="destructive" />
+  </div>
+
+  <h3>Sizes</h3>
+  <div class="demo-row" style="align-items: center;">
+    <Button text="Small" size="sm" />
+    <Button text="Medium" size="md" />
+    <Button text="Large" size="lg" />
+  </div>
+
+  <h3>Icon only</h3>
+  <p>Pair <code>iconOnly</code> with <code>ariaLabel</code> for an accessible name.</p>
+  <div class="demo-row" style="align-items: center;">
+    <Button iconOnly ariaLabel="Add" variant="primary">
+      {#snippet icon()}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          aria-hidden="true"
+        >
+          <line x1="8" y1="3" x2="8" y2="13" />
+          <line x1="3" y1="8" x2="13" y2="8" />
+        </svg>
+      {/snippet}
+    </Button>
+    <Button iconOnly ariaLabel="Edit" variant="secondary">
+      {#snippet icon()}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+        </svg>
+      {/snippet}
+    </Button>
+    <Button iconOnly ariaLabel="Delete" variant="destructive">
+      {#snippet icon()}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+        </svg>
+      {/snippet}
+    </Button>
+  </div>
+
+  <h3>Full width</h3>
+  <div class="demo-row" style="max-width: 360px; flex-direction: column;">
+    <Button text="Full-width button" fullWidth variant="primary" />
+  </div>
+
+  <h3>Loading</h3>
+  <p>The <code>loading</code> prop shows a spinner, sets <code>aria-busy</code>, and disables the button.</p>
+  <div class="demo-row">
+    <Button text={loadingDemo ? 'Saving…' : 'Save'} loading={loadingDemo} onclick={runLoading} />
+  </div>
+
+  <h3>Disabled</h3>
+  <div class="demo-row">
+    <Button text="Primary" variant="primary" disabled />
+    <Button text="Secondary" variant="secondary" disabled />
+    <Button text="Ghost" variant="ghost" disabled />
+  </div>
+
+  <h3>As a link (href)</h3>
+  <p>With <code>href</code> the button renders as a styled <code>&lt;a&gt;</code>.</p>
+  <div class="demo-row">
+    <Button text="Open docs" href="https://svelte.dev" target="_blank" variant="secondary" />
+  </div>
 </div>
+
+<style>
+  /* Keep the built-in variant palette readable on the docs dark theme. */
+  :global([data-theme='dark']) .btn-demos {
+    --button-hover-color: var(--doc-btn-hover-bg);
+  }
+</style>

--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -112,10 +112,3 @@
     <Button text="Open docs" href="https://svelte.dev" target="_blank" variant="secondary" />
   </div>
 </div>
-
-<style>
-  /* Keep the built-in variant palette readable on the docs dark theme. */
-  :global([data-theme='dark']) .btn-demos {
-    --button-hover-color: var(--doc-btn-hover-bg);
-  }
-</style>


### PR DESCRIPTION


https://github.com/user-attachments/assets/565d8041-1a9f-4266-bee7-5fa1008aabfa


## Why

Today's `Button` is effectively an **unstyled `<button>` primitive**, not a
design-system button. That has real costs:

1. **No variants / sizes / subtypes.** No `primary`/`secondary`/`ghost`/
   `destructive`, no `sm`/`md`/`lg`, no icon-only or full-width. So **every
   consumer reinvents them.** Lighthouse, for example, maintains a parallel
   `global-btn*` system across **~511 call sites** — and its own CSS comments
   record that the variants *"had drifted (filled vs transparent)… and are now
   unified here."* That drift is the direct cost of the library not owning
   variants.
2. **Confusing disabled API** — two overlapping props (`enable` *and*
   `disabled`) for one concept.
3. **`{@html text}`** — the label was always rendered as raw HTML (an XSS
   footgun for any server/user-derived label) with no opt-out.
4. **No `href`** — button-styled links had to be hand-rolled.
5. **A11y gaps** — no `aria-busy` on load, no first-class icon-only affordance.
6. **No usable default look** — quirky defaults (square-ish corners, 16px
   padding) mean a wall of `--button-*` overrides at every integration.

## What this adds

- **`variant`**: `primary` (default) / `secondary` / `ghost` / `destructive`
  (danger red matches Blend's `red[600]`).
- **`size`**: `sm` / `md` (default) / `lg`, plus **`iconOnly`** and **`fullWidth`**.
- **`href`** → renders a styled `<a>` (inert when disabled via `aria-disabled` +
  `tabindex="-1"`; auto `rel="noopener noreferrer"` for `target="_blank"`).
- **`loading`** → spinner + `aria-busy` + disabled (preferred over the legacy
  `showLoader`/`loaderType` pair).
- **`allowHtml`** → `text` renders as **plain text by default**; opt back into
  HTML explicitly.
- `enable` folded into a single `disabled` concept.

## "We already have CSS classes for this (e.g. `global-btn*`) — why change the library?"

That's exactly the problem this fixes, not a reason to keep things as-is:

- Those classes live **in each app** (Lighthouse's are in its own `theme.css` /
  `globalClasses.css`). Every consumer rebuilds the same vocabulary, and they
  **drift** — Lighthouse's comments literally document fixing that drift. A
  shared button is the single source of truth a library is *supposed* to provide.
- **Nothing is taken away.** The variant/size presets only set internal
  `--_btn-*` *default* layers, so **any explicit `--button-*` variable or
  `classes` recipe still wins.** Lighthouse's `global-btn`, `global-btn-secondary`,
  `global-btn-ghost`, `global-btn-sm`, `global-btn-icon-only`, etc. all set the
  primary `--button-*` variables, which override the new defaults — so all ~511
  existing usages render **unchanged**. This was verified against the class set.
- Apps can now **delete** their bespoke button CSS over time and migrate to
  `variant`/`size` at their own pace — no big-bang refactor required.

## Backward compatibility

- Fully additive. Legacy props (`enable`, `showLoader`, `loaderType`,
  `showProgressBar`) are retained and marked `@deprecated`.
- Two intentional behavior corrections:
  - `text` now defaults to plain-text rendering (was always `{@html}`). A search
    of Lighthouse found **0** Button labels containing HTML; `allowHtml` restores
    the old behavior where needed.
  - The legacy `ProgressBar` loader now stays **clickable until the first click**
    starts the bar (and disables thereafter). Previously `showLoader` disabled the
    button up-front, which prevented the bar from ever starting — this fix aligns
    the code with the documented flow. The `Circular`/`loading` states disable
    immediately, as before.
## What's included

- `src/lib/Button/` (`Button.svelte`, `properties.ts`)
- Updated `docs/Button.md` (Variants/Sizes/Icon-only/Full-width/Loading/Link +
  refreshed Props / CSS Variables / Type Reference)
- Rebuilt demo route `src/routes/components/button/`

## Verification

- `npm run check` — 0 errors
- Demo verified at `/components/button` (light + dark, disabled states, link)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Button variants and sizes, plus clearer support for icon-only, full-width, and link-style buttons.
  * Introduced a simpler loading state that shows a spinner, marks the button busy, and disables interaction.
  * Expanded the Button examples page with more real-world demos.

* **Bug Fixes**
  * Improved disabled link behavior so inactive buttons no longer respond to clicks or navigation.
  * Updated styling defaults and hover behavior for more consistent appearance across themes.

* **Documentation**
  * Refreshed Button docs with updated props, examples, and styling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->