### PR TITLE
style(modal): prettier formatting for inline header Img tags

### DIFF
--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -165,7 +165,13 @@
                 >
                   <!-- Inline SVGs so currentColor icons inherit the header text
                        colour; non-SVG URLs fall back to a plain <img>. -->
-                  <Img inlineSvg src={header.leftImage} alt="" fallback="" classes="header-left-img" />
+                  <Img
+                    inlineSvg
+                    src={header.leftImage}
+                    alt=""
+                    fallback=""
+                    classes="header-left-img"
+                  />
                 </div>
               {/if}
               {#if typeof header.text === 'string' && header.text.length > 0}
@@ -181,7 +187,13 @@
                   onkeydown={handleRightImageKeyDown}
                   data-pw={header.buttonTestId}
                 >
-                  <Img inlineSvg src={header.rightImage} alt="" fallback="" classes="header-right-img" />
+                  <Img
+                    inlineSvg
+                    src={header.rightImage}
+                    alt=""
+                    fallback=""
+                    classes="header-right-img"
+                  />
                 </div>
               {/if}
             </div>


### PR DESCRIPTION
Unblocks the release workflow: #351 introduced prettier drift in Modal.svelte (long inline `Img` tags), failing the `pnpm lint` step of Release and Publish. Formatting-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated image component formatting in the modal header for consistency and readability.
  * No functional or visual behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->