### PR TITLE
feat(Status): add an icon snippet slot for custom media

### DIFF
--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -9,13 +9,20 @@
     statusDescription = '',
     buttonProperties,
     classes,
-    onbuttonClick
+    onbuttonClick,
+    icon
   }: StatusProperties = $props();
 </script>
 
 <div class="background {classes ?? ''}">
   <div class="order-status">
-    <div class="status-image"><Img src={statusIcon} alt="status" /></div>
+    <div class="status-image">
+      {#if icon}
+        {@render icon()}
+      {:else}
+        <Img src={statusIcon} alt="status" />
+      {/if}
+    </div>
     <div class="status-text">{statusText}</div>
     <div class="status-description">
       <!-- eslint-disable-next-line -->

--- a/src/lib/Status/properties.ts
+++ b/src/lib/Status/properties.ts
@@ -1,11 +1,18 @@
+import type { Snippet } from 'svelte';
 import type { ButtonProperties } from '$lib/Button/properties';
 
 export type StatusProperties = StatusEventProperties & {
-  statusIcon: string;
+  statusIcon?: string;
   statusText: string;
   statusDescription: string;
   buttonProperties?: ButtonProperties;
   classes?: string;
+  /**
+   * Custom media rendered instead of the default `statusIcon` image — e.g. a
+   * `LottiePlayer` for animated success/failure/in-progress states. Takes
+   * priority over `statusIcon` when provided.
+   */
+  icon?: Snippet;
 };
 
 export type StatusEventProperties = {

--- a/src/routes/components/status/+page.svelte
+++ b/src/routes/components/status/+page.svelte
@@ -1,5 +1,21 @@
 <script lang="ts">
   import Status from '$lib/Status/Status.svelte';
+  import LottiePlayer from '$lib/LottiePlayer/LottiePlayer.svelte';
+
+  // Minimal valid Lottie document (zero layers) — enough to exercise the player
+  // without depending on a real animation asset.
+  const minimalAnimation = {
+    v: '5.5.7',
+    fr: 30,
+    ip: 0,
+    op: 30,
+    w: 100,
+    h: 100,
+    nm: 'minimal',
+    ddd: 0,
+    assets: [],
+    layers: []
+  };
 </script>
 
 <div class="page-header">
@@ -8,9 +24,21 @@
 </div>
 
 <div class="demo-row">
-  <Status
-    statusIcon="https://picsum.photos/48/48?random=20"
-    statusText="Payment Successful"
-    statusDescription="Your order has been confirmed"
-  />
+  <div data-pw="status-default-icon">
+    <Status
+      statusIcon="https://picsum.photos/48/48?random=20"
+      statusText="Payment Successful"
+      statusDescription="Your order has been confirmed"
+    />
+  </div>
+
+  <div data-pw="status-icon-slot">
+    <Status statusText="Processing" statusDescription="Hang tight…">
+      {#snippet icon()}
+        <div style="width: 48px; height: 48px;" data-pw="status-icon-slot-lottie">
+          <LottiePlayer animationData={minimalAnimation} />
+        </div>
+      {/snippet}
+    </Status>
+  </div>
 </div>

--- a/tests/status-icon-slot.test.ts
+++ b/tests/status-icon-slot.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the Status `icon` snippet: a consumer can render custom media (e.g. a
+// LottiePlayer) instead of the default statusIcon <Img>, and the default path
+// stays unchanged when `icon` isn't provided.
+test.describe('Status icon slot', () => {
+  test('default statusIcon renders an <img> when no icon snippet is given', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const defaultStatus = page.locator('[data-pw="status-default-icon"]');
+    await expect(defaultStatus.locator('img')).toBeVisible();
+  });
+
+  test('icon snippet replaces the default image with custom content', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const slotHost = page.locator('[data-pw="status-icon-slot"]');
+    await expect(slotHost).toBeVisible();
+
+    // No <img> is rendered for this instance — the snippet took over.
+    await expect(slotHost.locator('img')).toHaveCount(0);
+
+    // The custom content (the LottiePlayer wrapper) is present instead.
+    await expect(slotHost.locator('[data-pw="status-icon-slot-lottie"]')).toBeVisible();
+    await expect(slotHost.locator('.lottie-player')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Problem

`Status` only accepted `statusIcon` as an image `src` string, rendered via a static `<Img>`. A consumer that needs an animated status indicator — e.g. `LottiePlayer` (already shipped by this library) for success/failure/in-progress states — had no way to express it. This is the exact gap hit by a consumer app's hand-rolled status widget, which already reaches for the library's own `LottiePlayer` directly instead of `Status`, precisely because `Status` can't host one.

## Change

Add an optional `icon` snippet to `StatusProperties`. When provided, it renders instead of the default `<Img src={statusIcon}>`. `statusIcon` is now marked optional in the type (it already had a runtime default via destructuring — the type just hadn't caught up), since it's irrelevant once `icon` is supplied. Fully backward compatible: existing callers passing only `statusIcon` are unaffected.

## Demo

Added a second example to `/components/status` (`data-pw="status-icon-slot"`): a `Status` using the `icon` snippet to render a `LottiePlayer` with a minimal inline animation instead of the default image.

## Tests

`tests/status-icon-slot.test.ts`:
- Default `Status` (no `icon` prop): still renders an `<img>`.
- `Status` with the `icon` snippet: zero `<img>` elements, the custom content (the `LottiePlayer`) renders instead.

`npm run lint` / `npm run check`: clean. `npx playwright test tests/status-icon-slot.test.ts`: 2/2 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the status icon with a slot-like icon option.
  * Status displays can now render custom animated or inline content instead of only a default image.

* **Bug Fixes**
  * Improved fallback behavior so the default status image still appears when no custom icon is provided.
  * Ensured custom icon content fully replaces the default image when used.

* **Tests**
  * Added end-to-end coverage for both default and custom status icon rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->