### PR TITLE
feat(Table): pass sort-stable originalIndex to onRowClick and getRowId

### DIFF
--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -111,14 +111,19 @@
   };
 
   // ─── Row click ───────────────────────────────────────────────────────────────
-  const handleRowClick = (rowIndex: number, rowData: JSONValue[]): void => {
-    onRowClick?.(rowIndex, rowData);
+  const handleRowClick = (rowIndex: number, rowData: JSONValue[], originalIndex: number): void => {
+    onRowClick?.(rowIndex, rowData, originalIndex);
   };
 
-  const handleRowKeydown = (event: KeyboardEvent, rowIndex: number, rowData: JSONValue[]): void => {
+  const handleRowKeydown = (
+    event: KeyboardEvent,
+    rowIndex: number,
+    rowData: JSONValue[],
+    originalIndex: number
+  ): void => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      onRowClick?.(rowIndex, rowData);
+      onRowClick?.(rowIndex, rowData, originalIndex);
     }
   };
 
@@ -329,9 +334,10 @@
   const resolveRowId = (
     cfg: TableCheckboxSelectionConfig,
     row: JSONValue[],
-    rowIndex: number
+    rowIndex: number,
+    originalIndex: number
   ): string => {
-    return cfg.getRowId ? cfg.getRowId(row, rowIndex) : String(rowIndex);
+    return cfg.getRowId ? cfg.getRowId(row, rowIndex, originalIndex) : String(rowIndex);
   };
 
   let internalSelectedIds = new SvelteSet<string>();
@@ -374,7 +380,12 @@
       const originalIndex = indexMap.get(row) ?? -1;
       const stableIndex = originalIndex === -1 ? fallbackIndex : originalIndex;
       if (checkboxSelection && checkboxSelection.enabled !== false) {
-        return resolveRowId(checkboxSelection, row, stableIndex);
+        return resolveRowId(
+          checkboxSelection,
+          row,
+          stableIndex,
+          originalIndexByRow.get(row) ?? stableIndex
+        );
       }
       return String(stableIndex);
     });
@@ -725,9 +736,9 @@
               class:table-row-clickable={isRowClickable}
               class:table-row-selected={rowSelected}
               data-pw={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
-              onclick={isRowClickable ? () => handleRowClick(rowIndex, row) : null}
+              onclick={isRowClickable ? () => handleRowClick(rowIndex, row, originalIndex) : null}
               onkeydown={isRowClickable
-                ? (keyboardEvent) => handleRowKeydown(keyboardEvent, rowIndex, row)
+                ? (keyboardEvent) => handleRowKeydown(keyboardEvent, rowIndex, row, originalIndex)
                 : null}
               tabindex={isRowClickable ? 0 : null}
             >

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -275,7 +275,7 @@ export type TableCheckboxSelectionConfig = {
   enabled?: boolean;
   selectionMode?: 'single' | 'multiple';
   onSelectionChange?: (selectedIds: Set<string>) => void;
-  getRowId?: (row: JSONValue[], rowIndex: number) => string;
+  getRowId?: (row: JSONValue[], rowIndex: number, originalIndex: number) => string;
   disabledRowIds?: Set<string>;
   /**
    * Controlled-selection overlay. Omitted: today's uncontrolled behavior via
@@ -401,7 +401,7 @@ export type OptionalTableProperties = {
 };
 
 export type TableEventProperties = {
-  onRowClick?: (rowIndex: number, rowData: JSONValue[]) => void;
+  onRowClick?: (rowIndex: number, rowData: JSONValue[], originalIndex: number) => void;
   onSort?: (columnIndex: number, direction: SortDirection) => void;
   /**
    * C2-2: Callback invoked when a cell value changes via an editable element


### PR DESCRIPTION
Completes the sort-stability story started in 2.88.0. That release added `originalIndex` to the cell callbacks but not to `onRowClick` or the checkbox-selection `getRowId` — both still handed consumers the sorted DISPLAY index, so a consumer indexing its own pre-sort rows (or resolving a row id positionally) acts on the wrong row once sorted. This appends `originalIndex` (pre-sort/pre-filter index in the consumer's rows) to both, resolved via the existing reference-keyed `originalIndexByRow` map. `getRowId` previously got the sorted `stableIndex`; it now also gets the true `originalIndex`. Backward compatible (appended arg). **Verified:** `pnpm lint` clean, svelte-check 533 files 0 errors, vitest 94 passed, build + build:wc green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table row click actions now include the row’s original position, making row interactions more reliable after sorting or filtering.
  * Checkbox row selection can now use the original row order when generating row IDs, helping selections stay consistent through table transforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->