### PR TITLE
feat(charts): Highcharts-grade labels, tooltips, interactions, dark mode across funnel/line/bar charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .playwright-mcp/*
+
+# Playwright artifacts
+test-results/
+.superpowers/

--- a/docs/AreaChart.md
+++ b/docs/AreaChart.md
@@ -94,6 +94,9 @@ Each column is normalized so series values sum to 100%.
 | empty          | `Snippet`                                                   | No       | `-`          | Content rendered when all series are empty.                                                                                           |
 | testId         | `string`                                                    | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                               |
 | classes        | `string`                                                    | No       | `-`          | CSS class string applied to the top-level element.                                                                                    |
+| minHeight | `number` | No | `0` | Lower bound (px) on the rendered chart height. |
+| maxHeight | `number` | No | `420` | Upper bound (px) on the rendered chart height. |
+| tooltipPortal | `boolean` | No | `false` | Render the tooltip into `document.body` (`position: fixed`) so scroll/overflow ancestors never clip it. |
 
 ## Events
 
@@ -111,6 +114,17 @@ In addition to the shared `--chart-*` variables (see BarChart docs), AreaChart e
 | `--areachart-dimmed-opacity`  | `0.1`   | opacity      | Opacity of non-hovered series when hovering. |
 | `--areachart-value-color`     | `#333`  | fill         | Color of point value labels.                 |
 | `--areachart-value-font-size` | `11px`  | font-size    | Font size of point value labels.             |
+
+## Dark mode
+
+Chart colors resolve through CSS `light-dark()`. Set `color-scheme` on the chart's ancestor (or `:root`) so the correct side is chosen:
+
+```css
+:root { color-scheme: light; }
+[data-theme='dark'] { color-scheme: dark; }
+```
+
+Every `--chart-*` / component token can still be overridden per theme; overrides always win over the built-in `light-dark()` fallbacks.
 
 ## Type Reference
 

--- a/docs/BarChart.md
+++ b/docs/BarChart.md
@@ -178,6 +178,9 @@ Render axes, gridlines, and legend without drawing any bar rectangles — useful
 | renderOverlay         | `Snippet<[BarChartRenderContext]>`     | No       | `-`           | Escape-hatch snippet rendered inside the SVG transform group after all bars. Receives `{ innerWidth, innerHeight, margin }`.                                                                                                                                                  |
 | testId                | `string`                               | No       | `-`           | Value for the `data-pw` attribute on the chart container.                                                                                                                                                                                                                     |
 | classes               | `string`                               | No       | `-`           | CSS class string applied to the top-level element.                                                                                                                                                                                                                            |
+| interactiveLegend | `boolean` | No | `false` | Legend items become click/keyboard toggles for series visibility; hidden series are removed from the plot and the scales rescale to the remaining data. |
+| hideLegendBelow | `number` | No | `360` | Hide the legend when the measured chart width is below this pixel value; `0` disables the behavior. |
+| tooltipPortal | `boolean` | No | `false` | Render the tooltip into `document.body` (`position: fixed`) so scroll/overflow ancestors never clip it. |
 
 ## Events
 
@@ -221,6 +224,17 @@ Override these custom properties to theme the component.
 | `--barchart-value-color`           | `#333`                      | fill             | Color of value labels.                                                                                                                |
 | `--barchart-value-font-size`       | `11px`                      | font-size        | Font size of value labels.                                                                                                            |
 | `--barchart-scroll-area-height`    | `auto`                      | height           | Fixed height of the scroll area when `scrollable` is `true`.                                                                         |
+
+## Dark mode
+
+Chart colors resolve through CSS `light-dark()`. Set `color-scheme` on the chart's ancestor (or `:root`) so the correct side is chosen:
+
+```css
+:root { color-scheme: light; }
+[data-theme='dark'] { color-scheme: dark; }
+```
+
+Every `--chart-*` / component token can still be overridden per theme; overrides always win over the built-in `light-dark()` fallbacks.
 
 ## Type Reference
 

--- a/docs/DualAxisBarChart.md
+++ b/docs/DualAxisBarChart.md
@@ -100,6 +100,8 @@ A pure-SVG dual-axis chart with two completely independent Y-axes — left (`yAx
 | minBarHeight   | `number`                            | No       | `2`                                            | Minimum rendered bar height in pixels. Set `0` so an all-zero/dormant series renders nothing (e.g. to show an empty state instead of indistinguishable 2px baseline stubs). |
 | margin         | `{ top?; right?; bottom?; left? }`  | No       | `{ top: 24, right: 56, bottom: 40, left: 56 }` | Override plot margins (px) for axis titles/labels, merged over the defaults. Widen `left`/`right` for long currency tick labels in narrow containers.                       |
 | tooltipPortal  | `boolean`                           | No       | `false`                                        | Render the hover tooltip on `document.body` with `position: fixed` viewport coords so it is not clipped by an `overflow`/scroll ancestor (e.g. a scrollable sheet).         |
+| interactiveLegend | `boolean` | No | `false` | Legend items become click/keyboard toggles for series visibility; hidden series are removed from the plot and the scales rescale to the remaining data. |
+| hideLegendBelow | `number` | No | `360` | Hide the legend when the measured chart width is below this pixel value; `0` disables the behavior. |
 
 ## Events
 
@@ -189,6 +191,17 @@ Override these custom properties to theme the component.
 | `--dual-axis-guideline-dash`     | `4 3`                       | stroke-dasharray | Dash pattern of the vertical hover guideline.     |
 | `--chart-empty-padding`          | `32px 24px`                 | padding          | Padding around the empty-state message.           |
 | `--chart-empty-color`            | `#9ca3af`                   | color            | Text color of the empty-state message.            |
+
+## Dark mode
+
+Chart colors resolve through CSS `light-dark()`. Set `color-scheme` on the chart's ancestor (or `:root`) so the correct side is chosen:
+
+```css
+:root { color-scheme: light; }
+[data-theme='dark'] { color-scheme: dark; }
+```
+
+Every `--chart-*` / component token can still be overridden per theme; overrides always win over the built-in `light-dark()` fallbacks.
 
 ## Web Component
 

--- a/docs/FunnelChart.md
+++ b/docs/FunnelChart.md
@@ -83,7 +83,7 @@ A horizontal funnel chart built entirely from pure SVG — no external charting 
 | --------------- | ------------------------------------------------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | data            | `FunnelStage[]`                                   | Yes      | –                                     | Ordered array of `{ category, value }` stage objects. Stages are rendered left-to-right; the tallest bar corresponds to the maximum value.         |
 | stageColors     | `string[]`                                        | No       | chart palette                         | Fill color for each stage bar, index-matched to `data`. Unspecified entries fall back to the shared chart palette.                                 |
-| connectorColor  | `string`                                          | No       | `#BDFFFB`                             | Fill color for the trapezoidal connector shapes between consecutive stages.                                                                        |
+| connectorColor  | `string`                                          | No       | `light-dark(#BDFFFB, #164e4a)`        | Fill color for the trapezoidal connector shapes between consecutive stages. The default resolves per color scheme via CSS `light-dark()`.          |
 | slopeWidth      | `number`                                          | No       | `10`                                  | Horizontal width (SVG units) of each slope connector. Larger values produce steeper visual drops.                                                  |
 | onHoverExpand   | `number`                                          | No       | `10`                                  | Extra vertical pixels added symmetrically to the hovered stage bar. Set to `0` to disable.                                                        |
 | showValueLabels | `boolean`                                         | No       | `true`                                | Whether to render the value and percentage label centred inside each stage bar.                                                                    |
@@ -92,6 +92,7 @@ A horizontal funnel chart built entirely from pure SVG — no external charting 
 | testId          | `string`                                          | No       | –                                     | Value for the `data-pw` attribute on the chart root element.                                                                                      |
 | classes         | `string`                                          | No       | –                                     | CSS class string applied to the chart root element. Useful for scoping CSS-variable overrides.                                                     |
 | empty           | `Snippet`                                         | No       | –                                     | Content rendered when `data` is empty or all values are zero.                                                                                     |
+| tooltipPortal | `boolean` | No | `false` | Render the tooltip into `document.body` (`position: fixed`) so scroll/overflow ancestors never clip it. |
 
 ## Events
 
@@ -117,13 +118,24 @@ Override these custom properties to theme the component.
 | `--chart-tooltip-shadow`               | `0 2px 8px rgba(0,0,0,0.2)` | box-shadow       | Shadow on the tooltip.                                        |
 | `--chart-empty-padding`                | `32px 24px`                 | padding          | Padding around the empty state content.                       |
 | `--chart-empty-color`                  | `#9ca3af`                   | color            | Text color of the empty state.                                |
-| `--funnel-chart-connector-color`       | `#BDFFFB`                   | fill             | Default fill for trapezoidal connector shapes.                |
+| `--funnel-chart-connector-color`       | `light-dark(#BDFFFB, #164e4a)` | fill          | Default fill for trapezoidal connector shapes.                |
 | `--funnel-chart-label-color`           | `#666`                      | fill             | Color of the category labels above each stage bar.            |
 | `--funnel-chart-label-font-size`       | `11px`                      | font-size        | Font size of category labels.                                 |
-| `--funnel-chart-value-color`           | `#fff`                      | fill             | Color of the value/percentage labels inside bars.             |
+| `--funnel-chart-value-color`           | auto (contrast)             | fill             | Overrides the automatic per-stage contrast color of the value/percentage labels inside bars. |
 | `--funnel-chart-value-font-size`       | `11px`                      | font-size        | Font size of in-bar value labels.                             |
 | `--funnel-chart-bar-hover-opacity`     | `1`                         | opacity          | Opacity of the hovered stage bar.                             |
 | `--funnel-chart-bar-dimmed-opacity`    | `0.35`                      | opacity          | Opacity of non-hovered bars when another stage is hovered.    |
+
+## Dark mode
+
+Chart colors resolve through CSS `light-dark()`. Set `color-scheme` on the chart's ancestor (or `:root`) so the correct side is chosen:
+
+```css
+:root { color-scheme: light; }
+[data-theme='dark'] { color-scheme: dark; }
+```
+
+Every `--chart-*` / component token can still be overridden per theme; overrides always win over the built-in `light-dark()` fallbacks.
 
 ## Type Reference
 

--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -205,6 +205,10 @@ Hovering anywhere over the plot area finds the nearest point and shows a crossha
 | empty             | `Snippet`                                                    | No       | `-`          | Content rendered when all series are empty.                                                                                                                                                                                         |
 | testId            | `string`                                                     | No       | `-`          | Value for the data-pw attribute on the chart container.                                                                                                                                                                             |
 | classes           | `string`                                                     | No       | `-`          | CSS class string applied to the top-level element.                                                                                                                                                                                  |
+| sharedTooltip | `boolean` | No | auto | One anchored tooltip listing every visible series at the hovered x position. Defaults to `true` for multi-series charts, `false` for single-series. |
+| interactiveLegend | `boolean` | No | `false` | Legend items become click/keyboard toggles for series visibility; hidden series are removed from the plot and the scales rescale to the remaining data. |
+| hideLegendBelow | `number` | No | `360` | Hide the legend when the measured chart width is below this pixel value; `0` disables the behavior. |
+| tooltipPortal | `boolean` | No | `false` | Render the tooltip into `document.body` (`position: fixed`) so scroll/overflow ancestors never clip it. |
 
 ## Events
 
@@ -227,6 +231,17 @@ In addition to the shared `--chart-*` variables (see BarChart docs), LineChart e
 | `--linechart-value-font-size`       | `11px`  | font-size        | Font size of point value labels.                                   |
 | `--linechart-highlight-ring-color`  | `#fff`  | stroke           | Ring (outline) stroke colour of an actively highlighted dot.       |
 | `--linechart-highlight-ring-width`  | `2.5`   | stroke-width     | Ring stroke width of an actively highlighted dot.                  |
+
+## Dark mode
+
+Chart colors resolve through CSS `light-dark()`. Set `color-scheme` on the chart's ancestor (or `:root`) so the correct side is chosen:
+
+```css
+:root { color-scheme: light; }
+[data-theme='dark'] { color-scheme: dark; }
+```
+
+Every `--chart-*` / component token can still be overridden per theme; overrides always win over the built-in `light-dark()` fallbacks.
 
 ## Type Reference
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,10 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   webServer: {
-    command: 'npm run build && npm run preview',
-    port: 4173,
+    // Dedicated port: 4173 is vite's shared default and a preview server from
+    // an unrelated project on it silently satisfies reuseExistingServer.
+    command: 'pnpm run build && pnpm run preview --port 43199 --strictPort',
+    port: 43199,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000
   },
@@ -11,8 +13,15 @@ const config: PlaywrightTestConfig = {
   testMatch: /(.+\.)?(test|spec)\.[jt]s/,
   timeout: 30_000,
   use: {
-    baseURL: 'http://localhost:4173'
-  }
+    baseURL: 'http://localhost:43199',
+    // This repo's demo pages expose data-pw hooks; getByTestId must target them.
+    testIdAttribute: 'data-pw'
+  },
+  projects: [
+    {
+      name: 'functional'
+    }
+  ]
 };
 
 export default config;

--- a/src/lib/AreaChart/AreaChart.svelte
+++ b/src/lib/AreaChart/AreaChart.svelte
@@ -5,12 +5,16 @@
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
-  import { createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
-  import { computeChartDimensions, computeStackedValues } from '$lib/_chart/geometry';
+  import { createLinearScale, niceLinearDomain, computeLinearTicks } from '$lib/_chart/scales';
+  import { computeAutoLayout, computeStackedValues } from '$lib/_chart/geometry';
   import { linePath, areaPath } from '$lib/_chart/paths';
   import { getColor } from '$lib/_chart/colors';
-  import { formatNumber, formatPercent } from '$lib/_chart/format';
+  import { formatNumber, formatPercent, defaultTickFormat } from '$lib/_chart/format';
+  import { measureText } from '$lib/_chart/measure';
+  import { resolvePointLabels } from '$lib/_chart/labels';
+  import { pointerPositionIn, dismissOnOutsidePointerDown } from '$lib/_chart/interactions';
   import type { LegendItem, Point } from '$lib/_chart/types';
+  import { DEFAULT_CHART_MAX_HEIGHT } from '$lib/_chart/types';
 
   // ── Props ──────────────────────────────────────────────────────
 
@@ -42,8 +46,11 @@
     xTickFormat,
     yTickFormat,
     aspectRatio = 16 / 9,
+    minHeight = 0,
+    maxHeight = DEFAULT_CHART_MAX_HEIGHT,
     tooltipSnippet,
     empty,
+    tooltipPortal = false,
     onpointhover,
     onpointclick,
     testId,
@@ -53,6 +60,7 @@
   // ── State ──────────────────────────────────────────────────────
 
   let containerEl: HTMLDivElement | null = $state(null);
+  let plotEl: HTMLDivElement | null = $state(null);
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hovered = $state<{ si: number; pi: number } | null>(null);
@@ -65,7 +73,6 @@
 
   // ── Layout ─────────────────────────────────────────────────────
 
-  let dims = $derived(computeChartDimensions(chartWidth, chartHeight));
   let isStacked = $derived(stacked || stackNormalize);
   let isEmpty = $derived(series.length === 0 || series.every((s) => s.data.length === 0));
 
@@ -115,6 +122,24 @@
     }
     return niceLinearDomain(Math.min(0, ...allY), Math.max(...allY));
   });
+
+  let yTickCount = $derived(Math.max(2, Math.min(6, Math.floor(chartHeight / 70))));
+  let xTickCount = $derived(Math.max(2, Math.min(8, Math.floor(chartWidth / 90))));
+
+  let layout = $derived.by(() => {
+    const yFmt = yTickFormat ?? defaultTickFormat;
+    const xFmt = xTickFormat ?? defaultTickFormat;
+    return computeAutoLayout({
+      width: chartWidth,
+      height: chartHeight,
+      yTickLabels: showYAxis ? computeLinearTicks(yExtent, yTickCount).map((t) => yFmt(t)) : [],
+      xTickLabels: showXAxis ? computeLinearTicks(xExtent, xTickCount).map((t) => xFmt(t)) : [],
+      hasYAxisLabel: Boolean(yAxisLabel) && showYAxis,
+      hasXAxisLabel: Boolean(xAxisLabel) && showXAxis,
+      base: { top: 20, right: 20, bottom: showXAxis ? 40 : 8, left: showYAxis ? 50 : 20 }
+    });
+  });
+  let dims = $derived(layout);
 
   let xScale = $derived(createLinearScale(xExtent, [0, dims.innerWidth]));
   let yScale = $derived(createLinearScale(yExtent, [dims.innerHeight, 0]));
@@ -206,15 +231,40 @@
     };
   });
 
+  // ── Point labels ───────────────────────────────────────────────
+
+  function pointDisplayValue(si: number, pi: number): string {
+    const y = series[si]?.data[pi]?.y ?? 0;
+    if (stackNormalize) {
+      const columnTotal = series.reduce((sum, s) => sum + Math.max(0, s.data[pi]?.y ?? 0), 0);
+      return formatPercent(Math.max(0, y), columnTotal);
+    }
+    return formatNumber(y);
+  }
+
+  let pointLabelPlacements = $derived.by(() => {
+    if (!showValues) {
+      return [];
+    }
+    const plot = { width: dims.innerWidth, height: dims.innerHeight };
+    const font = { size: 11 };
+    return areas.map((area, si) =>
+      resolvePointLabels({
+        points: area.points,
+        labels: series[si].data.map((d, pi) => measureText(pointDisplayValue(si, pi), font)),
+        plot
+      })
+    );
+  });
+
   // ── Interactions ───────────────────────────────────────────────
 
-  function trackMouse(e: MouseEvent) {
-    if (containerEl === null) {
-      return;
+  function trackMouse(e: PointerEvent) {
+    const position = pointerPositionIn(plotEl, e);
+    if (position !== null) {
+      mouseX = position.x;
+      mouseY = position.y;
     }
-    const rect = containerEl.getBoundingClientRect();
-    mouseX = e.clientX - rect.left;
-    mouseY = e.clientY - rect.top;
   }
 
   function findNearest(plotX: number, plotY: number): { si: number; pi: number } | null {
@@ -253,7 +303,7 @@
     return { si: nearestSi, pi: nearestPi };
   }
 
-  function handleOverlayMove(e: MouseEvent) {
+  function handleOverlayMove(e: PointerEvent) {
     trackMouse(e);
     const plotX = mouseX - dims.margin.left;
     const plotY = mouseY - dims.margin.top;
@@ -285,6 +335,15 @@
       onpointclick?.({ seriesIndex: hovered.si, pointIndex: hovered.pi, point });
     }
   }
+
+  // Touch taps have no pointerleave: dismiss when a pointerdown lands outside.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (hovered === null) {
+      return;
+    }
+    return dismissOnOutsidePointerDown(containerEl, handleLeave);
+  });
 </script>
 
 <div
@@ -299,140 +358,181 @@
       <Legend items={legendItems} position="top" />
     {/if}
 
-    <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio}>
-      {#if gradientFill}
-        <!-- <defs> must be a direct child of <svg> (SVG root), not inside a transformed <g>.
+    <div class="chart-plot" bind:this={plotEl}>
+      <ChartContainer
+        bind:width={chartWidth}
+        bind:height={chartHeight}
+        {aspectRatio}
+        {minHeight}
+        {maxHeight}
+      >
+        {#if gradientFill}
+          <!-- <defs> must be a direct child of <svg> (SVG root), not inside a transformed <g>.
              gradientUnits="userSpaceOnUse" with y1/y2 in the inner coordinate space (0..innerHeight)
              correctly spans the full chart height regardless of how thin each band is. -->
-        <defs>
-          {#each areas as area, si (si)}
-            <linearGradient
-              id="area-grad-{uid}-{si}"
-              x1="0"
-              y1="0"
-              x2="0"
-              y2={dims.innerHeight}
-              gradientUnits="userSpaceOnUse"
-            >
-              <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
+          <defs>
+            {#each areas as area, si (si)}
+              <linearGradient
+                id="area-grad-{uid}-{si}"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2={dims.innerHeight}
+                gradientUnits="userSpaceOnUse"
+              >
+                <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
                    anchor at the top that fades to transparent at the bottom. This intentionally
                    exceeds the base fillOpacity so that gradient-fill areas appear more vivid
                    than their solid-fill counterparts (where fill-opacity equals fillOpacity). -->
-              <stop
-                offset="0%"
-                stop-color={area.color}
-                stop-opacity={Math.min(
-                  (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
-                  1
-                )}
+                <stop
+                  offset="0%"
+                  stop-color={area.color}
+                  stop-opacity={Math.min(
+                    (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
+                    1
+                  )}
+                />
+                <stop offset="100%" stop-color={area.color} stop-opacity={0} />
+              </linearGradient>
+            {/each}
+          </defs>
+        {/if}
+        <g transform="translate({dims.margin.left}, {dims.margin.top})">
+          {#if showYAxis}
+            <Axis
+              orientation="left"
+              scale={yScale}
+              tickCount={yTickCount}
+              {showGridlines}
+              gridlineLength={dims.innerWidth}
+              label={yAxisLabel}
+              tickFormat={yTickFormat}
+            />
+          {/if}
+          {#if showXAxis}
+            <g transform="translate(0, {dims.innerHeight})">
+              <Axis
+                orientation="bottom"
+                scale={xScale}
+                tickCount={xTickCount}
+                rotateTicks={layout.xRotate}
+                tickEvery={layout.xEvery}
+                labelOffset={layout.xLabelOffset}
+                label={xAxisLabel}
+                tickFormat={xTickFormat}
               />
-              <stop offset="100%" stop-color={area.color} stop-opacity={0} />
-            </linearGradient>
-          {/each}
-        </defs>
-      {/if}
-      <g transform="translate({dims.margin.left}, {dims.margin.top})">
-        {#if showYAxis}
-          <Axis
-            orientation="left"
-            scale={yScale}
-            {showGridlines}
-            gridlineLength={dims.innerWidth}
-            label={yAxisLabel}
-            tickFormat={yTickFormat}
-          />
-        {/if}
-        {#if showXAxis}
-          <g transform="translate(0, {dims.innerHeight})">
-            <Axis orientation="bottom" scale={xScale} label={xAxisLabel} tickFormat={xTickFormat} />
-          </g>
-        {/if}
+            </g>
+          {/if}
 
-        {#each areas as area, si (si)}
-          <path
-            class="area-fill"
-            class:dimmed={hovered !== null && hovered.si !== si}
-            d={area.areaD}
-            fill={gradientFill ? `url(#area-grad-${uid}-${si})` : area.color}
-            fill-opacity={gradientFill ? 1 : hovered?.si === si ? fillOpacity + 0.2 : fillOpacity}
-          />
-          {#if showLine}
+          {#each areas as area, si (si)}
             <path
-              class="area-line"
+              class="area-fill"
               class:dimmed={hovered !== null && hovered.si !== si}
-              d={area.lineD}
-              stroke={area.color}
-              stroke-width={strokeWidth}
-              fill="none"
+              d={area.areaD}
+              fill={gradientFill ? `url(#area-grad-${uid}-${si})` : area.color}
+              fill-opacity={gradientFill ? 1 : hovered?.si === si ? fillOpacity + 0.2 : fillOpacity}
             />
-          {/if}
-          {#if area.points.length === 1 && !showDots}
-            <circle
-              class="single-point"
-              class:dimmed={hovered !== null && hovered.si !== si}
-              cx={area.points[0].x}
-              cy={area.points[0].y}
-              r={6}
-              fill={area.color}
-            />
-          {/if}
-          {#if showDots}
-            {#each area.points as point, pi (pi)}
+            {#if showLine}
+              <path
+                class="area-line"
+                class:dimmed={hovered !== null && hovered.si !== si}
+                d={area.lineD}
+                stroke={area.color}
+                stroke-width={strokeWidth}
+                fill="none"
+              />
+            {/if}
+            {#if area.points.length === 1 && !showDots}
               <circle
-                class="dot"
-                cx={point.x}
-                cy={point.y}
-                r={hovered?.si === si && hovered?.pi === pi ? 6 : 3}
+                class="single-point"
+                class:dimmed={hovered !== null && hovered.si !== si}
+                cx={area.points[0].x}
+                cy={area.points[0].y}
+                r={6}
                 fill={area.color}
               />
-            {/each}
-          {/if}
-          {#if showValues}
-            {#each area.points as point, pi (pi)}
-              <text
-                class="point-value"
-                x={point.x}
-                y={point.y - 8}
-                text-anchor="middle"
-                dominant-baseline="auto">{formatNumber(series[si].data[pi].y)}</text
-              >
-            {/each}
-          {/if}
-        {/each}
+            {/if}
+            {#if showDots}
+              {#each area.points as point, pi (pi)}
+                <circle
+                  class="dot"
+                  cx={point.x}
+                  cy={point.y}
+                  r={hovered?.si === si && hovered?.pi === pi ? 6 : 3}
+                  fill={area.color}
+                />
+              {/each}
+            {/if}
+            {#if showValues && pointLabelPlacements[si]}
+              {#each area.points as _point, pi (pi)}
+                {@const pl = pointLabelPlacements[si][pi]}
+                {#if pl?.visible}
+                  <text
+                    class="point-value"
+                    x={pl.x}
+                    y={pl.y}
+                    text-anchor="middle"
+                    dominant-baseline={pl.dominantBaseline}>{pointDisplayValue(si, pi)}</text
+                  >
+                {/if}
+              {/each}
+            {/if}
+          {/each}
 
-        {#if hoverLineX !== null}
-          <line class="hover-line" x1={hoverLineX} x2={hoverLineX} y1={0} y2={dims.innerHeight} />
-        {/if}
+          {#if hoverLineX !== null}
+            <line class="hover-line" x1={hoverLineX} x2={hoverLineX} y1={0} y2={dims.innerHeight} />
+          {/if}
 
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <rect
-          class="hover-overlay"
-          x={0}
-          y={0}
-          width={dims.innerWidth}
-          height={dims.innerHeight}
-          fill="transparent"
-          onmousemove={handleOverlayMove}
-          onmouseleave={handleLeave}
-          onclick={handleClick}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <rect
+            class="hover-overlay"
+            x={0}
+            y={0}
+            width={dims.innerWidth}
+            height={dims.innerHeight}
+            fill="transparent"
+            onpointermove={handleOverlayMove}
+            onpointerleave={handleLeave}
+            onclick={handleClick}
+          />
+        </g>
+      </ChartContainer>
+
+      {#if typeof tooltipSnippet === 'function'}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          portal={tooltipPortal}
+          originEl={plotEl}
+          unstyled
+        >
+          {#snippet content()}
+            {#if tooltipContext !== null}
+              {@render tooltipSnippet(tooltipContext)}
+            {/if}
+          {/snippet}
+        </ChartTooltip>
+      {:else}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          portal={tooltipPortal}
+          originEl={plotEl}
         />
-      </g>
-    </ChartContainer>
-
-    {#if typeof tooltipSnippet === 'function' && tooltipContext !== null}
-      <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
-        {@render tooltipSnippet(tooltipContext)}
-      </div>
-    {:else}
-      <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
-    {/if}
+      {/if}
+    </div>
   {/if}
 </div>
 
 <style>
   .area-chart {
     width: 100%;
+    position: relative;
+  }
+  .chart-plot {
     position: relative;
   }
   .area-fill {
@@ -463,18 +563,21 @@
     transition:
       r var(--chart-transition-duration, 0.2s) ease,
       opacity var(--chart-transition-duration, 0.2s) ease;
-    stroke: var(--chart-background, #fff);
+    stroke: var(--chart-dot-stroke, light-dark(#fff, #111827));
     stroke-width: 2;
     pointer-events: none;
   }
   .point-value {
-    fill: var(--areachart-value-color, #333);
+    fill: var(--areachart-value-color, light-dark(#333, #e5e7eb));
     font-size: var(--areachart-value-font-size, 11px);
     font-family: var(--chart-font-family, inherit);
     pointer-events: none;
   }
   .hover-line {
-    stroke: var(--areachart-hover-line-color, var(--linechart-hover-line-color, #ccc));
+    stroke: var(
+      --areachart-hover-line-color,
+      var(--linechart-hover-line-color, light-dark(#ccc, #4b5563))
+    );
     stroke-width: 1;
     stroke-dasharray: var(--areachart-hover-line-dash, var(--linechart-hover-line-dash, 4 4));
     pointer-events: none;
@@ -482,14 +585,9 @@
   .hover-overlay {
     cursor: crosshair;
   }
-  .chart-tooltip-slot {
-    position: absolute;
-    z-index: 10;
-    pointer-events: none;
-  }
   .chart-empty {
     padding: var(--chart-empty-padding, 32px 24px);
-    color: var(--chart-empty-color, #9ca3af);
+    color: var(--chart-empty-color, light-dark(#9ca3af, #6b7280));
     text-align: center;
   }
 </style>

--- a/src/lib/AreaChart/properties.ts
+++ b/src/lib/AreaChart/properties.ts
@@ -47,8 +47,14 @@ export type OptionalAreaChartProperties = {
   xTickFormat?: (value: number | string) => string;
   yTickFormat?: (value: number | string) => string;
   aspectRatio?: number;
+  /** Minimum rendered height in px (parity with LineChart). */
+  minHeight?: number;
+  /** Maximum rendered height in px; defaults to DEFAULT_CHART_MAX_HEIGHT (420). */
+  maxHeight?: number;
   tooltipSnippet?: Snippet<[AreaChartTooltipContext]>;
   empty?: Snippet;
