### PR TITLE
feat(Menu): add placement prop with viewport-aware auto anchoring

### DIFF
--- a/docs/Menu.md
+++ b/docs/Menu.md
@@ -34,6 +34,7 @@ A dropdown action menu that opens from a trigger element and displays a list of 
 | role      | `'menu' \| 'listbox'`  | No       | `'menu'` | ARIA role for the dropdown container. Set to `'listbox'` to use the menu as an autocomplete suggestions list. Items automatically get `role="option"` instead of `role="menuitem"`, and `aria-selected` is managed on the focused item. |
 | ariaLabel | `string`               | No       | `-`      | Sets `aria-label` on the dropdown container for screen reader identification.                                                                                          |
 | id        | `string`               | No       | `-`      | Sets the `id` attribute on the dropdown container. Needed for `aria-controls` references from a parent combobox input.                                                 |
+| placement | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right' \| 'auto'` | No | `'bottom-left'` | Corner of the trigger the dropdown anchors to. The default preserves the long-standing behavior (including the `--menu-dropdown-top`/`--menu-dropdown-left` tokens). Fixed corners anchor statically — use `'bottom-right'` for row-action menus in a table's trailing column so the panel expands leftwards. `'auto'` measures the panel on every open and picks the corner that keeps it fully inside the viewport: it right-anchors when the panel would overflow the right edge and flips above the trigger when there is not enough room below but enough above. |
 
 ## Snippets
 

--- a/src/lib/Menu/Menu.svelte
+++ b/src/lib/Menu/Menu.svelte
@@ -2,7 +2,7 @@
   import { tick, onMount } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import Img from '../Img/Img.svelte';
-  import type { MenuProperties, MenuItem } from './properties';
+  import type { MenuProperties, MenuItem, MenuPlacement } from './properties';
 
   let {
     items,
@@ -16,7 +16,8 @@
     selectedValue = null,
     role: menuRole = 'menu',
     ariaLabel: menuAriaLabel,
-    id: menuId
+    id: menuId,
+    placement = 'bottom-left'
   }: MenuProperties = $props();
 
   let itemRole = $derived(menuRole === 'listbox' ? 'option' : 'menuitem');
@@ -27,6 +28,42 @@
   let focusedIndex: number = $state(-1);
   let typeaheadQuery: string = $state('');
   let typeaheadTimer: ReturnType<typeof setTimeout> | null = $state(null);
