### PR TITLE
feat(SplitInput): pass autoComplete and inputMode through FieldConfig

### DIFF
--- a/docs/SplitInput.md
+++ b/docs/SplitInput.md
@@ -113,6 +113,8 @@ type FieldConfig = {
   validationPattern?: RegExp | null;
   validators?: CustomValidator[];
   label?: string | null;
+  autoComplete?: HTMLInputAttributes['autocomplete'];
+  inputMode?: HTMLInputAttributes['inputmode'];
 };
 ```
 
@@ -124,6 +126,8 @@ type FieldConfig = {
 - `validationPattern` -- A `RegExp` used by the underlying Input to validate the field value. Defaults to `null` (no pattern validation).
 - `validators` -- Array of `CustomValidator` functions for custom validation logic. Each receives the input value and current validation state and returns a new `ValidationState`.
 - `label` -- Text label displayed below the field (e.g., `'R'`, `'G'`, `'B'` for color channels).
+- `autoComplete` -- Native `autocomplete` hint for the field. Set to `'one-time-code'` on OTP segments to enable WebOTP / SMS autofill. Defaults to `'on'`.
+- `inputMode` -- Native `inputmode` hint controlling the mobile virtual keyboard (e.g., `'numeric'` for a numeric keypad). Left off by default.
 
 ### CustomValidator
 

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -22,6 +22,7 @@
     actionInput = false,
     useTextArea = false,
     autoComplete = 'on',
+    inputMode,
     name = '',
     testId = '',
     textTransformers = [],
@@ -256,6 +257,7 @@
         {value}
         {placeholder}
         autocomplete={autoComplete}
+        inputmode={inputMode}
         {name}
         {role}
         aria-expanded={ariaExpanded}
@@ -286,6 +288,7 @@
         {value}
         {placeholder}
         autocomplete={autoComplete}
+        inputmode={inputMode}
         {name}
         {role}
         aria-expanded={ariaExpanded}

--- a/src/lib/Input/properties.ts
+++ b/src/lib/Input/properties.ts
@@ -46,6 +46,11 @@ export type OptionalInputProperties = {
   /** Show a live `current / maxLength` character counter beneath the field. */
   showCount?: boolean;
   autoComplete?: HTMLInputAttributes['autocomplete'];
+  /**
+   * Virtual-keyboard hint rendered as the native `inputmode` attribute
+   * (e.g. `'numeric'` for OTP/PIN fields). Left off by default.
+   */
+  inputMode?: HTMLInputAttributes['inputmode'];
   name?: string;
   textTransformers?: TextTransformer[];
   textViewPresentation?: TextTransformer[];

--- a/src/lib/SplitInput/SplitInput.svelte
+++ b/src/lib/SplitInput/SplitInput.svelte
@@ -159,6 +159,8 @@
         placeholder={config.placeholder}
         validationPattern={config.validationPattern ?? null}
         validators={config.validators ?? []}
+        autoComplete={config.autoComplete ?? 'on'}
+        inputMode={config.inputMode}
         disable={disabled}
         actionInput={true}
         classes="field-group-input"

--- a/src/lib/SplitInput/properties.ts
+++ b/src/lib/SplitInput/properties.ts
@@ -10,6 +10,8 @@ export type FieldConfig = Pick<
   | 'validationPattern'
   | 'validators'
   | 'label'
+  | 'autoComplete'
+  | 'inputMode'
 >;
 
 export type SplitInputProperties = MandatorySplitInputProperties &

--- a/src/routes/components/split-input/+page.svelte
+++ b/src/routes/components/split-input/+page.svelte
@@ -2,6 +2,7 @@
   import SplitInput from '$lib/SplitInput/SplitInput.svelte';
 
   let otpValues = $state(['', '', '', '']);
+  let smsOtpValues = $state(['', '', '', '']);
   let rgbValues = $state(['255', '0', '128']);
   let ipValues = $state(['192', '168', '1', '1']);
 </script>
@@ -15,6 +16,21 @@
   <h3>OTP / PIN (auto-advance)</h3>
   <SplitInput bind:values={otpValues} autoAdvance />
   <p>Value: {otpValues.join('')}</p>
+</div>
+
+<div class="demo-row" style="max-width: 400px;">
+  <h3>SMS OTP (one-time-code autofill + numeric keypad)</h3>
+  <SplitInput
+    bind:values={smsOtpValues}
+    autoAdvance
+    testId="split-input-sms-otp"
+    fields={[
+      { dataType: 'tel', maxLength: 1, autoComplete: 'one-time-code', inputMode: 'numeric' },
+      { dataType: 'tel', maxLength: 1, autoComplete: 'one-time-code', inputMode: 'numeric' },
+      { dataType: 'tel', maxLength: 1, autoComplete: 'one-time-code', inputMode: 'numeric' },
+      { dataType: 'tel', maxLength: 1, autoComplete: 'one-time-code', inputMode: 'numeric' }
+    ]}
+  />
 </div>
 
 <div class="demo-row" style="max-width: 400px;">

--- a/src/wc/components/Input.wc.svelte
+++ b/src/wc/components/Input.wc.svelte
@@ -19,6 +19,7 @@
       actionInput: { type: 'Boolean', attribute: 'action-input' },
       useTextArea: { type: 'Boolean', reflect: true, attribute: 'use-text-area' },
       autoComplete: { type: 'String', attribute: 'auto-complete' },
+      inputMode: { type: 'String', attribute: 'input-mode' },
       name: { type: 'String', reflect: true },
       textTransformers: { type: 'Object' },
       textViewPresentation: { type: 'Object' },

--- a/tests/split-input-autocomplete-inputmode.test.ts
+++ b/tests/split-input-autocomplete-inputmode.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('SplitInput — autoComplete / inputMode field passthrough', () => {
+  // OTP consumers need `autocomplete="one-time-code"` (WebOTP / SMS autofill
+  // suggestions) and `inputmode="numeric"` (numeric keypad on mobile web).
+  // FieldConfig previously had no way to express either, forcing hand-rolled
+  // segmented inputs for exactly the use case SplitInput exists for.
+  test('per-field autoComplete and inputMode render on the native inputs', async ({ page }) => {
+    await page.goto('/components/split-input');
+
+    const group = page.locator('[data-pw="split-input-sms-otp"]');
+    await expect(group).toBeVisible();
+
+    const fields = group.locator('input');
+    await expect(fields).toHaveCount(4);
+
+    for (let index = 0; index < 4; index++) {
+      await expect(fields.nth(index)).toHaveAttribute('autocomplete', 'one-time-code');
+      await expect(fields.nth(index)).toHaveAttribute('inputmode', 'numeric');
+      await expect(fields.nth(index)).toHaveAttribute('type', 'tel');
+    }
+  });
+
+  test('fields without the new config keep the previous defaults', async ({ page }) => {
+    await page.goto('/components/split-input');
+
+    // The plain OTP demo (length-based default fields) is unchanged: default
+    // autocomplete stays 'on' and no inputmode attribute is rendered.
+    const defaultGroup = page.locator('.field-group').first();
+    const firstField = defaultGroup.locator('input').first();
+    await expect(firstField).toHaveAttribute('autocomplete', 'on');
+    await expect(firstField).not.toHaveAttribute('inputmode', /.+/);
+  });
+});


### PR DESCRIPTION
## Problem

OTP entry — the flagship SplitInput use case — needs `autocomplete="one-time-code"` (WebOTP / SMS autofill suggestions) and `inputmode="numeric"` (numeric keypad on mobile web) on the segmented fields. `FieldConfig`'s `Pick` excludes `autoComplete`, and `Input` has no `inputMode` prop at all — so consumers migrating hand-rolled OTP inputs to SplitInput regress on mobile-web autofill/keyboard behaviour (this blocked a consumer app's auth-critical OTP migration).

## Change

- **Input**: new optional `inputMode?: HTMLInputAttributes['inputmode']` rendered as the native `inputmode` attribute on both the `<input>` and `<textarea>` elements. No default — the attribute is omitted when unset, so nothing changes for existing consumers.
- **SplitInput**: `FieldConfig` gains `'autoComplete' | 'inputMode'`; both pass through to the per-field `Input` (`autoComplete` keeps the existing `'on'` default when unset).

Non-breaking; additive only.

## Tests

New `tests/split-input-autocomplete-inputmode.test.ts` against a new SMS-OTP example on `/components/split-input`:
- all four fields render `autocomplete="one-time-code"`, `inputmode="numeric"`, `type="tel"`;
- unconfigured length-based fields keep the previous defaults (`autocomplete="on"`, no `inputmode`).

`npm run lint` and `npm run check` pass (0 errors).