### PR TITLE
feat(Table): cut the keyed-column minor release — lint fixes for the absorption train

### DIFF
--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import type { TableCellValue, TableColumn } from './properties';
-  import type { InputDataType } from '$lib/types';
   import {
     asActionGroupCellData,
     asAvatarStackData,
     asButtonCellData,
     asCompareCellData,
     asInputCellData,
+    asInputDataType,
     asJsonObject,
     asLinkCellData,
     asPopupMenuCellData,
@@ -268,7 +268,7 @@
         placeholder={inputData.placeholder ?? ''}
         disable={inputData.disabled ?? false}
         testId={inputData.testId ?? ''}
-        dataType={(inputData.dataType ?? 'text') as InputDataType}
+        dataType={asInputDataType(inputData.dataType ?? null)}
         validationPattern={inputData.validationPattern
           ? new RegExp(inputData.validationPattern)
           : null}

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -398,9 +398,10 @@
     if (!checkboxSelection || checkboxSelection.enabled === false) {
       return [];
     }
-    return paginatedTableData
-      .map((row) => rowIdByRow.get(row))
-      .filter((rowId): rowId is string => rowId !== undefined && !isRowDisabled(rowId));
+    return paginatedTableData.flatMap((row) => {
+      const rowId = rowIdByRow.get(row) ?? null;
+      return rowId !== null && !isRowDisabled(rowId) ? [rowId] : [];
+    });
   });
 
   /**

--- a/src/lib/Table/cellData.ts
+++ b/src/lib/Table/cellData.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from 'type-decoder';
+import type { InputDataType } from '$lib/types';
 import type { IconStackItem } from '../IconStack/properties';
 import type {
   TableActionGroupCellData,
@@ -191,6 +192,23 @@ export const asInputCellData = (value: TableCellValue): TableInputCellData | nul
     inputData.onErrorMessage = record.onErrorMessage;
   }
   return inputData;
+};
+
+/**
+ * Narrows a free-form `dataType` string from cell data to the `Input`
+ * component's `InputDataType` union, falling back to `'text'` for any
+ * unrecognised value.
+ */
+export const asInputDataType = (value: string | null): InputDataType => {
+  switch (value) {
+    case 'tel':
+    case 'password':
+    case 'email':
+    case 'number':
+      return value;
+    default:
+      return 'text';
+  }
 };
 
 export const asButtonCellData = (value: TableCellValue): TableButtonCellData | null => {

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -424,7 +424,10 @@
   const serverPagedRows = $derived(
     Array.from(
       {
-        length: Math.min(SERVER_PAGE_SIZE, SERVER_TOTAL_RECORDS - (serverPageNumber - 1) * SERVER_PAGE_SIZE)
+        length: Math.min(
+          SERVER_PAGE_SIZE,
+          SERVER_TOTAL_RECORDS - (serverPageNumber - 1) * SERVER_PAGE_SIZE
+        )
       },
       (_, index) => ({
         record: `Record ${String((serverPageNumber - 1) * SERVER_PAGE_SIZE + index + 1).padStart(2, '0')}`


### PR DESCRIPTION
## Why

The **Release and Publish** run for the keyed-column train ([47204c1, PR #357](https://github.com/juspay/svelte-ui-components/pull/357)) [failed at `pnpm lint`](https://github.com/juspay/svelte-ui-components/actions/runs/28739242926): `prettier --check` flagged the table demo page, and because `lint` short-circuits (`prettier && eslint`), it hid **two eslint errors** that would have failed the next run as well. PR CI does not run `pnpm lint`, which is how these slipped through.

## What (no behavior change)

1. **Demo page** — prettier-format one over-long line (`serverPagedRows` length expression).
2. **`Table.svelte`** — `selectableRowIds` narrows via `flatMap` instead of a type predicate (`rowId is string`) + `undefined` comparison, both banned by `no-restricted-syntax`.
3. **`BuiltinCell.svelte`** — the input cell's `dataType` narrows through a new `asInputDataType` helper in `cellData.ts` (same pattern as the other narrowing helpers) instead of an `as` assertion (`consistent-type-assertions`).

## Commit type

Typed `feat` deliberately: the release workflow derives the version bump from the **tip commit alone** (`git log -1`), and the unreleased content sitting on `release` is the keyed-column feature train — this commit must carry its **minor** bump (→ 2.81.0). A `style:`/`chore:` tip would mis-release the train as a patch.

## Verification (fresh worktree, frozen-lockfile install — exact CI reproduction)

- `pnpm lint` clean (prettier + eslint)
- svelte-check: 518 files, 0 errors
- vitest 51/51
- Playwright 23/23 on the two suites covering the touched paths (`table-pagination-selection`, `table-interactive-cells`)
- `pnpm build` + `pnpm build:wc` green (the remaining release-job steps)

Single-commit policy maintained (1 commit, based on current `release` tip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table cell input handling so values now map more reliably to the correct input type, with safer fallback behavior for unknown or missing types.
  * Fixed row selection behavior in tables so “select all” now better respects the current view, excluding disabled rows and rows without valid IDs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->