### PR TITLE
fix(DualAxisBarChart): add minBarHeight, margin, and tooltipPortal props

### DIFF
--- a/docs/DualAxisBarChart.md
+++ b/docs/DualAxisBarChart.md
@@ -83,26 +83,29 @@ A pure-SVG dual-axis chart with two completely independent Y-axes — left (`yAx
 
 ## Props
 
-| Prop            | Type                                          | Required | Default  | Description                                                                                                                                                     |
-| --------------- | --------------------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| categories      | `string[]`                                    | Yes      | —        | Ordered category labels for the shared X-axis (e.g. `['Jan', 'Feb', 'Mar']`). All series `data` arrays must have the same length as `categories`.              |
-| series          | `DualAxisSeries[]`                            | Yes      | —        | Array of series descriptors. Each series declares `yAxisIndex` (0=left, 1=right), `data` values, an optional render `type`, and an optional `color`.            |
-| leftAxis        | `DualAxisConfig`                              | No       | `{}`     | Configuration for the left (primary) Y-axis. Accepts `title`, `color`, and `valueFormat`.                                                                      |
-| rightAxis       | `DualAxisConfig`                              | No       | `{}`     | Configuration for the right (secondary) Y-axis. Accepts `title`, `color`, and `valueFormat`.                                                                   |
-| showGridlines   | `boolean`                                     | No       | `true`   | Whether to render dashed horizontal gridlines from the left-axis ticks.                                                                                         |
-| showLegend      | `boolean`                                     | No       | `true`   | Whether to render the shared series legend above the chart.                                                                                                     |
-| barRadius       | `number`                                      | No       | `3`      | Corner radius of column/bar shapes in pixels.                                                                                                                   |
-| barPadding      | `number`                                      | No       | `0.25`   | Padding between category bands as a fraction of band width (0–1).                                                                                               |
-| aspectRatio     | `number`                                      | No       | `16/9`   | Width-to-height ratio for the chart. Passed to ChartContainer's ResizeObserver sizing.                                                                          |
-| tooltipSnippet  | `Snippet<[DualAxisTooltipContext]>`            | No       | —        | Custom tooltip content rendered on hover. Receives a `DualAxisTooltipContext` with the hovered category and all series values. Replaces the default tooltip.    |
-| testId          | `string`                                      | No       | —        | Value for the `data-pw` attribute on the root element for test targeting.                                                                                       |
-| classes         | `string`                                      | No       | —        | Extra CSS class string on the root `<div>`. Useful for applying scoped CSS variable overrides.                                                                  |
+| Prop           | Type                                | Required | Default                                        | Description                                                                                                                                                                 |
+| -------------- | ----------------------------------- | -------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| categories     | `string[]`                          | Yes      | —                                              | Ordered category labels for the shared X-axis (e.g. `['Jan', 'Feb', 'Mar']`). All series `data` arrays must have the same length as `categories`.                           |
+| series         | `DualAxisSeries[]`                  | Yes      | —                                              | Array of series descriptors. Each series declares `yAxisIndex` (0=left, 1=right), `data` values, an optional render `type`, and an optional `color`.                        |
+| leftAxis       | `DualAxisConfig`                    | No       | `{}`                                           | Configuration for the left (primary) Y-axis. Accepts `title`, `color`, and `valueFormat`.                                                                                   |
+| rightAxis      | `DualAxisConfig`                    | No       | `{}`                                           | Configuration for the right (secondary) Y-axis. Accepts `title`, `color`, and `valueFormat`.                                                                                |
+| showGridlines  | `boolean`                           | No       | `true`                                         | Whether to render dashed horizontal gridlines from the left-axis ticks.                                                                                                     |
+| showLegend     | `boolean`                           | No       | `true`                                         | Whether to render the shared series legend above the chart.                                                                                                                 |
+| barRadius      | `number`                            | No       | `3`                                            | Corner radius of column/bar shapes in pixels.                                                                                                                               |
+| barPadding     | `number`                            | No       | `0.25`                                         | Padding between category bands as a fraction of band width (0–1).                                                                                                           |
+| aspectRatio    | `number`                            | No       | `16/9`                                         | Width-to-height ratio for the chart. Passed to ChartContainer's ResizeObserver sizing.                                                                                      |
+| tooltipSnippet | `Snippet<[DualAxisTooltipContext]>` | No       | —                                              | Custom tooltip content rendered on hover. Receives a `DualAxisTooltipContext` with the hovered category and all series values. Replaces the default tooltip.                |
+| testId         | `string`                            | No       | —                                              | Value for the `data-pw` attribute on the root element for test targeting.                                                                                                   |
+| classes        | `string`                            | No       | —                                              | Extra CSS class string on the root `<div>`. Useful for applying scoped CSS variable overrides.                                                                              |
+| minBarHeight   | `number`                            | No       | `2`                                            | Minimum rendered bar height in pixels. Set `0` so an all-zero/dormant series renders nothing (e.g. to show an empty state instead of indistinguishable 2px baseline stubs). |
+| margin         | `{ top?; right?; bottom?; left? }`  | No       | `{ top: 24, right: 56, bottom: 40, left: 56 }` | Override plot margins (px) for axis titles/labels, merged over the defaults. Widen `left`/`right` for long currency tick labels in narrow containers.                       |
+| tooltipPortal  | `boolean`                           | No       | `false`                                        | Render the hover tooltip on `document.body` with `position: fixed` viewport coords so it is not clipped by an `overflow`/scroll ancestor (e.g. a scrollable sheet).         |
 
 ## Events
 
-| Event      | Type                                                                                             | Description                                                                                              |
-| ---------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| onbarclick | `(event: { categoryIndex: number; context: DualAxisTooltipContext }) => void`                    | Fires when the user clicks anywhere within a category column. Provides the index and full series context. |
+| Event      | Type                                                                          | Description                                                                                               |
+| ---------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| onbarclick | `(event: { categoryIndex: number; context: DualAxisTooltipContext }) => void` | Fires when the user clicks anywhere within a category column. Provides the index and full series context. |
 
 ## Type Reference
 
@@ -153,39 +156,39 @@ type DualAxisTooltipContext = {
 
 Override these custom properties to theme the component.
 
-| Variable                              | Default                     | CSS Property     | Description                                               |
-| ------------------------------------- | --------------------------- | ---------------- | --------------------------------------------------------- |
-| `--chart-background`                  | `transparent`               | background       | Background color of the chart container.                  |
-| `--chart-font-family`                 | `inherit`                   | font-family      | Font family for all chart text.                           |
-| `--chart-transition-duration`         | `0.2s`                      | transition       | Duration of hover/opacity transitions.                    |
-| `--chart-axis-color`                  | `#666`                      | stroke, fill     | Color of axis lines, tick marks, and tick labels.         |
-| `--chart-axis-stroke-width`           | `1`                         | stroke-width     | Width of axis lines and tick marks.                       |
-| `--chart-axis-font-size`              | `11px`                      | font-size        | Font size of axis tick labels.                            |
-| `--chart-axis-label-color`            | `#333`                      | fill             | Color of axis title text.                                 |
-| `--chart-axis-label-font-size`        | `11px`                      | font-size        | Font size of axis title labels.                           |
-| `--chart-gridline-color`              | `#e0e0e0`                   | stroke           | Color of horizontal gridlines.                            |
-| `--chart-gridline-opacity`            | `0.5`                       | stroke-opacity   | Opacity of gridlines.                                     |
-| `--chart-gridline-dash`               | `4 4`                       | stroke-dasharray | Dash pattern for gridlines.                               |
-| `--chart-tooltip-background`          | `rgba(0,0,0,0.85)`          | background       | Background of the default tooltip.                        |
-| `--chart-tooltip-color`               | `#fff`                      | color            | Text color of the default tooltip.                        |
-| `--chart-tooltip-font-size`           | `12px`                      | font-size        | Font size of tooltip content.                             |
-| `--chart-tooltip-padding`             | `8px 12px`                  | padding          | Inner padding of the default tooltip.                     |
-| `--chart-tooltip-border-radius`       | `4px`                       | border-radius    | Border radius of the default tooltip.                     |
-| `--chart-tooltip-shadow`              | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Box shadow on the default tooltip.                        |
-| `--chart-legend-gap`                  | `16px`                      | gap              | Space between legend items.                               |
-| `--chart-legend-font-size`            | `12px`                      | font-size        | Font size of legend labels.                               |
-| `--chart-legend-swatch-size`          | `12px`                      | width, height    | Size of color swatches in the legend.                     |
-| `--chart-legend-color`                | `#333`                      | color            | Color of legend text.                                     |
-| `--dual-axis-bar-hover-opacity`       | `1`                         | opacity          | Opacity of bars in the hovered category.                  |
-| `--dual-axis-bar-dimmed-opacity`      | `0.3`                       | opacity          | Opacity of bars outside the hovered category.             |
-| `--dual-axis-line-stroke-width`       | `2`                         | stroke-width     | Stroke width of line series paths.                        |
-| `--dual-axis-dot-stroke`              | `#fff`                      | stroke           | Stroke color around line series dots.                     |
-| `--dual-axis-dot-stroke-width`        | `1.5`                       | stroke-width     | Stroke width of line series dots.                         |
-| `--dual-axis-guideline-color`         | `#aaa`                      | stroke           | Color of the vertical hover guideline.                    |
-| `--dual-axis-guideline-width`         | `1`                         | stroke-width     | Width of the vertical hover guideline.                    |
-| `--dual-axis-guideline-dash`          | `4 3`                       | stroke-dasharray | Dash pattern of the vertical hover guideline.             |
-| `--chart-empty-padding`               | `32px 24px`                 | padding          | Padding around the empty-state message.                   |
-| `--chart-empty-color`                 | `#9ca3af`                   | color            | Text color of the empty-state message.                    |
+| Variable                         | Default                     | CSS Property     | Description                                       |
+| -------------------------------- | --------------------------- | ---------------- | ------------------------------------------------- |
+| `--chart-background`             | `transparent`               | background       | Background color of the chart container.          |
+| `--chart-font-family`            | `inherit`                   | font-family      | Font family for all chart text.                   |
+| `--chart-transition-duration`    | `0.2s`                      | transition       | Duration of hover/opacity transitions.            |
+| `--chart-axis-color`             | `#666`                      | stroke, fill     | Color of axis lines, tick marks, and tick labels. |
+| `--chart-axis-stroke-width`      | `1`                         | stroke-width     | Width of axis lines and tick marks.               |
+| `--chart-axis-font-size`         | `11px`                      | font-size        | Font size of axis tick labels.                    |
+| `--chart-axis-label-color`       | `#333`                      | fill             | Color of axis title text.                         |
+| `--chart-axis-label-font-size`   | `11px`                      | font-size        | Font size of axis title labels.                   |
+| `--chart-gridline-color`         | `#e0e0e0`                   | stroke           | Color of horizontal gridlines.                    |
+| `--chart-gridline-opacity`       | `0.5`                       | stroke-opacity   | Opacity of gridlines.                             |
+| `--chart-gridline-dash`          | `4 4`                       | stroke-dasharray | Dash pattern for gridlines.                       |
+| `--chart-tooltip-background`     | `rgba(0,0,0,0.85)`          | background       | Background of the default tooltip.                |
+| `--chart-tooltip-color`          | `#fff`                      | color            | Text color of the default tooltip.                |
+| `--chart-tooltip-font-size`      | `12px`                      | font-size        | Font size of tooltip content.                     |
+| `--chart-tooltip-padding`        | `8px 12px`                  | padding          | Inner padding of the default tooltip.             |
+| `--chart-tooltip-border-radius`  | `4px`                       | border-radius    | Border radius of the default tooltip.             |
+| `--chart-tooltip-shadow`         | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Box shadow on the default tooltip.                |
+| `--chart-legend-gap`             | `16px`                      | gap              | Space between legend items.                       |
+| `--chart-legend-font-size`       | `12px`                      | font-size        | Font size of legend labels.                       |
+| `--chart-legend-swatch-size`     | `12px`                      | width, height    | Size of color swatches in the legend.             |
+| `--chart-legend-color`           | `#333`                      | color            | Color of legend text.                             |
+| `--dual-axis-bar-hover-opacity`  | `1`                         | opacity          | Opacity of bars in the hovered category.          |
+| `--dual-axis-bar-dimmed-opacity` | `0.3`                       | opacity          | Opacity of bars outside the hovered category.     |
+| `--dual-axis-line-stroke-width`  | `2`                         | stroke-width     | Stroke width of line series paths.                |
+| `--dual-axis-dot-stroke`         | `#fff`                      | stroke           | Stroke color around line series dots.             |
+| `--dual-axis-dot-stroke-width`   | `1.5`                       | stroke-width     | Stroke width of line series dots.                 |
+| `--dual-axis-guideline-color`    | `#aaa`                      | stroke           | Color of the vertical hover guideline.            |
+| `--dual-axis-guideline-width`    | `1`                         | stroke-width     | Width of the vertical hover guideline.            |
+| `--dual-axis-guideline-dash`     | `4 3`                       | stroke-dasharray | Dash pattern of the vertical hover guideline.     |
+| `--chart-empty-padding`          | `32px 24px`                 | padding          | Padding around the empty-state message.           |
+| `--chart-empty-color`            | `#9ca3af`                   | color            | Text color of the empty-state message.            |
 
 ## Web Component
 

--- a/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
+++ b/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
@@ -30,6 +30,9 @@
     barRadius = 3,
     barPadding = 0.25,
     aspectRatio = 16 / 9,
+    minBarHeight = 2,
+    margin,
+    tooltipPortal = false,
     tooltipSnippet,
     onbarclick,
     testId,
@@ -44,6 +47,8 @@
   let hoveredCategoryIndex = $state<number | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+  let mouseClientX = $state(0);
+  let mouseClientY = $state(0);
 
   // ── Formatters ─────────────────────────────────────────────────
 
@@ -53,7 +58,13 @@
   // ── Layout — wider right margin to accommodate right-axis labels ─
 
   const dims = $derived(
-    computeChartDimensions(chartWidth, chartHeight, { top: 24, right: 56, bottom: 40, left: 56 })
+    computeChartDimensions(chartWidth, chartHeight, {
+      top: 24,
+      right: 56,
+      bottom: 40,
+      left: 56,
+      ...margin
+    })
   );
 
   // ── Scales ─────────────────────────────────────────────────────
@@ -152,7 +163,7 @@
         const barX = bandStart + subIndex * subBandWidth + barGap;
         const valueY = scale(value);
         const barY = value >= 0 ? valueY : zeroY;
-        const barHeight = Math.max(2, Math.abs(valueY - zeroY));
+        const barHeight = Math.max(minBarHeight, Math.abs(valueY - zeroY));
 
         const path = roundedRectPath(barX, barY, barW, barHeight, barRadius, barRadius, 0, 0);
 
@@ -278,6 +289,22 @@
     const rect = containerEl.getBoundingClientRect();
     mouseX = event.clientX - rect.left;
     mouseY = event.clientY - rect.top;
+    mouseClientX = event.clientX;
+    mouseClientY = event.clientY;
+  };
+
+  /**
+   * Svelte action: relocates the tooltip layer to `document.body` so a `position:fixed`
+   * tooltip is never clipped by an `overflow`/scroll ancestor. Used only when
+   * `tooltipPortal` is set; `use:` actions never run during SSR.
+   */
+  const portalToBody = (node: HTMLElement) => {
+    document.body.appendChild(node);
+    return {
+      destroy: () => {
+        node.remove();
+      }
+    };
   };
 
   const handleCategoryEnter = (event: MouseEvent, catIdx: number) => {
@@ -439,12 +466,31 @@
     </ChartContainer>
 
     <!-- Tooltip -->
-    {#if typeof tooltipSnippet === 'function' && hoveredCategoryIndex !== null}
-      <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
-        {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
-      </div>
-    {:else}
-      <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
+    {#if hoveredCategoryIndex !== null}
+      {#if tooltipPortal}
+        <!-- Portaled to <body> with fixed viewport coords so the tooltip is never
+             clipped by an overflow/scroll ancestor (e.g. a scrollable report sheet).
+             The inner elements keep their own +12/-12 offset relative to this layer. -->
+        <div
+          class="chart-tooltip-portal"
+          style="left: {mouseClientX}px; top: {mouseClientY}px;"
+          use:portalToBody
+        >
+          {#if typeof tooltipSnippet === 'function'}
+            <div class="chart-tooltip-slot" style="left: 12px; top: -12px;">
+              {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
+            </div>
+          {:else}
+            <ChartTooltip data={tooltipData} mouseX={0} mouseY={0} />
+          {/if}
+        </div>
+      {:else if typeof tooltipSnippet === 'function'}
+        <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
+          {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
+        </div>
+      {:else}
+        <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
+      {/if}
     {/if}
   {:else}
     <div class="chart-empty">No data available.</div>
@@ -510,6 +556,12 @@
   .chart-tooltip-slot {
     position: absolute;
     z-index: 10;
+    pointer-events: none;
+  }
+
+  .chart-tooltip-portal {
+    position: fixed;
+    z-index: var(--chart-tooltip-z-index, 10);
     pointer-events: none;
   }
 

--- a/src/lib/DualAxisBarChart/properties.ts
+++ b/src/lib/DualAxisBarChart/properties.ts
@@ -111,6 +111,27 @@ export type OptionalDualAxisBarChartProperties = {
   testId?: string;
   /** Extra CSS class string on the root `<div>`. */
   classes?: string;
+  /**
+   * Minimum rendered bar height in pixels. The default `2` keeps very small non-zero
+   * values visible, but it also paints a 2px stub for genuine zeros — set `0` so an
+   * all-zero/dormant series renders nothing (letting the consumer detect it and show
+   * an empty state instead of a row of indistinguishable baseline stubs). Default `2`.
+   */
+  minBarHeight?: number;
+  /**
+   * Override the plot margins (px) reserved for axis titles and tick labels. Merged
+   * over the defaults `{ top: 24, right: 56, bottom: 40, left: 56 }`; widen `left`/`right`
+   * when long currency tick labels (e.g. `₹1,00,000`) would otherwise overlap the
+   * gridlines in a narrow container.
+   */
+  margin?: { top?: number; right?: number; bottom?: number; left?: number };
+  /**
+   * Render the hover tooltip on `document.body` with `position: fixed` viewport
+   * coordinates instead of `position: absolute` inside the chart. Set `true` when the
+   * chart sits in an `overflow:auto`/scrollable container that would otherwise clip the
+   * tooltip. Default `false` (in-chart positioning, unchanged).
+   */
+  tooltipPortal?: boolean;
 };
 
 export type DualAxisBarChartEventProperties = {


### PR DESCRIPTION
## Summary

Three **additive, non-breaking** props on `DualAxisBarChart`, motivated by audit-report charts rendered inside constrained / scrollable containers. Every prop defaults to the current behaviour, so existing consumers are unaffected.

| Prop | Default | Fixes |
|---|---|---|
| `minBarHeight` | `2` | Zero / dormant series rendering as indistinguishable 2px baseline stubs |
| `margin` | `{ top: 24, right: 56, bottom: 40, left: 56 }` | Long currency tick labels overlapping gridlines in a narrow container |
| `tooltipPortal` | `false` | Hover tooltip clipped by an `overflow`/scroll ancestor |

## Details

- **`minBarHeight`** — the bar geometry uses `Math.max(2, …)`, which paints a 2px stub even for a genuine `0`. For a dormant/all-zero series every bar collapses to an identical baseline sliver, visually indistinguishable from an empty grid. Exposing `minBarHeight` lets a consumer pass `0` to render nothing and detect the all-zero case to show its own empty state.
- **`margin`** — the plot margins were hardcoded at `{ top: 24, right: 56, bottom: 40, left: 56 }`. Long currency tick labels (e.g. `₹1,00,000`) overlap the gridlines when the chart is narrow. The new prop is a `Partial<Margin>` merged over the defaults, so callers can widen only what they need.
- **`tooltipPortal`** — the hover tooltip (`.chart-tooltip-slot` / `ChartTooltip`) is `position: absolute` inside the chart container, so a scrollable ancestor (`overflow: auto`) clips it. When `tooltipPortal` is `true`, the tooltip layer is moved to `document.body` via a small `use:` action and positioned with `position: fixed` viewport coordinates (tracked alongside the existing container-relative coords), escaping all `overflow` clips. Default `false` keeps in-chart positioning unchanged.

## Compatibility

Non-breaking — all three props are optional and default to the prior behaviour. SSR-safe (the portal `use:` action only runs in the browser).

## Testing

- `pnpm run check` → 0 errors.
- `pnpm exec eslint` / `prettier --check` → clean on the changed files.
- Docs (`docs/DualAxisBarChart.md`) Props table updated with the three props.

The chart family currently has no Playwright harness; happy to add one if the maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to fine-tune the bar chart, including minimum bar height, custom chart margins, and an optional tooltip overlay mode.
  * Tooltips can now render in a fixed overlay layer to help avoid clipping in tight layouts.

* **Documentation**
  * Updated the bar chart documentation to include the new options and refreshed the props and CSS variables tables for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->