+  /** Render the tooltip into document.body so scroll/overflow ancestors never clip it. */
+  tooltipPortal?: boolean;
   testId?: string;
   classes?: string;
 };

--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -12,18 +12,28 @@
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
-  import { createBandScale, createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
   import {
-    computeChartDimensions,
-    computeHorizontalCategoryGutter,
-    measureTextWidth
-  } from '$lib/_chart/geometry';
-  import { getColor } from '$lib/_chart/colors';
+    createBandScale,
+    createLinearScale,
+    niceLinearDomain,
+    computeLinearTicks
+  } from '$lib/_chart/scales';
+  import { computeAutoLayout } from '$lib/_chart/geometry';
+  import { getColor, getContrastColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
   import { roundedRectPath } from '$lib/_chart/paths';
+  import { measureText, readCssVarPx } from '$lib/_chart/measure';
+  import {
+    resolveEndLabel,
+    resolveInsideLabel,
+    placedLabelRect,
+    dropOverlapping
+  } from '$lib/_chart/labels';
   import type { LegendItem, BarRect } from '$lib/_chart/types';
   import { DEFAULT_CHART_CORNER_RADIUS, DEFAULT_CHART_MAX_HEIGHT } from '$lib/_chart/types';
-  import { SvelteMap } from 'svelte/reactivity';
+  import type { TooltipAnchor } from '$lib/_chart/types';
+  import { pointerPositionIn, dismissOnOutsidePointerDown } from '$lib/_chart/interactions';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
   // ── Per-instance uid prefix for <defs> ids (A1-3) ─────────────
   // Derived at module scope per the library uid pattern (e.g. AreaChart
@@ -77,6 +87,9 @@
     topN,
     overflowLabel = 'Other',
     hideBarGraphics = false,
+    interactiveLegend = false,
+    hideLegendBelow = 360,
+    tooltipPortal = false,
     onbarclick,
     onbarhover,
     testId,
@@ -86,17 +99,22 @@
   // ── State ──────────────────────────────────────────────────────
 
   let containerEl: HTMLDivElement | null = $state(null);
+  let plotEl: HTMLDivElement | null = $state(null);
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hovered = $state<{ si: number; pi: number } | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+  let anchor = $state<TooltipAnchor | null>(null);
+  let valueFontSize = $state(14);
   /** Internal tracking for the imperative highlight API (onChartReady). */
   let apiHighlightedIndex = $state<number | null>(null);
+  const hiddenSeries = new SvelteSet<number>();
 
   // ── onMount: emit ChartHighlightAPI via onChartReady ──────────
 
   onMount(() => {
+    valueFontSize = readCssVarPx(containerEl, '--barchart-value-font-size', 14);
     if (typeof onChartReady !== 'function') {
       return;
     }
@@ -185,62 +203,25 @@
     });
   });
 
+  // Legend-toggled series are excluded from geometry and scales (Highcharts
+  // rescales on toggle) but stay in legendItems so they can be re-enabled.
+  let visibleEntries = $derived(
+    resolvedSeries.map((s, si) => ({ s, si })).filter((e) => !hiddenSeries.has(e.si))
+  );
+  let visibleOrder = $derived(new Map(visibleEntries.map((e, vi) => [e.si, vi])));
+
+  function toggleSeries(index: number): void {
+    if (hiddenSeries.has(index)) {
+      hiddenSeries.delete(index);
+    } else {
+      hiddenSeries.add(index);
+    }
+  }
+
   let labels = $derived.by(() => {
     const first = resolvedSeries[0]?.data ?? [];
     return first.map((d) => d.label);
   });
-
-  /**
-   * Widest category label in the axis tick font, for the horizontal-orientation
-   * gutter below. Horizontal charts put category text (not short numeric ticks)
-   * on the Y axis, so the gutter must fit real words like "Submitted Address" —
-   * a fixed gutter clips them. Resolved from the mounted container so CSS-var
-   * theming (--chart-axis-font-size / --chart-axis-font-family) is honoured.
-   * Null when unmeasurable (SSR, no canvas) — the gutter then keeps its legacy
-   * fixed width.
-   */
-  let widestCategoryLabelWidth = $derived.by(() => {
-    if (isVertical || !showYAxis || labels.length === 0 || containerEl === null) {
-      return null;
-    }
-    const containerStyle = getComputedStyle(containerEl);
-    const axisFontSize = containerStyle.getPropertyValue('--chart-axis-font-size').trim() || '11px';
-    const axisFontFamilyToken = containerStyle.getPropertyValue('--chart-axis-font-family').trim();
-    const axisFontFamily =
-      axisFontFamilyToken === '' || axisFontFamilyToken === 'inherit'
-        ? containerStyle.fontFamily || 'sans-serif'
-        : axisFontFamilyToken;
-    const axisFont = `${axisFontSize} ${axisFontFamily}`;
-    let widest: number | null = null;
-    for (const label of labels) {
-      const labelWidth = measureTextWidth(label, axisFont);
-      if (labelWidth === null) {
-        return null;
-      }
-      if (widest === null || labelWidth > widest) {
-        widest = labelWidth;
-      }
-    }
-    return widest;
-  });
-
-  // When an axis is hidden its gutter (Y = 50px for tick labels, X = 40px) is dead
-  // space that squeezes the plot into the centre. Collapse the tick-label gutter but
-  // keep a symmetric breathing-room inset so the edge bars (and their value labels)
-  // don't sit flush against the container edges. In horizontal orientation the
-  // visible Y axis carries category text, so its gutter grows to fit the widest
-  // label (never shrinking below the legacy 50px, capped at 45% of the width).
-  let dims = $derived(
-    computeChartDimensions(chartWidth, chartHeight, {
-      left: showYAxis
-        ? isVertical
-          ? 50
-          : computeHorizontalCategoryGutter(widestCategoryLabelWidth, chartWidth)
-        : 28,
-      right: 28,
-      bottom: showXAxis ? 40 : 8
-    })
-  );
 
   // ── Effective highlighted index: merge declarative + imperative ─
 
@@ -262,6 +243,18 @@
     isNormalized && valueFormat == null ? (v: number) => `${formatNumber(v)}%` : format
   );
 
+  let isStackedMode = $derived(isMulti && groupMode === 'stacked');
+
+  function getDisplayValue(bar: BarRect): string {
+    if (isNormalized && bar.normalizedValue != null) {
+      return normalizedFormat(bar.normalizedValue);
+    }
+    if (bar.isFloating && Array.isArray(bar.dataPoint.range)) {
+      return `${format(bar.dataPoint.range[0])} – ${format(bar.dataPoint.range[1])}`;
+    }
+    return format(bar.dataPoint.value);
+  }
+
   // ── Y-extent: account for floating bars (A1-1) ────────────────
 
   let yExtent = $derived.by<[number, number]>(() => {
@@ -273,13 +266,13 @@
         return [0, 100];
       }
       const totalsPerLabel = labels.map((_, labelIndex) =>
-        resolvedSeries.reduce((sum, s) => sum + Math.max(0, s.data[labelIndex]?.value ?? 0), 0)
+        visibleEntries.reduce((sum, { s }) => sum + Math.max(0, s.data[labelIndex]?.value ?? 0), 0)
       );
       return niceLinearDomain(0, Math.max(0, ...totalsPerLabel));
     }
     // Collect all individual values including floating-bar low/high endpoints
     const all: number[] = [];
