### PR TITLE
fix(charts): swatch radius token + unblock release lint (Combobox null, demo prettier) — BZ-4233

### DIFF
--- a/src/lib/Combobox/Combobox.svelte
+++ b/src/lib/Combobox/Combobox.svelte
@@ -82,8 +82,8 @@
     filteredItems.filter((item) => item.disabled !== true)
   );
 
-  let exactMatch: ComboboxItem | undefined = $derived(
-    items.find((item) => item.label.toLowerCase() === trimmedQuery.toLowerCase())
+  let exactMatch: ComboboxItem | null = $derived(
+    items.find((item) => item.label.toLowerCase() === trimmedQuery.toLowerCase()) ?? null
   );
 
   let atLimit = $derived(
@@ -101,7 +101,7 @@
     allowCreate &&
       !atLimit &&
       trimmedQuery !== '' &&
-      exactMatch === undefined &&
+      exactMatch === null &&
       !(multiple && selectedSet.has(trimmedQuery))
   );
 

--- a/src/lib/_chart/ChartTooltip.svelte
+++ b/src/lib/_chart/ChartTooltip.svelte
@@ -60,7 +60,7 @@
     display: inline-block;
     width: 8px;
     height: 8px;
-    border-radius: 2px;
+    border-radius: var(--chart-swatch-radius, 2px);
     flex-shrink: 0;
   }
 

--- a/src/lib/_chart/Legend.svelte
+++ b/src/lib/_chart/Legend.svelte
@@ -48,7 +48,7 @@
     display: inline-block;
     width: var(--chart-legend-swatch-size, 12px);
     height: var(--chart-legend-swatch-size, 12px);
-    border-radius: 2px;
+    border-radius: var(--chart-swatch-radius, 2px);
     flex-shrink: 0;
   }
 

--- a/src/routes/components/combobox/+page.svelte
+++ b/src/routes/components/combobox/+page.svelte
@@ -50,7 +50,9 @@
 </div>
 
 <h3>Multi select (pills)</h3>
-<p>Set <code>multiple</code> with a bindable <code>selected</code> array. Picks become removable pills.</p>
+<p>
+  Set <code>multiple</code> with a bindable <code>selected</code> array. Picks become removable pills.
+</p>
 <div class="demo-row" style="max-width: 420px;">
   <Combobox items={fruits} multiple bind:selected={picked} placeholder="Pick fruits…" />
   {#if picked.length > 0}
@@ -82,7 +84,9 @@
 </div>
 
 <h3>Multi select + limit</h3>
-<p>Cap selections with <code>maxSelected</code>; the dropdown shows a limit message once reached.</p>
+<p>
+  Cap selections with <code>maxSelected</code>; the dropdown shows a limit message once reached.
+</p>
 <div class="demo-row" style="max-width: 420px;">
   <Combobox
     items={fruits}

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -77,7 +77,12 @@
 
 <h3>Single select with selected tick</h3>
 <div class="demo-row" style="max-width: 300px;">
-  <Select items={fruits} bind:value={singleTickValue} placeholder="Choose a fruit" showSelectedTick />
+  <Select
+    items={fruits}
+    bind:value={singleTickValue}
+    placeholder="Choose a fruit"
+    showSelectedTick
+  />
   {#if singleTickValue.length > 0}
     <p class="demo-info">Selected ID: {singleTickValue.at(0)}</p>
   {/if}


### PR DESCRIPTION
## Why
After #347 merged, the `release` build failed on `pnpm lint` so the version never published. This PR fixes the lint blockers + adds the swatch-radius tidy, with the **full gate green**.

## Changes
- **Combobox.svelte**: `exactMatch` `undefined` → `null` (the repo `no-restricted-syntax` eslint rule was erroring the release build). Semantics preserved (`?? null`; the truthy-guarded usages are unaffected).
- **routes/components/{combobox,select}/+page.svelte**: prettier drift that broke `prettier --check src`.
- **ChartTooltip/Legend swatch**: `border-radius: 2px` → `var(--chart-swatch-radius, 2px)` — overridable token, 2px default = **no visual change** (removes the magic number; the swatch-radii follow-up requested).

## Verification (full gate, no --no-verify)
- `prettier --check src` ✅ · `eslint src` ✅ (0 errors)
- `svelte-check` — 0 errors
- `pnpm build` ✅
- `vitest run` — 25/25 pass
- Pre-commit hook (check + format + lint + build + commitlint) passed on commit.