### PR TITLE
BZ-4330: fix: Incorrect timestamp for Single Date Selection

### DIFF
--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -154,6 +154,12 @@
     return n;
   }
 
+  function endOfDay(d: Date): Date {
+    const newDate = new SvelteDate(d);
+    newDate.setHours(23, 59, 59, 999);
+    return newDate;
+  }
+
   function isSameDay(a: Date, b: Date): boolean {
     return (
       a.getFullYear() === b.getFullYear() &&
@@ -206,6 +212,8 @@
         if (date.getTime() < normalizeDate(start).getTime()) {
           rangeEnd = start;
           rangeStart = date;
+        } else if (isSameDay(date, start)) {
+          rangeEnd = endOfDay(date);
         } else {
           rangeEnd = date;
         }

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -347,10 +347,10 @@
       if (draftStart !== null && draftEnd !== null) {
         // Fold the time-of-day inputs onto the committed dates when time selection is on.
         const appliedStart = showTimeSelection
-          ? (applyTimeDisplay(draftStart, startTimeDisplay) ?? draftStart)
+          ? (applyTimeDisplay(draftStart, startTimeDisplay, 'start') ?? draftStart)
           : draftStart;
         const appliedEnd = showTimeSelection
-          ? (applyTimeDisplay(draftEnd, endTimeDisplay) ?? draftEnd)
+          ? (applyTimeDisplay(draftEnd, endTimeDisplay, 'end') ?? draftEnd)
           : draftEnd;
         rangeStart = appliedStart;
         rangeEnd = appliedEnd;

--- a/src/lib/DateRangePicker/properties.ts
+++ b/src/lib/DateRangePicker/properties.ts
@@ -15,6 +15,7 @@ export type DateRangePreset = {
 export type DateRangePickerMode = 'range' | 'single';
 export type DateRangePickerAlign = 'left' | 'right';
 export type DateRangePickerTimeLayout = 'toggle' | 'inline';
+export type TimeDisplayBoundary = 'start' | 'end';
 
 export type OptionalDateRangePickerProperties = {
   /** Currently selected start of range (bindable). */

--- a/src/lib/DateRangePicker/timeUtils.ts
+++ b/src/lib/DateRangePicker/timeUtils.ts
@@ -1,4 +1,5 @@
 // Time-of-day helpers for the DateRangePicker's built-in date + time inputs.
+import type { TimeDisplayBoundary } from './properties';
 
 /** Matches a 12-hour clock display such as "2:30 PM" or "02:05 am". */
 export const TIME_DISPLAY_PATTERN = /^(1[0-2]|0?[1-9]):([0-5][0-9])\s?(AM|PM)$/i;
@@ -31,13 +32,21 @@ export const formatTimeDisplay = (date: Date): string => {
 };
 
 /** Return a new Date with the time-of-day from a 12-hour display string applied, or null when invalid. */
-export const applyTimeDisplay = (date: Date, display: string): Date | null => {
+export const applyTimeDisplay = (
+  date: Date,
+  display: string,
+  boundary: TimeDisplayBoundary
+): Date | null => {
   const parsed = parseTimeDisplay(display);
   if (parsed === null) {
     return null;
   }
   const next = new Date(date.getTime());
-  next.setHours(parsed.hours, parsed.minutes, 0, 0);
+  if (boundary === 'end') {
+    next.setHours(parsed.hours, parsed.minutes, 59, 999);
+  } else {
+    next.setHours(parsed.hours, parsed.minutes, 0, 0);
+  }
   return next;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar range selection so choosing the same day as the start date now includes the full day through 11:59:59.999 PM.
  * Made end-date handling more consistent for same-day range selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->