-    for (const s of resolvedSeries) {
+    for (const { s } of visibleEntries) {
       for (const d of s.data) {
         if (Array.isArray(d.range)) {
           all.push(d.range[0], d.range[1]);
@@ -293,6 +286,27 @@
     }
     return niceLinearDomain(Math.min(0, ...all), Math.max(0, ...all));
   });
+
+  let valTickCount = $derived(
+    isVertical
+      ? Math.max(2, Math.min(6, Math.floor(chartHeight / 70)))
+      : Math.max(2, Math.min(8, Math.floor(chartWidth / 90)))
+  );
+
+  let layout = $derived.by(() => {
+    const valFmt = isNormalized ? normalizedFormat : format;
+    const valTicks = computeLinearTicks(yExtent, valTickCount).map((t) => valFmt(t));
+    return computeAutoLayout({
+      width: chartWidth,
+      height: chartHeight,
+      yTickLabels: showYAxis ? (isVertical ? valTicks : labels) : [],
+      xTickLabels: showXAxis ? (isVertical ? labels : valTicks) : [],
+      hasYAxisLabel: Boolean(yAxisLabel) && showYAxis,
+      hasXAxisLabel: Boolean(xAxisLabel) && showXAxis,
+      base: { top: 20, left: showYAxis ? 50 : 28, right: 28, bottom: showXAxis ? 40 : 8 }
+    });
+  });
+  let dims = $derived(layout);
 
   let catScale = $derived(
     createBandScale(labels, isVertical ? [0, dims.innerWidth] : [0, dims.innerHeight], barPadding)
@@ -366,13 +380,13 @@
     };
 
     if (isMulti && groupMode === 'grouped') {
-      const subBand = catScale.bandwidth / resolvedSeries.length;
-      for (let si = 0; si < resolvedSeries.length; si++) {
-        const s = resolvedSeries[si];
+      const subBand = catScale.bandwidth / Math.max(1, visibleEntries.length);
+      for (let vi = 0; vi < visibleEntries.length; vi++) {
+        const { s, si } = visibleEntries[vi];
         const seriesFill: BarFill = s.color ?? getColor(si);
         for (let pi = 0; pi < s.data.length; pi++) {
           const d = s.data[pi];
-          const catPos = catScale(d.label) + si * subBand;
+          const catPos = catScale(d.label) + vi * subBand;
           const barW = Math.max(1, subBand * 0.9);
           const geom = barGeometry(d, catPos, barW);
           const effectiveFill: BarFill = d.color ?? seriesFill;
@@ -383,11 +397,11 @@
       }
     } else if (isMulti && groupMode === 'stacked') {
       const categoryTotals = labels.map((_, labelIndex) =>
-        resolvedSeries.reduce((sum, s) => sum + Math.max(0, s.data[labelIndex]?.value ?? 0), 0)
+        visibleEntries.reduce((sum, { s }) => sum + Math.max(0, s.data[labelIndex]?.value ?? 0), 0)
       );
       const stackBase = new Array(labels.length).fill(0);
-      for (let si = 0; si < resolvedSeries.length; si++) {
-        const s = resolvedSeries[si];
+      for (let vi = 0; vi < visibleEntries.length; vi++) {
+        const { s, si } = visibleEntries[vi];
         const seriesFill: BarFill = s.color ?? getColor(si);
         for (let pi = 0; pi < s.data.length; pi++) {
           const d = s.data[pi];
@@ -461,6 +475,41 @@
     return result;
   });
 
+  let valueFont = $derived({ size: valueFontSize, weight: 600 });
+
+  // Highcharts label chain per bar (outside → justify inside → crop), then a
+  // global allowOverlap:false pass so neighbouring labels never collide.
+  let barLabels = $derived.by(() => {
+    if (!showValues) {
+      return [];
+    }
+    const plot = { width: dims.innerWidth, height: dims.innerHeight };
+    const placements = bars.map((bar) => {
+      const text = getDisplayValue(bar);
+      const size = measureText(text, valueFont);
+      const p = isStackedMode
+        ? resolveInsideLabel({ bar, label: size })
+        : resolveEndLabel({
+            bar,
+            plot,
+            label: size,
+            orientation,
+            negative: !bar.isFloating && bar.dataPoint.value < 0
+          });
+      return { bar, text, size, p };
+    });
+    const mask = dropOverlapping(
+      placements.map(({ p, size }) => (p.placement === 'hidden' ? null : placedLabelRect(p, size)))
+    );
+    return placements.map((entry, i) => ({
+      ...entry,
+      visible: mask[i] === true && entry.p.placement !== 'hidden'
+    }));
+  });
+
+  const contrastOutline = (fill: string): string =>
+    getContrastColor(fill) === '#000000' ? '#ffffff' : '#000000';
+
   // ── Defs: pattern and gradient fill resolution (A1-2 / A1-3) ──
 
   /**
@@ -520,7 +569,8 @@
     isMulti
       ? resolvedSeries.map((s, i) => ({
           label: s.name,
-          color: fallbackColor(s.color ?? getColor(i), i)
+          color: fallbackColor(s.color ?? getColor(i), i),
+          hidden: hiddenSeries.has(i)
         }))
       : []
   );
@@ -535,14 +585,13 @@
 
   // ── Stacked bar path helper ────────────────────────────────────
 
-  let lastSeriesIndex = $derived(resolvedSeries.length - 1);
-
   function stackedBarPath(bar: BarRect): string {
     if (barRadius <= 0) {
       return roundedRectPath(bar.x, bar.y, bar.width, bar.height, 0, 0, 0, 0);
     }
-    const isFirst = bar.si === 0;
-    const isLast = bar.si === lastSeriesIndex;
+    const vi = visibleOrder.get(bar.si) ?? 0;
+    const isFirst = vi === 0;
+    const isLast = vi === visibleEntries.length - 1;
     if (isVertical) {
       const tl = isLast ? barRadius : 0;
       const tr = isLast ? barRadius : 0;
@@ -597,25 +646,74 @@
 
   // ── Interactions ───────────────────────────────────────────────
 
-  function trackMouse(e: MouseEvent) {
-    if (containerEl === null) {
-      return;
+  // Narrows an event's currentTarget to Element without an `as` cast (repo
+  // lint bans type assertions outside test files).
+  const targetElement = (e: Event): Element | null =>
+    e.currentTarget instanceof Element ? e.currentTarget : null;
+
+  function trackMouse(e: PointerEvent): void {
+    const position = pointerPositionIn(plotEl, e);
+    if (position !== null) {
+      mouseX = position.x;
+      mouseY = position.y;
     }
-    const rect = containerEl.getBoundingClientRect();
-    mouseX = e.clientX - rect.left;
-    mouseY = e.clientY - rect.top;
   }
 
-  function handleEnter(e: MouseEvent, bar: BarRect) {
+  // Anchor from the live element rect (not SVG math) so legend offset and
+  // scrollable-mode scroll position are automatically accounted for.
+  function anchorFromElement(el: Element): TooltipAnchor | null {
+    if (plotEl === null) {
+      return null;
+    }
+    const r = el.getBoundingClientRect();
+    const c = plotEl.getBoundingClientRect();
+    return isVertical
+      ? { x: r.left + r.width / 2 - c.left, y: r.top - c.top, side: 'top' }
+      : { x: r.right - c.left, y: r.top + r.height / 2 - c.top, side: 'right' };
+  }
+
+  function activateBar(target: Element, bar: BarRect): void {
     hovered = { si: bar.si, pi: bar.pi };
-    trackMouse(e);
+    anchor = anchorFromElement(target);
     onbarhover?.({ index: bar.pi, dataPoint: bar.dataPoint });
   }
 
-  function handleLeave() {
+  function handleEnter(e: PointerEvent, bar: BarRect): void {
+    const el = targetElement(e);
+    if (el !== null) {
+      activateBar(el, bar);
+    }
+    trackMouse(e);
+  }
+
+  function handleFocus(e: FocusEvent, bar: BarRect): void {
+    const el = targetElement(e);
+    if (el !== null) {
+      activateBar(el, bar);
+    }
+  }
+
+  function handleLeave(): void {
     hovered = null;
+    anchor = null;
     onbarhover?.(null);
   }
+
+  function handleKeydown(e: KeyboardEvent, bar: BarRect): void {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick(bar);
+    }
+  }
+
+  // Touch taps have no pointerleave: dismiss when a pointerdown lands outside.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (hovered === null) {
+      return;
+    }
+    return dismissOnOutsidePointerDown(containerEl, handleLeave);
+  });
 
   function handleClick(bar: BarRect) {
     onbarclick?.({ index: bar.pi, dataPoint: bar.dataPoint });
@@ -625,18 +723,6 @@
     return hovered === null
       ? null
       : (bars.find((b) => b.si === hovered!.si && b.pi === hovered!.pi) ?? null);
-  }
-
-  let isStackedMode = $derived(isMulti && groupMode === 'stacked');
-
-  function getDisplayValue(bar: BarRect): string {
-    if (isNormalized && bar.normalizedValue != null) {
-      return normalizedFormat(bar.normalizedValue);
-    }
-    if (bar.isFloating && Array.isArray(bar.dataPoint.range)) {
-      return `${format(bar.dataPoint.range[0])} – ${format(bar.dataPoint.range[1])}`;
-    }
-    return format(bar.dataPoint.value);
   }
 </script>
 
@@ -648,80 +734,85 @@
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
   {:else}
-    {#if isMulti && showLegend}
-      <Legend items={legendItems} position="top" />
+    {#if isMulti && showLegend && (chartWidth === 0 || hideLegendBelow === 0 || chartWidth >= hideLegendBelow)}
+      {#if interactiveLegend}
+        <Legend items={legendItems} position="top" onToggle={toggleSeries} />
+      {:else}
+        <Legend items={legendItems} position="top" />
+      {/if}
     {/if}
 
-    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-    <div
-      class="chart-scroll-area"
-      role="region"
-      aria-label={yAxisLabel ? `${yAxisLabel} bar chart` : 'Bar chart'}
-      tabindex={scrollable ? 0 : null}
-      style={scrollable
-        ? `overflow-x: auto; -webkit-overflow-scrolling: touch; height: var(--barchart-scroll-area-height, auto);`
-        : ''}
-    >
-      <div style={scrollable ? `min-width: ${minScrollWidth}px;` : ''}>
-        <ChartContainer
-          bind:width={chartWidth}
-          bind:height={chartHeight}
-          {aspectRatio}
-          {maxHeight}
-          {minHeight}
-        >
-          <!-- A1-2 / A1-3: SVG <defs> for pattern and gradient fills -->
-          {#if defsEntries.length > 0}
-            <defs>
-              {#each defsEntries as entry (entry.id)}
-                {#if 'pattern' in entry.fill}
-                  {@const pat = entry.fill.pattern}
-                  {@const patSize = pat.size ?? 8}
-                  {@const patColor = pat.color ?? entry.bar.color}
-                  {@const patBg = pat.background ?? 'transparent'}
-                  {@const patStrokeW = pat.strokeWidth ?? 1.5}
-                  <pattern
-                    id={entry.id}
-                    patternUnits="userSpaceOnUse"
-                    width={patSize}
-                    height={patSize}
-                  >
-                    <rect width={patSize} height={patSize} fill={patBg} />
-                    {#if pat.type === 'lines'}
-                      <line
-                        x1="0"
-                        y1={patSize}
-                        x2={patSize}
-                        y2="0"
-                        stroke={patColor}
-                        stroke-width={patStrokeW}
-                      />
-                    {:else if pat.type === 'crosshatch'}
-                      <line
-                        x1="0"
-                        y1={patSize}
-                        x2={patSize}
-                        y2="0"
-                        stroke={patColor}
-                        stroke-width={patStrokeW}
-                      />
-                      <line
-                        x1="0"
-                        y1="0"
-                        x2={patSize}
-                        y2={patSize}
-                        stroke={patColor}
-                        stroke-width={patStrokeW}
-                      />
-                    {:else}
-                      <!-- dots -->
-                      <circle cx={patSize / 2} cy={patSize / 2} r={patStrokeW} fill={patColor} />
-                    {/if}
-                  </pattern>
-                {:else if 'gradient' in entry.fill}
-                  {@const grad = entry.fill.gradient}
-                  {@const isHoriz = grad.direction === 'horizontal'}
-                  <!--
+    <div class="chart-plot" bind:this={plotEl}>
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+      <div
+        class="chart-scroll-area"
+        role="region"
+        aria-label={yAxisLabel ? `${yAxisLabel} bar chart` : 'Bar chart'}
+        tabindex={scrollable ? 0 : null}
+        style={scrollable
+          ? `overflow-x: auto; -webkit-overflow-scrolling: touch; height: var(--barchart-scroll-area-height, auto);`
+          : ''}
+      >
+        <div style={scrollable ? `min-width: ${minScrollWidth}px;` : ''}>
+          <ChartContainer
+            bind:width={chartWidth}
+            bind:height={chartHeight}
+            {aspectRatio}
+            {maxHeight}
+            {minHeight}
+          >
+            <!-- A1-2 / A1-3: SVG <defs> for pattern and gradient fills -->
+            {#if defsEntries.length > 0}
+              <defs>
+                {#each defsEntries as entry (entry.id)}
+                  {#if 'pattern' in entry.fill}
+                    {@const pat = entry.fill.pattern}
+                    {@const patSize = pat.size ?? 8}
+                    {@const patColor = pat.color ?? entry.bar.color}
+                    {@const patBg = pat.background ?? 'transparent'}
+                    {@const patStrokeW = pat.strokeWidth ?? 1.5}
+                    <pattern
+                      id={entry.id}
+                      patternUnits="userSpaceOnUse"
+                      width={patSize}
+                      height={patSize}
+                    >
+                      <rect width={patSize} height={patSize} fill={patBg} />
+                      {#if pat.type === 'lines'}
+                        <line
+                          x1="0"
+                          y1={patSize}
+                          x2={patSize}
+                          y2="0"
+                          stroke={patColor}
+                          stroke-width={patStrokeW}
+                        />
+                      {:else if pat.type === 'crosshatch'}
+                        <line
+                          x1="0"
+                          y1={patSize}
+                          x2={patSize}
+                          y2="0"
+                          stroke={patColor}
+                          stroke-width={patStrokeW}
+                        />
+                        <line
+                          x1="0"
+                          y1="0"
+                          x2={patSize}
+                          y2={patSize}
+                          stroke={patColor}
+                          stroke-width={patStrokeW}
+                        />
+                      {:else}
+                        <!-- dots -->
+                        <circle cx={patSize / 2} cy={patSize / 2} r={patStrokeW} fill={patColor} />
+                      {/if}
+                    </pattern>
+                  {:else if 'gradient' in entry.fill}
+                    {@const grad = entry.fill.gradient}
+                    {@const isHoriz = grad.direction === 'horizontal'}
+                    <!--
                     gradientUnits="userSpaceOnUse" is required here.
                     objectBoundingBox ratios are undefined on degenerate (zero-height)
                     path bounding boxes (stacked segments, Firefox renders black).
@@ -731,129 +822,163 @@
                     without any margin offset. This matches the AreaChart pattern
                     (feat/linechart-gradient ea5f794, lines 282-284).
                   -->
-                  <linearGradient
-                    id={entry.id}
-                    x1={entry.bar.x}
-                    y1={entry.bar.y}
-                    x2={isHoriz ? entry.bar.x + entry.bar.width : entry.bar.x}
-                    y2={isHoriz ? entry.bar.y : entry.bar.y + entry.bar.height}
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    {#each grad.stops as stop, stopIndex (`${stopIndex}-${stop.offset}`)}
-                      <stop
-                        offset="{stop.offset * 100}%"
-                        stop-color={stop.color}
-                        stop-opacity={stop.opacity ?? 1}
-                      />
-                    {/each}
-                  </linearGradient>
-                {/if}
-              {/each}
-            </defs>
-          {/if}
-
-          <g transform="translate({dims.margin.left}, {dims.margin.top})">
-            {#if showYAxis}
-              <Axis
-                orientation="left"
-                scale={isVertical ? valScale : catScale}
-                {showGridlines}
-                gridlineLength={dims.innerWidth}
-                label={yAxisLabel}
-              />
+                    <linearGradient
+                      id={entry.id}
+                      x1={entry.bar.x}
+                      y1={entry.bar.y}
+                      x2={isHoriz ? entry.bar.x + entry.bar.width : entry.bar.x}
+                      y2={isHoriz ? entry.bar.y : entry.bar.y + entry.bar.height}
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      {#each grad.stops as stop, stopIndex (`${stopIndex}-${stop.offset}`)}
+                        <stop
+                          offset="{stop.offset * 100}%"
+                          stop-color={stop.color}
+                          stop-opacity={stop.opacity ?? 1}
+                        />
+                      {/each}
+                    </linearGradient>
+                  {/if}
+                {/each}
+              </defs>
             {/if}
-            {#if showXAxis}
-              <g transform="translate(0, {dims.innerHeight})">
+
+            <g transform="translate({dims.margin.left}, {dims.margin.top})">
+              {#if showYAxis}
                 <Axis
-                  orientation="bottom"
-                  scale={isVertical ? catScale : valScale}
-                  showGridlines={!isVertical && showGridlines}
-                  gridlineLength={dims.innerHeight}
-                  label={xAxisLabel}
+                  orientation="left"
+                  scale={isVertical ? valScale : catScale}
+                  tickCount={valTickCount}
+                  {showGridlines}
+                  gridlineLength={dims.innerWidth}
+                  label={yAxisLabel}
                 />
-              </g>
-            {/if}
-
-            {#if !hideBarGraphics}
-              {#each bars as bar, i (i)}
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                {#if isStackedMode && barRadius > 0}
-                  <path
-                    class="bar"
-                    class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
-                    class:highlighted={effectiveHighlightedIndex !== null &&
-                      effectiveHighlightedIndex === bar.pi}
-                    class:dimmed={(hovered !== null &&
-                      (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
-                      (effectiveHighlightedIndex !== null && effectiveHighlightedIndex !== bar.pi)}
-                    d={stackedBarPath(bar)}
-                    fill={barFillAttr(bar)}
-                    aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
-                    onmouseenter={(e) => handleEnter(e, bar)}
-                    onmousemove={trackMouse}
-                    onmouseleave={handleLeave}
-                    onclick={() => handleClick(bar)}
+              {/if}
+              {#if showXAxis}
+                <g transform="translate(0, {dims.innerHeight})">
+                  <Axis
+                    orientation="bottom"
+                    scale={isVertical ? catScale : valScale}
+                    tickCount={valTickCount}
+                    rotateTicks={layout.xRotate}
+                    tickEvery={layout.xEvery}
+                    labelOffset={layout.xLabelOffset}
+                    showGridlines={!isVertical && showGridlines}
+                    gridlineLength={dims.innerHeight}
+                    label={xAxisLabel}
                   />
-                {:else}
-                  <rect
-                    class="bar"
-                    class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
-                    class:highlighted={effectiveHighlightedIndex !== null &&
-                      effectiveHighlightedIndex === bar.pi}
-                    class:dimmed={(hovered !== null &&
-                      (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
-                      (effectiveHighlightedIndex !== null && effectiveHighlightedIndex !== bar.pi)}
-                    x={bar.x}
-                    y={bar.y}
-                    width={bar.width}
-                    height={bar.height}
-                    rx={barRadius}
-                    ry={barRadius}
-                    fill={barFillAttr(bar)}
-                    aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
-                    onmouseenter={(e) => handleEnter(e, bar)}
-                    onmousemove={trackMouse}
-                    onmouseleave={handleLeave}
-                    onclick={() => handleClick(bar)}
-                  />
-                {/if}
-                <!-- Suppress the horizontal value label when its sub-band is thinner
-                     than the ~11px label, so cramped multi-series charts hide labels
-                     instead of overlapping them into an unreadable cluster. Consumers
-                     restore labels by giving the chart more height (aspectRatio /
-                     scrollable / minBandWidth). -->
-                {#if showValues && !isStackedMode && (isVertical || bar.height >= 13)}
-                  <text
-                    class="bar-value"
-                    x={isVertical ? bar.x + bar.width / 2 : bar.x + bar.width + 4}
-                    y={isVertical ? bar.y - 4 : bar.y + bar.height / 2}
-                    text-anchor={isVertical ? 'middle' : 'start'}
-                    dominant-baseline={isVertical ? 'auto' : 'middle'}>{getDisplayValue(bar)}</text
-                  >
-                {/if}
-              {/each}
-            {/if}
+                </g>
+              {/if}
 
-            <!-- A1-4: renderOverlay escape hatch — rendered after all bars -->
-            {#if typeof renderOverlay === 'function'}
-              {@render renderOverlay(overlayContext)}
-            {/if}
-          </g>
-        </ChartContainer>
-      </div>
-    </div>
+              {#if !hideBarGraphics}
+                {#each bars as bar, i (i)}
+                  {#if isStackedMode && barRadius > 0}
+                    <path
+                      class="bar"
+                      class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
+                      class:highlighted={effectiveHighlightedIndex !== null &&
+                        effectiveHighlightedIndex === bar.pi}
+                      class:dimmed={(hovered !== null &&
+                        (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
+                        (effectiveHighlightedIndex !== null &&
+                          effectiveHighlightedIndex !== bar.pi)}
+                      d={stackedBarPath(bar)}
+                      fill={barFillAttr(bar)}
+                      tabindex="0"
+                      role="button"
+                      aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
+                      onpointerenter={(e) => handleEnter(e, bar)}
+                      onpointermove={trackMouse}
+                      onpointerleave={handleLeave}
+                      onfocus={(e) => handleFocus(e, bar)}
+                      onblur={handleLeave}
+                      onkeydown={(e) => handleKeydown(e, bar)}
+                      onclick={() => handleClick(bar)}
+                    />
+                  {:else}
+                    <rect
+                      class="bar"
+                      class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
+                      class:highlighted={effectiveHighlightedIndex !== null &&
+                        effectiveHighlightedIndex === bar.pi}
+                      class:dimmed={(hovered !== null &&
+                        (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
+                        (effectiveHighlightedIndex !== null &&
+                          effectiveHighlightedIndex !== bar.pi)}
+                      x={bar.x}
+                      y={bar.y}
+                      width={bar.width}
+                      height={bar.height}
+                      rx={barRadius}
+                      ry={barRadius}
+                      fill={barFillAttr(bar)}
+                      tabindex="0"
+                      role="button"
+                      aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
+                      onpointerenter={(e) => handleEnter(e, bar)}
+                      onpointermove={trackMouse}
+                      onpointerleave={handleLeave}
+                      onfocus={(e) => handleFocus(e, bar)}
+                      onblur={handleLeave}
+                      onkeydown={(e) => handleKeydown(e, bar)}
+                      onclick={() => handleClick(bar)}
+                    />
+                  {/if}
+                {/each}
+                {#each barLabels as bl, i (i)}
+                  {#if bl.visible}
+                    <text
+                      class="bar-value"
+                      class:bar-value-inside={bl.p.placement === 'inside'}
+                      x={bl.p.x}
+                      y={bl.p.y}
+                      text-anchor={bl.p.textAnchor}
+                      dominant-baseline={bl.p.dominantBaseline}
+                      style={bl.p.placement === 'inside'
+                        ? `fill: ${getContrastColor(bl.bar.color)}; stroke: ${contrastOutline(bl.bar.color)};`
+                        : ''}>{bl.text}</text
+                    >
+                  {/if}
+                {/each}
+              {/if}
 
-    {#if typeof tooltipSnippet === 'function' && hoveredBar()}
-      {@const hb = hoveredBar()}
-      {#if hb}
-        <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
-          {@render tooltipSnippet(hb.dataPoint, hb.pi)}
+              <!-- A1-4: renderOverlay escape hatch — rendered after all bars -->
+              {#if typeof renderOverlay === 'function'}
+                {@render renderOverlay(overlayContext)}
+              {/if}
+            </g>
+          </ChartContainer>
         </div>
+      </div>
+
+      {#if typeof tooltipSnippet === 'function'}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          {anchor}
+          portal={tooltipPortal}
+          originEl={plotEl}
+          unstyled
+        >
+          {#snippet content()}
+            {@const hb = hoveredBar()}
+            {#if hb}
+              {@render tooltipSnippet(hb.dataPoint, hb.pi)}
+            {/if}
+          {/snippet}
+        </ChartTooltip>
+      {:else}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          {anchor}
+          portal={tooltipPortal}
+          originEl={plotEl}
+        />
       {/if}
-    {:else}
-      <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
-    {/if}
+    </div>
   {/if}
 </div>
 
@@ -864,6 +989,9 @@
   }
   .chart-scroll-area {
     width: 100%;
+  }
+  .chart-plot {
+    position: relative;
   }
   .bar {
     transition: opacity var(--chart-transition-duration, 0.2s) ease;
@@ -878,21 +1006,26 @@
   .bar.dimmed {
     opacity: var(--barchart-bar-dimmed-opacity, 0.3);
   }
+  .bar:focus-visible {
+    outline: 2px solid var(--chart-axis-label-color, light-dark(#333, #e5e7eb));
+    outline-offset: 1px;
+  }
   .bar-value {
-    fill: var(--barchart-value-color, #333);
+    fill: var(--barchart-value-color, light-dark(#333, #e5e7eb));
     font-size: var(--barchart-value-font-size, 14px);
     font-weight: var(--barchart-value-font-weight, 600);
     font-family: var(--chart-font-family, inherit);
     pointer-events: none;
   }
-  .chart-tooltip-slot {
-    position: absolute;
-    z-index: 10;
-    pointer-events: none;
+  .bar-value-inside {
+    paint-order: stroke;
+    stroke-width: 2px;
+    stroke-opacity: 0.35;
+    stroke-linejoin: round;
   }
   .chart-empty {
     padding: var(--chart-empty-padding, 32px 24px);
-    color: var(--chart-empty-color, #9ca3af);
+    color: var(--chart-empty-color, light-dark(#9ca3af, #6b7280));
     text-align: center;
   }
 </style>

--- a/src/lib/BarChart/properties.ts
+++ b/src/lib/BarChart/properties.ts
@@ -179,6 +179,12 @@ export type OptionalBarChartProperties = {
    * thumbnails alongside a full chart.
    */
   hideBarGraphics?: boolean;
+  /** Legend items become click/keyboard toggles for series visibility. */
+  interactiveLegend?: boolean;
+  /** Hide the legend when the measured chart width is below this px value; 0 disables. */
+  hideLegendBelow?: number;
+  /** Render the tooltip into document.body (position:fixed) so scroll/overflow ancestors never clip it. */
+  tooltipPortal?: boolean;
   testId?: string;
   classes?: string;
 };

--- a/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
+++ b/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
@@ -8,13 +8,27 @@
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
-  import { createBandScale, createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
-  import { computeChartDimensions } from '$lib/_chart/geometry';
+  import {
+    createBandScale,
+    createLinearScale,
+    niceLinearDomain,
+    computeLinearTicks
+  } from '$lib/_chart/scales';
+  import { computeChartDimensions, computeAutoLayout } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
   import { roundedRectPath, linePath } from '$lib/_chart/paths';
-  import type { LegendItem, TooltipData, LinearScale, BandScale, Point } from '$lib/_chart/types';
+  import type {
+    LegendItem,
+    TooltipData,
+    LinearScale,
+    BandScale,
+    Point,
+    TooltipAnchor
+  } from '$lib/_chart/types';
   import { DEFAULT_CHART_CORNER_RADIUS, DEFAULT_CHART_MAX_HEIGHT } from '$lib/_chart/types';
+  import { pointerPositionIn, dismissOnOutsidePointerDown } from '$lib/_chart/interactions';
+  import { SvelteSet } from 'svelte/reactivity';
 
   // ── Per-instance uid for SVG <defs> ids ────────────────────────
   const uid = Math.random().toString(36).slice(2, 9);
@@ -36,6 +50,8 @@
     minBarHeight = 2,
     margin,
     tooltipPortal = false,
+    interactiveLegend = false,
+    hideLegendBelow = 360,
     tooltipSnippet,
     onbarclick,
     testId,
@@ -45,43 +61,35 @@
   // ── State ──────────────────────────────────────────────────────
 
   let containerEl: HTMLDivElement | null = $state(null);
+  let plotEl: HTMLDivElement | null = $state(null);
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hoveredCategoryIndex = $state<number | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
-  let mouseClientX = $state(0);
-  let mouseClientY = $state(0);
+  const hiddenSeries = new SvelteSet<number>();
+
+  function toggleSeries(index: number): void {
+    if (hiddenSeries.has(index)) {
+      hiddenSeries.delete(index);
+    } else {
+      hiddenSeries.add(index);
+    }
+  }
 
   // ── Formatters ─────────────────────────────────────────────────
 
   const leftFormat = $derived(leftAxis.valueFormat ?? formatNumber);
   const rightFormat = $derived(rightAxis.valueFormat ?? formatNumber);
 
-  // ── Layout — wider right margin to accommodate right-axis labels ─
-
-  const dims = $derived(
-    computeChartDimensions(chartWidth, chartHeight, {
-      top: 24,
-      right: 56,
-      bottom: 40,
-      left: 56,
-      ...margin
-    })
-  );
-
-  // ── Scales ─────────────────────────────────────────────────────
-
-  const catScale: BandScale = $derived(
-    createBandScale(categories, [0, dims.innerWidth], barPadding)
-  );
-
   /**
    * Computes the [min, max] domain for all series mapped to the given axis index,
    * then applies nice rounding. Returns [0, 1] for empty series.
    */
   const axisDomain = (axisIndex: 0 | 1): [number, number] => {
-    const axisSeries = series.filter((s) => s.yAxisIndex === axisIndex);
+    const axisSeries = series.filter(
+      (s, si) => s.yAxisIndex === axisIndex && !hiddenSeries.has(si)
+    );
     if (axisSeries.length === 0) {
       return [0, 1];
     }
@@ -94,6 +102,39 @@
 
   const leftDomain: [number, number] = $derived(axisDomain(0));
   const rightDomain: [number, number] = $derived(axisDomain(1));
+
+  // ── Layout — auto-sized margins from measured tick-label widths ─
+
+  const yTickCount = $derived(Math.max(2, Math.min(6, Math.floor(chartHeight / 70))));
+
+  const layout = $derived.by(() =>
+    computeAutoLayout({
+      width: chartWidth,
+      height: chartHeight,
+      yTickLabels: computeLinearTicks(leftDomain, yTickCount).map((t) => leftFormat(t)),
+      y2TickLabels: computeLinearTicks(rightDomain, yTickCount).map((t) => rightFormat(t)),
+      xTickLabels: categories,
+      hasYAxisLabel: Boolean(leftAxis.title),
+      hasY2AxisLabel: Boolean(rightAxis.title),
+      base: { top: 24, right: 28, bottom: 40, left: 28 }
+    })
+  );
+
+  // The margin prop stays an explicit per-side override on top of auto-sizing.
+  const dims = $derived(
+    computeChartDimensions(chartWidth, chartHeight, {
+      top: margin?.top ?? layout.margin.top,
+      right: margin?.right ?? layout.margin.right,
+      bottom: margin?.bottom ?? layout.margin.bottom,
+      left: margin?.left ?? layout.margin.left
+    })
+  );
+
+  // ── Scales ─────────────────────────────────────────────────────
+
+  const catScale: BandScale = $derived(
+    createBandScale(categories, [0, dims.innerWidth], barPadding)
+  );
 
   const leftScale: LinearScale = $derived(createLinearScale(leftDomain, [dims.innerHeight, 0]));
   const rightScale: LinearScale = $derived(createLinearScale(rightDomain, [dims.innerHeight, 0]));
@@ -113,13 +154,23 @@
   const leftAxisSeries: AxisSeriesEntry[] = $derived(
     series
       .map((s, si) => ({ series: s, seriesIndex: si }))
-      .filter((entry) => entry.series.yAxisIndex === 0 && entry.series.type !== 'line')
+      .filter(
+        (entry) =>
+          entry.series.yAxisIndex === 0 &&
+          entry.series.type !== 'line' &&
+          !hiddenSeries.has(entry.seriesIndex)
+      )
   );
 
   const rightAxisSeries: AxisSeriesEntry[] = $derived(
     series
       .map((s, si) => ({ series: s, seriesIndex: si }))
-      .filter((entry) => entry.series.yAxisIndex === 1 && entry.series.type !== 'line')
+      .filter(
+        (entry) =>
+          entry.series.yAxisIndex === 1 &&
+          entry.series.type !== 'line' &&
+          !hiddenSeries.has(entry.seriesIndex)
+      )
   );
 
   const columnSeriesEntries: AxisSeriesEntry[] = $derived([...leftAxisSeries, ...rightAxisSeries]);
@@ -168,7 +219,10 @@
         const barY = value >= 0 ? valueY : zeroY;
         const barHeight = Math.max(minBarHeight, Math.abs(valueY - zeroY));
 
-        const path = roundedRectPath(barX, barY, barW, barHeight, barRadius, barRadius, 0, 0);
+        const path =
+          value >= 0
+            ? roundedRectPath(barX, barY, barW, barHeight, barRadius, barRadius, 0, 0)
+            : roundedRectPath(barX, barY, barW, barHeight, 0, 0, barRadius, barRadius);
 
         result.push({
           x: barX,
@@ -201,7 +255,7 @@
     }
     return series
       .map((s, si) => ({ series: s, seriesIndex: si }))
-      .filter((entry) => entry.series.type === 'line')
+      .filter((entry) => entry.series.type === 'line' && !hiddenSeries.has(entry.seriesIndex))
       .map((entry) => {
         const scale = entry.series.yAxisIndex === 0 ? leftScale : rightScale;
         const color = resolvedColor(entry.series, entry.seriesIndex);
@@ -223,7 +277,11 @@
   // ── Legend items ───────────────────────────────────────────────
 
   const legendItems: LegendItem[] = $derived(
-    series.map((s, si) => ({ label: s.name, color: resolvedColor(s, si) }))
+    series.map((s, si) => ({
+      label: s.name,
+      color: resolvedColor(s, si),
+      hidden: hiddenSeries.has(si)
+    }))
   );
 
   // ── Tooltip ────────────────────────────────────────────────────
@@ -246,15 +304,45 @@
     }
     const catIdx = hoveredCategoryIndex;
     const category = categories[catIdx];
-    const items = series.map((s, si) => {
-      const fmt = s.yAxisIndex === 0 ? leftFormat : rightFormat;
-      return {
-        label: s.name,
-        value: fmt(s.data[catIdx] ?? 0),
-        color: resolvedColor(s, si)
-      };
-    });
+    const items = series
+      .map((s, si) => ({ s, si }))
+      .filter(({ si }) => !hiddenSeries.has(si))
+      .map(({ s, si }) => {
+        const fmt = s.yAxisIndex === 0 ? leftFormat : rightFormat;
+        return {
+          label: s.name,
+          value: fmt(s.data[catIdx] ?? 0),
+          color: resolvedColor(s, si)
+        };
+      });
     return { title: category, items };
+  });
+
+  // Category-anchored tooltip position: the topmost bar-top or line-dot y
+  // across all visible series at the hovered category, matching the
+  // Highcharts shared-tooltip anchor convention.
+  const anchor = $derived.by<TooltipAnchor | null>(() => {
+    if (hoveredCategoryIndex === null) {
+      return null;
+    }
+    const catIdx = hoveredCategoryIndex;
+    const ys: number[] = [];
+    for (const bar of bars) {
+      if (bar.categoryIndex === catIdx) {
+        ys.push(bar.y);
+      }
+    }
+    for (const ls of lineSeriesData) {
+      const p = ls.points[catIdx];
+      if (p) {
+        ys.push(p.y);
+      }
+    }
+    return {
+      x: dims.margin.left + catScale(categories[catIdx]) + catScale.bandwidth / 2,
+      y: dims.margin.top + (ys.length > 0 ? Math.min(...ys) : 0),
+      side: 'top'
+    };
   });
 
   // ── Axis tick formatters ───────────────────────────────────────
@@ -283,36 +371,34 @@
     }))
   );
 
+  function categoryAriaLabel(catIdx: number): string {
+    const parts = series
+      .map((s, si) => ({ s, si }))
+      .filter(({ si }) => !hiddenSeries.has(si))
+      .map(
+        ({ s }) =>
+          `${s.name} ${(s.yAxisIndex === 0 ? leftFormat : rightFormat)(s.data[catIdx] ?? 0)}`
+      );
+    return `${categories[catIdx]}: ${parts.join(', ')}`;
+  }
+
   // ── Interactions ───────────────────────────────────────────────
 
-  const trackMouse = (event: MouseEvent) => {
-    if (containerEl === null) {
-      return;
+  const trackMouse = (event: PointerEvent) => {
+    const position = pointerPositionIn(plotEl, event);
+    if (position !== null) {
+      mouseX = position.x;
+      mouseY = position.y;
     }
-    const rect = containerEl.getBoundingClientRect();
-    mouseX = event.clientX - rect.left;
-    mouseY = event.clientY - rect.top;
-    mouseClientX = event.clientX;
-    mouseClientY = event.clientY;
   };
 
-  /**
-   * Svelte action: relocates the tooltip layer to `document.body` so a `position:fixed`
-   * tooltip is never clipped by an `overflow`/scroll ancestor. Used only when
-   * `tooltipPortal` is set; `use:` actions never run during SSR.
-   */
-  const portalToBody = (node: HTMLElement) => {
-    document.body.appendChild(node);
-    return {
-      destroy: () => {
-        node.remove();
-      }
-    };
-  };
-
-  const handleCategoryEnter = (event: MouseEvent, catIdx: number) => {
+  const handleCategoryEnter = (event: PointerEvent, catIdx: number) => {
     hoveredCategoryIndex = catIdx;
     trackMouse(event);
+  };
+
+  const handleFocus = (catIdx: number) => {
+    hoveredCategoryIndex = catIdx;
   };
 
   const handleCategoryLeave = () => {
@@ -325,6 +411,24 @@
     }
     onbarclick({ categoryIndex: catIdx, context: buildTooltipContext(catIdx) });
   };
+
+  const handleKeydown = (event: KeyboardEvent, catIdx: number) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleCategoryClick(catIdx);
+    }
+  };
+
+  // Touch taps have no pointerleave: dismiss when a pointerdown lands outside.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (hoveredCategoryIndex === null) {
+      return;
+    }
+    return dismissOnOutsidePointerDown(containerEl, () => {
+      hoveredCategoryIndex = null;
+    });
+  });
 
   // ── Empty state ────────────────────────────────────────────────
 
