### PR TITLE
feat(LoadingDots): add --loading-dots-pulse-min-scale token for breathing pulses

### DIFF
--- a/docs/LoadingDots.md
+++ b/docs/LoadingDots.md
@@ -25,16 +25,17 @@ Animated dot sequence for inline loading indication. Three dots animate in seque
 
 Override these custom properties to theme the component.
 
-| Variable                           | Default        | CSS Property       | Description                                                                                                                 |
-| ---------------------------------- | -------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `--loading-dots-color`             | `currentColor` | background-color   | Color of the dots. Inherits from the parent text color by default, so it automatically matches surrounding content.         |
-| `--loading-dots-size`              | `6px`          | width, height      | Diameter of each dot.                                                                                                       |
-| `--loading-dots-gap`               | `3px`          | gap                | Horizontal spacing between dots.                                                                                            |
-| `--loading-dots-border-radius`     | `50%`          | border-radius      | Corner rounding of each dot. Default of 50% creates circles; set to 0 for squares.                                          |
-| `--loading-dots-duration`          | `1.4s`         | animation-duration | Total duration of one animation cycle.                                                                                      |
-| `--loading-dots-stagger`           | `0.16s`        | animation-delay    | Delay between each successive dot's animation start, creating the sequential wave effect.                                   |
-| `--loading-dots-bounce-height`     | `-6px`         | translateY         | How far the dots travel upward during the bounce animation. Negative values move up. Only applies when animation is bounce. |
-| `--loading-dots-pulse-min-opacity` | `0.2`          | opacity            | The minimum opacity a dot fades to during the pulse animation. Only applies when animation is pulse.                        |
+| Variable                           | Default        | CSS Property       | Description                                                                                                                                                                                                                     |
+| ---------------------------------- | -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--loading-dots-color`             | `currentColor` | background-color   | Color of the dots. Inherits from the parent text color by default, so it automatically matches surrounding content.                                                                                                             |
+| `--loading-dots-size`              | `6px`          | width, height      | Diameter of each dot.                                                                                                                                                                                                           |
+| `--loading-dots-gap`               | `3px`          | gap                | Horizontal spacing between dots.                                                                                                                                                                                                |
+| `--loading-dots-border-radius`     | `50%`          | border-radius      | Corner rounding of each dot. Default of 50% creates circles; set to 0 for squares.                                                                                                                                              |
+| `--loading-dots-duration`          | `1.4s`         | animation-duration | Total duration of one animation cycle.                                                                                                                                                                                          |
+| `--loading-dots-stagger`           | `0.16s`        | animation-delay    | Delay between each successive dot's animation start, creating the sequential wave effect.                                                                                                                                       |
+| `--loading-dots-bounce-height`     | `-6px`         | translateY         | How far the dots travel upward during the bounce animation. Negative values move up. Only applies when animation is bounce.                                                                                                     |
+| `--loading-dots-pulse-min-opacity` | `0.2`          | opacity            | The minimum opacity a dot fades to during the pulse animation. Only applies when animation is pulse.                                                                                                                            |
+| `--loading-dots-pulse-min-scale`   | `1`            | transform: scale   | The minimum scale a dot shrinks to during the pulse animation. Values below `1` add a "breathing" size pulse alongside the opacity fade; the default of `1` keeps the pulse opacity-only. Only applies when animation is pulse. |
 
 ## Web Component
 

--- a/src/lib/LoadingDots/LoadingDots.svelte
+++ b/src/lib/LoadingDots/LoadingDots.svelte
@@ -56,9 +56,11 @@
     80%,
     100% {
       opacity: var(--loading-dots-pulse-min-opacity, 0.2);
+      transform: scale(var(--loading-dots-pulse-min-scale, 1));
     }
     40% {
       opacity: 1;
+      transform: scale(1);
     }
   }
 </style>

--- a/src/routes/components/loading-dots/+page.svelte
+++ b/src/routes/components/loading-dots/+page.svelte
@@ -13,4 +13,7 @@
   <div style="--loading-dots-size: 10px;">
     <LoadingDots dots={5} />
   </div>
+  <div style="--loading-dots-pulse-min-scale: 0.5; --loading-dots-pulse-min-opacity: 0.5;">
+    <LoadingDots animation="pulse" testId="loading-dots-breathing" />
+  </div>
 </div>

--- a/tests/loading-dots-pulse-scale.test.ts
+++ b/tests/loading-dots-pulse-scale.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('LoadingDots — pulse min-scale token', () => {
+  // The pulse variant previously animated opacity only; consumers replacing
+  // hand-rolled "breathing" (scale + opacity) loaders had no token to express
+  // the size component. --loading-dots-pulse-min-scale drives the keyframe's
+  // resting scale; the default of 1 keeps existing consumers pixel-identical.
+  test('the min-scale token reaches the dots and defaults to 1', async ({ page }) => {
+    await page.goto('/components/loading-dots');
+
+    const breathing = page.locator('[data-pw="loading-dots-breathing"]');
+    await expect(breathing).toBeVisible();
+
+    const configuredScale = await breathing
+      .locator('.dot')
+      .first()
+      .evaluate((dot) => getComputedStyle(dot).getPropertyValue('--loading-dots-pulse-min-scale'));
+    expect(configuredScale.trim()).toBe('0.5');
+
+    // An unconfigured pulse instance resolves no override — the keyframe's
+    // scale(var(--loading-dots-pulse-min-scale, 1)) falls back to 1.
+    const plainPulse = page.locator('.loading-dots').nth(1);
+    const unsetScale = await plainPulse
+      .locator('.dot')
+      .first()
+      .evaluate((dot) => getComputedStyle(dot).getPropertyValue('--loading-dots-pulse-min-scale'));
+    expect(unsetScale.trim()).toBe('');
+  });
+});


### PR DESCRIPTION
## Problem

The `pulse` animation variant animates opacity only. Hand-rolled loaders being migrated to LoadingDots commonly "breathe" (scale + opacity together); there is no token to express the scale component, so those migrations ship a visible motion regression (found migrating a consumer app's status dots).

## Change

`--loading-dots-pulse-min-scale` drives the pulse keyframe's resting `transform: scale(...)`; peak stays `scale(1)`. **Default is `1`** — the transform is a no-op for every existing consumer, so this is purely additive.

## Tests

`tests/loading-dots-pulse-scale.test.ts` against a new breathing example on `/components/loading-dots`: the token resolves on the dots when configured and resolves empty (keyframe falls back to 1) when not.

`npm run lint` / `npm run check` pass.