### PR TITLE
fix(Table): forward itemTestId through select cells so options keep their data-pw contract

### DIFF
--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -244,6 +244,7 @@
         placeholder={selectData.placeholder ?? ''}
         disabled={selectData.disabled ?? false}
         testId={selectData.testId}
+        itemTestId={selectData.itemTestId}
         onchange={(selectedIds) => {
           if (selectedIds.length > 0) {
             column.onSelect?.(rowIndex, selectedIds[0]);

--- a/src/lib/Table/cellData.ts
+++ b/src/lib/Table/cellData.ts
@@ -161,6 +161,9 @@ export const asSelectCellData = (value: TableCellValue): TableSelectCellData | n
   if (typeof record.testId === 'string') {
     selectData.testId = record.testId;
   }
+  if (typeof record.itemTestId === 'string') {
+    selectData.itemTestId = record.itemTestId;
+  }
   return selectData;
 };
 

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -122,6 +122,8 @@ export type TableSelectCellData = {
   placeholder?: string;
   disabled?: boolean;
   testId?: string;
+  /** Per-option test id prefix — each option emits `data-pw="{itemTestId}-{id}"`. */
+  itemTestId?: string;
 };
 
 /** Cell shape for `type: 'input'` — the handler lives on the column. */

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -254,7 +254,8 @@
           { id: 'pro', label: 'Pro' }
         ],
         selectedId: 'pro',
-        testId: 'demo-tier-0'
+        testId: 'demo-tier-0',
+        itemTestId: 'demo-tier-option'
       },
       note: { value: 'renews in June', testId: 'demo-note-0' },
       action: { text: 'Renew', testId: 'demo-renew-0' },

--- a/tests/table-interactive-cells.test.ts
+++ b/tests/table-interactive-cells.test.ts
@@ -25,6 +25,18 @@ test.describe('Table — interactive cell renderers', () => {
     await expect(table.locator('[data-pw="demo-renew-1"]')).toBeDisabled();
   });
 
+  test('select cell forwards itemTestId — options carry data-pw="{prefix}-{id}"', async ({
+    page
+  }) => {
+    await page.goto('/components/table');
+    const table = page.locator('[data-pw="table-interactive-cells"]');
+    const select = table.locator('[data-pw="demo-tier-0"]');
+    await select.getByRole('combobox').click();
+    await expect(select.locator('[data-pw="demo-tier-option-basic"]')).toBeVisible();
+    await expect(select.locator('[data-pw="demo-tier-option-pro"]')).toBeVisible();
+    await page.keyboard.press('Escape');
+  });
+
   test('select cell fires onSelect with the chosen option id, no row click', async ({ page }) => {
     await page.goto('/components/table');
     const table = page.locator('[data-pw="table-interactive-cells"]');


### PR DESCRIPTION
## Why

The legacy DataGrid select cells passed `SelectProperties.itemTestId` through to the library `Select`, which stamps every option with `data-pw="{itemTestId}-{id}"` (e.g. `pp-PERCENTAGE` in Lighthouse's Token Advance grid). `TableSelectCellData` had no `itemTestId` field, so consumers migrated to the Table's built-in select cells silently lose their per-option test ids. Found during Lighthouse's end-to-end workflow verification (the gap was masked by an earlier assertion in the same spec until that was repaired).

## What

- `TableSelectCellData.itemTestId?: string` (properties)
- `asSelectCellData` passes it through (cellData)
- `BuiltinCell` forwards it to `<Select itemTestId={...}>`
- Demo select cell wires `itemTestId='demo-tier-option'`; regression test asserts both options carry the prefixed `data-pw`

## Verification

- `table-interactive-cells` suite 10/10 (incl. the new regression test)
- svelte-check 518 files, 0 errors; lint clean
- Single commit on the current `release` tip; `fix:` type → patch release (2.81.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table select cells now support per-option test IDs, making individual options easier to target in interactive demos and automated checks.
  * The table component demo has been updated to include this option-level identifier behavior.

* **Tests**
  * Added coverage for select-cell option rendering to verify option identifiers are exposed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->