### PR TITLE
chore: prettier-format button demo page

### DIFF
--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -82,7 +82,9 @@
           aria-hidden="true"
         >
           <polyline points="3 6 5 6 21 6" />
-          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+          <path
+            d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+          />
         </svg>
       {/snippet}
     </Button>
@@ -94,7 +96,10 @@
   </div>
 
   <h3>Loading</h3>
-  <p>The <code>loading</code> prop shows a spinner, sets <code>aria-busy</code>, and disables the button.</p>
+  <p>
+    The <code>loading</code> prop shows a spinner, sets <code>aria-busy</code>, and disables the
+    button.
+  </p>
   <div class="demo-row">
     <Button text={loadingDemo ? 'Saving…' : 'Save'} loading={loadingDemo} onclick={runLoading} />
   </div>


### PR DESCRIPTION
`prettier --check src` (the first half of `pnpm run lint`) currently fails on `release` for `src/routes/components/button/+page.svelte` — two over-length lines (an SVG `<path d>` and a `<p>`). This wraps them per the repo's Prettier config.

Formatting only, no behaviour change. After this, `pnpm run lint` is green again on `release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted the button demo page markup for improved readability.
  * Adjusted the inline SVG and loading description layout without changing any visible behavior or text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->