### PR TITLE
fix(ci): run lint on release pull requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main, release]
+  pull_request:
+    branches: [release]
 
 permissions:
   contents: read
@@ -33,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run lint and format checks
+        run: pnpm lint
+
       - name: Build static site
         env:
           BASE_PATH: /svelte-ui-components
@@ -47,12 +52,14 @@ jobs:
           cp dist-wc/index.js build/wc/index.js
 
       - name: Upload Pages artifact
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: build
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -642,8 +642,9 @@
                     icon={headerTooltipIcon}
                     iconPosition="trailing"
                   >
-                    <span class="table-header-label" class:table-header-label-plain={headerTooltipIcon}
-                      >{header}</span
+                    <span
+                      class="table-header-label"
+                      class:table-header-label-plain={headerTooltipIcon}>{header}</span
                     >
                   </Tooltip>
                 {:else}


### PR DESCRIPTION
**Changes?**
- Add lint and format checks to release pull request workflow
- Keep GitHub Pages deployment limited to push events
- Apply Prettier formatting to table header tooltip markup

**Dev Proof** 
<img width="2776" height="2172" alt="image" src="https://github.com/user-attachments/assets/5afd35cc-67d6-4612-a573-63efc01b9aa9" />
