### PR TITLE
feat(Toolbar): expose content-row geometry tokens

### DIFF
--- a/docs/Toolbar.md
+++ b/docs/Toolbar.md
@@ -45,32 +45,36 @@ Svelte 5 Snippet props — pass content blocks to the component.
 
 Override these custom properties to theme the component.
 
-| Variable                                  | Default                  | CSS Property    | Description                                          |
-| ----------------------------------------- | ------------------------ | --------------- | ---------------------------------------------------- |
-| `--toolbar-padding`                       | `0px`                    | padding         | Inner padding of the toolbar container.              |
-| `--toolbar-height`                        | `fit-content`            | height          | Height of the toolbar.                               |
-| `--toolbar-width`                         | `100vw`                  | width           | Width of the toolbar.                                |
-| `--toolbar-position`                      | `fixed`                  | position        | CSS position (fixed by default, sticks to viewport). |
-| `--toolbar-top`                           | `0`                      | top             | Top position of the toolbar.                         |
-| `--toolbar-left`                          | `0`                      | left            | Left position of the toolbar.                        |
-| `--toolbar-right`                         | `0`                      | right           | Right position of the toolbar.                       |
-| `--toolbar-background`                    | `#ffffff`                | background      | Background color of the toolbar.                     |
-| `--toolbar-box-shadow`                    | `0px 2px 12px #55687c1a` | box-shadow      | Box shadow of the toolbar.                           |
-| `--toolbar-z-index`                       | `10`                     | z-index         | Z-index stacking order of the toolbar.               |
-| `--toolbar-border-radius`                 | `0px`                    | border-radius   | Corner rounding of the toolbar.                      |
-| `--toolbar-content-padding`               | `0px`                    | padding         | Padding inside the main content row.                 |
-| `--toolbar-justify-content`               | `normal`                 | justify-content | Horizontal alignment of toolbar content.             |
-| `--toolbar-content-visibility`            | `visible`                | visibility      | Visibility of the main content row.                  |
-| `--toolbar-additional-content-padding`    | `0px`                    | padding         | Padding inside the additional content row.           |
-| `--toolbar-additional-content-height`     | `fit-content`            | height          | Height of the additional content row.                |
-| `--toolbar-justify-additional-content`    | `normal`                 | justify-content | Horizontal alignment of additional content.          |
-| `--toolbar-additional-content-visibility` | `visible`                | visibility      | Visibility of the additional content row.            |
-| `--toolbar-back-button-height`            | `20px`                   | height          | Height of the back button container.                 |
-| `--toolbar-back-button-width`             | `20px`                   | width           | Width of the back button container.                  |
-| `--toolbar-back-button-padding`           | `20px 14px`              | padding         | Padding around the back button.                      |
-| `--toolbar-back-button-cursor`            | `pointer`                | cursor          | Cursor style for the back button.                    |
-| `--toolbar-back-image-height`             | `16px`                   | height          | Height of the back button icon image.                |
-| `--toolbar-back-image-width`              | `16px`                   | width           | Width of the back button icon image.                 |
+| Variable                                  | Default                  | CSS Property    | Description                                                                                                                           |
+| ----------------------------------------- | ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `--toolbar-padding`                       | `0px`                    | padding         | Inner padding of the toolbar container.                                                                                               |
+| `--toolbar-height`                        | `fit-content`            | height          | Height of the toolbar.                                                                                                                |
+| `--toolbar-width`                         | `100vw`                  | width           | Width of the toolbar.                                                                                                                 |
+| `--toolbar-position`                      | `fixed`                  | position        | CSS position (fixed by default, sticks to viewport).                                                                                  |
+| `--toolbar-top`                           | `0`                      | top             | Top position of the toolbar.                                                                                                          |
+| `--toolbar-left`                          | `0`                      | left            | Left position of the toolbar.                                                                                                         |
+| `--toolbar-right`                         | `0`                      | right           | Right position of the toolbar.                                                                                                        |
+| `--toolbar-background`                    | `#ffffff`                | background      | Background color of the toolbar.                                                                                                      |
+| `--toolbar-box-shadow`                    | `0px 2px 12px #55687c1a` | box-shadow      | Box shadow of the toolbar.                                                                                                            |
+| `--toolbar-z-index`                       | `10`                     | z-index         | Z-index stacking order of the toolbar.                                                                                                |
+| `--toolbar-border-radius`                 | `0px`                    | border-radius   | Corner rounding of the toolbar.                                                                                                       |
+| `--toolbar-content-padding`               | `0px`                    | padding         | Padding inside the main content row.                                                                                                  |
+| `--toolbar-justify-content`               | `normal`                 | justify-content | Horizontal alignment of toolbar content.                                                                                              |
+| `--toolbar-content-visibility`            | `visible`                | visibility      | Visibility of the main content row.                                                                                                   |
+| `--toolbar-content-width`                 | `auto`                   | width           | Width of the main content row.                                                                                                        |
+| `--toolbar-content-height`                | `auto`                   | height          | Height of the main content row. Set to `100%` to vertically fill a fixed-height toolbar.                                              |
+| `--toolbar-content-max-width`             | `none`                   | max-width       | Maximum width of the main content row. Combine with `--toolbar-content-margin: 0 auto` to clamp and center content on wide viewports. |
+| `--toolbar-content-margin`                | `0`                      | margin          | Margin around the main content row.                                                                                                   |
+| `--toolbar-additional-content-padding`    | `0px`                    | padding         | Padding inside the additional content row.                                                                                            |
+| `--toolbar-additional-content-height`     | `fit-content`            | height          | Height of the additional content row.                                                                                                 |
+| `--toolbar-justify-additional-content`    | `normal`                 | justify-content | Horizontal alignment of additional content.                                                                                           |
+| `--toolbar-additional-content-visibility` | `visible`                | visibility      | Visibility of the additional content row.                                                                                             |
+| `--toolbar-back-button-height`            | `20px`                   | height          | Height of the back button container.                                                                                                  |
+| `--toolbar-back-button-width`             | `20px`                   | width           | Width of the back button container.                                                                                                   |
+| `--toolbar-back-button-padding`           | `20px 14px`              | padding         | Padding around the back button.                                                                                                       |
+| `--toolbar-back-button-cursor`            | `pointer`                | cursor          | Cursor style for the back button.                                                                                                     |
+| `--toolbar-back-image-height`             | `16px`                   | height          | Height of the back button icon image.                                                                                                 |
+| `--toolbar-back-image-width`              | `16px`                   | width           | Width of the back button icon image.                                                                                                  |
 
 ## Web Component
 

