### PR TITLE
feat(Table): prettier-reflow BuiltinCell tag to unblock the originalIndex release

### DIFF
--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -788,7 +788,12 @@
                     {#if keyedColumn && typeof keyedColumn.cell === 'function' && keyedRow}
                       {@render keyedColumn.cell(keyedRow, rowIndex, originalIndex)}
                     {:else if keyedColumn?.type && keyedColumn.type !== 'text' && keyedColumn.type !== 'custom'}
-                      <BuiltinCell column={keyedColumn} value={cellValue} {rowIndex} {originalIndex} />
+                      <BuiltinCell
+                        column={keyedColumn}
+                        value={cellValue}
+                        {rowIndex}
+                        {originalIndex}
+                      />
                     {:else if typeof cell === 'function'}
                       {@render cell(cellValue, rowIndex, colIndex)}
                     {:else}


### PR DESCRIPTION
Release run 28921069486 for 2d6899e (the originalIndex minor from #369) failed at `pnpm lint` — `prettier --check src` rejected `src/lib/Table/Table.svelte` because appending `{originalIndex}` pushed the `<BuiltinCell>` self-closing tag past prettier's printWidth. This reflows the attributes onto separate lines. **Pure formatting, zero behavior change.**

Typed `feat` deliberately: the release workflow derives the version bump from the tip commit alone (`release.yml`: `git log -1`), and the unreleased content on `release` is the originalIndex feature — this commit carries its minor bump (2.87.0 → 2.88.0). A `fix`/`chore` tip would wrongly cut a patch. Same pattern as #358.

**Verified:** `pnpm lint` clean (prettier + eslint), svelte-check 533 files 0 errors, vitest 94 passed, Playwright 106 passed, `build` and `build:wc` green.