### PR TITLE
fix(BarChart): size the horizontal category-axis gutter to the widest label

### DIFF
--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -13,7 +13,11 @@
   import ChartTooltip from '$lib/_chart/ChartTooltip.svelte';
   import Legend from '$lib/_chart/Legend.svelte';
   import { createBandScale, createLinearScale, niceLinearDomain } from '$lib/_chart/scales';
-  import { computeChartDimensions } from '$lib/_chart/geometry';
+  import {
+    computeChartDimensions,
+    computeHorizontalCategoryGutter,
+    measureTextWidth
+  } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
   import { roundedRectPath } from '$lib/_chart/paths';
@@ -110,17 +114,6 @@
 
   let format = $derived(valueFormat ?? formatNumber);
   let isVertical = $derived(orientation === 'vertical');
-  // When an axis is hidden its gutter (Y = 50px for tick labels, X = 40px) is dead
-  // space that squeezes the plot into the centre. Collapse the tick-label gutter but
-  // keep a symmetric breathing-room inset so the edge bars (and their value labels)
-  // don't sit flush against the container edges.
-  let dims = $derived(
-    computeChartDimensions(chartWidth, chartHeight, {
-      left: showYAxis ? 50 : 28,
-      right: 28,
-      bottom: showXAxis ? 40 : 8
-    })
-  );
 
   let isMulti = $derived(Array.isArray(series) && series.length > 0);
 
@@ -196,6 +189,58 @@
     const first = resolvedSeries[0]?.data ?? [];
     return first.map((d) => d.label);
   });
+
+  /**
+   * Widest category label in the axis tick font, for the horizontal-orientation
+   * gutter below. Horizontal charts put category text (not short numeric ticks)
+   * on the Y axis, so the gutter must fit real words like "Submitted Address" —
+   * a fixed gutter clips them. Resolved from the mounted container so CSS-var
+   * theming (--chart-axis-font-size / --chart-axis-font-family) is honoured.
+   * Null when unmeasurable (SSR, no canvas) — the gutter then keeps its legacy
+   * fixed width.
+   */
+  let widestCategoryLabelWidth = $derived.by(() => {
+    if (isVertical || !showYAxis || labels.length === 0 || containerEl === null) {
+      return null;
+    }
+    const containerStyle = getComputedStyle(containerEl);
+    const axisFontSize = containerStyle.getPropertyValue('--chart-axis-font-size').trim() || '11px';
+    const axisFontFamilyToken = containerStyle.getPropertyValue('--chart-axis-font-family').trim();
+    const axisFontFamily =
+      axisFontFamilyToken === '' || axisFontFamilyToken === 'inherit'
+        ? containerStyle.fontFamily || 'sans-serif'
+        : axisFontFamilyToken;
+    const axisFont = `${axisFontSize} ${axisFontFamily}`;
+    let widest: number | null = null;
+    for (const label of labels) {
+      const labelWidth = measureTextWidth(label, axisFont);
+      if (labelWidth === null) {
+        return null;
+      }
+      if (widest === null || labelWidth > widest) {
+        widest = labelWidth;
+      }
+    }
+    return widest;
+  });
+
+  // When an axis is hidden its gutter (Y = 50px for tick labels, X = 40px) is dead
+  // space that squeezes the plot into the centre. Collapse the tick-label gutter but
+  // keep a symmetric breathing-room inset so the edge bars (and their value labels)
+  // don't sit flush against the container edges. In horizontal orientation the
+  // visible Y axis carries category text, so its gutter grows to fit the widest
+  // label (never shrinking below the legacy 50px, capped at 45% of the width).
+  let dims = $derived(
+    computeChartDimensions(chartWidth, chartHeight, {
+      left: showYAxis
+        ? isVertical
+          ? 50
+          : computeHorizontalCategoryGutter(widestCategoryLabelWidth, chartWidth)
+        : 28,
+      right: 28,
+      bottom: showXAxis ? 40 : 8
+    })
+  );
 
   // ── Effective highlighted index: merge declarative + imperative ─
 

--- a/src/lib/_chart/geometry.test.ts
+++ b/src/lib/_chart/geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeSankeyLayout } from './geometry';
+import { computeHorizontalCategoryGutter, computeSankeyLayout, measureTextWidth } from './geometry';
 
 describe('computeSankeyLayout', () => {
   it('produces finite node positions when every link weight is zero (no NaN collapse)', () => {
@@ -143,5 +143,46 @@ describe('computeSankeyLayout', () => {
         `column ${column} bottom (${columnBottom}) exceeds height (${height})`
       ).toBeLessThanOrEqual(height);
     }
+  });
+});
+
+describe('computeHorizontalCategoryGutter', () => {
+  it('keeps the legacy fixed gutter when the label width is unmeasurable (SSR / no canvas)', () => {
+    expect(computeHorizontalCategoryGutter(null, 800)).toBe(50);
+  });
+
+  it('never shrinks below the legacy gutter for short labels', () => {
+    // "Jan"-style labels measure ~20px; 20 + 14 inset = 34 < 50 → stay at 50 so
+    // every chart whose labels already fit keeps its exact current layout.
+    expect(computeHorizontalCategoryGutter(20, 800)).toBe(50);
+  });
+
+  it('grows the gutter to fit a long category label plus the tick inset', () => {
+    // The BZ-4372 case: "Submitted Address" measures ~97px at 11px axis font.
+    // Labels right-align 10px left of the axis line, so the gutter must be
+    // label + 10 (tick inset) + 4 (breathing pad) = 111 to avoid clipping.
+    expect(computeHorizontalCategoryGutter(97, 350)).toBe(111);
+  });
+
+  it('caps the gutter at 45% of the chart width so a pathological label cannot crush the plot', () => {
+    expect(computeHorizontalCategoryGutter(300, 350)).toBe(Math.round(350 * 0.45));
+  });
+
+  it('keeps at least the legacy gutter when the chart itself is tiny', () => {
+    // cap = max(50, 100 * 0.45) = 50 → the label still bleeds, but the plot survives.
+    expect(computeHorizontalCategoryGutter(97, 100)).toBe(50);
+  });
+
+  it('respects a custom fallback gutter', () => {
+    expect(computeHorizontalCategoryGutter(null, 800, 28)).toBe(28);
+    expect(computeHorizontalCategoryGutter(10, 800, 28)).toBe(28);
+  });
+});
+
+describe('measureTextWidth', () => {
+  it('returns null in environments without a working canvas (jsdom) instead of a bogus 0', () => {
+    // jsdom's canvas 2D context either does not exist or measures every string
+    // as 0 — both must map to null so the caller falls back to fixed layout.
+    expect(measureTextWidth('Submitted Address', '11px sans-serif')).toBeNull();
   });
 });