@@ -339,168 +443,184 @@
   data-pw={typeof testId === 'string' ? testId : null}
 >
   {#if !isEmpty}
-    {#if showLegend}
-      <Legend items={legendItems} position="top" />
+    {#if showLegend && (chartWidth === 0 || hideLegendBelow === 0 || chartWidth >= hideLegendBelow)}
+      {#if interactiveLegend}
+        <Legend items={legendItems} position="top" onToggle={toggleSeries} />
+      {:else}
+        <Legend items={legendItems} position="top" />
+      {/if}
     {/if}
 
-    <ChartContainer
-      bind:width={chartWidth}
-      bind:height={chartHeight}
-      {aspectRatio}
-      {maxHeight}
-      {minHeight}
-    >
-      <g transform="translate({dims.margin.left}, {dims.margin.top})">
-        <!-- Left Y-axis (index 0) -->
-        <Axis
-          orientation="left"
-          scale={leftScale}
-          {showGridlines}
-          gridlineLength={dims.innerWidth}
-          tickFormat={leftTickFormat}
-          classes={leftAxis.color ? `axis-left-colored` : ''}
-        />
-
-        <!-- Right Y-axis (index 1) — positioned at innerWidth -->
-        <g transform="translate({dims.innerWidth}, 0)">
+    <div class="chart-plot" bind:this={plotEl}>
+      <ChartContainer
+        bind:width={chartWidth}
+        bind:height={chartHeight}
+        {aspectRatio}
+        {maxHeight}
+        {minHeight}
+      >
+        <g transform="translate({dims.margin.left}, {dims.margin.top})">
+          <!-- Left Y-axis (index 0) -->
           <Axis
-            orientation="right"
-            scale={rightScale}
-            showGridlines={false}
-            tickFormat={rightTickFormat}
-            classes={rightAxis.color ? `axis-right-colored` : ''}
+            orientation="left"
+            scale={leftScale}
+            tickCount={yTickCount}
+            {showGridlines}
+            gridlineLength={dims.innerWidth}
+            tickFormat={leftTickFormat}
+            classes={leftAxis.color ? `axis-left-colored` : ''}
           />
-        </g>
 
-        <!-- X-axis at bottom -->
-        <g transform="translate(0, {dims.innerHeight})">
-          <Axis orientation="bottom" scale={catScale} showGridlines={false} />
-        </g>
-
-        <!-- Axis titles -->
-        {#if leftAxis.title}
-          <text
-            class="axis-title axis-title-left"
-            transform="translate({-dims.margin.left + 12}, {dims.innerHeight / 2}) rotate(-90)"
-            text-anchor="middle"
-            style={leftAxis.color ? `fill: ${leftAxis.color}` : ''}
-          >
-            {leftAxis.title}
-          </text>
-        {/if}
-        {#if rightAxis.title}
-          <text
-            class="axis-title axis-title-right"
-            transform="translate({dims.innerWidth + dims.margin.right - 12}, {dims.innerHeight /
-              2}) rotate(90)"
-            text-anchor="middle"
-            style={rightAxis.color ? `fill: ${rightAxis.color}` : ''}
-          >
-            {rightAxis.title}
-          </text>
-        {/if}
-
-        <!-- Column/bar shapes -->
-        {#each bars as bar, barIdx (barIdx)}
-          <path
-            class="bar-shape"
-            class:bar-hovered={hoveredCategoryIndex === bar.categoryIndex}
-            class:bar-dimmed={hoveredCategoryIndex !== null &&
-              hoveredCategoryIndex !== bar.categoryIndex}
-            d={bar.path}
-            fill={bar.color}
-            aria-label="{categories[bar.categoryIndex]}: {bar.value}"
-            role="img"
-          />
-        {/each}
-
-        <!-- Line series drawn above columns -->
-        {#each lineSeriesData as ls, lsi (lsi)}
-          {#if ls.points.length >= 2}
-            <path
-              class="line-series"
-              d={linePath(ls.points, 'monotone')}
-              stroke={ls.color}
-              fill="none"
+          <!-- Right Y-axis (index 1) — positioned at innerWidth -->
+          <g transform="translate({dims.innerWidth}, 0)">
+            <Axis
+              orientation="right"
+              scale={rightScale}
+              tickCount={yTickCount}
+              showGridlines={false}
+              tickFormat={rightTickFormat}
+              classes={rightAxis.color ? `axis-right-colored` : ''}
             />
+          </g>
+
+          <!-- X-axis at bottom -->
+          <g transform="translate(0, {dims.innerHeight})">
+            <Axis
+              orientation="bottom"
+              scale={catScale}
+              rotateTicks={layout.xRotate}
+              tickEvery={layout.xEvery}
+              showGridlines={false}
+            />
+          </g>
+
+          <!-- Axis titles -->
+          {#if leftAxis.title}
+            <text
+              class="axis-title axis-title-left"
+              transform="translate({-dims.margin.left + 12}, {dims.innerHeight / 2}) rotate(-90)"
+              text-anchor="middle"
+              style={leftAxis.color ? `fill: ${leftAxis.color}` : ''}
+            >
+              {leftAxis.title}
+            </text>
           {/if}
-          <!-- Line dots -->
-          {#each ls.points as pt, ptIdx (ptIdx)}
-            <circle
-              class="line-dot"
-              class:dot-hovered={hoveredCategoryIndex === ptIdx}
-              class:dot-dimmed={hoveredCategoryIndex !== null && hoveredCategoryIndex !== ptIdx}
-              cx={pt.x}
-              cy={pt.y}
-              r={hoveredCategoryIndex === ptIdx ? 6 : 4}
-              fill={ls.color}
-              stroke="var(--dual-axis-dot-stroke, #fff)"
-              stroke-width="var(--dual-axis-dot-stroke-width, 1.5)"
-              aria-label="{categories[ptIdx]}: {series[ls.seriesIndex]?.data[ptIdx] ?? 0}"
+          {#if rightAxis.title}
+            <text
+              class="axis-title axis-title-right"
+              transform="translate({dims.innerWidth + dims.margin.right - 12}, {dims.innerHeight /
+                2}) rotate(90)"
+              text-anchor="middle"
+              style={rightAxis.color ? `fill: ${rightAxis.color}` : ''}
+            >
+              {rightAxis.title}
+            </text>
+          {/if}
+
+          <!-- Column/bar shapes -->
+          {#each bars as bar, barIdx (barIdx)}
+            <path
+              class="bar-shape"
+              class:bar-hovered={hoveredCategoryIndex === bar.categoryIndex}
+              class:bar-dimmed={hoveredCategoryIndex !== null &&
+                hoveredCategoryIndex !== bar.categoryIndex}
+              d={bar.path}
+              fill={bar.color}
+              aria-label="{categories[bar.categoryIndex]}: {bar.value}"
               role="img"
             />
           {/each}
-        {/each}
 
-        <!-- Invisible per-category hover targets (full inner height) -->
-        {#each hoverRects as hr (hr.catIdx)}
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <rect
-            class="hover-target"
-            x={hr.x}
-            y={0}
-            width={hr.width}
-            height={dims.innerHeight}
-            fill="transparent"
-            data-category-index={hr.catIdx}
-            onmouseenter={(event) => handleCategoryEnter(event, hr.catIdx)}
-            onmousemove={trackMouse}
-            onmouseleave={handleCategoryLeave}
-            onclick={() => handleCategoryClick(hr.catIdx)}
-          />
-        {/each}
+          <!-- Line series drawn above columns -->
+          {#each lineSeriesData as ls, lsi (lsi)}
+            {#if ls.points.length >= 2}
+              <path
+                class="line-series"
+                d={linePath(ls.points, 'monotone')}
+                stroke={ls.color}
+                fill="none"
+              />
+            {/if}
+            <!-- Line dots -->
+            {#each ls.points as pt, ptIdx (ptIdx)}
+              <circle
+                class="line-dot"
+                class:dot-hovered={hoveredCategoryIndex === ptIdx}
+                class:dot-dimmed={hoveredCategoryIndex !== null && hoveredCategoryIndex !== ptIdx}
+                cx={pt.x}
+                cy={pt.y}
+                r={hoveredCategoryIndex === ptIdx ? 6 : 4}
+                fill={ls.color}
+                style="stroke: var(--dual-axis-dot-stroke, light-dark(#fff, #111827)); stroke-width: var(--dual-axis-dot-stroke-width, 1.5);"
+                aria-label="{categories[ptIdx]}: {series[ls.seriesIndex]?.data[ptIdx] ?? 0}"
+                role="img"
+              />
+            {/each}
+          {/each}
 
-        <!-- Hover vertical guideline -->
-        {#if hoveredCategoryIndex !== null}
-          {@const guideX = catScale(categories[hoveredCategoryIndex]) + catScale.bandwidth / 2}
-          <line class="hover-guideline" x1={guideX} x2={guideX} y1={0} y2={dims.innerHeight} />
-        {/if}
-      </g>
+          <!-- Invisible per-category hover targets (full inner height) -->
+          {#each hoverRects as hr (hr.catIdx)}
+            <rect
+              class="hover-target"
+              x={hr.x}
+              y={0}
+              width={hr.width}
+              height={dims.innerHeight}
+              fill="transparent"
+              data-category-index={hr.catIdx}
+              tabindex="0"
+              role="button"
+              aria-label={categoryAriaLabel(hr.catIdx)}
+              onpointerenter={(event) => handleCategoryEnter(event, hr.catIdx)}
+              onpointermove={trackMouse}
+              onpointerleave={handleCategoryLeave}
+              onfocus={() => handleFocus(hr.catIdx)}
+              onblur={handleCategoryLeave}
+              onkeydown={(event) => handleKeydown(event, hr.catIdx)}
+              onclick={() => handleCategoryClick(hr.catIdx)}
+            />
+          {/each}
 
-      <!-- SVG defs id namespace anchor (keeps uid live in reactive graph) -->
-      <defs>
-        <marker id="{uid}-anchor" />
-      </defs>
-    </ChartContainer>
-
-    <!-- Tooltip -->
-    {#if hoveredCategoryIndex !== null}
-      {#if tooltipPortal}
-        <!-- Portaled to <body> with fixed viewport coords so the tooltip is never
-             clipped by an overflow/scroll ancestor (e.g. a scrollable report sheet).
-             The inner elements keep their own +12/-12 offset relative to this layer. -->
-        <div
-          class="chart-tooltip-portal"
-          style="left: {mouseClientX}px; top: {mouseClientY}px;"
-          use:portalToBody
-        >
-          {#if typeof tooltipSnippet === 'function'}
-            <div class="chart-tooltip-slot" style="left: 12px; top: -12px;">
-              {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
-            </div>
-          {:else}
-            <ChartTooltip data={tooltipData} mouseX={0} mouseY={0} />
+          <!-- Hover vertical guideline -->
+          {#if hoveredCategoryIndex !== null}
+            {@const guideX = catScale(categories[hoveredCategoryIndex]) + catScale.bandwidth / 2}
+            <line class="hover-guideline" x1={guideX} x2={guideX} y1={0} y2={dims.innerHeight} />
           {/if}
-        </div>
-      {:else if typeof tooltipSnippet === 'function'}
-        <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
-          {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
-        </div>
+        </g>
+
+        <!-- SVG defs id namespace anchor (keeps uid live in reactive graph) -->
+        <defs>
+          <marker id="{uid}-anchor" />
+        </defs>
+      </ChartContainer>
+
+      {#if typeof tooltipSnippet === 'function'}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          {anchor}
+          portal={tooltipPortal}
+          originEl={plotEl}
+          unstyled
+        >
+          {#snippet content()}
+            {#if hoveredCategoryIndex !== null}
+              {@render tooltipSnippet(buildTooltipContext(hoveredCategoryIndex))}
+            {/if}
+          {/snippet}
+        </ChartTooltip>
       {:else}
-        <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          {anchor}
+          portal={tooltipPortal}
+          originEl={plotEl}
+        />
       {/if}
-    {/if}
+    </div>
   {:else}
     <div class="chart-empty">No data available.</div>
   {/if}
@@ -509,6 +629,10 @@
 <style>
   .dual-axis-bar-chart {
     width: 100%;
+    position: relative;
+  }
+
+  .chart-plot {
     position: relative;
   }
 
@@ -547,8 +671,13 @@
     cursor: pointer;
   }
 
+  .hover-target:focus-visible {
+    outline: 2px solid var(--chart-axis-label-color, light-dark(#333, #e5e7eb));
+    outline-offset: -2px;
+  }
+
   .hover-guideline {
-    stroke: var(--dual-axis-guideline-color, #aaa);
+    stroke: var(--dual-axis-guideline-color, light-dark(#aaa, #4b5563));
     stroke-width: var(--dual-axis-guideline-width, 1);
     stroke-dasharray: var(--dual-axis-guideline-dash, 4 3);
     pointer-events: none;
@@ -556,27 +685,15 @@
   }
 
   .axis-title {
-    fill: var(--chart-axis-label-color, #333);
+    fill: var(--chart-axis-label-color, light-dark(#333, #e5e7eb));
     font-size: var(--chart-axis-label-font-size, 11px);
     font-family: var(--chart-font-family, inherit);
     font-weight: 500;
   }
 
-  .chart-tooltip-slot {
-    position: absolute;
-    z-index: 10;
-    pointer-events: none;
-  }
-
-  .chart-tooltip-portal {
-    position: fixed;
-    z-index: var(--chart-tooltip-z-index, 10);
-    pointer-events: none;
-  }
-
   .chart-empty {
     padding: var(--chart-empty-padding, 32px 24px);
-    color: var(--chart-empty-color, #9ca3af);
+    color: var(--chart-empty-color, light-dark(#9ca3af, #6b7280));
     text-align: center;
   }
 </style>

--- a/src/lib/DualAxisBarChart/properties.ts
+++ b/src/lib/DualAxisBarChart/properties.ts
@@ -144,6 +144,10 @@ export type OptionalDualAxisBarChartProperties = {
    * tooltip. Default `false` (in-chart positioning, unchanged).
    */
   tooltipPortal?: boolean;
+  /** Legend items become click/keyboard toggles for series visibility. */
+  interactiveLegend?: boolean;
+  /** Hide the legend when the measured chart width is below this px value; 0 disables. */
+  hideLegendBelow?: number;
 };
 
 export type DualAxisBarChartEventProperties = {

--- a/src/lib/FunnelChart/FunnelChart.svelte
+++ b/src/lib/FunnelChart/FunnelChart.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { FunnelChartProperties, FunnelStage } from './properties';
   import ChartContainer from '$lib/_chart/ChartContainer.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
-  import { getColor } from '$lib/_chart/colors';
+  import { getColor, getContrastColor } from '$lib/_chart/colors';
   import { formatNumber, formatPercent } from '$lib/_chart/format';
+  import { measureText, readCssVarPx } from '$lib/_chart/measure';
+  import { truncateToWidth } from '$lib/_chart/labels';
+  import { pointerPositionIn, dismissOnOutsidePointerDown } from '$lib/_chart/interactions';
   import { DEFAULT_CHART_CORNER_RADIUS, DEFAULT_CHART_MAX_HEIGHT } from '$lib/_chart/types';
 
   // ── Props ──────────────────────────────────────────────────────
@@ -11,7 +15,7 @@
   let {
     data,
     stageColors,
-    connectorColor = 'var(--funnel-chart-connector-color, #BDFFFB)',
+    connectorColor = 'var(--funnel-chart-connector-color, light-dark(#BDFFFB, #164e4a))',
     slopeWidth = 10,
     onHoverExpand = 10,
     showValueLabels = true,
@@ -20,6 +24,7 @@
     maxHeight = DEFAULT_CHART_MAX_HEIGHT,
     minHeight = 0,
     radius = DEFAULT_CHART_CORNER_RADIUS,
+    tooltipPortal = false,
     testId,
     classes,
     empty,
@@ -30,11 +35,19 @@
   // ── State ──────────────────────────────────────────────────────
 
   let containerEl: HTMLDivElement | null = $state(null);
+  let plotEl: HTMLDivElement | null = $state(null);
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hoveredIndex = $state<number | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+  let labelFontSize = $state(11);
+  let valueFontSize = $state(11);
+
+  onMount(() => {
+    labelFontSize = readCssVarPx(containerEl, '--funnel-chart-label-font-size', 11);
+    valueFontSize = readCssVarPx(containerEl, '--funnel-chart-value-font-size', 11);
+  });
 
   // ── Derived geometry ───────────────────────────────────────────
 
@@ -42,7 +55,6 @@
   const MARGIN_RIGHT = 8;
   const MARGIN_BOTTOM = 8;
   const MARGIN_LEFT = 8;
-  const LABEL_AREA_HEIGHT = 24;
 
   let innerWidth = $derived(Math.max(0, chartWidth - MARGIN_LEFT - MARGIN_RIGHT));
   let innerHeight = $derived(Math.max(0, chartHeight - MARGIN_TOP - MARGIN_BOTTOM));
@@ -79,8 +91,11 @@
     data.length === 0 ? 0 : Math.max(1, (innerWidth - totalSlopeSpace) / data.length)
   );
 
+  /** Vertical band reserved above the bars for the category label, sized to the actual font. */
+  let labelAreaHeight = $derived(Math.ceil(labelFontSize * 1.2) + 10);
+
   /** Available height for the bars themselves (below the category labels). */
-  let barAreaHeight = $derived(Math.max(0, innerHeight - LABEL_AREA_HEIGHT));
+  let barAreaHeight = $derived(Math.max(0, innerHeight - labelAreaHeight));
 
   /**
    * Resolve the fill color for a stage. Uses explicitly-provided `stageColors` array
@@ -117,7 +132,7 @@
    */
   function barY(stageValue: number, expandPixels: number = 0): number {
     const h = barHeight(stageValue, expandPixels);
-    return LABEL_AREA_HEIGHT + (barAreaHeight - h) / 2;
+    return labelAreaHeight + (barAreaHeight - h) / 2;
   }
 
   /**
@@ -158,6 +173,33 @@
     return `${formatNumber(stage.value)}  |  ${pct}`;
   }
 
+  // ── Label fitting ──────────────────────────────────────────────
+
+  let labelFont = $derived({ size: labelFontSize });
+  let valueFont = $derived({ size: valueFontSize });
+
+  function categoryLabel(stage: FunnelStage): string {
+    return truncateToWidth(stage.category, Math.max(0, stageColumnWidth - 4), labelFont);
+  }
+
+  /** Highcharts crop chain for in-bar labels: full "value | pct" → "pct" → hidden. */
+  function valueLabel(stage: FunnelStage, bh: number): string {
+    const full = formatLabel(stage);
+    const fullSize = measureText(full, valueFont);
+    if (bh >= fullSize.height + 4 && stageColumnWidth >= fullSize.width + 8) {
+      return full;
+    }
+    const compact = formatPercent(stage.value, maxValue);
+    const compactSize = measureText(compact, valueFont);
+    if (bh >= compactSize.height + 4 && stageColumnWidth >= compactSize.width + 8) {
+      return compact;
+    }
+    return '';
+  }
+
+  const contrastOutline = (fill: string): string =>
+    getContrastColor(fill) === '#000000' ? '#ffffff' : '#000000';
+
   // ── Tooltip ────────────────────────────────────────────────────
 
   let tooltipData = $derived.by(() => {
@@ -182,18 +224,37 @@
 
   // ── Interaction ────────────────────────────────────────────────
 
-  function trackMouse(event: MouseEvent) {
-    if (containerEl === null) {
-      return;
+  // Narrows an event's currentTarget to Element without an `as` cast (repo
+  // lint bans type assertions outside test files).
+  const targetElement = (e: Event): Element | null =>
+    e.currentTarget instanceof Element ? e.currentTarget : null;
+
+  function trackMouse(event: PointerEvent) {
+    const position = pointerPositionIn(plotEl, event);
+    if (position !== null) {
+      mouseX = position.x;
+      mouseY = position.y;
     }
-    const rect = containerEl.getBoundingClientRect();
-    mouseX = event.clientX - rect.left;
-    mouseY = event.clientY - rect.top;
   }
 
-  function handleEnter(event: MouseEvent, index: number) {
+  function handleEnter(event: PointerEvent, index: number) {
     hoveredIndex = index;
     trackMouse(event);
+    const stage = data[index] ?? null;
+    if (stage !== null) {
+      onstagehover?.({ index, stage });
+    }
+  }
+
+  function handleFocus(e: FocusEvent, index: number) {
+    hoveredIndex = index;
+    const el = targetElement(e);
+    if (plotEl !== null && el !== null) {
+      const r = el.getBoundingClientRect();
+      const c = plotEl.getBoundingClientRect();
+      mouseX = r.left + r.width / 2 - c.left;
+      mouseY = r.top - c.top;
+    }
     const stage = data[index] ?? null;
     if (stage !== null) {
       onstagehover?.({ index, stage });
@@ -204,6 +265,22 @@
     hoveredIndex = null;
     onstagehover?.(null);
   }
+
+  function handleKeydown(e: KeyboardEvent, index: number) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick(index);
+    }
+  }
+
+  // Touch taps have no pointerleave: dismiss when a pointerdown lands outside.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (hoveredIndex === null) {
+      return;
+    }
+    return dismissOnOutsidePointerDown(containerEl, handleLeave);
+  });
 
   function handleClick(index: number) {
     const stage = data[index] ?? null;
@@ -221,91 +298,105 @@
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
   {:else}
-    <ChartContainer
-      bind:width={chartWidth}
-      bind:height={chartHeight}
-      {aspectRatio}
-      {maxHeight}
-      {minHeight}
-    >
-      <g transform="translate({MARGIN_LEFT}, {MARGIN_TOP})">
-        <!-- Stage bars and category labels -->
-        {#each data as stage, index (index)}
-          {@const expand = hoveredIndex === index ? onHoverExpand : 0}
-          {@const bh = barHeight(stage.value, expand)}
-          {@const by = barY(stage.value, expand)}
-          {@const bx = stageX(index)}
-          {@const color = resolveStageColor(index)}
-          {@const labelX = bx + stageColumnWidth / 2}
+    <div class="chart-plot" bind:this={plotEl}>
+      <ChartContainer
+        bind:width={chartWidth}
+        bind:height={chartHeight}
+        {aspectRatio}
+        {maxHeight}
+        {minHeight}
+      >
+        <g transform="translate({MARGIN_LEFT}, {MARGIN_TOP})">
+          <!-- Stage bars and category labels -->
+          {#each data as stage, index (index)}
+            {@const expand = hoveredIndex === index ? onHoverExpand : 0}
+            {@const bh = barHeight(stage.value, expand)}
+            {@const by = barY(stage.value, expand)}
+            {@const bx = stageX(index)}
+            {@const color = resolveStageColor(index)}
+            {@const labelX = bx + stageColumnWidth / 2}
 
-          <!-- Category label above the bar -->
-          <text
-            class="funnel-category-label"
-            x={labelX}
-            y={LABEL_AREA_HEIGHT - 6}
-            text-anchor="middle"
-            dominant-baseline="auto">{stage.category}</text
-          >
-
-          <!-- Stage bar -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <rect
-            class="funnel-bar"
-            class:funnel-bar-hovered={hoveredIndex === index}
-            class:funnel-bar-dimmed={hoveredIndex !== null && hoveredIndex !== index}
-            x={bx}
-            y={by}
-            width={stageColumnWidth}
-            height={bh}
-            fill={color}
-            rx={radius}
-            aria-label="{stage.category}: {formatLabel(stage)}"
-            onmouseenter={(event) => handleEnter(event, index)}
-            onmousemove={trackMouse}
-            onmouseleave={handleLeave}
-            onclick={() => handleClick(index)}
-          />
-
-          <!-- Value label centred inside the bar -->
-          {#if showValueLabels}
+            <!-- Category label above the bar -->
             <text
-              class="funnel-value-label"
+              class="funnel-category-label"
               x={labelX}
-              y={by + bh / 2}
+              y={labelAreaHeight - 6}
               text-anchor="middle"
-              dominant-baseline="middle"
-              pointer-events="none">{formatLabel(stage)}</text
+              dominant-baseline="auto">{categoryLabel(stage)}</text
             >
-          {/if}
-        {/each}
 
-        <!-- Trapezoidal connectors between stages -->
-        {#each data as _stage, index (index)}
-          {#if index < data.length - 1}
-            <polygon
-              class="funnel-connector"
-              points={connectorPoints(index)}
-              fill={connectorColor}
-              pointer-events="none"
+            <!-- Stage bar -->
+            <rect
+              class="funnel-bar"
+              class:funnel-bar-hovered={hoveredIndex === index}
+              class:funnel-bar-dimmed={hoveredIndex !== null && hoveredIndex !== index}
+              x={bx}
+              y={by}
+              width={stageColumnWidth}
+              height={bh}
+              fill={color}
+              rx={radius}
+              aria-label="{stage.category}: {formatLabel(stage)}"
+              onpointerenter={(event) => handleEnter(event, index)}
+              onpointermove={trackMouse}
+              onpointerleave={handleLeave}
+              onfocus={(e) => handleFocus(e, index)}
+              onblur={handleLeave}
+              onkeydown={(e) => handleKeydown(e, index)}
+              onclick={() => handleClick(index)}
+              tabindex="0"
+              role="button"
             />
-          {/if}
-        {/each}
-      </g>
-    </ChartContainer>
 
-    <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
+            <!-- Value label centred inside the bar -->
+            {#if showValueLabels}
+              {@const vl = valueLabel(stage, bh)}
+              {#if vl !== ''}
+                <text
+                  class="funnel-value-label"
+                  x={labelX}
+                  y={by + bh / 2}
+                  text-anchor="middle"
+                  dominant-baseline="middle"
+                  style="fill: var(--funnel-chart-value-color, {getContrastColor(
+                    color
+                  )}); stroke: {contrastOutline(color)};"
+                  pointer-events="none">{vl}</text
+                >
+              {/if}
+            {/if}
+          {/each}
+
+          <!-- Trapezoidal connectors between stages -->
+          {#each data as _stage, index (index)}
+            {#if index < data.length - 1}
+              <polygon
+                class="funnel-connector"
+                points={connectorPoints(index)}
+                style="fill: {connectorColor}"
+                pointer-events="none"
+              />
+            {/if}
+          {/each}
+        </g>
+      </ChartContainer>
+
+      <ChartTooltip data={tooltipData} {mouseX} {mouseY} portal={tooltipPortal} originEl={plotEl} />
+    </div>
   {/if}
 </div>
 
 <style>
   .funnel-chart {
     width: 100%;
+  }
+
+  .chart-plot {
     position: relative;
   }
 
   .funnel-category-label {
-    fill: var(--funnel-chart-label-color, #666);
+    fill: var(--funnel-chart-label-color, light-dark(#666, #9ca3af));
     font-size: var(--funnel-chart-label-font-size, 11px);
     font-family: var(--chart-font-family, inherit);
     pointer-events: none;
@@ -327,10 +418,18 @@
     opacity: var(--funnel-chart-bar-dimmed-opacity, 0.35);
   }
 
+  .funnel-bar:focus-visible {
+    outline: 2px solid var(--chart-axis-label-color, light-dark(#333, #e5e7eb));
+    outline-offset: 1px;
+  }
+
   .funnel-value-label {
-    fill: var(--funnel-chart-value-color, #fff);
     font-size: var(--funnel-chart-value-font-size, 11px);
     font-family: var(--chart-font-family, inherit);
+    paint-order: stroke;
+    stroke-width: 2px;
+    stroke-opacity: 0.35;
+    stroke-linejoin: round;
   }
 
   .funnel-connector {
@@ -339,7 +438,7 @@
 
   .chart-empty {
     padding: var(--chart-empty-padding, 32px 24px);
-    color: var(--chart-empty-color, #9ca3af);
+    color: var(--chart-empty-color, light-dark(#9ca3af, #6b7280));
     text-align: center;
   }
 </style>

--- a/src/lib/FunnelChart/properties.ts
+++ b/src/lib/FunnelChart/properties.ts
@@ -72,6 +72,8 @@ export type OptionalFunnelChartProperties = {
   maxHeight?: number;
   /** Lower bound (px) on the rendered chart height (defaults to `0`). */
   minHeight?: number;
+  /** Render the tooltip into document.body (position:fixed) so scroll/overflow ancestors never clip it. */
+  tooltipPortal?: boolean;
   /** Value for the `data-pw` attribute on the chart root element. */
   testId?: string;
   /** CSS class string applied to the chart root element. Useful for CSS-variable theming. */

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -7,12 +7,16 @@
   import Axis from '$lib/_chart/Axis.svelte';
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
-  import { createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
-  import { computeChartDimensions } from '$lib/_chart/geometry';
+  import { createLinearScale, niceLinearDomain, computeLinearTicks } from '$lib/_chart/scales';
+  import { computeAutoLayout } from '$lib/_chart/geometry';
   import { linePath, areaPath } from '$lib/_chart/paths';
   import { getColor } from '$lib/_chart/colors';
-  import { formatNumber } from '$lib/_chart/format';
-  import type { LegendItem, Point } from '$lib/_chart/types';
+  import { formatNumber, defaultTickFormat } from '$lib/_chart/format';
+  import { measureText } from '$lib/_chart/measure';
+  import { resolvePointLabels } from '$lib/_chart/labels';
+  import type { LegendItem, Point, TooltipAnchor } from '$lib/_chart/types';
+  import { pointerPositionIn, dismissOnOutsidePointerDown } from '$lib/_chart/interactions';
+  import { SvelteSet } from 'svelte/reactivity';
 
   // Per-instance ID for SVG gradient <linearGradient id> references. Initialised
   // inside onMount so the value is only ever generated on the client — avoids an
@@ -49,6 +53,10 @@
     maxHeight = DEFAULT_CHART_MAX_HEIGHT,
     tooltipSnippet,
     empty,
+    sharedTooltip,
+    interactiveLegend = false,
+    hideLegendBelow = 360,
+    tooltipPortal = false,
     highlightedIndex = null,
     onChartReady,
     onpointclick,
@@ -60,6 +68,7 @@
   // ── State ──────────────────────────────────────────────────────
 
   let containerEl: HTMLDivElement | null = $state(null);
+  let plotEl: HTMLDivElement | null = $state(null);
   let chartWidth = $state(0);
   let chartHeight = $state(0);
   let hovered = $state<{ si: number; pi: number } | null>(null);
@@ -68,6 +77,19 @@
   let internalHighlight = $state<number | null>(null);
   let mouseX = $state(0);
   let mouseY = $state(0);
+  const hiddenSeries = new SvelteSet<number>();
+
+  function toggleSeries(index: number): void {
+    if (hiddenSeries.has(index)) {
+      hiddenSeries.delete(index);
+    } else {
+      hiddenSeries.add(index);
+    }
+  }
+
+  // Shared-mode switch: one tooltip listing every visible series at the
+  // hovered x. Defaults to true for multi-series charts.
+  let shared = $derived(sharedTooltip ?? series.length > 1);
 
   // Effective highlighted index: the declarative prop takes precedence when it is a non-null
   // number; otherwise the imperative API value (internalHighlight) is used. This lets callers
@@ -103,15 +125,15 @@
 
   // ── Layout ─────────────────────────────────────────────────────
 
-  let dims = $derived(computeChartDimensions(chartWidth, chartHeight));
-
   let isEmpty = $derived(series.length === 0 || series.every((s) => s.data.length === 0));
 
   let xExtent = $derived.by<[number, number]>(() => {
     if (xDomain) {
       return xDomain;
     }
-    const allX = series.flatMap((s) => s.data.map((d) => d.x));
+    const allX = series
+      .filter((_, si) => !hiddenSeries.has(si))
+      .flatMap((s) => s.data.map((d) => d.x));
     if (allX.length === 0) {
       return [0, 1];
     }
@@ -121,32 +143,14 @@
     if (yDomain) {
       return yDomain;
     }
-    const allY = series.flatMap((s) => s.data.map((d) => d.y));
+    const allY = series
+      .filter((_, si) => !hiddenSeries.has(si))
+      .flatMap((s) => s.data.map((d) => d.y));
     if (allY.length === 0) {
       return [0, 1];
     }
     return niceLinearDomain(Math.min(0, ...allY), Math.max(...allY));
   });
-
-  let xScale = $derived(createLinearScale(xExtent, [0, dims.innerWidth]));
-  let yScale = $derived(createLinearScale(yExtent, [dims.innerHeight, 0]));
-
-  let lines = $derived(
-    series.map((s, si) => {
-      const color = s.color ?? getColor(si);
-      const points: Point[] = s.data.map((d) => ({ x: xScale(d.x), y: yScale(d.y) }));
-      return {
-        color,
-        points,
-        path: linePath(points, curve),
-        areaD: areaPath(points, dims.innerHeight, curve)
-      };
-    })
-  );
-
-  let legendItems = $derived<LegendItem[]>(
-    series.map((s, i) => ({ label: s.name, color: s.color ?? getColor(i) }))
-  );
 
   // ── Category tick formatter ────────────────────────────────────
 
@@ -165,6 +169,53 @@
     return xTickFormat;
   });
 
+  let yTickCount = $derived(Math.max(2, Math.min(6, Math.floor(chartHeight / 70))));
+  let xTickCount = $derived(Math.max(2, Math.min(8, Math.floor(chartWidth / 90))));
+  // Category positions are whole numbers — fractional tick steps would repeat labels.
+  let xIntegerTicks = $derived(Boolean(xAxisCategories && xAxisCategories.length > 0));
+
+  let layout = $derived.by(() => {
+    const yFmt = yTickFormat ?? defaultTickFormat;
+    const xFmt = resolvedXTickFormat ?? defaultTickFormat;
+    return computeAutoLayout({
+      width: chartWidth,
+      height: chartHeight,
+      yTickLabels: showYAxis ? computeLinearTicks(yExtent, yTickCount).map((t) => yFmt(t)) : [],
+      xTickLabels: showXAxis
+        ? computeLinearTicks(xExtent, xTickCount, xIntegerTicks).map((t) => xFmt(t))
+        : [],
+      hasYAxisLabel: Boolean(yAxisLabel) && showYAxis,
+      hasXAxisLabel: Boolean(xAxisLabel) && showXAxis,
+      base: { top: 20, right: 20, bottom: showXAxis ? 40 : 8, left: showYAxis ? 50 : 20 }
+    });
+  });
+  let dims = $derived(layout);
+
+  let xScale = $derived(createLinearScale(xExtent, [0, dims.innerWidth]));
+  let yScale = $derived(createLinearScale(yExtent, [dims.innerHeight, 0]));
+
+  let lines = $derived(
+    series.map((s, si) => {
+      const color = s.color ?? getColor(si);
+      const points: Point[] = s.data.map((d) => ({ x: xScale(d.x), y: yScale(d.y) }));
+      return {
+        color,
+        points,
+        path: linePath(points, curve),
+        areaD: areaPath(points, dims.innerHeight, curve),
+        hidden: hiddenSeries.has(si)
+      };
+    })
+  );
+
+  let legendItems = $derived<LegendItem[]>(
+    series.map((s, i) => ({
+      label: s.name,
+      color: s.color ?? getColor(i),
+      hidden: hiddenSeries.has(i)
+    }))
+  );
+
   // ── Tooltip ────────────────────────────────────────────────────
 
   let hoveredPoint = $derived(
@@ -181,8 +232,11 @@
     if (effectiveHighlight === null) {
       return null;
     }
-    // Use the first series that has a point at this index.
+    // Use the first VISIBLE series that has a point at this index.
     for (const line of lines) {
+      if (line.hidden) {
+        continue;
+      }
       const point = line.points[effectiveHighlight];
       if (point) {
         return point.x;
@@ -220,12 +274,60 @@
       : `x: ${formatNumber(tooltipContext.x)}`;
     return {
       title: xLabel,
-      items: tooltipContext.points.map((p) => ({
-        label: p.name,
-        value: formatNumber(p.y),
-        color: p.color
-      }))
+      items: tooltipContext.points
+        .map((p, si) => ({ p, si }))
+        .filter(
+          ({ si }) =>
+            !hiddenSeries.has(si) &&
+            (shared || si === hovered?.si) &&
+            series[si]?.data[hovered!.pi] != null
+        )
+        .map(({ p }) => ({ label: p.name, value: formatNumber(p.y), color: p.color }))
     };
+  });
+
+  // Highcharts hover halo: a translucent ring behind the active marker(s).
+  let haloPoints = $derived.by(() => {
+    if (hovered === null) {
+      return [];
+    }
+    return lines.flatMap((line, si) => {
+      if (line.hidden || (!shared && si !== hovered!.si)) {
+        return [];
+      }
+      const p = line.points[hovered!.pi];
+      return p ? [{ x: p.x, y: p.y, color: line.color }] : [];
+    });
+  });
+
+  let anchor = $derived.by<TooltipAnchor | null>(() => {
+    if (hovered === null || haloPoints.length === 0) {
+      return null;
+    }
+    return {
+      x: haloPoints[0].x + dims.margin.left,
+      y: Math.min(...haloPoints.map((p) => p.y)) + dims.margin.top,
+      side: 'top'
+    };
+  });
+
+  // ── Point labels ───────────────────────────────────────────────
+
+  let pointLabelPlacements = $derived.by(() => {
+    if (!showValues) {
+      return [];
+    }
+    const plot = { width: dims.innerWidth, height: dims.innerHeight };
+    const font = { size: 11 };
+    return lines.map((line, si) =>
+      line.hidden
+        ? []
+        : resolvePointLabels({
+            points: line.points,
+            labels: series[si].data.map((d) => measureText(formatNumber(d.y), font)),
+            plot
+          })
+    );
   });
 
   // ── Highlight dim logic ────────────────────────────────────────
@@ -233,6 +335,15 @@
   // A point index is "dimmed" when the highlight system is active (hover or
   // imperative highlight) and the point is not the active one.
   const isDotDimmed = (si: number, pi: number): boolean => {
+    if (shared) {
+      if (hovered !== null) {
+        return hovered.pi !== pi;
+      }
+      if (effectiveHighlight !== null) {
+        return pi !== effectiveHighlight;
+      }
+      return false;
+    }
     // Hover interaction takes precedence over imperative highlight.
     if (hovered !== null) {
       return hovered.si !== si || hovered.pi !== pi;
@@ -244,6 +355,9 @@
   };
 
   const isLineDimmed = (si: number): boolean => {
+    if (shared) {
+      return false;
+    }
     if (hovered !== null) {
       return hovered.si !== si;
     }
@@ -263,22 +377,31 @@
 
   // ── Interactions ───────────────────────────────────────────────
 
-  const trackMouse = (e: MouseEvent): void => {
-    if (containerEl === null) {
-      return;
+  const trackMouse = (e: PointerEvent): void => {
+    const position = pointerPositionIn(plotEl, e);
+    if (position !== null) {
+      mouseX = position.x;
+      mouseY = position.y;
     }
-    const rect = containerEl.getBoundingClientRect();
-    mouseX = e.clientX - rect.left;
-    mouseY = e.clientY - rect.top;
   };
 
   const findNearest = (plotX: number, plotY: number): { si: number; pi: number } | null => {
     if (series.length === 0) {
       return null;
     }
-    // Use the longest series as the index reference so hover still works when
-    // the first series is empty or shorter than the others.
-    const reference = series.reduce((a, b) => (b.data.length > a.data.length ? b : a)).data;
+    // Use the longest VISIBLE series as the index reference so hover still works
+    // when the first series is empty or shorter than the others, and never
+    // anchors to a series the user has toggled off via the legend.
+    const visibleEntries = series
+      .map((s, si) => ({ s, si }))
+      .filter((entry) => !hiddenSeries.has(entry.si));
+    if (visibleEntries.length === 0) {
+      return null;
+    }
+    const referenceEntry = visibleEntries.reduce((a, b) =>
+      b.s.data.length > a.s.data.length ? b : a
+    );
+    const reference = referenceEntry.s.data;
     if (reference.length === 0) {
       return null;
     }
@@ -292,9 +415,14 @@
         nearestPi = i;
       }
     }
-    let nearestSi = 0;
+    // The reference series is visible and owns nearestPi by construction, so
+    // it's a safe default if no other visible series' point is nearer in y.
+    let nearestSi = referenceEntry.si;
     let nearestYDist = Infinity;
     for (let si = 0; si < series.length; si++) {
+      if (hiddenSeries.has(si)) {
+        continue;
+      }
       const p = series[si].data[nearestPi];
       if (!p) {
         continue;
@@ -309,7 +437,7 @@
     return { si: nearestSi, pi: nearestPi };
   };
 
-  const handleOverlayMove = (e: MouseEvent): void => {
+  const handleOverlayMove = (e: PointerEvent): void => {
     trackMouse(e);
     const plotX = mouseX - dims.margin.left;
     const plotY = mouseY - dims.margin.top;
@@ -341,6 +469,15 @@
       onpointclick?.({ seriesIndex: hovered.si, pointIndex: hovered.pi, point });
     }
   };
+
+  // Touch taps have no pointerleave: dismiss when a pointerdown lands outside.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (hovered === null) {
+      return;
+    }
+    return dismissOnOutsidePointerDown(containerEl, handleLeave);
+  });
 </script>
 
 <div
@@ -351,183 +488,233 @@
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
   {:else}
-    {#if showLegend && series.length > 1}
-      <Legend items={legendItems} position="top" />
+    {#if showLegend && series.length > 1 && (chartWidth === 0 || hideLegendBelow === 0 || chartWidth >= hideLegendBelow)}
+      {#if interactiveLegend}
+        <Legend items={legendItems} position="top" onToggle={toggleSeries} />
+      {:else}
+        <Legend items={legendItems} position="top" />
+      {/if}
     {/if}
 
-    <ChartContainer
-      bind:width={chartWidth}
-      bind:height={chartHeight}
-      {aspectRatio}
-      {minHeight}
-      {maxHeight}
-    >
-      {#if gradientFill || showArea}
-        <defs>
-          {#each lines as line, si (si)}
-            {#if gradientFill}
-              <linearGradient
-                id="line-grad-{uid}-{si}"
-                x1="0"
-                y1="0"
-                x2="0"
-                y2={dims.innerHeight}
-                gradientUnits="userSpaceOnUse"
-              >
-                <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
+    <div class="chart-plot" bind:this={plotEl}>
+      <ChartContainer
+        bind:width={chartWidth}
+        bind:height={chartHeight}
+        {aspectRatio}
+        {minHeight}
+        {maxHeight}
+      >
+        {#if gradientFill || showArea}
+          <defs>
+            {#each lines as line, si (si)}
+              {#if gradientFill}
+                <linearGradient
+                  id="line-grad-{uid}-{si}"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2={dims.innerHeight}
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <!-- The gradient top stop is fillOpacity + 0.3 (clamped to 1), giving a richer
                      anchor at the top that fades to transparent at the bottom. This intentionally
                      exceeds the base fillOpacity so that gradient-fill areas appear more vivid
                      than a flat solid-fill at fillOpacity alone. -->
-                <stop
-                  offset="0%"
-                  stop-color={line.color}
-                  stop-opacity={Math.min(
-                    (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
-                    1
-                  )}
+                  <stop
+                    offset="0%"
+                    stop-color={line.color}
+                    stop-opacity={Math.min(
+                      (hovered?.si === si ? fillOpacity + 0.2 : fillOpacity) + 0.3,
+                      1
+                    )}
+                  />
+                  <stop offset="100%" stop-color={line.color} stop-opacity={0} />
+                </linearGradient>
+              {/if}
+              {#if showArea}
+                <linearGradient
+                  id="line-area-{uid}-{si}"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2={dims.innerHeight}
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop
+                    offset="0%"
+                    stop-color={areaGradient ? areaGradient.from : line.color}
+                    stop-opacity={areaGradient ? 1 : 0.35}
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color={areaGradient ? areaGradient.to : line.color}
+                    stop-opacity={areaGradient ? 1 : 0}
+                  />
+                </linearGradient>
+              {/if}
+            {/each}
+          </defs>
+        {/if}
+        <g transform="translate({dims.margin.left}, {dims.margin.top})">
+          {#if showYAxis}
+            <Axis
+              orientation="left"
+              scale={yScale}
+              tickCount={yTickCount}
+              {showGridlines}
+              gridlineLength={dims.innerWidth}
+              label={yAxisLabel}
+              tickFormat={yTickFormat}
+            />
+          {/if}
+          {#if showXAxis}
+            <g transform="translate(0, {dims.innerHeight})">
+              <Axis
+                orientation="bottom"
+                scale={xScale}
+                tickCount={xTickCount}
+                integerTicks={xIntegerTicks}
+                rotateTicks={layout.xRotate}
+                tickEvery={layout.xEvery}
+                labelOffset={layout.xLabelOffset}
+                label={xAxisLabel}
+                tickFormat={resolvedXTickFormat}
+              />
+            </g>
+          {/if}
+
+          {#each haloPoints as hp, i (i)}
+            <circle class="dot-halo" cx={hp.x} cy={hp.y} r={dotRadius + 6} fill={hp.color} />
+          {/each}
+
+          {#each lines as line, si (si)}
+            {#if !line.hidden}
+              {#if showArea}
+                <path
+                  class="line-area-fill"
+                  class:dimmed={isLineDimmed(si)}
+                  d={line.areaD}
+                  fill="url(#line-area-{uid}-{si})"
                 />
-                <stop offset="100%" stop-color={line.color} stop-opacity={0} />
-              </linearGradient>
-            {/if}
-            {#if showArea}
-              <linearGradient
-                id="line-area-{uid}-{si}"
-                x1="0"
-                y1="0"
-                x2="0"
-                y2={dims.innerHeight}
-                gradientUnits="userSpaceOnUse"
-              >
-                <stop
-                  offset="0%"
-                  stop-color={areaGradient ? areaGradient.from : line.color}
-                  stop-opacity={areaGradient ? 1 : 0.35}
+              {:else if gradientFill}
+                <path
+                  class="line-area-fill"
+                  class:dimmed={hovered !== null && hovered.si !== si}
+                  d={line.areaD}
+                  fill="url(#line-grad-{uid}-{si})"
                 />
-                <stop
-                  offset="100%"
-                  stop-color={areaGradient ? areaGradient.to : line.color}
-                  stop-opacity={areaGradient ? 1 : 0}
+              {/if}
+              <path
+                class="line-path"
+                class:dimmed={isLineDimmed(si)}
+                d={line.path}
+                stroke={line.color}
+                stroke-width={strokeWidth}
+                fill="none"
+              />
+              {#if line.points.length === 1 && !showDots}
+                <circle
+                  class="single-point"
+                  class:dimmed={isLineDimmed(si)}
+                  cx={line.points[0].x}
+                  cy={line.points[0].y}
+                  r={dotRadius * 1.5}
+                  fill={line.color}
                 />
-              </linearGradient>
+              {/if}
+              {#if showDots}
+                {#each line.points as point, pi (pi)}
+                  <circle
+                    class="dot"
+                    class:dimmed={isDotDimmed(si, pi)}
+                    class:highlighted={isHighlightedDot(si, pi)}
+                    cx={point.x}
+                    cy={point.y}
+                    r={isHighlightedDot(si, pi) ? dotRadius * 1.5 : dotRadius}
+                    fill={line.color}
+                  />
+                {/each}
+              {/if}
+              {#if showValues && pointLabelPlacements[si]}
+                {#each line.points as _point, pi (pi)}
+                  {@const pl = pointLabelPlacements[si][pi]}
+                  {#if pl?.visible}
+                    <text
+                      class="point-value"
+                      x={pl.x}
+                      y={pl.y}
+                      text-anchor="middle"
+                      dominant-baseline={pl.dominantBaseline}
+                      >{formatNumber(series[si].data[pi].y)}</text
+                    >
+                  {/if}
+                {/each}
+              {/if}
             {/if}
           {/each}
-        </defs>
-      {/if}
-      <g transform="translate({dims.margin.left}, {dims.margin.top})">
-        {#if showYAxis}
-          <Axis
-            orientation="left"
-            scale={yScale}
-            {showGridlines}
-            gridlineLength={dims.innerWidth}
-            label={yAxisLabel}
-            tickFormat={yTickFormat}
+
+          {#if activeLineX !== null}
+            <line
+              class="hover-line"
+              x1={activeLineX}
+              x2={activeLineX}
+              y1={0}
+              y2={dims.innerHeight}
+            />
+          {/if}
+
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <rect
+            class="hover-overlay"
+            x={0}
+            y={0}
+            width={dims.innerWidth}
+            height={dims.innerHeight}
+            fill="transparent"
+            onpointermove={handleOverlayMove}
+            onpointerleave={handleLeave}
+            onclick={handleClick}
           />
-        {/if}
-        {#if showXAxis}
-          <g transform="translate(0, {dims.innerHeight})">
-            <Axis
-              orientation="bottom"
-              scale={xScale}
-              label={xAxisLabel}
-              tickFormat={resolvedXTickFormat}
-            />
-          </g>
-        {/if}
+        </g>
+      </ChartContainer>
 
-        {#each lines as line, si (si)}
-          {#if showArea}
-            <path
-              class="line-area-fill"
-              class:dimmed={isLineDimmed(si)}
-              d={line.areaD}
-              fill="url(#line-area-{uid}-{si})"
-            />
-          {:else if gradientFill}
-            <path
-              class="line-area-fill"
-              class:dimmed={hovered !== null && hovered.si !== si}
-              d={line.areaD}
-              fill="url(#line-grad-{uid}-{si})"
-            />
-          {/if}
-          <path
-            class="line-path"
-            class:dimmed={isLineDimmed(si)}
-            d={line.path}
-            stroke={line.color}
-            stroke-width={strokeWidth}
-            fill="none"
-          />
-          {#if line.points.length === 1 && !showDots}
-            <circle
-              class="single-point"
-              class:dimmed={isLineDimmed(si)}
-              cx={line.points[0].x}
-              cy={line.points[0].y}
-              r={dotRadius * 1.5}
-              fill={line.color}
-            />
-          {/if}
-          {#if showDots}
-            {#each line.points as point, pi (pi)}
-              <circle
-                class="dot"
-                class:dimmed={isDotDimmed(si, pi)}
-                class:highlighted={isHighlightedDot(si, pi)}
-                cx={point.x}
-                cy={point.y}
-                r={isHighlightedDot(si, pi) ? dotRadius * 1.5 : dotRadius}
-                fill={line.color}
-              />
-            {/each}
-          {/if}
-          {#if showValues}
-            {#each line.points as point, pi (pi)}
-              <text
-                class="point-value"
-                x={point.x}
-                y={point.y - 8}
-                text-anchor="middle"
-                dominant-baseline="auto">{formatNumber(series[si].data[pi].y)}</text
-              >
-            {/each}
-          {/if}
-        {/each}
-
-        {#if activeLineX !== null}
-          <line class="hover-line" x1={activeLineX} x2={activeLineX} y1={0} y2={dims.innerHeight} />
-        {/if}
-
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <rect
-          class="hover-overlay"
-          x={0}
-          y={0}
-          width={dims.innerWidth}
-          height={dims.innerHeight}
-          fill="transparent"
-          onmousemove={handleOverlayMove}
-          onmouseleave={handleLeave}
-          onclick={handleClick}
+      {#if typeof tooltipSnippet === 'function'}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          {anchor}
+          portal={tooltipPortal}
+          originEl={plotEl}
+          unstyled
+        >
+          {#snippet content()}
+            {#if tooltipContext !== null}
+              {@render tooltipSnippet(tooltipContext)}
+            {/if}
+          {/snippet}
+        </ChartTooltip>
+      {:else}
+        <ChartTooltip
+          data={tooltipData}
+          {mouseX}
+          {mouseY}
+          {anchor}
+          portal={tooltipPortal}
+          originEl={plotEl}
         />
-      </g>
-    </ChartContainer>
-
-    {#if typeof tooltipSnippet === 'function' && tooltipContext !== null}
-      <div class="chart-tooltip-slot" style="left: {mouseX + 12}px; top: {mouseY - 12}px;">
-        {@render tooltipSnippet(tooltipContext)}
-      </div>
-    {:else}
-      <ChartTooltip data={tooltipData} {mouseX} {mouseY} />
-    {/if}
+      {/if}
+    </div>
   {/if}
 </div>
 
 <style>
   .line-chart {
     width: 100%;
+    position: relative;
+  }
+  .chart-plot {
     position: relative;
   }
   .line-area-fill {
@@ -558,7 +745,7 @@
     transition:
       r var(--chart-transition-duration, 0.2s) ease,
       opacity var(--chart-transition-duration, 0.2s) ease;
-    stroke: var(--chart-background, #fff);
+    stroke: var(--chart-dot-stroke, light-dark(#fff, #111827));
     stroke-width: 2;
     pointer-events: none;
   }
@@ -566,17 +753,21 @@
     opacity: var(--linechart-dimmed-opacity, 0.2);
   }
   .dot.highlighted {
-    stroke: var(--linechart-highlight-ring-color, #fff);
+    stroke: var(--linechart-highlight-ring-color, light-dark(#fff, #111827));
     stroke-width: var(--linechart-highlight-ring-width, 2.5);
   }
+  .dot-halo {
+    opacity: 0.25;
+    pointer-events: none;
+  }
   .point-value {
-    fill: var(--linechart-value-color, #333);
+    fill: var(--linechart-value-color, light-dark(#333, #e5e7eb));
     font-size: var(--linechart-value-font-size, 11px);
     font-family: var(--chart-font-family, inherit);
     pointer-events: none;
   }
   .hover-line {
-    stroke: var(--linechart-hover-line-color, #ccc);
+    stroke: var(--linechart-hover-line-color, light-dark(#ccc, #4b5563));
     stroke-width: 1;
     stroke-dasharray: var(--linechart-hover-line-dash, 4 4);
     pointer-events: none;
@@ -584,14 +775,9 @@
   .hover-overlay {
     cursor: crosshair;
   }
-  .chart-tooltip-slot {
-    position: absolute;
-    z-index: 10;
-    pointer-events: none;
-  }
   .chart-empty {
     padding: var(--chart-empty-padding, 32px 24px);
-    color: var(--chart-empty-color, #9ca3af);
+    color: var(--chart-empty-color, light-dark(#9ca3af, #6b7280));
     text-align: center;
   }
 </style>

--- a/src/lib/LineChart/properties.ts
+++ b/src/lib/LineChart/properties.ts
@@ -107,6 +107,15 @@ export type OptionalLineChartProperties = {
   tooltipSnippet?: Snippet<[LineChartTooltipContext]>;
   /** Content rendered when all series are empty. */
   empty?: Snippet;
+  /** One tooltip listing every series at the hovered x (Highcharts shared tooltip).
+   *  Defaults to true for multi-series charts; single-series behavior is unchanged. */
+  sharedTooltip?: boolean;
+  /** Legend items become click/keyboard toggles for series visibility. */
+  interactiveLegend?: boolean;
+  /** Hide the legend when the measured chart width is below this px value; 0 disables. */
+  hideLegendBelow?: number;
+  /** Render the tooltip into document.body so scroll/overflow ancestors never clip it. */
+  tooltipPortal?: boolean;
   /** Value for the data-pw attribute on the chart container. */
   testId?: string;
   /** CSS class string applied to the top-level element. */

--- a/src/lib/_chart/Axis.svelte
+++ b/src/lib/_chart/Axis.svelte
@@ -10,6 +10,10 @@
     showGridlines = false,
     gridlineLength = 0,
     label,
+    rotateTicks = false,
+    tickEvery = 1,
+    labelOffset = 36,
+    integerTicks = false,
     classes
   }: AxisProperties = $props();
 
@@ -19,7 +23,7 @@
 
   let tickValues = $derived.by(() => {
     if ('ticks' in scale && typeof scale.ticks === 'function') {
-      return scale.ticks(tickCount);
+      return scale.ticks(tickCount, integerTicks);
     }
     if ('domain' in scale && Array.isArray(scale.domain)) {
       return scale.domain;
@@ -47,14 +51,27 @@
       {@const x = positionTick(tick)}
       <g class="tick" transform="translate({x}, 0)">
         <line class="tick-mark" y2={orientation === 'bottom' ? TICK_SIZE : -TICK_SIZE} />
-        <text
-          class="tick-label"
-          y={orientation === 'bottom' ? TICK_SIZE + 4 : -(TICK_SIZE + 4)}
-          text-anchor="middle"
-          dominant-baseline={orientation === 'bottom' ? 'hanging' : 'auto'}
-        >
-          {format(tick)}
-        </text>
+        {#if i % tickEvery === 0}
+          {#if rotateTicks && orientation === 'bottom'}
+            <text
+              class="tick-label"
+              transform="translate(0, {TICK_SIZE + 4}) rotate(-45)"
+              text-anchor="end"
+              dominant-baseline="auto"
+            >
+              {format(tick)}
+            </text>
+          {:else}
+            <text
+              class="tick-label"
+              y={orientation === 'bottom' ? TICK_SIZE + 4 : -(TICK_SIZE + 4)}
+              text-anchor="middle"
+              dominant-baseline={orientation === 'bottom' ? 'hanging' : 'auto'}
+            >
+              {format(tick)}
+            </text>
+          {/if}
+        {/if}
         {#if showGridlines && gridlineLength > 0}
           <line
             class="gridline"
@@ -68,7 +85,7 @@
       <text
         class="axis-label"
         x={(scale.range[0] + scale.range[1]) / 2}
-        y={orientation === 'bottom' ? 36 : -30}
+        y={orientation === 'bottom' ? labelOffset : -30}
         text-anchor="middle"
       >
         {label}
@@ -113,30 +130,30 @@
 
 <style>
   .axis-line {
-    stroke: var(--chart-axis-color, #666);
+    stroke: var(--chart-axis-color, light-dark(#666, #9ca3af));
     stroke-width: var(--chart-axis-stroke-width, 1);
   }
 
   .tick-mark {
-    stroke: var(--chart-axis-color, #666);
+    stroke: var(--chart-axis-color, light-dark(#666, #9ca3af));
     stroke-width: var(--chart-axis-stroke-width, 1);
   }
 
   .tick-label {
-    fill: var(--chart-axis-color, #666);
+    fill: var(--chart-axis-color, light-dark(#666, #9ca3af));
     font-size: var(--chart-axis-font-size, 11px);
     font-family: var(--chart-axis-font-family, inherit);
   }
 
   .axis-label {
-    fill: var(--chart-axis-label-color, #333);
+    fill: var(--chart-axis-label-color, light-dark(#333, #e5e7eb));
     font-size: var(--chart-axis-label-font-size, 12px);
     font-family: var(--chart-axis-font-family, inherit);
     font-weight: 500;
   }
 
   .gridline {
-    stroke: var(--chart-gridline-color, #e0e0e0);
+    stroke: var(--chart-gridline-color, light-dark(#e0e0e0, #374151));
     stroke-opacity: var(--chart-gridline-opacity, 0.5);
     stroke-dasharray: var(--chart-gridline-dash, 4 4);
   }

--- a/src/lib/_chart/ChartTooltip.svelte
+++ b/src/lib/_chart/ChartTooltip.svelte
@@ -1,81 +1,159 @@
 <script lang="ts">
-  import type { ChartTooltipProperties } from './types';
+  import type { ChartTooltipProperties, TooltipData } from './types';
+  import { computeTooltipPosition } from './tooltipPosition';
 
-  let { data, mouseX = 0, mouseY = 0, customSnippet, classes }: ChartTooltipProperties = $props();
-
-  const OFFSET = 12;
+  let {
+    data,
+    mouseX = 0,
+    mouseY = 0,
+    anchor = null,
+    portal = false,
+    originEl = null,
+    unstyled = false,
+    content,
+    customSnippet,
+    classes
+  }: ChartTooltipProperties = $props();
 
   let tooltipEl = $state<HTMLDivElement | null>(null);
   let tooltipWidth = $state(0);
   let tooltipHeight = $state(0);
+  // Portal position depends on untracked DOM reads (originEl rect, viewport
+  // size); bump a tick on scroll/resize so the $derived re-runs while open.
+  let portalTick = $state(0);
 
-  // Clamp against the positioned chart container so the tooltip never spills past
-  // (and gets clipped by) an overflow:hidden edge. Re-read on each measure/move.
-  const containerWidth = $derived(tooltipEl?.offsetParent?.clientWidth ?? Number.POSITIVE_INFINITY);
-  const containerHeight = $derived(
-    tooltipEl?.offsetParent?.clientHeight ?? Number.POSITIVE_INFINITY
-  );
-
-  // Horizontal: flip to the left of the cursor when it would overflow the right edge.
-  const left = $derived.by(() => {
-    let value = mouseX + OFFSET;
-    if (value + tooltipWidth > containerWidth) {
-      value = mouseX - tooltipWidth - OFFSET;
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (!portal || data === null || typeof window === 'undefined') {
+      return;
     }
-    return Math.max(0, value);
+    const bump = () => {
+      portalTick += 1;
+    };
+    window.addEventListener('scroll', bump, { capture: true, passive: true });
+    window.addEventListener('resize', bump);
+    return () => {
+      window.removeEventListener('scroll', bump, { capture: true });
+      window.removeEventListener('resize', bump);
+    };
   });
 
-  // Vertical: keep the tooltip within the container's top and bottom edges.
-  const top = $derived.by(() => {
-    let value = mouseY - OFFSET;
-    if (value + tooltipHeight > containerHeight) {
-      value = containerHeight - tooltipHeight;
+  /**
+   * Svelte action: relocates the tooltip to document.body so a position:fixed
+   * tooltip is never clipped by an overflow/scroll ancestor. `use:` actions
+   * never run during SSR.
+   */
+  const portalToBody = (node: HTMLElement) => {
+    document.body.appendChild(node);
+    return { destroy: () => node.remove() };
+  };
+
+  const pos = $derived.by(() => {
+    const tooltip = { width: tooltipWidth, height: tooltipHeight };
+    if (portal) {
+      void portalTick;
+      // Convert container coords to viewport coords and clamp to the viewport.
+      const rect = originEl?.getBoundingClientRect();
+      const dx = rect?.left ?? 0;
+      const dy = rect?.top ?? 0;
+      const container =
+        typeof window === 'undefined'
+          ? { width: Number.POSITIVE_INFINITY, height: Number.POSITIVE_INFINITY }
+          : { width: window.innerWidth, height: window.innerHeight };
+      return computeTooltipPosition({
+        mouseX: mouseX + dx,
+        mouseY: mouseY + dy,
+        anchor: anchor === null ? null : { ...anchor, x: anchor.x + dx, y: anchor.y + dy },
+        tooltip,
+        container
+      });
     }
-    return Math.max(0, value);
+    const container = {
+      width: tooltipEl?.offsetParent?.clientWidth ?? Number.POSITIVE_INFINITY,
+      height: tooltipEl?.offsetParent?.clientHeight ?? Number.POSITIVE_INFINITY
+    };
+    return computeTooltipPosition({ mouseX, mouseY, anchor, tooltip, container });
   });
 </script>
 
-{#if data !== null}
-  <div
-    bind:this={tooltipEl}
-    bind:clientWidth={tooltipWidth}
-    bind:clientHeight={tooltipHeight}
-    class="chart-tooltip {classes ?? ''}"
-    style="left: {left}px; top: {top}px;"
-  >
-    {#if typeof customSnippet === 'function'}
-      {@render customSnippet(data)}
-    {:else}
-      {#if data.title}
-        <div class="tooltip-title">{data.title}</div>
-      {/if}
-      {#each data.items as item, i (i)}
-        <div class="tooltip-item">
-          {#if item.color}
-            <span class="tooltip-swatch" style="background: {item.color}"></span>
-          {/if}
-          <span class="tooltip-label">{item.label}</span>
-          <span class="tooltip-value">{item.value}</span>
-        </div>
-      {/each}
+{#snippet inner(tooltipData: TooltipData)}
+  {#if content}
+    {@render content()}
+  {:else if typeof customSnippet === 'function'}
+    {@render customSnippet(tooltipData)}
+  {:else}
+    {#if tooltipData.title}
+      <div class="tooltip-title">{tooltipData.title}</div>
     {/if}
-  </div>
+    {#each tooltipData.items as item, i (i)}
+      <div class="tooltip-item">
+        {#if item.color}
+          <span class="tooltip-swatch" style="background: {item.color}"></span>
+        {/if}
+        <span class="tooltip-label">{item.label}</span>
+        <span class="tooltip-value">{item.value}</span>
+      </div>
+    {/each}
+  {/if}
+{/snippet}
+
+{#if data !== null}
+  {#if portal}
+    <div
+      bind:this={tooltipEl}
+      bind:clientWidth={tooltipWidth}
+      bind:clientHeight={tooltipHeight}
+      class="chart-tooltip portal {unstyled ? 'unstyled' : ''} {classes ?? ''}"
+      style="left: {pos.left}px; top: {pos.top}px;"
+      use:portalToBody
+    >
+      {@render inner(data)}
+    </div>
+  {:else}
+    <div
+      bind:this={tooltipEl}
+      bind:clientWidth={tooltipWidth}
+      bind:clientHeight={tooltipHeight}
+      class="chart-tooltip {unstyled ? 'unstyled' : ''} {classes ?? ''}"
+      style="left: {pos.left}px; top: {pos.top}px;"
+    >
+      {@render inner(data)}
+    </div>
+  {/if}
 {/if}
 
 <style>
   .chart-tooltip {
     position: absolute;
     z-index: var(--chart-tooltip-z-index, 10);
-    background: var(--chart-tooltip-background, rgba(0, 0, 0, 0.85));
-    color: var(--chart-tooltip-color, #fff);
+    background: var(--chart-tooltip-background, light-dark(rgba(0, 0, 0, 0.85), #1f2937));
+    color: var(--chart-tooltip-color, light-dark(#fff, #f3f4f6));
     font-size: var(--chart-tooltip-font-size, 12px);
     font-family: var(--chart-font-family, inherit);
     padding: var(--chart-tooltip-padding, 8px 12px);
     border-radius: var(--chart-tooltip-border-radius, var(--radius, 4px));
     box-shadow: var(--chart-tooltip-shadow, 0 2px 8px rgba(0, 0, 0, 0.2));
+    border: 1px solid
+      var(
+        --chart-tooltip-border-color,
+        light-dark(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.08))
+      );
     pointer-events: none;
     max-width: var(--chart-tooltip-max-width, 280px);
     width: fit-content;
+  }
+
+  .chart-tooltip.portal {
+    position: fixed;
+  }
+
+  .chart-tooltip.unstyled {
+    background: none;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    max-width: none;
   }
 
   .tooltip-title {

--- a/src/lib/_chart/Legend.svelte
+++ b/src/lib/_chart/Legend.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { LegendProperties } from './types';
 
-  let { items, position = 'bottom', customSnippet, classes }: LegendProperties = $props();
+  let { items, position = 'bottom', onToggle, customSnippet, classes }: LegendProperties = $props();
 </script>
 
 {#if items.length > 0}
@@ -10,10 +10,23 @@
       {@render customSnippet(items)}
     {:else}
       {#each items as item, i (i)}
-        <div class="legend-item">
-          <span class="legend-swatch" style="background: {item.color}"></span>
-          <span class="legend-label">{item.label}</span>
-        </div>
+        {#if typeof onToggle === 'function'}
+          <button
+            type="button"
+            class="legend-item legend-toggle"
+            class:legend-hidden={item.hidden}
+            aria-pressed={!item.hidden}
+            onclick={() => onToggle(i)}
+          >
+            <span class="legend-swatch" style="background: {item.color}"></span>
+            <span class="legend-label">{item.label}</span>
+          </button>
+        {:else}
+          <div class="legend-item">
+            <span class="legend-swatch" style="background: {item.color}"></span>
+            <span class="legend-label">{item.label}</span>
+          </div>
+        {/if}
       {/each}
     {/if}
   </div>
@@ -54,6 +67,23 @@
 
   .legend-label {
     font-size: var(--chart-legend-font-size, 12px);
-    color: var(--chart-legend-color, #333);
+    color: var(--chart-legend-color, light-dark(#333, #e5e7eb));
+  }
+
+  .legend-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .legend-hidden .legend-swatch {
+    opacity: 0.25;
+  }
+
+  .legend-hidden .legend-label {
+    color: var(--chart-legend-hidden-color, light-dark(#bbb, #555));
   }
 </style>

--- a/src/lib/_chart/geometry.test.ts
+++ b/src/lib/_chart/geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeHorizontalCategoryGutter, computeSankeyLayout, measureTextWidth } from './geometry';
+import { computeAutoLayout, computeSankeyLayout } from './geometry';
 
 describe('computeSankeyLayout', () => {
   it('produces finite node positions when every link weight is zero (no NaN collapse)', () => {
@@ -146,43 +146,58 @@ describe('computeSankeyLayout', () => {
   });
 });
 
-describe('computeHorizontalCategoryGutter', () => {
-  it('keeps the legacy fixed gutter when the label width is unmeasurable (SSR / no canvas)', () => {
-    expect(computeHorizontalCategoryGutter(null, 800)).toBe(50);
+describe('computeAutoLayout (heuristic text widths: len * 11 * 0.6 = 6.6px/char)', () => {
+  it('sizes the left margin to the widest y tick label', () => {
+    const layout = computeAutoLayout({
+      width: 600,
+      height: 400,
+      yTickLabels: ['0', '50,000', '1,00,000'],
+      xTickLabels: ['A', 'B']
+    });
+    // '1,00,000' = 8 chars * 6.6 = 52.8 → ceil 53 + tickPad 10 + 6 = 69
+    expect(layout.margin.left).toBe(69);
+    expect(layout.xRotate).toBe(false);
+    expect(layout.xEvery).toBe(1);
   });
 
-  it('never shrinks below the legacy gutter for short labels', () => {
-    // "Jan"-style labels measure ~20px; 20 + 14 inset = 34 < 50 → stay at 50 so
-    // every chart whose labels already fit keeps its exact current layout.
-    expect(computeHorizontalCategoryGutter(20, 800)).toBe(50);
+  it('respects base minimums and reserves title bands', () => {
+    const layout = computeAutoLayout({
+      width: 600,
+      height: 400,
+      yTickLabels: ['0'],
+      xTickLabels: ['A'],
+      hasYAxisLabel: true,
+      base: { left: 50, bottom: 40 }
+    });
+    // tiny label → measured left (1*6.6→7+16+18=41) loses to base 50
+    expect(layout.margin.left).toBe(50);
+    expect(layout.margin.bottom).toBeGreaterThanOrEqual(40);
   });
 
-  it('grows the gutter to fit a long category label plus the tick inset', () => {
-    // The BZ-4372 case: "Submitted Address" measures ~97px at 11px axis font.
-    // Labels right-align 10px left of the axis line, so the gutter must be
-    // label + 10 (tick inset) + 4 (breathing pad) = 111 to avoid clipping.
-    expect(computeHorizontalCategoryGutter(97, 350)).toBe(111);
+  it('rotates and thins crowded x labels and deepens the bottom margin', () => {
+    const labels = Array.from({ length: 30 }, (_, i) => `Category ${i + 1}`);
+    const layout = computeAutoLayout({
+      width: 400,
+      height: 300,
+      yTickLabels: ['0', '100'],
+      xTickLabels: labels
+    });
+    expect(layout.xRotate).toBe(true);
+    expect(layout.xEvery).toBeGreaterThanOrEqual(2);
+    expect(layout.margin.bottom).toBeGreaterThan(40);
   });
 
-  it('caps the gutter at 45% of the chart width so a pathological label cannot crush the plot', () => {
-    expect(computeHorizontalCategoryGutter(300, 350)).toBe(Math.round(350 * 0.45));
-  });
-
-  it('keeps at least the legacy gutter when the chart itself is tiny', () => {
-    // cap = max(50, 100 * 0.45) = 50 → the label still bleeds, but the plot survives.
-    expect(computeHorizontalCategoryGutter(97, 100)).toBe(50);
-  });
-
-  it('respects a custom fallback gutter', () => {
-    expect(computeHorizontalCategoryGutter(null, 800, 28)).toBe(28);
-    expect(computeHorizontalCategoryGutter(10, 800, 28)).toBe(28);
-  });
-});
-
-describe('measureTextWidth', () => {
-  it('returns null in environments without a working canvas (jsdom) instead of a bogus 0', () => {
-    // jsdom's canvas 2D context either does not exist or measures every string
-    // as 0 — both must map to null so the caller falls back to fixed layout.
-    expect(measureTextWidth('Submitted Address', '11px sans-serif')).toBeNull();
+  it('places the bottom axis title baseline inside the reserved title band', () => {
+    const layout = computeAutoLayout({
+      width: 600,
+      height: 400,
+      yTickLabels: ['0'],
+      xTickLabels: ['A'],
+      hasXAxisLabel: true
+    });
+    // tick band depth = TICK_PAD(10) + ceil(11 * 1.2) = 24; title band = 18
+    expect(layout.xLabelOffset).toBe(42);
+    expect(layout.margin.bottom).toBe(48);
+    expect(layout.xLabelOffset).toBeLessThan(layout.margin.bottom);
   });
 });

--- a/src/lib/_chart/geometry.ts
+++ b/src/lib/_chart/geometry.ts
@@ -6,6 +6,8 @@ import type {
   ComputedSankeyLink,
   StackedPoint
 } from './types';
+import { measureText, type FontSpec } from './measure';
+import { thinTicks } from './labels';
 
 export function computeChartDimensions(
   width: number,
@@ -27,57 +29,93 @@ export function computeChartDimensions(
   };
 }
 
-// ── Text measurement ────────────────────────────────────────────
+export type AutoLayoutInput = {
+  width: number;
+  height: number;
+  yTickLabels: string[];
+  xTickLabels: string[];
+  y2TickLabels?: string[];
+  font?: FontSpec;
+  hasXAxisLabel?: boolean;
+  hasYAxisLabel?: boolean;
+  hasY2AxisLabel?: boolean;
+  base?: Partial<Margin>;
+};
 
-let textMeasurementContext: CanvasRenderingContext2D | null = null;
+export type AutoLayout = ChartDimensions & {
+  xRotate: boolean;
+  xEvery: number;
+  /**
+   * Baseline y for the bottom-axis title, already inside the reserved title
+   * band — pass straight to Axis.labelOffset, no extra padding needed.
+   */
+  xLabelOffset: number;
+};
+
+// Offset from the axis line to the tick-label text (Axis.svelte TICK_SIZE + 4).
+const TICK_PAD = 10;
+// Vertical space reserved for a rotated/horizontal axis title.
+const TITLE_BAND = 18;
+// Cap on how deep rotated x labels may grow the bottom margin (long labels crop).
+const MAX_ROTATED_DEPTH = 72;
 
 /**
- * Measures rendered text width via a shared offscreen canvas context.
- * Returns null when measurement is unavailable (SSR, or the environment
- * provides no working 2D canvas — e.g. jsdom) so callers can fall back to
- * a fixed layout instead of acting on a bogus 0.
+ * Measured, Highcharts-style margins: gutters grow to fit formatted tick labels
+ * (instead of clipping) and the bottom axis rotates/thins its labels when the
+ * per-category step is too narrow. Order matters to avoid feedback loops:
+ * left/right derive from label text only, then innerWidth decides x rotation,
+ * then bottom derives from the rotation outcome.
  */
-export function measureTextWidth(text: string, font: string): number | null {
-  if (typeof document === 'undefined') {
-    return null;
-  }
-  if (textMeasurementContext === null) {
-    textMeasurementContext = document.createElement('canvas').getContext('2d');
-  }
-  if (textMeasurementContext === null) {
-    return null;
-  }
-  textMeasurementContext.font = font;
-  const width = textMeasurementContext.measureText(text).width;
-  // jsdom's canvas stub reports 0 for any text; treat that as "cannot measure".
-  return width > 0 ? width : null;
-}
+export function computeAutoLayout(input: AutoLayoutInput): AutoLayout {
+  const font = input.font ?? { size: 11 };
+  const labelHeight = font.size * 1.2;
 
-/**
- * Left margin for a horizontal bar chart's category axis, sized to fit the
- * widest category label. Category tick labels render right-aligned 10px left
- * of the axis line (tick mark 6px + 4px gap), so any label wider than
- * `margin.left - 10` bleeds out of the SVG and gets clipped by the page.
- *
- * - Never shrinks below `fallback` (the legacy fixed gutter), so charts whose
- *   labels already fit keep their exact current layout.
- * - Caps at 45% of the chart width so one pathological label cannot crush the
- *   plot area; past the cap the label bleeds as before, but the plot survives.
- * - `widestLabelWidth === null` (SSR / unmeasurable) keeps the legacy gutter.
- */
-export function computeHorizontalCategoryGutter(
-  widestLabelWidth: number | null,
-  chartWidth: number,
-  fallback: number = 50
-): number {
-  if (widestLabelWidth === null) {
-    return fallback;
-  }
-  const tickLabelInset = 10;
-  const breathingPad = 4;
-  const cap = Math.max(fallback, chartWidth * 0.45);
-  const fitted = widestLabelWidth + tickLabelInset + breathingPad;
-  return Math.round(Math.min(Math.max(fallback, fitted), cap));
+  const widthOf = (labels: string[]): number =>
+    labels.reduce((max, t) => Math.max(max, measureText(t, font).width), 0);
+
+  const left = Math.max(
+    input.base?.left ?? 0,
+    input.yTickLabels.length > 0
+      ? Math.ceil(widthOf(input.yTickLabels)) +
+          TICK_PAD +
+          6 +
+          (input.hasYAxisLabel ? TITLE_BAND : 0)
+      : 0
+  );
+
+  const xWidths = input.xTickLabels.map((t) => measureText(t, font).width);
+  const maxXWidth = xWidths.reduce((m, w) => Math.max(m, w), 0);
+  const y2Width =
+    typeof input.y2TickLabels !== 'undefined' && input.y2TickLabels.length > 0
+      ? Math.ceil(widthOf(input.y2TickLabels)) +
+        TICK_PAD +
+        6 +
+        (input.hasY2AxisLabel ? TITLE_BAND : 0)
+      : 0;
+  // Right gutter: the right axis when present, else half the last x label so
+  // edge labels don't clip.
+  const right = Math.max(input.base?.right ?? 0, y2Width, Math.ceil(maxXWidth / 2) + 8);
+
+  const innerWidth = Math.max(0, input.width - left - right);
+  const step = input.xTickLabels.length > 0 ? innerWidth / input.xTickLabels.length : innerWidth;
+  const { rotate, every } =
+    input.xTickLabels.length > 0
+      ? thinTicks({ labelWidths: xWidths, labelHeight, step })
+      : { rotate: false, every: 1 };
+
+  const rotatedDepth = rotate
+    ? Math.min(MAX_ROTATED_DEPTH, Math.ceil(maxXWidth * Math.SQRT1_2))
+    : 0;
+  const xLabelDepth =
+    input.xTickLabels.length > 0 ? TICK_PAD + (rotate ? rotatedDepth : Math.ceil(labelHeight)) : 0;
+  const bottom = Math.max(
+    input.base?.bottom ?? 0,
+    xLabelDepth + 6 + (input.hasXAxisLabel ? TITLE_BAND : 0)
+  );
+  const top = Math.max(input.base?.top ?? 0, Math.ceil(labelHeight / 2) + 8);
+
+  const dims = computeChartDimensions(input.width, input.height, { top, right, bottom, left });
+  return { ...dims, xRotate: rotate, xEvery: every, xLabelOffset: xLabelDepth + TITLE_BAND };
 }
 
 // ── Pie layout ──────────────────────────────────────────────────

--- a/src/lib/_chart/interactions.ts
+++ b/src/lib/_chart/interactions.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared pointer-interaction helpers used by the chart components.
+ */
+
+export type RelativePointerPosition = { x: number; y: number };
+
+/**
+ * Pointer position relative to the top-left corner of `el`, or null when the
+ * element is not mounted yet.
+ */
+export function pointerPositionIn(
+  el: HTMLElement | null,
+  event: PointerEvent
+): RelativePointerPosition | null {
+  if (el === null) {
+    return null;
+  }
+  const rect = el.getBoundingClientRect();
+  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+}
+
+/**
+ * Touch taps never fire pointerleave, so a tap-opened tooltip would otherwise
+ * stay stuck: dismiss when a pointerdown lands outside `containerEl`.
+ *
+ * Attaches a window listener and returns its cleanup, making it directly
+ * usable as an `$effect` body's return value. No-op during SSR.
+ */
+export function dismissOnOutsidePointerDown(
+  containerEl: HTMLElement | null,
+  onDismiss: () => void
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  const dismiss = (event: PointerEvent): void => {
+    const target = event.target;
+    if (containerEl !== null && !(target instanceof Node && containerEl.contains(target))) {
+      onDismiss();
+    }
+  };
+  window.addEventListener('pointerdown', dismiss);
+  return () => window.removeEventListener('pointerdown', dismiss);
+}

--- a/src/lib/_chart/labels.test.ts
+++ b/src/lib/_chart/labels.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveEndLabel,
+  resolveInsideLabel,
+  resolvePointLabels,
+  thinTicks,
+  truncateToWidth,
+  placedLabelRect,
+  dropOverlapping
+} from './labels';
+
+const plot = { width: 400, height: 300 };
+
+describe('resolveEndLabel — vertical', () => {
+  it('places outside above the bar when there is headroom', () => {
+    const p = resolveEndLabel({
+      bar: { x: 100, y: 50, width: 30, height: 200 },
+      plot,
+      label: { width: 24, height: 13 },
+      orientation: 'vertical'
+    });
+    expect(p.placement).toBe('outside');
+    expect(p.x).toBe(115); // bar center
+    expect(p.y).toBe(46); // bar.y - gap(4)
+    expect(p.textAnchor).toBe('middle');
+    expect(p.dominantBaseline).toBe('auto');
+  });
+
+  it('flips inside when the label would overflow the plot top', () => {
+    const p = resolveEndLabel({
+      bar: { x: 100, y: 8, width: 30, height: 250 },
+      plot,
+      label: { width: 24, height: 13 },
+      orientation: 'vertical'
+    });
+    expect(p.placement).toBe('inside');
+    expect(p.y).toBe(12); // bar.y + padding(4)
+    expect(p.dominantBaseline).toBe('hanging');
+  });
+
+  it('hides when neither outside nor inside fits', () => {
+    const p = resolveEndLabel({
+      bar: { x: 100, y: 2, width: 30, height: 10 },
+      plot,
+      label: { width: 24, height: 13 },
+      orientation: 'vertical'
+    });
+    expect(p.placement).toBe('hidden');
+  });
+
+  it('places below the bar for negative values', () => {
+    const p = resolveEndLabel({
+      bar: { x: 100, y: 150, width: 30, height: 80 },
+      plot,
+      label: { width: 24, height: 13 },
+      orientation: 'vertical',
+      negative: true
+    });
+    expect(p.placement).toBe('outside');
+    expect(p.y).toBe(234); // bar.y + bar.height + gap(4)
+    expect(p.dominantBaseline).toBe('hanging');
+  });
+});
+
+describe('resolveEndLabel — horizontal', () => {
+  it('places outside right of the bar end', () => {
+    const p = resolveEndLabel({
+      bar: { x: 0, y: 100, width: 200, height: 20 },
+      plot,
+      label: { width: 30, height: 13 },
+      orientation: 'horizontal'
+    });
+    expect(p.placement).toBe('outside');
+    expect(p.x).toBe(204);
+    expect(p.textAnchor).toBe('start');
+    expect(p.dominantBaseline).toBe('middle');
+  });
+
+  it('flips inside the bar end when it would overflow the plot right edge', () => {
+    const p = resolveEndLabel({
+      bar: { x: 0, y: 100, width: 390, height: 20 },
+      plot,
+      label: { width: 30, height: 13 },
+      orientation: 'horizontal'
+    });
+    expect(p.placement).toBe('inside');
+    expect(p.x).toBe(386); // bar end - padding(4)
+    expect(p.textAnchor).toBe('end');
+  });
+
+  it('hides when the sub-band is thinner than the label', () => {
+    const p = resolveEndLabel({
+      bar: { x: 0, y: 100, width: 390, height: 10 },
+      plot,
+      label: { width: 30, height: 13 },
+      orientation: 'horizontal'
+    });
+    expect(p.placement).toBe('hidden');
+  });
+});
+
+describe('resolveInsideLabel', () => {
+  it('centers when the segment fits the label plus padding', () => {
+    const p = resolveInsideLabel({
+      bar: { x: 10, y: 20, width: 60, height: 30 },
+      label: { width: 40, height: 13 }
+    });
+    expect(p.placement).toBe('inside');
+    expect(p.x).toBe(40);
+    expect(p.y).toBe(35);
+    expect(p.textAnchor).toBe('middle');
+    expect(p.dominantBaseline).toBe('middle');
+  });
+
+  it('hides when the segment is too small', () => {
+    const p = resolveInsideLabel({
+      bar: { x: 10, y: 20, width: 60, height: 18 },
+      label: { width: 40, height: 13 }
+    });
+    expect(p.placement).toBe('hidden');
+  });
+});
+
+describe('resolvePointLabels', () => {
+  it('places labels above points and flips below at the plot top', () => {
+    const out = resolvePointLabels({
+      points: [
+        { x: 0, y: 100 },
+        { x: 200, y: 5 }
+      ],
+      labels: [
+        { width: 20, height: 13 },
+        { width: 20, height: 13 }
+      ],
+      plot
+    });
+    expect(out[0].dominantBaseline).toBe('auto');
+    expect(out[0].y).toBe(92); // y - gap(8)
+    expect(out[1].dominantBaseline).toBe('hanging');
+    expect(out[1].y).toBe(13); // y + gap(8)
+  });
+
+  it('thins labels when density exceeds label width', () => {
+    const points = Array.from({ length: 21 }, (_, i) => ({ x: i * 10, y: 100 }));
+    const labels = points.map(() => ({ width: 24, height: 13 }));
+    const out = resolvePointLabels({ points, labels, plot: { width: 200, height: 300 } });
+    // step = 200/20 = 10px, need 24+4 → every = ceil(28/10) = 3
+    expect(out[0].visible).toBe(true);
+    expect(out[1].visible).toBe(false);
+    expect(out[3].visible).toBe(true);
+  });
+
+  it('thins for the densest run of points, not the average spacing', () => {
+    // 3 tightly packed points then one far away: average spacing is generous
+    // but the packed run still needs every-3rd thinning (min gap 10px, need 28).
+    const points = [
+      { x: 0, y: 100 },
+      { x: 10, y: 100 },
+      { x: 20, y: 100 },
+      { x: 200, y: 100 }
+    ];
+    const labels = points.map(() => ({ width: 24, height: 13 }));
+    const out = resolvePointLabels({ points, labels, plot: { width: 200, height: 300 } });
+    expect(out.map((o) => o.visible)).toEqual([true, false, false, true]);
+  });
+});
+
+describe('thinTicks', () => {
+  it('keeps horizontal labels when they fit', () => {
+    expect(thinTicks({ labelWidths: [30, 32], labelHeight: 13, step: 50 })).toEqual({
+      rotate: false,
+      every: 1
+    });
+  });
+
+  it('rotates when labels overlap', () => {
+    const r = thinTicks({ labelWidths: [60, 62, 58], labelHeight: 13, step: 50 });
+    expect(r.rotate).toBe(true);
+    expect(r.every).toBe(1); // rotated footprint ≈ 13*1.414+8 ≈ 26.4 < 50
+  });
+
+  it('thins every Nth when rotation alone is not enough', () => {
+    const r = thinTicks({ labelWidths: [60, 62, 58], labelHeight: 13, step: 10 });
+    expect(r.rotate).toBe(true);
+    expect(r.every).toBe(3); // ceil(26.4/10)
+  });
+});
+
+describe('truncateToWidth (heuristic width = len*size*0.6)', () => {
+  it('returns the text unchanged when it fits', () => {
+    expect(truncateToWidth('abc', 100, { size: 10 })).toBe('abc');
+  });
+
+  it('truncates with an ellipsis to the available width', () => {
+    // each char = 6px; 'abcdefghij' = 60px; budget 40px → 5 chars + … = 36px
+    expect(truncateToWidth('abcdefghij', 40, { size: 10 })).toBe('abcde…');
+  });
+
+  it('returns empty when fewer than 2 chars fit', () => {
+    expect(truncateToWidth('abcdefghij', 10, { size: 10 })).toBe('');
+  });
+});
+
+describe('placedLabelRect + dropOverlapping', () => {
+  it('converts an anchored placement into its bounding rect', () => {
+    const rect = placedLabelRect(
+      { x: 100, y: 50, textAnchor: 'middle', dominantBaseline: 'auto' },
+      { width: 40, height: 12 }
+    );
+    expect(rect).toEqual({ x: 80, y: 38, width: 40, height: 12 });
+  });
+
+  it('greedily hides labels that overlap an earlier kept label', () => {
+    const keep = dropOverlapping([
+      { x: 0, y: 0, width: 30, height: 12 },
+      { x: 20, y: 0, width: 30, height: 12 },
+      { x: 60, y: 0, width: 30, height: 12 },
+      null
+    ]);
+    expect(keep).toEqual([true, false, true, false]);
+  });
+});

--- a/src/lib/_chart/labels.ts
+++ b/src/lib/_chart/labels.ts
@@ -1,0 +1,262 @@
+import { measureText, type FontSpec } from './measure';
+
+export type LabelRect = { x: number; y: number; width: number; height: number };
+export type LabelSize = { width: number; height: number };
+
+export type LabelPlacement = {
+  x: number;
+  y: number;
+  placement: 'outside' | 'inside' | 'hidden';
+  textAnchor: 'start' | 'middle' | 'end';
+  dominantBaseline: 'auto' | 'middle' | 'hanging';
+};
+
+/**
+ * Highcharts-style end-of-bar label chain: place just past the bar's value end
+ * (outside) → justify back inside the bar end when the plot area would clip it →
+ * hide (crop) when the bar cannot fit the label either.
+ */
+export function resolveEndLabel(opts: {
+  bar: LabelRect;
+  plot: LabelSize;
+  label: LabelSize;
+  orientation: 'vertical' | 'horizontal';
+  negative?: boolean;
+  gap?: number;
+  padding?: number;
+}): LabelPlacement {
+  const { bar, plot, label, orientation } = opts;
+  const gap = opts.gap ?? 4;
+  const padding = opts.padding ?? 4;
+  const negative = opts.negative ?? false;
+
+  if (orientation === 'vertical') {
+    const x = bar.x + bar.width / 2;
+    const insideFits = bar.height >= label.height + 2 * padding;
+    if (!negative) {
+      if (bar.y - gap - label.height >= 0) {
+        return {
+          x,
+          y: bar.y - gap,
+          placement: 'outside',
+          textAnchor: 'middle',
+          dominantBaseline: 'auto'
+        };
+      }
+      if (insideFits) {
+        return {
+          x,
+          y: bar.y + padding,
+          placement: 'inside',
+          textAnchor: 'middle',
+          dominantBaseline: 'hanging'
+        };
+      }
+      return { x, y: 0, placement: 'hidden', textAnchor: 'middle', dominantBaseline: 'auto' };
+    }
+    const end = bar.y + bar.height;
+    if (end + gap + label.height <= plot.height) {
+      return {
+        x,
+        y: end + gap,
+        placement: 'outside',
+        textAnchor: 'middle',
+        dominantBaseline: 'hanging'
+      };
+    }
+    if (insideFits) {
+      return {
+        x,
+        y: end - padding,
+        placement: 'inside',
+        textAnchor: 'middle',
+        dominantBaseline: 'auto'
+      };
+    }
+    return { x, y: 0, placement: 'hidden', textAnchor: 'middle', dominantBaseline: 'auto' };
+  }
+
+  const y = bar.y + bar.height / 2;
+  // A sub-band thinner than the label height cannot host a legible label in
+  // either position (generalises the old `bar.height >= 13` special case).
+  if (bar.height < label.height) {
+    return { x: 0, y, placement: 'hidden', textAnchor: 'start', dominantBaseline: 'middle' };
+  }
+  const insideFits = bar.width >= label.width + 2 * padding;
+  if (!negative) {
+    const end = bar.x + bar.width;
+    if (end + gap + label.width <= plot.width) {
+      return {
+        x: end + gap,
+        y,
+        placement: 'outside',
+        textAnchor: 'start',
+        dominantBaseline: 'middle'
+      };
+    }
+    if (insideFits) {
+      return {
+        x: end - padding,
+        y,
+        placement: 'inside',
+        textAnchor: 'end',
+        dominantBaseline: 'middle'
+      };
+    }
+    return { x: 0, y, placement: 'hidden', textAnchor: 'start', dominantBaseline: 'middle' };
+  }
+  if (bar.x - gap - label.width >= 0) {
+    return {
+      x: bar.x - gap,
+      y,
+      placement: 'outside',
+      textAnchor: 'end',
+      dominantBaseline: 'middle'
+    };
+  }
+  if (insideFits) {
+    return {
+      x: bar.x + padding,
+      y,
+      placement: 'inside',
+      textAnchor: 'start',
+      dominantBaseline: 'middle'
+    };
+  }
+  return { x: 0, y, placement: 'hidden', textAnchor: 'start', dominantBaseline: 'middle' };
+}
+
+/** Center a label inside a segment (stacked bars, funnel stages); hide when it cannot fit. */
+export function resolveInsideLabel(opts: {
+  bar: LabelRect;
+  label: LabelSize;
+  padding?: number;
+}): LabelPlacement {
+  const { bar, label } = opts;
+  const padding = opts.padding ?? 4;
+  const fits = bar.width >= label.width + 2 * padding && bar.height >= label.height + 2 * padding;
+  return {
+    x: bar.x + bar.width / 2,
+    y: bar.y + bar.height / 2,
+    placement: fits ? 'inside' : 'hidden',
+    textAnchor: 'middle',
+    dominantBaseline: 'middle'
+  };
+}
+
+/** Line/area point-value labels: above the point, flipped below at the plot top, thinned by density. */
+export function resolvePointLabels(opts: {
+  points: Array<{ x: number; y: number }>;
+  labels: LabelSize[];
+  plot: LabelSize;
+  gap?: number;
+}): Array<{ x: number; y: number; visible: boolean; dominantBaseline: 'auto' | 'hanging' }> {
+  const gap = opts.gap ?? 8;
+  const n = opts.points.length;
+  // Thinning cadence from the tightest real gap between consecutive points —
+  // non-uniform x data must thin for its densest run, not the average spread.
+  let step = Number.POSITIVE_INFINITY;
+  for (let i = 1; i < n; i++) {
+    step = Math.min(step, Math.abs(opts.points[i].x - opts.points[i - 1].x));
+  }
+  const maxWidth = opts.labels.reduce((m, l) => Math.max(m, l.width), 0);
+  const every = Math.max(1, Math.ceil((maxWidth + 4) / step));
+  return opts.points.map((point, i) => {
+    const label = opts.labels[i] ?? { width: 0, height: 0 };
+    const flip = point.y - gap - label.height < 0;
+    return {
+      x: point.x,
+      y: flip ? point.y + gap : point.y - gap,
+      visible: i % every === 0,
+      dominantBaseline: flip ? 'hanging' : 'auto'
+    };
+  });
+}
+
+/**
+ * Axis tick-label crowding chain: horizontal → rotate -45° → thin to every Nth,
+ * where N is the smallest integer such that rotated labels no longer overlap.
+ */
+export function thinTicks(opts: {
+  labelWidths: number[];
+  labelHeight: number;
+  step: number;
+  gap?: number;
+}): { rotate: boolean; every: number } {
+  const gap = opts.gap ?? 8;
+  const maxWidth = opts.labelWidths.reduce((m, w) => Math.max(m, w), 0);
+  if (opts.step <= 0) {
+    return { rotate: false, every: 1 };
+  }
+  if (maxWidth + gap <= opts.step) {
+    return { rotate: false, every: 1 };
+  }
+  // A -45°-rotated label's horizontal footprint is governed by its line height
+  // projected onto the axis: height * √2.
+  const rotatedFootprint = opts.labelHeight * Math.SQRT2 + gap;
+  return { rotate: true, every: Math.max(1, Math.ceil(rotatedFootprint / opts.step)) };
+}
+
+/** Measurement-based ellipsis truncation; empty string when fewer than 2 chars fit. */
+export function truncateToWidth(text: string, maxWidth: number, font: FontSpec): string {
+  if (measureText(text, font).width <= maxWidth) {
+    return text;
+  }
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (measureText(text.slice(0, mid) + '…', font).width <= maxWidth) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo >= 2 ? text.slice(0, lo) + '…' : '';
+}
+
+/** Convert an anchored SVG text placement into its bounding rect for collision checks. */
+export function placedLabelRect(
+  p: Pick<LabelPlacement, 'x' | 'y' | 'textAnchor' | 'dominantBaseline'>,
+  label: LabelSize
+): LabelRect {
+  const x =
+    p.textAnchor === 'middle'
+      ? p.x - label.width / 2
+      : p.textAnchor === 'end'
+        ? p.x - label.width
+        : p.x;
+  const y =
+    p.dominantBaseline === 'middle'
+      ? p.y - label.height / 2
+      : p.dominantBaseline === 'hanging'
+        ? p.y
+        : p.y - label.height;
+  return { x, y, width: label.width, height: label.height };
+}
+
+/**
+ * Highcharts `allowOverlap: false` equivalent: greedy first-come pass that hides
+ * any label whose rect intersects an already-kept label. `null` entries are
+ * pre-hidden labels and always return false.
+ */
+export function dropOverlapping(rects: Array<LabelRect | null>, gap: number = 2): boolean[] {
+  const kept: LabelRect[] = [];
+  return rects.map((r) => {
+    if (r === null) {
+      return false;
+    }
+    const collides = kept.some(
+      (k) =>
+        r.x < k.x + k.width + gap &&
+        k.x < r.x + r.width + gap &&
+        r.y < k.y + k.height + gap &&
+        k.y < r.y + r.height + gap
+    );
+    if (collides) {
+      return false;
+    }
+    kept.push(r);
+    return true;
+  });
+}

--- a/src/lib/_chart/measure.test.ts
+++ b/src/lib/_chart/measure.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { measureText, readCssVarPx } from './measure';
+
+describe('measureText (Node heuristic path)', () => {
+  it('falls back to a per-char heuristic without a DOM', () => {
+    const { width, height } = measureText('abcd', { size: 10 });
+    expect(width).toBeCloseTo(4 * 10 * 0.6);
+    expect(height).toBeCloseTo(12);
+  });
+
+  it('returns zero width for empty text', () => {
+    expect(measureText('', { size: 11 }).width).toBe(0);
+  });
+
+  it('is deterministic across repeated calls (cache)', () => {
+    const a = measureText('Revenue', { size: 11, weight: 600 });
+    const b = measureText('Revenue', { size: 11, weight: 600 });
+    expect(a).toEqual(b);
+  });
+
+  it('does not collide cache entries when text contains delimiter-like characters', () => {
+    const a = measureText('b|c', { size: 10, family: 'a' });
+    const b = measureText('c', { size: 10, family: 'a|b' });
+    expect(a.width).not.toBe(b.width); // 3 chars vs 1 char on the heuristic path
+  });
+});
+
+describe('readCssVarPx', () => {
+  it('returns the fallback when window is unavailable', () => {
+    expect(readCssVarPx(null as unknown as Element, '--x', 14)).toBe(14);
+  });
+});

--- a/src/lib/_chart/measure.ts
+++ b/src/lib/_chart/measure.ts
@@ -1,0 +1,58 @@
+export type FontSpec = {
+  /** Font size in px. */
+  size: number;
+  family?: string;
+  weight?: number | string;
+};
+
+const DEFAULT_FAMILY = 'system-ui, -apple-system, sans-serif';
+// Average glyph width ≈ 0.6em for UI sans fonts — only used when canvas is
+// unavailable (SSR / unit tests); the client always re-measures after mount.
+const HEURISTIC_WIDTH_PER_CHAR = 0.6;
+const LINE_HEIGHT_FACTOR = 1.2;
+const CACHE_LIMIT = 4000;
+
+let ctx: CanvasRenderingContext2D | null = null;
+const cache = new Map<string, number>();
+
+function context(): CanvasRenderingContext2D | null {
+  if (ctx !== null) {
+    return ctx;
+  }
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  ctx = document.createElement('canvas').getContext('2d');
+  return ctx;
+}
+
+export function measureText(text: string, font: FontSpec): { width: number; height: number } {
+  const height = font.size * LINE_HEIGHT_FACTOR;
+  // NUL-delimited so free-form family/text strings (which may contain any
+  // printable character, e.g. "12,000 | 100%") can never collide across fields.
+  const key = [font.weight ?? 400, font.size, font.family ?? '', text].join('\u0000');
+  const cached = cache.get(key);
+  if (typeof cached !== 'undefined') {
+    return { width: cached, height };
+  }
+  const c = context();
+  const width =
+    c === null
+      ? text.length * font.size * HEURISTIC_WIDTH_PER_CHAR
+      : ((c.font = `${font.weight ?? 400} ${font.size}px ${font.family ?? DEFAULT_FAMILY}`),
+        c.measureText(text).width);
+  if (cache.size >= CACHE_LIMIT) {
+    cache.clear();
+  }
+  cache.set(key, width);
+  return { width, height };
+}
+
+/** Reads a px-valued CSS custom property off an element, with an SSR-safe fallback. */
+export function readCssVarPx(el: Element | null, name: string, fallback: number): number {
+  if (typeof window === 'undefined' || el === null) {
+    return fallback;
+  }
+  const parsed = parseFloat(getComputedStyle(el).getPropertyValue(name));
+  return Number.isNaN(parsed) ? fallback : parsed;
+}

--- a/src/lib/_chart/scales.test.ts
+++ b/src/lib/_chart/scales.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { computeLinearTicks } from './scales';
+
+describe('computeLinearTicks — integer mode (category axes)', () => {
+  it('never emits fractional ticks when integer mode is on', () => {
+    // Regression: the responsive x tick count (up to 8) picked a 0.5 step for
+    // the [1, 6] category domain, so the category formatter repeated labels
+    // ("Q2 Q2 Q3 Q3 …"). Category positions are whole numbers.
+    expect(computeLinearTicks([1, 6], 8, true)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('clamps small domains that picked fractional steps even at the default count', () => {
+    expect(computeLinearTicks([1, 3], 5, true)).toEqual([1, 2, 3]);
+  });
+
+  it('leaves integer steps untouched in integer mode', () => {
+    expect(computeLinearTicks([0, 20], 8, true)).toEqual(computeLinearTicks([0, 20], 8));
+  });
+
+  it('still produces fractional steps when integer mode is off', () => {
+    expect(computeLinearTicks([1, 6], 8)).toContain(1.5);
+  });
+});

--- a/src/lib/_chart/scales.ts
+++ b/src/lib/_chart/scales.ts
@@ -12,7 +12,11 @@ export function niceLinearDomain(min: number, max: number): [number, number] {
   return [niceMin, niceMax];
 }
 
-export function computeLinearTicks(domain: [number, number], count: number = 5): number[] {
+export function computeLinearTicks(
+  domain: [number, number],
+  count: number = 5,
+  integer: boolean = false
+): number[] {
   const [min, max] = domain;
   if (min === max) {
     return [min];
@@ -30,6 +34,11 @@ export function computeLinearTicks(domain: [number, number], count: number = 5):
     step = base * 5;
   } else {
     step = base * 10;
+  }
+  // Category axes (Highcharts semantics): ticks sit on whole category
+  // positions, so a fractional step would repeat labels — floor it to 1.
+  if (integer && step < 1) {
+    step = 1;
   }
 
   const ticks: number[] = [];
@@ -52,7 +61,7 @@ export function createLinearScale(domain: [number, number], range: [number, numb
   return Object.assign(fn, {
     domain,
     range,
-    ticks: (count?: number) => computeLinearTicks(domain, count),
+    ticks: (count?: number, integer?: boolean) => computeLinearTicks(domain, count, integer),
     invert: (pixel: number) => d0 + ((pixel - r0) / rSpan) * dSpan
   });
 }

--- a/src/lib/_chart/tooltipPosition.test.ts
+++ b/src/lib/_chart/tooltipPosition.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { computeTooltipPosition } from './tooltipPosition';
+
+const tooltip = { width: 100, height: 40 };
+const container = { width: 500, height: 300 };
+
+describe('cursor mode', () => {
+  it('offsets right of and above the cursor', () => {
+    const p = computeTooltipPosition({ mouseX: 50, mouseY: 100, tooltip, container });
+    expect(p).toEqual({ left: 62, top: 88 });
+  });
+
+  it('flips left of the cursor at the right edge', () => {
+    const p = computeTooltipPosition({ mouseX: 450, mouseY: 100, tooltip, container });
+    expect(p.left).toBe(450 - 100 - 12);
+  });
+
+  it('flips fully above the cursor at the bottom edge', () => {
+    const p = computeTooltipPosition({ mouseX: 50, mouseY: 295, tooltip, container });
+    expect(p.top).toBe(295 - 40 - 12);
+  });
+
+  it('clamps into the container when both flip directions overflow', () => {
+    const p = computeTooltipPosition({
+      mouseX: 10,
+      mouseY: 10,
+      tooltip: { width: 600, height: 40 },
+      container
+    });
+    expect(p.left).toBe(0);
+  });
+});
+
+describe('anchor mode', () => {
+  it('centers above a top anchor', () => {
+    const p = computeTooltipPosition({
+      anchor: { x: 250, y: 100, side: 'top' },
+      tooltip,
+      container
+    });
+    expect(p).toEqual({ left: 200, top: 100 - 40 - 12 });
+  });
+
+  it('flips below when there is no headroom', () => {
+    const p = computeTooltipPosition({
+      anchor: { x: 250, y: 20, side: 'top' },
+      tooltip,
+      container
+    });
+    expect(p.top).toBe(32);
+  });
+
+  it('places right of a right anchor and flips left at the edge', () => {
+    const ok = computeTooltipPosition({
+      anchor: { x: 100, y: 150, side: 'right' },
+      tooltip,
+      container
+    });
+    expect(ok).toEqual({ left: 112, top: 130 });
+    const flipped = computeTooltipPosition({
+      anchor: { x: 480, y: 150, side: 'right' },
+      tooltip,
+      container
+    });
+    expect(flipped.left).toBe(480 - 100 - 12);
+  });
+
+  it('clamps horizontally so an edge anchor never clips', () => {
+    const p = computeTooltipPosition({
+      anchor: { x: 10, y: 100, side: 'top' },
+      tooltip,
+      container
+    });
+    expect(p.left).toBe(0);
+  });
+});

--- a/src/lib/_chart/tooltipPosition.ts
+++ b/src/lib/_chart/tooltipPosition.ts
@@ -1,0 +1,61 @@
+import type { TooltipAnchor } from './types';
+
+type Size = { width: number; height: number };
+
+const clamp = (value: number, max: number): number =>
+  Math.max(0, Number.isFinite(max) ? Math.min(value, max) : value);
+
+/**
+ * Pure tooltip placement: anchor mode positions relative to a data point with
+ * side-flipping; cursor mode follows the pointer with flip-then-clamp on both
+ * axes. All coordinates are relative to the positioned container.
+ */
+export function computeTooltipPosition(opts: {
+  mouseX?: number;
+  mouseY?: number;
+  anchor?: TooltipAnchor | null;
+  tooltip: Size;
+  container: Size;
+  offset?: number;
+}): { left: number; top: number } {
+  const offset = opts.offset ?? 12;
+  const { tooltip, container } = opts;
+  const maxLeft = container.width - tooltip.width;
+  const maxTop = container.height - tooltip.height;
+
+  const a = opts.anchor ?? null;
+  if (a !== null) {
+    let left: number;
+    let top: number;
+    if (a.side === 'top' || a.side === 'bottom') {
+      left = a.x - tooltip.width / 2;
+      top = a.side === 'top' ? a.y - tooltip.height - offset : a.y + offset;
+      if (a.side === 'top' && top < 0) {
+        top = a.y + offset;
+      } else if (a.side === 'bottom' && top > maxTop) {
+        top = a.y - tooltip.height - offset;
+      }
+    } else {
+      top = a.y - tooltip.height / 2;
+      left = a.side === 'right' ? a.x + offset : a.x - tooltip.width - offset;
+      if (a.side === 'right' && left > maxLeft) {
+        left = a.x - tooltip.width - offset;
+      } else if (a.side === 'left' && left < 0) {
+        left = a.x + offset;
+      }
+    }
+    return { left: clamp(left, maxLeft), top: clamp(top, maxTop) };
+  }
+
+  const mouseX = opts.mouseX ?? 0;
+  const mouseY = opts.mouseY ?? 0;
+  let left = mouseX + offset;
+  if (left + tooltip.width > container.width) {
+    left = mouseX - tooltip.width - offset;
+  }
+  let top = mouseY - offset;
+  if (top + tooltip.height > container.height) {
+    top = mouseY - tooltip.height - offset;
+  }
+  return { left: clamp(left, maxLeft), top: clamp(top, maxTop) };
+}

--- a/src/lib/_chart/types.ts
+++ b/src/lib/_chart/types.ts
@@ -51,7 +51,7 @@ export type LinearScale = {
   (value: number): number;
   domain: [number, number];
   range: [number, number];
-  ticks: (count?: number) => number[];
+  ticks: (count?: number, integer?: boolean) => number[];
   invert: (pixel: number) => number;
 };
 
@@ -148,6 +148,15 @@ export type TooltipData = {
 export type LegendItem = {
   label: string;
   color: string;
+  /** True when the series is toggled off via an interactive legend. */
+  hidden?: boolean;
+};
+
+/** Data-space anchor for point/category-anchored tooltips (coords are container px). */
+export type TooltipAnchor = {
+  x: number;
+  y: number;
+  side: 'top' | 'right' | 'bottom' | 'left';
 };
 
 // ── Sub-component props ───────────────────────────────────────
@@ -171,6 +180,14 @@ export type AxisProperties = {
   showGridlines?: boolean;
   gridlineLength?: number;
   label?: string;
+  /** Rotate horizontal-axis tick labels -45° (crowding fallback). */
+  rotateTicks?: boolean;
+  /** Render every Nth tick label (tick marks always render). */
+  tickEvery?: number;
+  /** y-offset of the bottom axis title (grows when tick labels rotate). */
+  labelOffset?: number;
+  /** Clamp linear tick steps to whole numbers (category axes). */
+  integerTicks?: boolean;
   classes?: string;
 };
 
@@ -178,6 +195,16 @@ export type ChartTooltipProperties = {
   data: TooltipData | null;
   mouseX?: number;
   mouseY?: number;
+  /** When set, the tooltip anchors to this point instead of following the cursor. */
+  anchor?: TooltipAnchor | null;
+  /** Render into document.body with position:fixed, clamped to the viewport. */
+  portal?: boolean;
+  /** The positioned chart wrapper; required to convert coords in portal mode. */
+  originEl?: HTMLElement | null;
+  /** Strip the tooltip card chrome (used when `content` supplies its own UI). */
+  unstyled?: boolean;
+  /** Custom content rendered inside the positioned (and clamped) wrapper. */
+  content?: Snippet;
   customSnippet?: Snippet<[TooltipData]>;
   classes?: string;
 };
@@ -185,6 +212,8 @@ export type ChartTooltipProperties = {
 export type LegendProperties = {
   items: LegendItem[];
   position?: 'top' | 'bottom';
+  /** When provided, items render as toggle buttons and call back with their index. */
+  onToggle?: (index: number) => void;
   customSnippet?: Snippet<[LegendItem[]]>;
   classes?: string;
 };

--- a/src/routes/components/bar-chart/+page.svelte
+++ b/src/routes/components/bar-chart/+page.svelte
@@ -197,6 +197,70 @@
   <BarChart data={labelOnlyData} hideBarGraphics showXAxis showYAxis showGridlines />
 </div>
 
+<h3>Labels near the axis max (outside → inside flip)</h3>
+<div class="demo-row">
+  <BarChart
+    data={[
+      { label: 'North', value: 9800 },
+      { label: 'South', value: 4200 },
+      { label: 'East', value: 10000 },
+      { label: 'West', value: 150 }
+    ]}
+    yDomain={[0, 10000]}
+    showValues={true}
+    testId="bar-inside-flip-chart"
+  />
+</div>
+
+<h3>Crowded categories (rotate → thin)</h3>
+<div class="demo-row">
+  <BarChart
+    data={Array.from({ length: 18 }, (_, i) => ({
+      label: `Category name ${i + 1}`,
+      value: 100 + ((i * 37) % 400)
+    }))}
+    testId="bar-crowded-chart"
+  />
+</div>
+
+<h3>Interactive legend (3 series × 4 categories)</h3>
+<div class="demo-row">
+  <BarChart
+    series={[
+      {
+        name: 'Alpha',
+        data: [
+          { label: 'Q1', value: 120 },
+          { label: 'Q2', value: 180 },
+          { label: 'Q3', value: 140 },
+          { label: 'Q4', value: 210 }
+        ]
+      },
+      {
+        name: 'Beta',
+        data: [
+          { label: 'Q1', value: 90 },
+          { label: 'Q2', value: 130 },
+          { label: 'Q3', value: 170 },
+          { label: 'Q4', value: 110 }
+        ]
+      },
+      {
+        name: 'Gamma',
+        data: [
+          { label: 'Q1', value: 60 },
+          { label: 'Q2', value: 80 },
+          { label: 'Q3', value: 100 },
+          { label: 'Q4', value: 95 }
+        ]
+      }
+    ]}
+    showLegend={true}
+    interactiveLegend={true}
+    testId="bar-legend-toggle-chart"
+  />
+</div>
+
 <style>
   .intro {
     max-width: 680px;

--- a/src/routes/components/dual-axis-bar-chart/+page.svelte
+++ b/src/routes/components/dual-axis-bar-chart/+page.svelte
@@ -96,6 +96,27 @@
   const handleBarClick = (event: { categoryIndex: number; context: DualAxisTooltipContext }) => {
     lastClickedCategory = event.context.category;
   };
+
+  // ── Demo 6: Negative values + wide currency ticks ────────────────
+
+  const negativeCategories = ['Q1', 'Q2', 'Q3', 'Q4'];
+
+  const negativeSeries = [
+    {
+      name: 'Net Change (₹)',
+      data: [420, -180, 260, -90],
+      yAxisIndex: 0 as const,
+      type: 'column' as const,
+      color: '#e15759'
+    },
+    {
+      name: 'Index',
+      data: [12, 18, 9, 22],
+      yAxisIndex: 1 as const,
+      type: 'line' as const,
+      color: '#4e79a7'
+    }
+  ];
 </script>
 
 <div class="page-header">
@@ -190,6 +211,17 @@
     showGridlines={false}
     showLegend={false}
     testId="demo-no-gridlines"
+  />
+</div>
+
+<!-- Demo 6: Negative values + wide currency ticks -->
+<h3>Negative Values + Wide Currency Ticks</h3>
+<div class="demo-row">
+  <DualAxisBarChart
+    categories={negativeCategories}
+    series={negativeSeries}
+    leftAxis={{ valueFormat: (v) => '₹' + v.toLocaleString('en-IN') }}
+    testId="dual-axis-negative-chart"
   />
 </div>
 

--- a/src/routes/components/funnel-chart/+page.svelte
+++ b/src/routes/components/funnel-chart/+page.svelte
@@ -22,6 +22,17 @@
 
   const warmColors = ['#f28e2b', '#e15759', '#b07aa1', '#ff9da7', '#9c755f'];
 
+  const manyStagesFunnel = [
+    { category: 'Impressions on all channels', value: 120000 },
+    { category: 'Qualified marketing leads', value: 64000 },
+    { category: 'Sales accepted leads', value: 30000 },
+    { category: 'Product demos scheduled', value: 14000 },
+    { category: 'Proposals sent out', value: 6400 },
+    { category: 'Contract negotiation', value: 2800 },
+    { category: 'Verbal commitment', value: 900 },
+    { category: 'Closed won', value: 240 }
+  ];
+
   let lastClickedStage = $state<string | null>(null);
   let lastHoveredStage = $state<string | null>(null);
 </script>
@@ -103,6 +114,11 @@
 <h3>Custom Aspect Ratio (4:3)</h3>
 <div class="demo-row">
   <FunnelChart data={conversionFunnel} aspectRatio={4 / 3} />
+</div>
+
+<h3>Many Stages with Long Names</h3>
+<div class="demo-row">
+  <FunnelChart data={manyStagesFunnel} testId="funnel-many-stages-chart" />
 </div>
 
 <style>

--- a/src/routes/components/line-chart/+page.svelte
+++ b/src/routes/components/line-chart/+page.svelte
@@ -121,6 +121,59 @@
       ]
     }
   ];
+
+  // ── sharedTooltip + interactiveLegend demo ─────────────────────
+
+  const sharedTooltipSeries = [
+    {
+      name: 'Desktop',
+      data: [
+        { x: 1, y: 12 },
+        { x: 2, y: 18 },
+        { x: 3, y: 15 },
+        { x: 4, y: 22 },
+        { x: 5, y: 19 },
+        { x: 6, y: 26 },
+        { x: 7, y: 23 },
+        { x: 8, y: 30 }
+      ]
+    },
+    {
+      name: 'Mobile',
+      data: [
+        { x: 1, y: 8 },
+        { x: 2, y: 11 },
+        { x: 3, y: 14 },
+        { x: 4, y: 12 },
+        { x: 5, y: 17 },
+        { x: 6, y: 15 },
+        { x: 7, y: 20 },
+        { x: 8, y: 18 }
+      ]
+    },
+    {
+      name: 'Tablet',
+      data: [
+        { x: 1, y: 3 },
+        { x: 2, y: 4 },
+        { x: 3, y: 6 },
+        { x: 4, y: 5 },
+        { x: 5, y: 7 },
+        { x: 6, y: 8 },
+        { x: 7, y: 6 },
+        { x: 8, y: 9 }
+      ]
+    }
+  ];
+
+  // ── Dense values demo (40 points, showValues + no dots) ─────────
+
+  const denseValuesSeries = [
+    {
+      name: 'Signal',
+      data: Array.from({ length: 40 }, (_, i) => ({ x: i + 1, y: 50 + 40 * Math.sin(i / 3) }))
+    }
+  ];
 </script>
 
 <div class="page-header">
@@ -234,6 +287,34 @@
 <h3>Legacy gradientFill (backward-compatible)</h3>
 <div class="demo-row">
   <LineChart series={singleSeries} gradientFill />
+</div>
+
+<h3>Shared Tooltip + Interactive Legend (3 series × 8 points)</h3>
+<p>
+  Hovering any point shows one shared tooltip listing every series at that x. Legend items are
+  click/keyboard toggles for series visibility.
+</p>
+<div class="demo-row">
+  <LineChart
+    series={sharedTooltipSeries}
+    showLegend
+    interactiveLegend
+    testId="line-shared-tooltip-chart"
+  />
+</div>
+
+<h3>Dense Values (40 points, no dots)</h3>
+<p>
+  A single series with 40 points and value labels shown at every point, with point dots disabled to
+  keep the dense line readable.
+</p>
+<div class="demo-row">
+  <LineChart
+    series={denseValuesSeries}
+    showValues
+    showDots={false}
+    testId="line-dense-values-chart"
+  />
 </div>
 
 <style>

--- a/src/routes/components/tooltip/+page.svelte
+++ b/src/routes/components/tooltip/+page.svelte
@@ -11,7 +11,7 @@
 
 <h3>Positions</h3>
 <div class="demo-row" style="gap: 32px;">
-  <Tooltip text="This is a top tooltip" position="top">
+  <Tooltip text="This is a top tooltip" position="top" testId="tooltip-container">
     <Button text="Hover (Top)" />
   </Tooltip>
   <Tooltip text="This is a bottom tooltip" position="bottom">

--- a/tests/chart-behaviors.spec.ts
+++ b/tests/chart-behaviors.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('interactive legend', () => {
+  test('clicking a legend item hides that series and rescales', async ({ page }) => {
+    await page.goto('/components/bar-chart');
+    const chart = page.locator('[data-pw="bar-legend-toggle-chart"]');
+    await expect(chart.locator('.bar')).toHaveCount(12); // 3 series × 4 categories
+    const firstToggle = chart.locator('.legend-toggle').first();
+    await firstToggle.click();
+    await expect(chart.locator('.bar')).toHaveCount(8);
+    await expect(firstToggle).toHaveAttribute('aria-pressed', 'false');
+    await firstToggle.click();
+    await expect(chart.locator('.bar')).toHaveCount(12);
+  });
+});
+
+test.describe('bar value labels', () => {
+  test('bars at the axis max flip their label inside', async ({ page }) => {
+    await page.goto('/components/bar-chart');
+    const chart = page.locator('[data-pw="bar-inside-flip-chart"]');
+    await expect(chart.locator('.bar-value-inside')).not.toHaveCount(0);
+    // Short bars keep outside labels.
+    await expect(chart.locator('.bar-value:not(.bar-value-inside)')).not.toHaveCount(0);
+  });
+});
+
+test.describe('tooltip clamping', () => {
+  test('anchored tooltip never overflows the chart box', async ({ page }) => {
+    await page.goto('/components/bar-chart');
+    const chart = page.locator('[data-pw="bar-inside-flip-chart"]');
+    await chart.locator('.bar').last().hover();
+    const tooltip = chart.locator('.chart-tooltip');
+    await expect(tooltip).toBeVisible();
+    const tb = await tooltip.boundingBox();
+    const cb = await chart.boundingBox();
+    expect(tb).not.toBeNull();
+    expect(cb).not.toBeNull();
+    expect(tb!.x).toBeGreaterThanOrEqual(cb!.x - 1);
+    expect(tb!.x + tb!.width).toBeLessThanOrEqual(cb!.x + cb!.width + 1);
+  });
+});
+
+test.describe('axis crowding', () => {
+  test('crowded category labels rotate and thin instead of overlapping', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 720 });
+    await page.goto('/components/bar-chart');
+    // The docs layout has no mobile breakpoint: wide <pre> blocks pin the
+    // content column near 800px, so the chart never actually narrows. Collapse
+    // the chrome (same override as the visual mobile project) so the chart
+    // genuinely renders at viewport width, where thinning must engage.
+    await page.addStyleTag({
+      content: [
+        '.app-layout { grid-template-columns: 1fr !important; }',
+        '.sidebar { display: none !important; }',
+        'main, .content { min-width: 0 !important; max-width: 100vw !important; }',
+        'pre, table { max-width: 100% !important; overflow-x: auto !important; }'
+      ].join(' ')
+    });
+    const chart = page.locator('[data-pw="bar-crowded-chart"]');
+    // 18 bars always render; the axis rotates labels and shows a thinned subset.
+    await expect(chart.locator('.bar')).toHaveCount(18);
+    await expect
+      .poll(async () => chart.locator('.axis-bottom .tick-label').count())
+      .toBeLessThan(18);
+    expect(await chart.locator('.axis-bottom .tick-label').count()).toBeGreaterThan(0);
+    const transform = await chart
+      .locator('.axis-bottom .tick-label')
+      .first()
+      .getAttribute('transform');
+    expect(transform).toContain('rotate(-45)');
+  });
+});
+
+test.describe('line hover', () => {
+  test('hover shows a halo and a shared tooltip listing all series', async ({ page }) => {
+    await page.goto('/components/line-chart');
+    const chart = page.locator('[data-pw="line-shared-tooltip-chart"]');
+    await chart.locator('.hover-overlay').hover({ position: { x: 200, y: 100 } });
+    await expect(chart.locator('.dot-halo')).toHaveCount(3);
+    await expect(chart.locator('.chart-tooltip .tooltip-item')).toHaveCount(3);
+  });
+});
+
+test.describe('keyboard', () => {
+  test('Enter on a focused category fires onbarclick', async ({ page }) => {
+    await page.goto('/components/dual-axis-bar-chart');
+    const chart = page.locator('[data-pw="demo-custom-tooltip"]');
+    const target = chart.locator('.hover-target').first();
+    await target.focus();
+    await page.keyboard.press('Enter');
+    const feedback = page.locator('.click-feedback');
+    await expect(feedback).toBeVisible();
+    await expect(feedback).toContainText('Last clicked:');
+  });
+});
+
+test.describe('touch', () => {
+  test.use({ hasTouch: true });
+
+  test('tapping a funnel stage shows the tooltip; tapping outside dismisses', async ({ page }) => {
+    await page.goto('/components/funnel-chart');
+    const chart = page.locator('[data-pw="funnel-many-stages-chart"]');
+    await chart.locator('.funnel-bar').first().tap();
+    await expect(chart.locator('.chart-tooltip')).toBeVisible();
+    await page.locator('h1').first().tap();
+    await expect(chart.locator('.chart-tooltip')).toHaveCount(0);
+  });
+
+  test('keyboard focus on a bar shows its tooltip', async ({ page }) => {
+    await page.goto('/components/bar-chart');
+    const chart = page.locator('[data-pw="bar-inside-flip-chart"]');
+    await chart.locator('.bar').first().focus();
+    await expect(chart.locator('.chart-tooltip')).toBeVisible();
+  });
+});

--- a/tests/date-range-picker-toggle.test.ts
+++ b/tests/date-range-picker-toggle.test.ts
@@ -12,7 +12,9 @@ test.describe('DateRangePicker — trigger toggles the panel', () => {
     const picker = page.locator('[data-pw="drp-range-demo"]');
     await expect(picker).toBeVisible();
 
-    const trigger = picker.getByRole('button', { name: 'Open date picker' });
+    // The trigger's accessible name flips to 'Close date picker' while open,
+    // so locate it by its stable class rather than by name.
+    const trigger = picker.locator('.drp-trigger button');
 
     await trigger.click();
     await expect(picker.locator('.drp-panel')).toBeVisible();

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,8 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('index page has expected h1', async ({ page }) => {
-  await page.goto('/');
-  await expect(
-    page.getByRole('heading', { name: 'Welcome to your library project' })
-  ).toBeVisible();
-});

--- a/tests/tooltip.test.ts
+++ b/tests/tooltip.test.ts
@@ -92,6 +92,9 @@ test.describe('tooltip action — use:tooltip directive', () => {
     // The bottom trigger has delay=300.
     const trigger = page.getByTestId('tooltip-action-bottom');
     await expect(trigger).toBeVisible();
+    // The action section sits below the fold; raw mouse.move cannot reach
+    // coordinates outside the viewport, so bring the trigger on-screen first.
+    await trigger.scrollIntoViewIfNeeded();
     const box = await trigger.boundingBox();
     if (box === null) {
       throw new Error('Trigger element boundingBox is null — element may not be visible');


### PR DESCRIPTION
## Summary

Aligns FunnelChart, LineChart, BarChart, AreaChart, and DualAxisBarChart with Highcharts conventions while preserving the library's visual design (additive API, minor release):

- **Label engine** (`src/lib/_chart/labels.ts`): bar end-labels follow the Highcharts chain (outside → flip inside with contrast color + text outline → hidden); dense point labels thin by densest consecutive gap; overlapping labels culled greedily; funnel categories truncate with ellipsis and value labels degrade (full → percent → hidden) on tiny stages.
- **Axes** (`computeAutoLayout` + Axis v2): measured margins grow to fit formatted ticks; crowded bottom axes rotate labels −45° then thin every Nth; category axes clamp to integer tick steps (fixes duplicated labels, incl. a pre-existing small-domain case).
- **Tooltips** (ChartTooltip v2): anchored to data with side-aware flip-then-clamp; optional `tooltipPortal` renders to `document.body` (position: fixed, scroll/resize tracked) so overflow ancestors never clip; funnel keeps cursor-follow (Highcharts extent-type behavior).
- **Interactions**: hover halos on line points, clickable/keyboard legend toggles (`interactiveLegend`) with rescaling, touch tap + tap-away dismissal, focus/Enter/Space activation on bars and categories.
- **Dark mode**: every chart token resolves through CSS `light-dark()`; user CSS-var overrides always win. Docs include the `color-scheme` setup snippet.
- **Small devices**: `hideLegendBelow` sheds the legend on narrow charts; funnel label areas compact; negative dual-axis bars round at the value tip.

### Improved defaults (intentional behavior changes, per approved design)
- `hideLegendBelow` defaults to `360` — legends hide on very narrow charts.
- LineChart `sharedTooltip` defaults on for multi-series charts.
- AreaChart now clamps height at `maxHeight` 420 (parity with LineChart; previously unbounded).

## Test plan

- 30 Playwright visual tests (5 demo pages × light/dark × 1280px/375px), 188 committed baselines at a 64px diff budget, double-run stable; every dark desktop + mobile baseline manually inspected.
- 8 functional specs: legend toggle rescaling + `aria-pressed`, inside/outside label split, tooltip clamping, axis rotation + thinning at true mobile width, shared tooltip + halos, Enter-key `onbarclick`, funnel tap + tap-away, focus tooltip.
- 92 vitest unit tests (label engine, tooltip positioning, auto-layout, tick generation, measurement cache).
- `pnpm lint` / `pnpm check` clean. The 3 failing Playwright tests (`tooltip.test.ts` ×2, `date-range-picker-toggle`) fail identically on clean `release` — pre-existing, unrelated.
- Before/after evidence: `docs/superpowers/evidence/2026-07-06-charts/`.

## Follow-up candidates
- Docs-app mobile breakpoint (the visual suite contains the docs layout test-side for now).
- Roving tabindex for bar focus order; Safari pass over `.legend-toggle` button reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Charts now support interactive legends, shared tooltips, tooltip popovers, and improved responsive behavior.
  * Added better support for dark mode styling across chart components.
  * Improved label handling, including auto-rotation, truncation, and smarter value placement.

* **Bug Fixes**
  * Tooltips now stay within chart bounds more reliably.
  * Touch, keyboard, and focus interactions are more consistent across charts.
  * Charts better handle dense data, crowded axes, and hidden series.

* **Documentation**
  * Updated chart docs with the latest configuration options and theming guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->