### PR TITLE
feat(Table): pass sort-stable originalIndex to cell callbacks

### DIFF
--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -33,11 +33,13 @@
   let {
     column,
     value,
-    rowIndex
+    rowIndex,
+    originalIndex
   }: {
     column: TableColumn;
     value: TableCellValue;
     rowIndex: number;
+    originalIndex: number;
   } = $props();
 
   let copied = $state(false);
@@ -226,7 +228,7 @@
     <Toggle
       checked={isChecked}
       text=""
-      onclick={(newChecked) => column.onToggle?.(rowIndex, newChecked)}
+      onclick={(newChecked) => column.onToggle?.(rowIndex, newChecked, originalIndex)}
     />
   </span>
 {:else if column.type === 'select'}
@@ -247,7 +249,7 @@
         itemTestId={selectData.itemTestId}
         onchange={(selectedIds) => {
           if (selectedIds.length > 0) {
-            column.onSelect?.(rowIndex, selectedIds[0]);
+            column.onSelect?.(rowIndex, selectedIds[0], originalIndex);
           }
         }}
       />
@@ -275,7 +277,7 @@
           : null}
         onErrorMessage={inputData.onErrorMessage ?? null}
         actionInput={false}
-        onInput={(newValue) => column.onInput?.(rowIndex, newValue)}
+        onInput={(newValue) => column.onInput?.(rowIndex, newValue, originalIndex)}
       />
     </span>
   {:else}
@@ -295,7 +297,7 @@
         disabled={buttonData.disabled ?? false}
         classes={buttonData.classes ?? ''}
         testId={buttonData.testId}
-        onclick={() => column.onButtonClick?.(rowIndex)}
+        onclick={() => column.onButtonClick?.(rowIndex, originalIndex)}
       />
     </span>
   {:else}
@@ -317,7 +319,7 @@
           disabled={primary.disabled ?? false}
           classes={primary.classes ?? ''}
           testId={primary.testId}
-          onclick={() => column.onPrimaryAction?.(rowIndex)}
+          onclick={() => column.onPrimaryAction?.(rowIndex, originalIndex)}
         />
       {/if}
       {#if actionData.menuItems && actionData.menuItems.length > 0}
@@ -329,7 +331,7 @@
             separator: item.separator
           }))}
           testId={column.testId && `${column.testId}-menu-${rowIndex}`}
-          onselect={(menuItem) => column.onMenuAction?.(rowIndex, menuItem.value)}
+          onselect={(menuItem) => column.onMenuAction?.(rowIndex, menuItem.value, originalIndex)}
         >
           {#snippet trigger()}
             <span class="builtin-icon-button">
@@ -367,7 +369,7 @@
           separator: item.separator
         }))}
         testId={column.testId && `${column.testId}-popup-${rowIndex}`}
