### PR TITLE
fix: prevent date picker clipping and restore month navigation

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -982,6 +982,7 @@
     flex-direction: column;
     min-width: var(--drp-panel-min-width, 320px);
     max-width: var(--drp-panel-max-width, 760px);
+    max-height: var(--drp-panel-max-height, calc(100dvh - 80px));
     overflow: hidden;
   }
 
@@ -998,6 +999,9 @@
   .drp-panel-inner {
     display: flex;
     flex-direction: row;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
   }
 
   /* ── Sidebar ── */
@@ -1139,7 +1143,10 @@
     --calendar-box-shadow: none;
     --calendar-background: transparent;
     --calendar-padding: 0;
-    /* Suppress Calendar's own header in dual-month context via CSS var */
+  }
+
+  /* Suppress Calendar's own header in dual-month mode; single mode keeps it for navigation */
+  :global(.drp-months-row .drp-calendar-embedded) {
     --calendar-header-display: none;
   }
 


### PR DESCRIPTION
## Problem

There were two issues with the DateRangePicker in the grant points flow:

1. When the merchant’s Chrome page was at 100% zoom or fit-to-screen, the calendar dropdown was getting cut off and was not fully viewable.
2. The merchant was not able to navigate past the current month, for example past July, while selecting an expiry date. This blocked merchants from setting longer validity periods such as 1 year.

## Fix

- Updated the shared DateRangePicker so the calendar panel remains viewable inside constrained modal layouts.
- Restored month navigation visibility for single-month DateRangePicker usage, allowing merchants to move to future months and select longer expiry dates.
- Updated Lighthouse `GrantPointsModal` to rely on the shared DateRangePicker’s default trigger and styling instead of local/global overrides.
- Added local open-state handling in Lighthouse only for modal layout spacing, so the date picker has enough room when opened.

**Before:**
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/c68a6bbf-d1cb-4a15-bd1a-a0360f38d588" />


**Dev Proof:**
<img width="1728" height="1117" alt="Screenshot 2026-07-03 at 5 31 15 PM" src="https://github.com/user-attachments/assets/14adae7a-b677-4aa0-9ec4-232a8044562a" />
<img width="1728" height="1117" alt="Screenshot 2026-07-03 at 5 31 18 PM" src="https://github.com/user-attachments/assets/55a0bd1b-51c2-454a-b54c-16362b43c65d" />