--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -72,6 +72,15 @@
     padding: var(--toolbar-content-padding, 0px);
     justify-content: var(--toolbar-justify-content, normal);
     visibility: var(--toolbar-content-visibility, visible);
+
+    /* Content-row geometry: lets a fixed-height toolbar keep its row vertically
+       centered (height 100%) and clamp/center the row on wide viewports —
+       previously only reachable by piercing the component's internal DOM. All
+       defaults reproduce the previous rendering exactly. */
+    width: var(--toolbar-content-width, auto);
+    height: var(--toolbar-content-height, auto);
+    max-width: var(--toolbar-content-max-width, none);
+    margin: var(--toolbar-content-margin, 0);
   }
 
   .additional-content {

--- a/src/routes/components/toolbar/+page.svelte
+++ b/src/routes/components/toolbar/+page.svelte
@@ -17,4 +17,21 @@
     showBackButton
     onbackClick={() => alert('Back clicked')}
   />
+
+  <div
+    style="position: relative; width: 100%; background: #eef1f5;
+           --toolbar-position: relative;
+           --toolbar-width: 100%;
+           --toolbar-height: 64px;
+           --toolbar-content-height: 100%;
+           --toolbar-content-max-width: 320px;
+           --toolbar-content-margin: 0 auto;"
+  >
+    <Toolbar
+      text="Centered & Clamped"
+      testId="toolbar-content-tokens"
+      showBackButton
+      onbackClick={() => alert('Back clicked')}
+    />
+  </div>
 </div>

--- a/tests/toolbar-content-geometry.test.ts
+++ b/tests/toolbar-content-geometry.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the Toolbar content-row geometry tokens (--toolbar-content-width/-height/
+// -max-width/-margin): defaults must reproduce the previous rendering exactly, and
+// an instance overriding them must resolve to the overridden values.
+test.describe('Toolbar content-row geometry tokens', () => {
+  test('defaults leave an unconfigured toolbar content row unchanged', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    const content = page.locator('[data-pw="toolbar-root"] .content');
+    await expect(content).toBeVisible();
+
+    const style = await content.evaluate((element) => {
+      const computed = getComputedStyle(element);
+      return {
+        width: computed.width,
+        maxWidth: computed.maxWidth,
+        marginLeft: computed.marginLeft,
+        marginRight: computed.marginRight
+      };
+    });
+
+    expect(style.maxWidth).toBe('none');
+    expect(style.marginLeft).toBe('0px');
+    expect(style.marginRight).toBe('0px');
+  });
+
+  test('an instance can clamp and center its content row via tokens', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    const toolbar = page.locator('[data-pw="toolbar-content-tokens"]');
+    const content = toolbar.locator('.content');
+    await expect(content).toBeVisible();
+
+    const style = await content.evaluate((element) => {
+      const computed = getComputedStyle(element);
+      return {
+        height: computed.height,
+        maxWidth: computed.maxWidth,
+        marginLeft: computed.marginLeft,
+        marginRight: computed.marginRight
+      };
+    });
+
+    expect(style.height).toBe('64px');
+    expect(style.maxWidth).toBe('320px');
+
+    // margin: 0 auto centers the row — both sides get an equal, non-zero share
+    // of the leftover space once the row is narrower than its 100%-wide parent.
+    expect(Number.parseFloat(style.marginLeft)).toBeGreaterThan(0);
+    expect(style.marginLeft).toBe(style.marginRight);
+  });
+});


