### PR TITLE
fix(charts): clamp ChartTooltip to its container + suppress cramped horizontal bar labels (BZ-4294)

### DIFF
--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -755,7 +755,12 @@
                     onclick={() => handleClick(bar)}
                   />
                 {/if}
-                {#if showValues && !isStackedMode}
+                <!-- Suppress the horizontal value label when its sub-band is thinner
+                     than the ~11px label, so cramped multi-series charts hide labels
+                     instead of overlapping them into an unreadable cluster. Consumers
+                     restore labels by giving the chart more height (aspectRatio /
+                     scrollable / minBandWidth). -->
+                {#if showValues && !isStackedMode && (isVertical || bar.height >= 13)}
                   <text
                     class="bar-value"
                     x={isVertical ? bar.x + bar.width / 2 : bar.x + bar.width + 4}

--- a/src/lib/_chart/ChartTooltip.svelte
+++ b/src/lib/_chart/ChartTooltip.svelte
@@ -2,10 +2,47 @@
   import type { ChartTooltipProperties } from './types';
 
   let { data, mouseX = 0, mouseY = 0, customSnippet, classes }: ChartTooltipProperties = $props();
+
+  const OFFSET = 12;
+
+  let tooltipEl = $state<HTMLDivElement | null>(null);
+  let tooltipWidth = $state(0);
+  let tooltipHeight = $state(0);
+
+  // Clamp against the positioned chart container so the tooltip never spills past
+  // (and gets clipped by) an overflow:hidden edge. Re-read on each measure/move.
+  const containerWidth = $derived(tooltipEl?.offsetParent?.clientWidth ?? Number.POSITIVE_INFINITY);
+  const containerHeight = $derived(
+    tooltipEl?.offsetParent?.clientHeight ?? Number.POSITIVE_INFINITY
+  );
+
+  // Horizontal: flip to the left of the cursor when it would overflow the right edge.
+  const left = $derived.by(() => {
+    let value = mouseX + OFFSET;
+    if (value + tooltipWidth > containerWidth) {
+      value = mouseX - tooltipWidth - OFFSET;
+    }
+    return Math.max(0, value);
+  });
+
+  // Vertical: keep the tooltip within the container's top and bottom edges.
+  const top = $derived.by(() => {
+    let value = mouseY - OFFSET;
+    if (value + tooltipHeight > containerHeight) {
+      value = containerHeight - tooltipHeight;
+    }
+    return Math.max(0, value);
+  });
 </script>
 
 {#if data !== null}
-  <div class="chart-tooltip {classes ?? ''}" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
+  <div
+    bind:this={tooltipEl}
+    bind:clientWidth={tooltipWidth}
+    bind:clientHeight={tooltipHeight}
+    class="chart-tooltip {classes ?? ''}"
+    style="left: {left}px; top: {top}px;"
+  >
     {#if typeof customSnippet === 'function'}
       {@render customSnippet(data)}
     {:else}


### PR DESCRIPTION
Fixes the two chart defects from the Lighthouse BZ-4294 release blocker (mobile "Weekly Sales Update" charts). Verified in the consuming app (lighthouse) reproduction.

## Changes
- **`_chart/ChartTooltip.svelte` — edge-aware positioning.** The tooltip was positioned unconditionally at `left: mouseX + 12` with no boundary check, so a tooltip near the right edge (e.g. a donut slice at ~3 o'clock) spilled past the container and got clipped by the consumer's `overflow: hidden` wrapper. It now measures its own size and its positioned container, flips to the **left** of the cursor when it would overflow the right edge, and clamps within the top/bottom edges.
- **`BarChart.svelte` — horizontal dataLabel overlap.** With many categories × series squeezed into a short chart, the horizontal value labels overlapped into an unreadable cluster (there was no collision avoidance). The horizontal value label is now suppressed when its sub-band is thinner than the ~11px label, so cramped charts hide labels instead of jumbling them. Consumers restore labels by giving the chart more height (`aspectRatio` / `scrollable` / `minBandWidth`).

## Not changed (for reviewer awareness)
Lighthouse **BZ-4295 #2** (StatCard trend arrows "don't match legacy") was investigated: `DeltaIndicator`'s direction/tone/colour logic is correct, and the report is a subjective visual-style complaint without a reference for the expected arrow style — flagging here rather than guessing a new glyph. Happy to follow up once the intended legacy style is specified.

## Checks
`svelte-check` — no new errors from these files (2 pre-existing `lottie-web` peer-dep errors are unrelated). `eslint` clean on both files.

## Follow-up
After this publishes, bump `@juspay/svelte-ui-components` in lighthouse (currently 2.80.2) so BZ-4294 lands there.