### PR TITLE
fix(Checkbox): keep the native input's checked state in sync on label clicks

### DIFF
--- a/src/lib/Checkbox/Checkbox.svelte
+++ b/src/lib/Checkbox/Checkbox.svelte
@@ -37,7 +37,19 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<label class="container {classes ?? ''}" class:disabled onclick={handleClick} data-pw={testId}>
+<!-- preventDefault stops the label's default activation from firing a synthesized
+     click that re-toggles the native input AFTER handleClick has flipped the state,
+     which left input.checked out of sync with the rendered box (and with
+     :checked-based selectors/testing probes). State has one owner: handleClick. -->
+<label
+  class="container {classes ?? ''}"
+  class:disabled
+  onclick={(e: MouseEvent) => {
+    e.preventDefault();
+    handleClick();
+  }}
+  data-pw={testId}
+>
   <input
     type="checkbox"
     class="native-checkbox"

--- a/src/routes/components/checkbox/+page.svelte
+++ b/src/routes/components/checkbox/+page.svelte
@@ -11,7 +11,7 @@
 </div>
 
 <div class="demo-row">
-  <Checkbox text="Default checkbox" bind:checked={checkboxChecked} />
+  <Checkbox text="Default checkbox" bind:checked={checkboxChecked} testId="checkbox-default" />
   <Checkbox text="Disabled" disabled />
   <Checkbox text="Indeterminate" bind:indeterminate={checkboxIndeterminate} checked={false} />
   <Checkbox text="Checked disabled" checked disabled />

--- a/tests/checkbox-native-input-sync.test.ts
+++ b/tests/checkbox-native-input-sync.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Checkbox — native input stays in sync with the rendered state', () => {
+  // Regression guard: clicking the label used to fire handleClick (flipping the
+  // Svelte state) AND the label's default activation, whose synthesized click
+  // re-toggled the hidden native input afterwards. The visual box then showed
+  // checked while input.checked was false — breaking form submission values,
+  // :checked-based CSS, and state probes. The label now prevents the default
+  // activation so handleClick is the single owner of the state.
+  test('clicking the label toggles the box, aria-checked, and the native input together', async ({
+    page
+  }) => {
+    await page.goto('/components/checkbox');
+
+    const checkbox = page.locator('[data-pw="checkbox-default"]');
+    await expect(checkbox).toBeVisible();
+
+    const nativeInput = checkbox.locator('input.native-checkbox');
+    const box = checkbox.locator('[role="checkbox"]');
+
+    await expect(box).toHaveAttribute('aria-checked', 'false');
+    await expect(nativeInput).not.toBeChecked();
+
+    await checkbox.click();
+    await expect(box).toHaveAttribute('aria-checked', 'true');
+    await expect(nativeInput).toBeChecked();
+
+    await checkbox.click();
+    await expect(box).toHaveAttribute('aria-checked', 'false');
+    await expect(nativeInput).not.toBeChecked();
+  });
+
+  test('keyboard toggling via the box keeps the native input in sync', async ({ page }) => {
+    await page.goto('/components/checkbox');
+
+    const checkbox = page.locator('[data-pw="checkbox-default"]');
+    const nativeInput = checkbox.locator('input.native-checkbox');
+    const box = checkbox.locator('[role="checkbox"]');
+
+    await box.focus();
+    await page.keyboard.press('Space');
+    await expect(box).toHaveAttribute('aria-checked', 'true');
+    await expect(nativeInput).toBeChecked();
+
+    await page.keyboard.press('Enter');
+    await expect(box).toHaveAttribute('aria-checked', 'false');
+    await expect(nativeInput).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
## Problem

Clicking the Checkbox label fires `handleClick` (flipping the Svelte state) and **then** the label's default activation dispatches a synthesized click that re-toggles the hidden native input — its propagation is stopped (`.native-checkbox` has `onclick stopPropagation`) but its default is not. The rendered `.box` then shows checked while `input.checked` is `false`.

Consequences downstream:
- form submissions carry the wrong value for the native input,
- `:checked`-based CSS/selectors don't match the visual state,
- Playwright `toBeChecked()` probes on the input report the opposite of what the user sees (found while migrating a consumer app's DataGrid to this Checkbox).

## Fix

`preventDefault()` on the label click, making `handleClick` the single owner of the state. The native input's `checked` property then always follows the rendered box through the normal Svelte binding. No API change; no visual change.

## Tests

New `tests/checkbox-native-input-sync.test.ts` (against the existing `/components/checkbox` demo, which gains a `testId`):
- pointer: label click toggles the box, `aria-checked`, and the native input together (on → off → on),
- keyboard: Space/Enter on the `.box` keeps the native input in sync.

Both pass locally alongside `npm run lint` and `npm run check` (0 errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox label clicks so the visual checkbox state and the native input stay in sync.
  * Improved keyboard interaction so toggling the checkbox updates both states consistently.
* **Tests**
  * Added end-to-end coverage for label and keyboard interactions to prevent regressions.
* **Chores**
  * Updated the checkbox demo to use a stable test identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->