### PR DESCRIPTION
## Problem

`Toolbar`'s `.content` row (the flex row holding `leftContent`/`centerContent`/`rightContent`) only exposed `--toolbar-content-padding`, `--toolbar-justify-content`, and `--toolbar-content-visibility`. A consumer that needs a fixed-height toolbar with the content row vertically centered (`height: 100%`) or width-clamped/centered on wide viewports (`max-width` + `margin-inline: auto`) had no supported way to do it — the only option was selecting the library's internal `.content` class by name from a consumer theme sheet, which is a documented fragility (breaks silently on a future internal DOM/class rename).

This is the exact gap hit by a consumer app migrating a hand-rolled chat header to `Toolbar`: it needed `.automatic-chat-toolbar .content { max-width: ...; margin-inline: auto; height: 100%; }` and had to reach into the internal class to get it.

## Change

Add four tokens to `.content` in `Toolbar.svelte`, mirroring the existing token-per-property pattern already used elsewhere in the component:

- `--toolbar-content-width` (default `auto`)
- `--toolbar-content-height` (default `auto`)
- `--toolbar-content-max-width` (default `none`)
- `--toolbar-content-margin` (default `0`)

All defaults reproduce the exact previous rendering — this is additive only, no existing toolbar changes appearance.

## Demo

Added a second example to `/components/toolbar` (`testId="toolbar-content-tokens"`): a 64px-tall toolbar whose content row is vertically centered and clamped to 320px, centered within a wider wrapper.

## Tests

`tests/toolbar-content-geometry.test.ts`:
- Default toolbar (`toolbar-root`): `.content` resolves `max-width: none`, `margin: 0` — unchanged from before.
- Token-configured toolbar (`toolbar-content-tokens`): `.content` resolves `height: 64px`, `max-width: 320px`, and equal non-zero left/right margins (centered).

`npm run lint` / `npm run check`: clean. `npx playwright test tests/toolbar-content-geometry.test.ts`: 2/2 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new toolbar example showing a centered, clamped content row inside a constrained container.
  * Toolbar content now supports additional layout controls for width, height, max width, and spacing, while preserving existing behavior by default.

* **Tests**
  * Added automated coverage to verify the toolbar’s default layout and its centered, clamped behavior when custom settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->