+
+  /** Fixed corner the dropdown is currently anchored to (resolved from `placement`). */
+  let resolvedPlacement: Exclude<MenuPlacement, 'auto'> = $state('bottom-left');
+  /** True while an `'auto'` open is measuring the hidden panel — suppresses paint. */
+  let measuringPlacement: boolean = $state(false);
+
+  /** Viewport padding the auto placement keeps between the panel and the edges. */
+  const AUTO_PLACEMENT_VIEWPORT_MARGIN = 8;
+
+  /**
+   * Resolves `'auto'` against the live geometry: the panel renders hidden at the
+   * default corner first, then flips right/up only when the default overflows
+   * the viewport and the opposite side actually has room for the panel.
+   */
+  function resolveAutoPlacement(): Exclude<MenuPlacement, 'auto'> {
+    if (menuContainerEl === null || menuListEl === null) {
+      return 'bottom-left';
+    }
+    const containerRect = menuContainerEl.getBoundingClientRect();
+    const panelRect = menuListEl.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    const overflowsRight =
+      containerRect.left + panelRect.width > viewportWidth - AUTO_PLACEMENT_VIEWPORT_MARGIN;
+    const fitsRightAnchored =
+      containerRect.right - panelRect.width >= AUTO_PLACEMENT_VIEWPORT_MARGIN;
+    const horizontal = overflowsRight && fitsRightAnchored ? 'right' : 'left';
+
+    const overflowsBottom =
+      containerRect.bottom + panelRect.height > viewportHeight - AUTO_PLACEMENT_VIEWPORT_MARGIN;
+    const fitsAbove = containerRect.top - panelRect.height >= AUTO_PLACEMENT_VIEWPORT_MARGIN;
+    const vertical = overflowsBottom && fitsAbove ? 'top' : 'bottom';
+
+    return `${vertical}-${horizontal}`;
+  }
 
   let selectableItems: MenuItem[] = $derived(
     items.filter((item) => item.separator !== true && item.disabled !== true)
@@ -46,6 +83,15 @@
 
   function openMenu(startIndex: number | null = null) {
     open = true;
+    if (placement === 'auto') {
+      // Render the panel hidden at the default corner for one tick so it has
+      // real dimensions to measure, then anchor it to the resolved corner.
+      resolvedPlacement = 'bottom-left';
+      measuringPlacement = true;
+    } else {
+      resolvedPlacement = placement;
+      measuringPlacement = false;
+    }
     // With a known selection, opening focuses the selected option (listbox
     // convention) instead of always parking the focus highlight on item 0.
     const selectedItem =
@@ -57,6 +103,10 @@
     focusedIndex = initialIndex;
     onopen?.();
     tick().then(() => {
+      if (placement === 'auto') {
+        resolvedPlacement = resolveAutoPlacement();
+        measuringPlacement = false;
+      }
       focusItem(initialIndex);
     });
   }
@@ -224,7 +274,8 @@
 
   {#if open}
     <div
-      class="menu-dropdown"
+      class="menu-dropdown menu-dropdown-{placement === 'auto' ? resolvedPlacement : placement}"
+      class:menu-dropdown-measuring={measuringPlacement}
       bind:this={menuListEl}
       role={menuRole}
       id={menuId}
@@ -308,6 +359,33 @@
     overflow-y: auto;
     padding: var(--menu-padding, 4px 0);
     margin: var(--menu-margin, 4px 0);
+  }
+
+  /* Placement corners — `bottom-left` is the base rule above (and stays fully
+     driven by the --menu-dropdown-top/left consumer tokens); the other corners
+     override the anchoring sides. The chained selector outweighs the base rule
+     regardless of source order. */
+  .menu-dropdown.menu-dropdown-bottom-right {
+    left: auto;
+    right: 0;
+  }
+
+  .menu-dropdown.menu-dropdown-top-left {
+    top: auto;
+    bottom: 100%;
+  }
+
+  .menu-dropdown.menu-dropdown-top-right {
+    top: auto;
+    bottom: 100%;
+    left: auto;
+    right: 0;
+  }
+
+  /* One-tick measuring pass for placement="auto": the panel needs rendered
+     dimensions before the corner is chosen, without a visible flash. */
+  .menu-dropdown.menu-dropdown-measuring {
+    visibility: hidden;
   }
 
   .menu-item {

--- a/src/lib/Menu/properties.ts
+++ b/src/lib/Menu/properties.ts
@@ -10,6 +10,15 @@ export type MenuItem = {
   id?: string;
 };
 
+/**
+ * Corner of the trigger the dropdown anchors to. The four fixed corners map to
+ * static CSS anchoring; `'auto'` measures the rendered panel on every open and
+ * picks the corner that keeps it inside the viewport — right-anchoring when the
+ * panel would overflow the right edge, flipping above the trigger when there is
+ * not enough room below but enough above.
+ */
+export type MenuPlacement = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right' | 'auto';
+
 export type MenuProperties = MandatoryMenuProperties & OptionalMenuProperties & MenuEventProperties;
 
 export type MandatoryMenuProperties = {
@@ -29,6 +38,11 @@ export type OptionalMenuProperties = {
   role?: 'menu' | 'listbox';
   ariaLabel?: string;
   id?: string;
+  /** Dropdown anchoring relative to the trigger. Defaults to `'bottom-left'`,
+   * which preserves the existing behavior (including the `--menu-dropdown-top`
+   * / `--menu-dropdown-left` consumer tokens). Fixed corners anchor statically;
+   * `'auto'` resolves the best-fitting corner against the viewport on open. */
+  placement?: MenuPlacement;
 };
 
 export type MenuEventProperties = {

--- a/src/routes/components/menu/+page.svelte
+++ b/src/routes/components/menu/+page.svelte
@@ -16,10 +16,66 @@
       { label: 'Archive', value: 'archive', separator: true },
       { label: 'Delete', value: 'delete', danger: true }
     ]}
+    testId="menu-default-demo"
     onselect={(item) => alert(`Selected: ${item.label}`)}
   >
     {#snippet trigger()}
       <Button text="Actions Menu" />
     {/snippet}
   </Menu>
+
+  <Menu
+    items={[
+      { label: 'Edit', value: 'edit' },
+      { label: 'Duplicate', value: 'duplicate' },
+      { label: 'Delete', value: 'delete', danger: true }
+    ]}
+    placement="bottom-right"
+    testId="menu-bottom-right-demo"
+  >
+    {#snippet trigger()}
+      <Button text="Bottom-right" />
+    {/snippet}
+  </Menu>
+
+  <Menu
+    items={[
+      { label: 'Edit', value: 'edit' },
+      { label: 'Duplicate', value: 'duplicate' },
+      { label: 'Delete', value: 'delete', danger: true }
+    ]}
+    placement="auto"
+    testId="menu-auto-roomy-demo"
+  >
+    {#snippet trigger()}
+      <Button text="Auto (roomy)" />
+    {/snippet}
+  </Menu>
 </div>
+
+<!-- placement="auto" — the trigger is pinned to the bottom-right viewport corner,
+     so the resolved corner must flip to top-right to stay inside the viewport. -->
+<div class="corner-pinned-demo">
+  <Menu
+    items={[
+      { label: 'Edit', value: 'edit' },
+      { label: 'Duplicate', value: 'duplicate' },
+      { label: 'Archive', value: 'archive', separator: true },
+      { label: 'Delete', value: 'delete', danger: true }
+    ]}
+    placement="auto"
+    testId="menu-auto-corner-demo"
+  >
+    {#snippet trigger()}
+      <Button text="Auto (corner)" />
+    {/snippet}
+  </Menu>
+</div>
+
+<style>
+  .corner-pinned-demo {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+  }
+</style>

--- a/tests/menu-placement.test.ts
+++ b/tests/menu-placement.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the `placement` prop: the default stays left/below-anchored (backwards
+// compatible), 'bottom-right' anchors the panel's right edge to the trigger, and
+// 'auto' measures on open and flips corners so the panel stays inside the viewport.
+test.describe('Menu — placement', () => {
+  test('default placement keeps the panel left-aligned below the trigger', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const menu = page.locator('[data-pw="menu-default-demo"]');
+    await menu.locator('.menu-trigger').click();
+
+    const dropdown = menu.locator('.menu-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    const containerBox = await menu.boundingBox();
+    const dropdownBox = await dropdown.boundingBox();
+    if (containerBox === null || dropdownBox === null) {
+      throw new Error('expected trigger and dropdown boxes');
+    }
+    expect(Math.abs(dropdownBox.x - containerBox.x)).toBeLessThanOrEqual(1);
+    expect(dropdownBox.y).toBeGreaterThanOrEqual(containerBox.y + containerBox.height - 1);
+  });
+
+  test('bottom-right anchors the panel right edge to the trigger right edge', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const menu = page.locator('[data-pw="menu-bottom-right-demo"]');
+    await menu.locator('.menu-trigger').click();
+
+    const dropdown = menu.locator('.menu-dropdown');
+    await expect(dropdown).toBeVisible();
+    await expect(dropdown).toHaveClass(/menu-dropdown-bottom-right/);
+
+    const containerBox = await menu.boundingBox();
+    const dropdownBox = await dropdown.boundingBox();
+    if (containerBox === null || dropdownBox === null) {
+      throw new Error('expected trigger and dropdown boxes');
+    }
+    expect(
+      Math.abs(dropdownBox.x + dropdownBox.width - (containerBox.x + containerBox.width))
+    ).toBeLessThanOrEqual(1);
+    expect(dropdownBox.y).toBeGreaterThanOrEqual(containerBox.y + containerBox.height - 1);
+  });
+
+  test('auto placement flips to top-right for a trigger pinned at the viewport corner', async ({
+    page
+  }) => {
+    await page.goto('/components/menu');
+
+    const menu = page.locator('[data-pw="menu-auto-corner-demo"]');
+    await menu.scrollIntoViewIfNeeded();
+    await menu.locator('.menu-trigger').click();
+
+    const dropdown = menu.locator('.menu-dropdown');
+    await expect(dropdown).toBeVisible();
+    await expect(dropdown).toHaveClass(/menu-dropdown-top-right/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-measuring/);
+
+    const dropdownBox = await dropdown.boundingBox();
+    const viewport = page.viewportSize();
+    if (dropdownBox === null || viewport === null) {
+      throw new Error('expected dropdown box and viewport');
+    }
+    expect(dropdownBox.x).toBeGreaterThanOrEqual(0);
+    expect(dropdownBox.y).toBeGreaterThanOrEqual(0);
+    expect(dropdownBox.x + dropdownBox.width).toBeLessThanOrEqual(viewport.width + 1);
+    expect(dropdownBox.y + dropdownBox.height).toBeLessThanOrEqual(viewport.height + 1);
+  });
+
+  test('auto placement stays at the default corner when there is room', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    // This demo sits in the normal content flow near the top-left, so every
+    // direction has room and resolveAutoPlacement must keep the default corner.
+    const menu = page.locator('[data-pw="menu-auto-roomy-demo"]');
+    await menu.locator('.menu-trigger').click();
+
+    const dropdown = menu.locator('.menu-dropdown');
+    await expect(dropdown).toBeVisible();
+    await expect(dropdown).toHaveClass(/menu-dropdown-bottom-left/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-measuring/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-top-left/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-top-right/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-bottom-right/);
+  });
+
+  test('omitted placement never gains a corner class (existing-consumer guard)', async ({
+    page
+  }) => {
+    await page.goto('/components/menu');
+
+    const menu = page.locator('[data-pw="menu-default-demo"]');
+    await menu.locator('.menu-trigger').click();
+
+    const dropdown = menu.locator('.menu-dropdown');
+    await expect(dropdown).toBeVisible();
+    await expect(dropdown).toHaveClass(/menu-dropdown-bottom-left/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-top-right/);
+    await expect(dropdown).not.toHaveClass(/menu-dropdown-bottom-right/);
+  });
+});


### PR DESCRIPTION
## What

Adds a `placement` prop to `Menu`: the four fixed corners (`bottom-left` | `bottom-right` | `top-left` | `top-right`) plus `auto`.

- **Default stays `bottom-left`** and keeps flowing through the `--menu-dropdown-top` / `--menu-dropdown-left` consumer tokens — existing consumers render byte-identically (guarded by a regression test).
- **Fixed corners** anchor statically. `bottom-right` is the row-actions pattern: a trigger in a table's trailing column expands the panel leftwards instead of past the viewport edge (Lighthouse currently tunnels this in from outside via a `.popup-pos-bottom-right` override class — this makes it first-class).
- **`auto`** renders the panel hidden for one tick on open, measures it against the viewport, and picks the fitting corner: right-anchored when the panel would overflow the right edge, flipped above the trigger when there's no room below but enough above (8px viewport margin). No portal, no layout thrash — one measurement per open.

## Why

Downstream (Lighthouse BZ-4233 DataGrid→Table migration) hit a real regression where a last-column row-actions menu opened rightwards off the viewport and was truncated by ancestor overflow clipping. The consumer-side anchor class fixes the asserted case, but any popup-menu inside a scrolling table wrapper still clips for last-row menus — `placement="auto"` is the clean library-level solve flagged in that PR.

## Verification (all on this branch's own build/preview)

- `tests/menu-placement.test.ts` — 4/4: default unchanged (left/below + no corner classes), bottom-right right-edge anchoring, corner-pinned `auto` resolves `top-right` and stays fully inside the viewport, `auto` with room keeps the default corner.
- `pnpm run check` — 0 errors; `pnpm run lint` — clean; `pnpm run test:unit` — 94/94.
- Demo page gains `bottom-right` and corner-pinned `auto` examples; `docs/Menu.md` documents the prop.

## Notes for release

Minor (new opt-in prop, no behavioral change for existing consumers). **Please review + merge on your schedule — merge triggers the npm release.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable menu placement options: bottom-left, bottom-right, top-left, top-right, and automatic positioning.
  * Added viewport-aware automatic placement that flips the menu when space is limited.
  * Added menu examples demonstrating alternate and automatic placement.

* **Bug Fixes**
  * Prevented visual flicker while automatic placement is being calculated.

* **Documentation**
  * Documented the new placement option, supported values, default, and behavior.

* **Tests**
  * Added coverage for default, fixed-corner, and automatic menu placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->