### PR TITLE
feat(Table,Tooltip): opt-in header tooltip icons, row-number label, and configurable cell alignment/width

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -551,6 +551,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    text-align: var(--select-value-align, left);
   }
 
   .select-placeholder {
@@ -559,6 +560,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    text-align: var(--select-value-align, left);
   }
 
   .select-search {

--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -543,6 +543,7 @@
     display: inline-flex;
     align-items: center;
     min-width: 0;
+    width: var(--table-interactive-width, auto);
   }
 
   .builtin-action-group {

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -49,7 +49,10 @@
     onSearchChange,
     pagination,
     toolbarSlot,
-    rowNumberColumn = false
+    rowNumberColumn = false,
+    rowNumberLabel = '#',
+    headerTooltipIcon,
+    headerTooltipPosition
   }: TableProperties = $props();
 
   // ─── Keyed column model → positional projection ─────────────────────────────
@@ -612,7 +615,7 @@
           {/if}
           {#if rowNumberColumn}
             <th class="table-header table-row-number-col" class:table-header-sticky={isStickyHeader}
-              >#</th
+              >{rowNumberLabel}</th
             >
           {/if}
           {#each effectiveHeaders as header, colIndex (colIndex)}
@@ -633,8 +636,15 @@
                     : null}
               >
                 {#if headerColumn?.tooltip}
-                  <Tooltip text={headerColumn.tooltip}>
-                    <span class="table-header-label">{header}</span>
+                  <Tooltip
+                    text={headerColumn.tooltip}
+                    position={headerTooltipPosition}
+                    icon={headerTooltipIcon}
+                    iconPosition="trailing"
+                  >
+                    <span class="table-header-label" class:table-header-label-plain={headerTooltipIcon}
+                      >{header}</span
+                    >
                   </Tooltip>
                 {:else}
                   {header}
@@ -990,18 +1000,24 @@
     letter-spacing: var(--table-header-letter-spacing, 0.02em);
     text-transform: var(--table-header-text-transform);
     color: var(--table-header-color, var(--table-header-font-color, #6b7280));
+    border-bottom: var(--table-header-border, var(--table-inner-border, none));
   }
 
   .table-header-content {
     display: flex;
     align-items: center;
     gap: 4px;
+    justify-content: var(--table-header-justify, flex-start);
   }
 
   .table-header-label {
     text-decoration: var(--table-header-tooltip-underline, underline dotted);
     text-underline-offset: 2px;
     cursor: help;
+  }
+
+  .table-header-label-plain {
+    text-decoration: none;
   }
 
   .table-header-filter {
@@ -1256,6 +1272,7 @@
     width: var(--table-row-number-col-width, 48px);
     color: var(--table-row-number-color, #6b7280);
     font-variant-numeric: tabular-nums;
+    text-align: var(--table-row-number-align, var(--table-text-align, left));
   }
 
   /* ── Accessibility ──────────────────────────────────────────────────────── */

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -1,5 +1,6 @@
 import type { JSONValue } from 'type-decoder';
 import type { Snippet } from 'svelte';
+import type { TooltipPosition } from '../Tooltip/properties';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -368,6 +369,16 @@ export type OptionalTableProperties = {
   toolbarSlot?: Snippet<[{ selectedIds: Set<string> }]>;
   /** Prepends a sequential row-number column (1-based, pagination-aware). */
   rowNumberColumn?: boolean;
+  /** Header label for the row-number column. Defaults to `'#'`. */
+  rowNumberLabel?: string;
+  /**
+   * Icon snippet shown after each header label that has a `tooltip` — the
+   * consumer supplies the glyph; the table places it trailing inside the tooltip
+   * trigger. When set, the default underline affordance on those labels is dropped.
+   */
+  headerTooltipIcon?: Snippet;
+  /** Placement of every header tooltip bubble. Defaults to `'top'`. */
+  headerTooltipPosition?: TooltipPosition;
   sortable?: boolean;
   sortableColumns?: number[];
   stickyHeader?: boolean;

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -11,6 +11,7 @@
     classes,
     children,
     icon,
+    iconPosition = 'leading',
     content,
     usePortal = false
   }: TooltipProperties = $props();
@@ -355,10 +356,13 @@
   onfocusout={hideTooltip}
   data-pw={testId}
 >
-  {#if typeof icon === 'function'}
+  {#if typeof icon === 'function' && iconPosition === 'leading'}
     <span class="tooltip-icon" aria-hidden="true">{@render icon()}</span>
   {/if}
   {@render children()}
+  {#if typeof icon === 'function' && iconPosition === 'trailing'}
+    <span class="tooltip-icon" aria-hidden="true">{@render icon()}</span>
+  {/if}
   {#if visible && !usePortal}
     <div
       use:clampInlineBubble

--- a/src/lib/Tooltip/properties.ts
+++ b/src/lib/Tooltip/properties.ts
@@ -12,8 +12,10 @@ export type OptionalTooltipProperties = {
   delay?: number;
   testId?: string | null;
   classes?: string;
-  /** Snippet rendered as a leading icon in the trigger wrapper. No default glyph is provided — consumers supply their own. */
+  /** Snippet rendered as an icon in the trigger wrapper, beside the content. No default glyph is provided — consumers supply their own. Placement is controlled by `iconPosition`. */
   icon?: Snippet;
+  /** Which side of the trigger content the `icon` sits on. Defaults to `'leading'`. */
+  iconPosition?: 'leading' | 'trailing';
   /** Snippet rendered as the bubble body. When provided, replaces the plain `text` string inside the tooltip bubble. */
   content?: Snippet;
   /**


### PR DESCRIPTION
**Changes?**
- Tooltip: add `iconPosition` ('leading' | 'trailing', default 'leading') so the icon snippet can sit on either side of the trigger content
- Table: add `headerTooltipIcon` + `headerTooltipPosition` — forward a consumer-supplied icon and bubble placement to the header tooltip; the underline affordance is dropped when an icon is provided
- Table: add `rowNumberLabel` to override the row-number header (defaults to '#')
- Table: add `--table-header-border`, `--table-row-number-align`, `--table-header-justify` tokens
- Select: add `--select-value-align` token for the trigger value/placeholder
- BuiltinCell: add `--table-interactive-width` so input/select cells can fill their column
- All additions are opt-in; every default preserves current rendering, so existing consumers are unaffected

**Dev Proof**
https://drive.google.com/file/d/1zdAp2Kt3SBmMF6oAh8pFMOSBUB1EPtHK/view?usp=sharing

**Plane Ticket**
https://plane.breezehq.dev/breeze/browse/BZ-4541/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more control over table headers, including a customizable row-number label and tooltip icon placement.
  * Tooltips can now show their icon before or after the text.
  * Select values and placeholders can now align according to a configurable setting.
  * Built-in interactive table cells now support adjustable width for better layout control.
* **Bug Fixes**
  * Improved table header styling and alignment behavior for a more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->