--- a/src/lib/_chart/geometry.ts
+++ b/src/lib/_chart/geometry.ts
@@ -27,6 +27,59 @@ export function computeChartDimensions(
   };
 }
 
+// ── Text measurement ────────────────────────────────────────────
+
+let textMeasurementContext: CanvasRenderingContext2D | null = null;
+
+/**
+ * Measures rendered text width via a shared offscreen canvas context.
+ * Returns null when measurement is unavailable (SSR, or the environment
+ * provides no working 2D canvas — e.g. jsdom) so callers can fall back to
+ * a fixed layout instead of acting on a bogus 0.
+ */
+export function measureTextWidth(text: string, font: string): number | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  if (textMeasurementContext === null) {
+    textMeasurementContext = document.createElement('canvas').getContext('2d');
+  }
+  if (textMeasurementContext === null) {
+    return null;
+  }
+  textMeasurementContext.font = font;
+  const width = textMeasurementContext.measureText(text).width;
+  // jsdom's canvas stub reports 0 for any text; treat that as "cannot measure".
+  return width > 0 ? width : null;
+}
+
+/**
+ * Left margin for a horizontal bar chart's category axis, sized to fit the
+ * widest category label. Category tick labels render right-aligned 10px left
+ * of the axis line (tick mark 6px + 4px gap), so any label wider than
+ * `margin.left - 10` bleeds out of the SVG and gets clipped by the page.
+ *
+ * - Never shrinks below `fallback` (the legacy fixed gutter), so charts whose
+ *   labels already fit keep their exact current layout.
+ * - Caps at 45% of the chart width so one pathological label cannot crush the
+ *   plot area; past the cap the label bleeds as before, but the plot survives.
+ * - `widestLabelWidth === null` (SSR / unmeasurable) keeps the legacy gutter.
+ */
+export function computeHorizontalCategoryGutter(
+  widestLabelWidth: number | null,
+  chartWidth: number,
+  fallback: number = 50
+): number {
+  if (widestLabelWidth === null) {
+    return fallback;
+  }
+  const tickLabelInset = 10;
+  const breathingPad = 4;
+  const cap = Math.max(fallback, chartWidth * 0.45);
+  const fitted = widestLabelWidth + tickLabelInset + breathingPad;
+  return Math.round(Math.min(Math.max(fallback, fitted), cap));
+}
+
 // ── Pie layout ──────────────────────────────────────────────────
 
 export function computePieLayout(


### PR DESCRIPTION
## Problem

In horizontal orientation the Y axis carries **category text**, but the left margin was a fixed `showYAxis ? 50 : 28`. Any label wider than ~40px (`margin.left − 10`, since category ticks right-align 10px left of the axis line) bled past the SVG edge and was clipped by the page.

Real-world failure (Breeze lighthouse, BZ-4372): a chat-generated checkout-funnel bar chart on a 360px mobile viewport renders "Submitted Address" (96.87px at 11px axis font) starting at **x = −3.87px — off the left edge of the screen**, and consumer-side padding band-aids cannot cover arbitrary label lengths.

## Fix

- `_chart/geometry.ts`: new `measureTextWidth` (shared offscreen canvas; SSR/jsdom-safe → `null`) and pure `computeHorizontalCategoryGutter(widestLabelWidth, chartWidth, fallback = 50)`.
- `BarChart.svelte`: in **horizontal + showYAxis** only, measure every category label in the resolved axis tick font (honouring `--chart-axis-font-size` / `--chart-axis-font-family` CSS-var theming) and grow `margin.left` to fit the widest one.

Behavioural guarantees:
- **Never shrinks below the legacy 50px** — every chart whose labels already fit keeps its exact current layout.
- **Caps at 45% of chart width** — a pathological label cannot crush the plot (it bleeds as before past the cap, but the plot survives).
- **Vertical orientation and hidden-axis (28px) paths untouched** — verified pixel-identical on a live consumer (vertical conversion chart: plot translate/bar rects byte-for-byte identical before/after).
- **SSR-safe**: unmeasurable environments keep the legacy fixed gutter.

## Verification

- 6 new unit tests for the gutter math + the jsdom null path (58/58 total pass), `svelte-check` 0 errors, lint clean, `pnpm run package` clean.
- Live-verified in the lighthouse consumer at 360px and 390px mobile: plot margin 50 → 111 (= 97px widest label + 14px inset), `minLabelLeft` −3.87 → **+57.13**, zero clipped labels, bars/values/axis intact.

| | before | after |
|---|---|---|
| plot transform | `translate(50, 20)` | `translate(111, 20)` |
| "Submitted Address" left edge | −3.87px (off-screen) | +57.13px |
| labels clipped | 1 (+1 touching edge) | 0 |