-        onselect={(menuItem) => column.onMenuAction?.(rowIndex, menuItem.value)}
+        onselect={(menuItem) => column.onMenuAction?.(rowIndex, menuItem.value, originalIndex)}
       >
         {#snippet trigger()}
           <span class="builtin-icon-button">

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -59,6 +59,10 @@
   let normalized = $derived(columns ? normalizeColumns(columns, rows ?? []) : null);
   let effectiveHeaders = $derived(normalized ? normalized.tableHeaders : tableHeaders);
   let effectiveData = $derived(normalized ? normalized.tableData : tableData);
+  // Maps each row reference back to its index in the consumer-supplied `rows`
+  // (pre-sort/pre-filter). Row refs are preserved through sort/filter/paginate,
+  // so cell callbacks can hand consumers a sort-stable `originalIndex`.
+  let originalIndexByRow = $derived(new Map(effectiveData.map((row, index) => [row, index])));
   let effectiveSortableColumns = $derived(
     normalized ? normalized.sortableColumns : sortableColumns
   );
@@ -712,6 +716,7 @@
         {:else}
           {#each paginatedTableData as row, pageRowIndex (rowIdByRow.get(row) ?? pageRowIndex)}
             {@const rowIndex = pageRowIndex + rowIndexOffset}
+            {@const originalIndex = originalIndexByRow.get(row) ?? rowIndex}
             {@const rowId = rowIdByRow.get(row) ?? String(rowIndex)}
             {@const rowDisabled = isCheckboxMode && isRowDisabled(rowId)}
             {@const rowSelected = isCheckboxMode && isRowSelected(rowId)}
@@ -781,9 +786,9 @@
                     class:table-cell-clamp={keyedColumn?.maxWidth && isScalarCell}
                   >
                     {#if keyedColumn && typeof keyedColumn.cell === 'function' && keyedRow}
-                      {@render keyedColumn.cell(keyedRow, rowIndex)}
+                      {@render keyedColumn.cell(keyedRow, rowIndex, originalIndex)}
                     {:else if keyedColumn?.type && keyedColumn.type !== 'text' && keyedColumn.type !== 'custom'}
-                      <BuiltinCell column={keyedColumn} value={cellValue} {rowIndex} />
+                      <BuiltinCell column={keyedColumn} value={cellValue} {rowIndex} {originalIndex} />
                     {:else if typeof cell === 'function'}
                       {@render cell(cellValue, rowIndex, colIndex)}
                     {:else}

--- a/src/lib/Table/original-index.test.ts
+++ b/src/lib/Table/original-index.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Proves the mechanism Table.svelte uses to hand cell callbacks a sort-stable
+ * `originalIndex`. The component builds `originalIndexByRow = new Map(effectiveData.map(...))`
+ * over the consumer's ORIGINAL row order, and its `sortedTableData` returns the SAME row
+ * object references reordered (never clones), so a Map lookup on any displayed (sorted) row
+ * yields its index in the consumer's unsorted `rows` array. That is exactly what a consumer
+ * needs to index its own source array correctly after the user sorts.
+ */
+describe('Table originalIndex under sort', () => {
+  it('resolves each sorted display row back to its original consumer index', () => {
+    // Projected rows in the consumer's original order (as normalizeColumns produces).
+    const rows: Array<[string, number]> = [
+      ['Charlie', 30],
+      ['Alice', 10],
+      ['Bob', 20]
+    ];
+
+    // Table.svelte: originalIndexByRow = new Map(effectiveData.map((row, index) => [row, index]))
+    const originalIndexByRow = new Map(rows.map((row, index) => [row, index]));
+
+    // Table.svelte sortedTableData: `[...effectiveData].sort(...)` — reorders the SAME refs.
+    const sorted = [...rows].sort((a, b) => a[1] - b[1]); // ascending by the numeric column
+    expect(sorted.map((row) => row[0])).toEqual(['Alice', 'Bob', 'Charlie']); // display order changed
+
+    // For each displayed row, `originalIndex` points back to its pre-sort position.
+    const resolved = sorted.map((row, displayIndex) => ({
+      display: row[0],
+      displayIndex,
+      originalIndex: originalIndexByRow.get(row)
+    }));
+
+    expect(resolved).toEqual([
+      { display: 'Alice', displayIndex: 0, originalIndex: 1 },
+      { display: 'Bob', displayIndex: 1, originalIndex: 2 },
+      { display: 'Charlie', displayIndex: 2, originalIndex: 0 }
+    ]);
+
+    // The exact bug the fix closes: acting on the DISPLAY index would target the wrong
+    // source row. First sorted row is Alice (originalIndex 1); the old display index (0)
+    // would have wrongly addressed rows[0] = Charlie.
+    expect(originalIndexByRow.get(sorted[0])).toBe(1);
+    expect(originalIndexByRow.get(sorted[0])).not.toBe(0);
+  });
+
+  it('is identity when unsorted (originalIndex === displayIndex)', () => {
+    const rows: Array<[string, number]> = [
+      ['Charlie', 30],
+      ['Alice', 10],
+      ['Bob', 20]
+    ];
+    const originalIndexByRow = new Map(rows.map((row, index) => [row, index]));
+    const unsorted = [...rows]; // no sort applied
+    unsorted.forEach((row, displayIndex) => {
+      expect(originalIndexByRow.get(row)).toBe(displayIndex);
+    });
+  });
+});

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -202,9 +202,9 @@ export type TableRow = Record<string, TableCellValue>;
  *   `sortable` prop. Equivalent to listing/omitting the column's index in
  *   `sortableColumns`.
  * - `testId` — `data-pw` attribute emitted on this column's header cell.
- * - `cell` — column-scoped renderer snippet receiving the full keyed row and
- *   the row index. Takes precedence over the table-wide `cell` snippet for
- *   this column; required when `type` is `'custom'`.
+ * - `cell` — column-scoped renderer snippet receiving the full keyed row, the
+ *   display row index, and the original (pre-sort) row index. Takes precedence
+ *   over the table-wide `cell` snippet for this column; required when `type` is `'custom'`.
  * - `onToggle`/`onSelect`/`onInput`/`onButtonClick`/`onPrimaryAction`/`onMenuAction`
  *   — change/action handlers for the matching interactive cell types. Behavior
  *   lives on the column so row data stays plain JSON.
@@ -215,7 +215,7 @@ export type TableColumn = {
   type?: TableColumnType;
   sortable?: boolean;
   testId?: string;
-  cell?: Snippet<[TableRow, number]>;
+  cell?: Snippet<[TableRow, number, number]>;
   /** Header tooltip text, shown on hover over the column label. */
   tooltip?: string;
   /**
@@ -237,13 +237,19 @@ export type TableColumn = {
    * the cell value itself.
    */
   getSortValue?: (row: TableRow, rowIndex: number) => string | number | boolean;
-  /** `checked` is the NEW state after the flip, not the pre-click value. */
-  onToggle?: (rowIndex: number, checked: boolean) => void;
-  onSelect?: (rowIndex: number, selectedId: string) => void;
-  onInput?: (rowIndex: number, value: string) => void;
-  onButtonClick?: (rowIndex: number) => void;
-  onPrimaryAction?: (rowIndex: number) => void;
-  onMenuAction?: (rowIndex: number, itemId: string) => void;
+  /**
+   * Row-action handlers. `rowIndex` is the row's position in the CURRENT
+   * (sorted/filtered/paginated) view; `originalIndex` is its position in the
+   * consumer-supplied `rows` array, stable under sort/filter — index your own
+   * source array with `originalIndex` so actions hit the correct row when the
+   * table is sorted. `checked` is the NEW state after the flip, not the pre-click value.
+   */
+  onToggle?: (rowIndex: number, checked: boolean, originalIndex: number) => void;
+  onSelect?: (rowIndex: number, selectedId: string, originalIndex: number) => void;
+  onInput?: (rowIndex: number, value: string, originalIndex: number) => void;
+  onButtonClick?: (rowIndex: number, originalIndex: number) => void;
+  onPrimaryAction?: (rowIndex: number, originalIndex: number) => void;
+  onMenuAction?: (rowIndex: number, itemId: string, originalIndex: number) => void;
 };
 
 /**


### PR DESCRIPTION
Cell callbacks (onMenuAction/onToggle/onSelect/onInput/onButtonClick/onPrimaryAction) and the column cell snippet received only the sorted/filtered DISPLAY rowIndex, so a consumer indexing its own rows array acted on the wrong row once sorted. Adds an originalIndex trailing arg = the row's index in the consumer rows (pre-sort/pre-filter), via a reference-keyed Map over effectiveData. Backward compatible. Proven by src/lib/Table/original-index.test.ts (build OK, svelte-check 0 errors, 28/28 vitest). No npm publish yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table interactions now preserve both the displayed row position and the row’s original position in the source data.
  * Custom cell rendering and row actions can now access the original row index, even after sorting or filtering.

* **Bug Fixes**
  * Row actions and menu selections now report the correct source-row index instead of relying only on the current visible order.
  * Sorting no longer changes the index information passed to interactive cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->