### PR TITLE
fix(Tooltip,PieChart,SankeyChart): action viewport clamping, pie label engine, measured widths

### DIFF
--- a/docs/PieChart.md
+++ b/docs/PieChart.md
@@ -127,6 +127,17 @@ The `type` field on the returned API is always `'donut-chart'`, regardless of wh
 </PieChart>
 ```
 
+### Label overflow & collisions
+
+Slice labels (`showLabels` / `showValues`) are laid out defensively so a crowded pie never renders
+overlapping text:
+
+- Each label is truncated against its real rendered width (canvas-measured, SSR-safe fallback) to
+  the horizontal room the chart actually has at that label's position.
+- Labels that would collide are dropped, larger slices winning; `labelPosition="inside"` labels are
+  also dropped when their wedge is thinner than one text line.
+- Every dropped or truncated label keeps its full text on the slice tooltip and `aria-label`.
+
 ## Props
 
 | Prop               | Type                               | Required | Default      | Description                                                                                                                                                                              |

--- a/docs/SankeyChart.md
+++ b/docs/SankeyChart.md
@@ -117,9 +117,10 @@ When you want the overall flow structure to remain fully readable while the user
 
 Node labels are laid out defensively so a crowded chart never renders overlapping text:
 
-- Labels are truncated with a width-aware estimate (per character class, not a flat average), so
-  uppercase-heavy labels cannot run under a neighbouring column's bars. Middle columns also budget
-  for `dataLabelOffsetX`.
+- Labels are truncated against their real rendered width (canvas-measured, with an SSR-safe
+  heuristic fallback), so uppercase-heavy labels cannot run under a neighbouring column's bars and
+  the right label gutter reserves exactly the space the longest sink label needs. Middle columns
+  also budget for `dataLabelOffsetX`.
 - Within each column, when two node centres sit closer than one label line, the smaller-value
   node's label is dropped entirely rather than overlapping.
 - Any truncated or dropped label keeps its full text available via the node's hover `<title>`

--- a/docs/Tooltip.md
+++ b/docs/Tooltip.md
@@ -65,7 +65,7 @@ Override these custom properties to theme the component.
 
 ## Tooltip Action
 
-The `tooltip` Svelte action is a renderless alternative to the `<Tooltip>` component. It attaches hover and focus listeners directly to the host element without injecting a wrapper `<div>`, so it does not affect flex-child sizing inside toolbars and icon rows. The bubble is always mounted on `document.body` with `position: fixed` coordinates, so it is never clipped by `overflow: hidden` ancestors.
+The `tooltip` Svelte action is a renderless alternative to the `<Tooltip>` component. It attaches hover and focus listeners directly to the host element without injecting a wrapper `<div>`, so it does not affect flex-child sizing inside toolbars and icon rows. The bubble is always mounted on `document.body` with `position: fixed` coordinates, so it is never clipped by `overflow: hidden` ancestors. The bubble is measured after mounting, clamped so it never crosses the viewport edge (8px margin), and flipped to the opposite side when the preferred side has no room; the arrow stays anchored over the trigger even when the bubble shifts.
 
 ```svelte
 <script>

--- a/src/lib/PieChart/PieChart.svelte
+++ b/src/lib/PieChart/PieChart.svelte
@@ -10,7 +10,11 @@
   import { computePieLayout } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
+  import { measureText, readCssVarPx } from '$lib/_chart/measure';
+  import { truncateToWidth, placedLabelRect, dropOverlapping } from '$lib/_chart/labels';
+  import type { LabelRect } from '$lib/_chart/labels';
   import type { LegendItem } from '$lib/_chart/types';
+  import { SvelteMap } from 'svelte/reactivity';
 
   // ── Props ──────────────────────────────────────────────────────
 
@@ -153,6 +157,76 @@
     data.map((d, i) => ({ label: d.label, color: d.color ?? getColor(i) }))
   );
 
+  // ── Label engine ───────────────────────────────────────────────
+  // A crowded pie (many slices, long labels) used to render every label
+  // unconditionally at its mid-angle: stacked unreadable text that also ran
+  // past the chart box. Labels are now measured, truncated to the horizontal
+  // room the chart actually has, gated on the slice's arc length (inside
+  // position), and de-collided with larger slices winning. Dropped or
+  // truncated text stays available on the tooltip and aria-label.
+  let visibleSliceLabels = $derived.by(() => {
+    const visible = new SvelteMap<number, string>();
+    if ((!showLabels && !showValues) || chartWidth <= 0) {
+      return visible;
+    }
+    const font = {
+      size: containerEl ? readCssVarPx(containerEl, '--piechart-label-font-size', 12) : 12
+    };
+    const lineHeight = measureText('Ag', font).height;
+
+    type LabelCandidate = { index: number; value: number; text: string; rect: LabelRect };
+    const candidates: LabelCandidate[] = [];
+    for (const slice of slices) {
+      const parts: string[] = [];
+      if (showLabels) {
+        parts.push(slice.label);
+      }
+      if (showValues) {
+        parts.push(pctFormat(slice.value));
+      }
+      const raw = parts.join(' ').trim();
+      if (raw.length === 0) {
+        continue;
+      }
+      const absX = cx + slice.labelX;
+      const absY = cy + slice.labelY;
+      // text-anchor is middle, so the budget is twice the room to the nearer edge.
+      const budget = Math.max(0, Math.min(absX, chartWidth - absX) * 2 - 8);
+      const labelRadius = labelPosition === 'outside' ? outerR : (innerR + outerR) / 2;
+      const arcLength = (slice.endAngle - slice.startAngle) * labelRadius;
+      // An inside label sits ON its wedge — hide it when the wedge is thinner
+      // than one text line (outside labels rely on the collision pass instead).
+      if (labelPosition === 'inside' && arcLength < lineHeight) {
+        continue;
+      }
+      const text = truncateToWidth(raw, budget, font);
+      if (text === '') {
+        continue;
+      }
+      const size = measureText(text, font);
+      candidates.push({
+        index: slice.index,
+        value: slice.value,
+        text,
+        rect: placedLabelRect(
+          { x: absX, y: absY, textAnchor: 'middle', dominantBaseline: 'middle' },
+          size
+        )
+      });
+    }
+
+    // Feed the greedy first-come collision pass in value order so the larger
+    // slice keeps its label whenever two collide.
+    const ordered = [...candidates].sort((a, b) => b.value - a.value);
+    const keptFlags = dropOverlapping(ordered.map((candidate) => candidate.rect));
+    ordered.forEach((candidate, orderedIndex) => {
+      if (keptFlags[orderedIndex]) {
+        visible.set(candidate.index, candidate.text);
+      }
+    });
+    return visible;
+  });
+
   let centerBoxSize = $derived(innerR > 0 ? Math.max(0, innerR * 1.3) : 0);
 
   // The foreignObject for the center snippet is positioned relative to the <g>
@@ -243,19 +317,15 @@
             onmouseleave={handleLeave}
             onclick={() => onsliceclick?.({ index: slice.index, slice: data[slice.index] })}
           />
-          {#if showLabels || showValues}
+          {#if visibleSliceLabels.has(slice.index)}
             <text
               class="slice-label"
               class:label-outside={labelPosition === 'outside'}
               x={slice.labelX}
               y={slice.labelY}
               text-anchor="middle"
-              dominant-baseline="middle"
+              dominant-baseline="middle">{visibleSliceLabels.get(slice.index)}</text
             >
-              {#if showLabels}{slice.label}{/if}
-              {#if showValues}
-                {pctFormat(slice.value)}{/if}
-            </text>
           {/if}
         {/each}
 

--- a/src/lib/SankeyChart/SankeyChart.svelte
+++ b/src/lib/SankeyChart/SankeyChart.svelte
@@ -5,6 +5,8 @@
   import { computeSankeyLayout } from '$lib/_chart/geometry';
   import { getColor } from '$lib/_chart/colors';
   import { formatNumber } from '$lib/_chart/format';
+  import { measureText, readCssVarPx } from '$lib/_chart/measure';
+  import { truncateToWidth } from '$lib/_chart/labels';
   import { DEFAULT_CHART_CORNER_RADIUS, DEFAULT_CHART_MAX_HEIGHT } from '$lib/_chart/types';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
@@ -52,54 +54,20 @@
   let format = $derived(valueFormat ?? formatNumber);
   let isEmpty = $derived(nodes.length === 0);
   const MARGIN = 40;
-  const LABEL_CHAR_PX = 7.2; // ≈ 0.6em at the 12px default label size
   // A 12px label's rendered line box measures ~16px (≈1.33em) across common
   // font stacks; two label centres closer than this overlap visibly.
   const LABEL_LINE_PX = 16;
 
-  // Per-character width estimate at the 12px default label size. A flat
-  // 7.2px/char average underestimates uppercase-heavy labels ("OTP SKIPPED
-  // (1,234)" is ~8.2px/char), so "truncated" labels still overflowed their
-  // budget and slid under the next column's node bar.
-  const estimateCharWidth = (ch: string): number => {
-    if (/[mwMW@]/.test(ch)) {
-      return 10.6;
-    }
-    if (/[A-Z0-9_#%&]/.test(ch)) {
-      return 8.2;
-    }
-    if (/[iljtfr.,:;'’()[\]!|]/.test(ch)) {
-      return 3.6;
-    }
-    if (ch === ' ') {
-      return 3.8;
-    }
-    return 6.6;
-  };
-
-  const estimateTextWidth = (text: string): number => {
-    let width = 0;
-    for (const ch of text) {
-      width += estimateCharWidth(ch);
-    }
-    return width;
-  };
-
-  // Trim `text` (appending an ellipsis) until its estimated width fits
-  // `available` px. Returns '' when even 3 chars + ellipsis cannot fit —
-  // callers hide the label and rely on the <title> tooltip instead.
-  const fitTextToWidth = (text: string, available: number): string => {
-    if (estimateTextWidth(text) <= available) {
-      return text;
-    }
-    for (let keep = text.length - 1; keep >= 3; keep--) {
-      const candidate = text.slice(0, keep) + '…';
-      if (estimateTextWidth(candidate) <= available) {
-        return candidate;
-      }
-    }
-    return '';
-  };
+  // Real text measurement via the shared canvas-backed helper (exact on the
+  // client, 0.6em/char heuristic under SSR/tests). Character estimates used
+  // to both over-reserve the right label gutter (dead canvas) and under-budget
+  // uppercase-heavy labels (text sliding under the next column's bars).
+  let labelFont = $derived({
+    size: containerEl ? readCssVarPx(containerEl, '--sankey-label-font-size', 12) : 12
+  });
+  let colLabelFont = $derived({
+    size: containerEl ? readCssVarPx(containerEl, '--sankey-col-label-font-size', 11) : 11
+  });
 
   // Final-column labels render to the RIGHT of their node; the bare 40px margin is
   // nowhere near enough for real funnel labels ("PARTIALLY_FAILED (1,234)"), so they
@@ -118,8 +86,8 @@
       return 0;
     }
     const longestPx =
-      Math.max(...sinkLabels.map((label) => estimateTextWidth(label))) +
-      (showValues ? 9 * LABEL_CHAR_PX : 0);
+      Math.max(...sinkLabels.map((label) => measureText(label, labelFont).width)) +
+      (showValues ? measureText(' (999,999)', labelFont).width : 0);
     const wanted = longestPx + 10 + dataLabelOffsetX;
     // Cap the reservation so labels can never squeeze the diagram below 3/4 width,
     // and floor at 0 — a negative dataLabelOffsetX must not inflate the plot
@@ -175,7 +143,7 @@
   // column count grow; untruncated they collide into one unreadable run. Clip to
   // the column pitch with an ellipsis — the full text stays on the <title>.
   const truncateColumnLabel = (text: string): string => {
-    return fitTextToWidth(text, Math.max(0, colWidth - 6));
+    return truncateToWidth(text, Math.max(0, colWidth - 6), colLabelFont);
   };
 
   const truncateLabel = (text: string, column: number): string => {
@@ -194,7 +162,7 @@
           : Math.max(0, colWidth - nodeWidth - 12 - dataLabelOffsetX);
     // No usable room — hide the label rather than force text that would overflow;
     // the full text is still reachable via the node's <title> on hover.
-    return fitTextToWidth(text, available);
+    return truncateToWidth(text, available, labelFont);
   };
 
   // Vertical label de-collision: labels sit at each node's centre-y, so two

--- a/src/lib/Tooltip/tooltip-action.ts
+++ b/src/lib/Tooltip/tooltip-action.ts
@@ -31,75 +31,25 @@ export const tooltip = (
   const bubbleId = `sui-tooltip-${++tooltipIdCounter}`;
 
   const OFFSET = 8; // px — matches --tooltip-offset default
+  const EDGE_MARGIN = 8; // px — minimum air between the bubble and the viewport edge
+  const ARROW_INSET = 9; // px — arrow centre never closer than this to a bubble corner
 
-  type PositionCoords = {
-    top: number;
-    left: number;
-    transform: string;
-    arrowTop: string;
-    arrowLeft: string;
-    arrowRight: string;
-    arrowTransform: string;
-    arrowBorderWidth: string;
-    arrowBorderColor: string;
+  const oppositeOf = (side: TooltipPosition): TooltipPosition => {
+    if (side === 'top') {
+      return 'bottom';
+    }
+    if (side === 'bottom') {
+      return 'top';
+    }
+    if (side === 'left') {
+      return 'right';
+    }
+    return 'left';
   };
 
-  const computeCoords = (rect: DOMRect, pos: TooltipPosition): PositionCoords => {
-    const arrowSize = 5; // px — matches --tooltip-arrow-size default
-    const bg = 'var(--tooltip-arrow-color,var(--tooltip-background,#333333))';
-    const t = 'transparent';
-
-    if (pos === 'top') {
-      return {
-        top: rect.top - OFFSET,
-        left: rect.left + rect.width / 2,
-        transform: 'translate(-50%, -100%)',
-        arrowTop: '100%',
-        arrowLeft: '50%',
-        arrowRight: '',
-        arrowTransform: 'translateX(-50%)',
-        arrowBorderWidth: `${arrowSize}px ${arrowSize}px 0 ${arrowSize}px`,
-        arrowBorderColor: `${bg} ${t} ${t} ${t}`
-      };
-    }
-    if (pos === 'bottom') {
-      return {
-        top: rect.bottom + OFFSET,
-        left: rect.left + rect.width / 2,
-        transform: 'translate(-50%, 0)',
-        arrowTop: `-${arrowSize}px`,
-        arrowLeft: '50%',
-        arrowRight: '',
-        arrowTransform: 'translateX(-50%)',
-        arrowBorderWidth: `0 ${arrowSize}px ${arrowSize}px ${arrowSize}px`,
-        arrowBorderColor: `${t} ${t} ${bg} ${t}`
-      };
-    }
-    if (pos === 'left') {
-      return {
-        top: rect.top + rect.height / 2,
-        left: rect.left - OFFSET,
-        transform: 'translate(-100%, -50%)',
-        arrowTop: '50%',
-        arrowLeft: '100%',
-        arrowRight: '',
-        arrowTransform: 'translateY(-50%)',
-        arrowBorderWidth: `${arrowSize}px 0 ${arrowSize}px ${arrowSize}px`,
-        arrowBorderColor: `${t} ${t} ${t} ${bg}`
-      };
-    }
-    // right
-    return {
-      top: rect.top + rect.height / 2,
-      left: rect.right + OFFSET,
-      transform: 'translate(0, -50%)',
-      arrowTop: '50%',
-      arrowLeft: '',
-      arrowRight: `${arrowSize}px`,
-      arrowTransform: 'translateY(-50%)',
-      arrowBorderWidth: `${arrowSize}px ${arrowSize}px ${arrowSize}px 0`,
-      arrowBorderColor: `${t} ${bg} ${t} ${t}`
-    };
+  // min > max (bubble wider/taller than the viewport) degrades to the raw value.
+  const clampValue = (value: number, min: number, max: number): number => {
+    return max < min ? value : Math.min(Math.max(value, min), max);
   };
 
   /**
@@ -154,6 +104,13 @@ export const tooltip = (
   /**
    * Compute and apply `top`/`left` fixed coordinates plus arrow styles based on the
    * current bounding rect of the host element and the active `position` option.
+   *
+   * The bubble is measured after mounting and then (1) FLIPPED to the opposite
+   * side when the preferred side has no room but the opposite side does, and
+   * (2) CLAMPED so it never crosses the viewport edge — a tooltip on a trigger
+   * near the screen edge used to spill off-screen or cover the nav beneath it.
+   * The arrow is positioned in bubble-local pixels anchored to the TRIGGER
+   * centre, so it keeps pointing at the trigger even when the bubble shifts.
    */
   const positionBubble = (): void => {
     if (bubbleEl === null || arrowEl === null) {
@@ -161,21 +118,91 @@ export const tooltip = (
     }
 
     const rect = node.getBoundingClientRect();
-    const pos: TooltipPosition = currentOptions.position ?? 'top';
-    const coords = computeCoords(rect, pos);
+    const preferred: TooltipPosition = currentOptions.position ?? 'top';
+    const arrowSize = 5; // px — matches --tooltip-arrow-size default
+    const bg = 'var(--tooltip-arrow-color,var(--tooltip-background,#333333))';
+    const t = 'transparent';
 
-    bubbleEl.style.top = `${coords.top}px`;
-    bubbleEl.style.left = `${coords.left}px`;
-    bubbleEl.style.transform = coords.transform;
+    // Stubbed DOMs (unit tests) report no dimensions; clamping then no-ops.
+    const bubbleWidth = bubbleEl.offsetWidth || 0;
+    const bubbleHeight = bubbleEl.offsetHeight || 0;
+    const viewportWidth =
+      typeof window !== 'undefined' && window.innerWidth > 0
+        ? window.innerWidth
+        : Number.POSITIVE_INFINITY;
+    const viewportHeight =
+      typeof window !== 'undefined' && window.innerHeight > 0
+        ? window.innerHeight
+        : Number.POSITIVE_INFINITY;
 
-    arrowEl.style.top = coords.arrowTop;
-    arrowEl.style.left = coords.arrowLeft;
-    if (coords.arrowRight !== '') {
-      arrowEl.style.right = coords.arrowRight;
+    const fits = (side: TooltipPosition): boolean => {
+      if (side === 'top') {
+        return rect.top - OFFSET - bubbleHeight >= EDGE_MARGIN;
+      }
+      if (side === 'bottom') {
+        return rect.bottom + OFFSET + bubbleHeight <= viewportHeight - EDGE_MARGIN;
+      }
+      if (side === 'left') {
+        return rect.left - OFFSET - bubbleWidth >= EDGE_MARGIN;
+      }
+      return rect.right + OFFSET + bubbleWidth <= viewportWidth - EDGE_MARGIN;
+    };
+
+    const side: TooltipPosition =
+      !fits(preferred) && fits(oppositeOf(preferred)) ? oppositeOf(preferred) : preferred;
+
+    let top: number;
+    let left: number;
+    if (side === 'top' || side === 'bottom') {
+      top = side === 'top' ? rect.top - OFFSET - bubbleHeight : rect.bottom + OFFSET;
+      left = clampValue(
+        rect.left + rect.width / 2 - bubbleWidth / 2,
+        EDGE_MARGIN,
+        viewportWidth - EDGE_MARGIN - bubbleWidth
+      );
+    } else {
+      left = side === 'left' ? rect.left - OFFSET - bubbleWidth : rect.right + OFFSET;
+      top = clampValue(
+        rect.top + rect.height / 2 - bubbleHeight / 2,
+        EDGE_MARGIN,
+        viewportHeight - EDGE_MARGIN - bubbleHeight
+      );
     }
-    arrowEl.style.transform = coords.arrowTransform;
-    arrowEl.style.borderWidth = coords.arrowBorderWidth;
-    arrowEl.style.borderColor = coords.arrowBorderColor;
+
+    bubbleEl.style.top = `${top}px`;
+    bubbleEl.style.left = `${left}px`;
+    bubbleEl.style.transform = 'none';
+
+    arrowEl.style.right = '';
+    if (side === 'top' || side === 'bottom') {
+      const arrowLeft = clampValue(
+        rect.left + rect.width / 2 - left,
+        ARROW_INSET,
+        Math.max(ARROW_INSET, bubbleWidth - ARROW_INSET)
+      );
+      arrowEl.style.left = `${arrowLeft}px`;
+      arrowEl.style.top = side === 'top' ? '100%' : `-${arrowSize}px`;
+      arrowEl.style.transform = 'translateX(-50%)';
+      arrowEl.style.borderWidth =
+        side === 'top'
+          ? `${arrowSize}px ${arrowSize}px 0 ${arrowSize}px`
+          : `0 ${arrowSize}px ${arrowSize}px ${arrowSize}px`;
+      arrowEl.style.borderColor = side === 'top' ? `${bg} ${t} ${t} ${t}` : `${t} ${t} ${bg} ${t}`;
+    } else {
+      const arrowTop = clampValue(
+        rect.top + rect.height / 2 - top,
+        ARROW_INSET,
+        Math.max(ARROW_INSET, bubbleHeight - ARROW_INSET)
+      );
+      arrowEl.style.top = `${arrowTop}px`;
+      arrowEl.style.left = side === 'left' ? '100%' : `-${arrowSize}px`;
+      arrowEl.style.transform = 'translateY(-50%)';
+      arrowEl.style.borderWidth =
+        side === 'left'
+          ? `${arrowSize}px 0 ${arrowSize}px ${arrowSize}px`
+          : `${arrowSize}px ${arrowSize}px ${arrowSize}px 0`;
+      arrowEl.style.borderColor = side === 'left' ? `${t} ${t} ${t} ${bg}` : `${t} ${bg} ${t} ${t}`;
+    }
   };
 
   const show = (): void => {

--- a/src/routes/components/pie-chart/+page.svelte
+++ b/src/routes/components/pie-chart/+page.svelte
@@ -18,6 +18,42 @@
     { label: 'Entertainment', value: 150, color: '#59a14f' }
   ];
 
+  // Crowded pie — many categories, long labels, a fat head and a long tail of
+  // slivers. This is the shape that used to stack every label into an
+  // unreadable pile around the 3 o'clock / 9 o'clock regions.
+  const crowdedSources = Array.from({ length: 24 }, (_, index) => {
+    const names = [
+      'Organic Search Traffic',
+      'Direct Navigation',
+      'Facebook Paid Campaigns',
+      'Instagram Influencer Posts',
+      'Google Shopping Ads',
+      'Email Newsletter Clicks',
+      'Affiliate Partner Network',
+      'YouTube Product Reviews',
+      'WhatsApp Referral Shares',
+      'Pinterest Boards',
+      'TikTok Organic Mentions',
+      'Reddit Community Threads',
+      'Quora Answer Links',
+      'LinkedIn Company Page',
+      'Twitter / X Promotions',
+      'Snapchat Story Ads',
+      'Telegram Channel Posts',
+      'Push Notification Reopens',
+      'SMS Campaign Clicks',
+      'QR Code Scans In-Store',
+      'Marketplace Cross-Listing',
+      'Price Comparison Engines',
+      'Cashback Portal Referrals',
+      'Browser Extension Deals'
+    ];
+    return {
+      label: names[index],
+      value: index < 3 ? 4000 - index * 900 : Math.max(30, 700 - index * 30)
+    };
+  });
+
   // ── Highlight hook demo ────────────────────────────────────────
   let chartApi: ChartHighlightAPI | null = $state(null);
   let highlightedSlice = $state<number | null>(null);
@@ -54,6 +90,35 @@
 <h3>With Legend</h3>
 <div class="demo-row" style="max-width: 400px;">
   <PieChart data={expenses} innerRadius={0.5} showLegend />
+</div>
+
+<h3>
+  Crowded — 24 sources with long labels and sliver slices (labels measure, truncate, de-collide;
+  every value stays on the hover tooltip)
+</h3>
+<div class="demo-row" style="max-width: 640px;">
+  <PieChart
+    data={crowdedSources}
+    showLabels
+    showValues
+    labelPosition="outside"
+    testId="pie-crowded-chart"
+  />
+</div>
+
+<h3>All-zero values — degrades to the empty state, never NaN geometry</h3>
+<div class="demo-row" style="max-width: 400px;">
+  <PieChart
+    data={[
+      { label: 'A', value: 0 },
+      { label: 'B', value: 0 }
+    ]}
+    testId="pie-all-zero"
+  >
+    {#snippet empty()}
+      <p>No distribution data yet.</p>
+    {/snippet}
+  </PieChart>
 </div>
 
 <h3>Delta Badge — positive change</h3>

--- a/src/routes/components/tooltip/+page.svelte
+++ b/src/routes/components/tooltip/+page.svelte
@@ -159,3 +159,31 @@
     Forward
   </button>
 </div>
+
+<h3>Edge clamping — the bubble never leaves the viewport, the arrow never leaves the trigger</h3>
+<p>
+  Triggers hugging a viewport edge used to spill their bubble off-screen (the action centred it with
+  a bare <code>translate(-50%)</code>). The bubble now clamps to the viewport with an 8px margin and
+  flips to the opposite side when the preferred side has no room, while the arrow stays anchored to
+  the trigger.
+</p>
+<div class="demo-row" style="justify-content: space-between; width: 100%;">
+  <button
+    data-pw="tooltip-edge-left"
+    use:tooltip={{
+      text: 'A long tooltip on a left-edge trigger that used to spill past the viewport edge',
+      position: 'bottom'
+    }}
+  >
+    Left-edge trigger
+  </button>
+  <button
+    data-pw="tooltip-edge-right"
+    use:tooltip={{
+      text: 'A long tooltip on a right-edge trigger that used to spill past the viewport edge',
+      position: 'bottom'
+    }}
+  >
+    Right-edge trigger
+  </button>
+</div>

--- a/tests/pie-label-engine.spec.ts
+++ b/tests/pie-label-engine.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+
+// The crowded demo (24 sources, long labels, sliver slices) is the shape that
+// used to render every label unconditionally at its mid-angle — stacked
+// unreadable text spilling past the chart box. The engine invariant: visible
+// labels never overlap each other, never leave the chart box, and slivers
+// drop their labels (full text stays on the tooltip / aria-label).
+test.describe('PieChart label engine', () => {
+  test('crowded pie renders zero overlapping labels, all inside the chart box', async ({
+    page
+  }) => {
+    await page.goto('/components/pie-chart');
+
+    const chart = page.getByTestId('pie-crowded-chart');
+    await expect(chart.locator('.slice').first()).toBeVisible();
+    await expect(chart.locator('.slice-label').first()).toBeVisible();
+
+    const result = await chart.evaluate((root) => {
+      const boxes = Array.from(root.querySelectorAll('.slice-label')).map((el) =>
+        el.getBoundingClientRect()
+      );
+      const chartBox = root.getBoundingClientRect();
+      const intersects = (a: DOMRect, b: DOMRect) =>
+        a.left < b.right - 1 &&
+        b.left < a.right - 1 &&
+        a.top < b.bottom - 1 &&
+        b.top < a.bottom - 1;
+
+      let overlaps = 0;
+      for (let i = 0; i < boxes.length; i++) {
+        for (let j = i + 1; j < boxes.length; j++) {
+          if (intersects(boxes[i], boxes[j])) {
+            overlaps++;
+          }
+        }
+      }
+      const outside = boxes.filter(
+        (b) => b.left < chartBox.left - 1 || b.right > chartBox.right + 1
+      ).length;
+      return { labelCount: boxes.length, overlaps, outside };
+    });
+
+    // The engine must be selective, not silent: some labels visible, some dropped.
+    expect(result.labelCount).toBeGreaterThan(3);
+    expect(result.labelCount).toBeLessThan(24);
+    expect(result.overlaps).toBe(0);
+    expect(result.outside).toBe(0);
+  });
+
+  test('all-zero data renders the empty state with no NaN geometry', async ({ page }) => {
+    await page.goto('/components/pie-chart');
+
+    const chart = page.getByTestId('pie-all-zero');
+    await expect(chart.locator('.chart-empty')).toBeVisible();
+    await expect(chart.locator('.chart-empty')).toContainText('No distribution data yet.');
+    await expect(chart.locator('path.slice')).toHaveCount(0);
+
+    const nanPaths = await page.evaluate(() => document.querySelectorAll('path[d*="NaN"]').length);
+    expect(nanPaths).toBe(0);
+  });
+
+  test('sparse pie keeps every label (defaults unchanged)', async ({ page }) => {
+    await page.goto('/components/pie-chart');
+
+    // The 5-slice expenses demo has ample room — the engine must not drop or
+    // truncate anything there.
+    const chart = page.locator('.demo-row', { has: page.locator('.slice-label') }).first();
+    const labels = await chart.locator('.slice-label').allTextContents();
+    expect(labels.length).toBe(5);
+    for (const label of labels) {
+      expect(label).not.toContain('…');
+    }
+  });
+});

--- a/tests/tooltip-action-clamping.spec.ts
+++ b/tests/tooltip-action-clamping.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+
+// The use:tooltip action used to centre its bubble on the trigger with a bare
+// translate(-50%) and no edge handling: a trigger near the viewport edge
+// spilled its bubble off-screen, and a trigger near the bottom pushed the
+// bubble out of view. The bubble now clamps to the viewport (8px margin),
+// flips to the opposite side when the preferred side lacks room, and keeps
+// its arrow anchored over the trigger.
+test.describe('tooltip action — viewport clamping', () => {
+  test('left-edge trigger keeps its bubble inside the viewport with the arrow on the trigger', async ({
+    page
+  }) => {
+    await page.goto('/components/tooltip');
+
+    const trigger = page.getByTestId('tooltip-edge-left');
+    // Pin the trigger to the exact viewport edge so the test is independent of
+    // the demo page's own gutters.
+    await trigger.evaluate((el) => {
+      el.style.position = 'fixed';
+      el.style.left = '4px';
+      el.style.top = '300px';
+    });
+    await trigger.hover();
+    const bubble = page.locator('[role="tooltip"]');
+    await expect(bubble).toBeVisible();
+
+    const bubbleBox = await bubble.boundingBox();
+    const triggerBox = await trigger.boundingBox();
+    if (bubbleBox === null || triggerBox === null) {
+      throw new Error('boundingBox is null');
+    }
+    expect(bubbleBox.x).toBeGreaterThanOrEqual(0);
+
+    // The arrow (first child div) must still point at the trigger.
+    const arrowBox = await bubble.locator('div').first().boundingBox();
+    if (arrowBox === null) {
+      throw new Error('arrow boundingBox is null');
+    }
+    const arrowCenter = arrowBox.x + arrowBox.width / 2;
+    expect(arrowCenter).toBeGreaterThanOrEqual(triggerBox.x - 1);
+    expect(arrowCenter).toBeLessThanOrEqual(triggerBox.x + triggerBox.width + 1);
+  });
+
+  test('right-edge trigger keeps its bubble inside the viewport', async ({ page }) => {
+    await page.goto('/components/tooltip');
+
+    const trigger = page.getByTestId('tooltip-edge-right');
+    await trigger.evaluate((el) => {
+      el.style.position = 'fixed';
+      el.style.left = 'auto';
+      el.style.right = '4px';
+      el.style.top = '300px';
+    });
+    await trigger.hover();
+    const bubble = page.locator('[role="tooltip"]');
+    await expect(bubble).toBeVisible();
+
+    const bubbleBox = await bubble.boundingBox();
+    const viewport = page.viewportSize();
+    if (bubbleBox === null || viewport === null) {
+      throw new Error('boundingBox or viewport is null');
+    }
+    expect(Math.round(bubbleBox.x + bubbleBox.width)).toBeLessThanOrEqual(viewport.width);
+    // The old code shrank-to-fit against the viewport's right edge instead of
+    // shifting left — a degenerate ~60px-wide, 200px-tall text column. The
+    // clamped bubble keeps its natural max-width shape.
+    expect(bubbleBox.width).toBeGreaterThan(150);
+    expect(bubbleBox.height).toBeLessThan(120);
+  });
+
+  test('bottom-positioned tooltip flips above a trigger sitting at the viewport bottom', async ({
+    page
+  }) => {
+    await page.goto('/components/tooltip');
+
+    const trigger = page.getByTestId('tooltip-edge-left');
+    // Scroll so the trigger sits ~30px above the viewport bottom — no room below.
+    await trigger.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      window.scrollBy(0, rect.bottom - window.innerHeight + 30);
+    });
+    await trigger.hover();
+    const bubble = page.locator('[role="tooltip"]');
+    await expect(bubble).toBeVisible();
+
+    const bubbleBox = await bubble.boundingBox();
+    const triggerBox = await trigger.boundingBox();
+    if (bubbleBox === null || triggerBox === null) {
+      throw new Error('boundingBox is null');
+    }
+    // Flipped: the bubble sits fully above the trigger instead of below it.
+    expect(bubbleBox.y + bubbleBox.height).toBeLessThanOrEqual(triggerBox.y + 1);
+  });
+});


### PR DESCRIPTION
## What

Extreme-data and edge-position hardening for three components, each fixed at its default so every consumer inherits the behaviour (follow-up to #375):

### 1. `use:tooltip` action — viewport clamping, flip, anchored arrow

The renderless action centred its bubble with a bare `translate(-50%)` and had **no edge handling** (unlike `Tooltip.svelte`, which clamps): a trigger near a viewport edge spilled its bubble off-screen — or, against the right edge, the fixed-position box shrank-to-fit into a degenerate ~60px-wide text column — and a trigger near the bottom pushed the bubble out of view entirely. The bubble is now **measured after mounting**, **clamped** to the viewport (8px margin), **flipped** to the opposite side when the preferred side lacks room, and the **arrow stays anchored over the trigger** (bubble-local px) even when the bubble shifts. This is the root cause behind a whole cluster of downstream Lighthouse findings (filter tooltips covering nav tabs at 7 different widths, carets detached from triggers, tooltips clipped at the viewport).

### 2. PieChart — label engine for crowded data

A pie with many slices and long labels rendered **every label unconditionally at its mid-angle**: stacked unreadable text spilling past the chart box. Labels now measure against their real rendered width (shared canvas helper), truncate to the room the chart actually has, inside-position labels hide when their wedge is thinner than one text line, and colliding labels drop with **larger slices winning**. Dropped/truncated text stays on the slice tooltip and `aria-label`. All-zero data already degraded to the empty state (`total === 0`) — now spec-guarded against NaN geometry.

### 3. SankeyChart — exact text measurement

Swaps #375's per-character width estimates for the shared `measureText` helper: the estimator both **over-reserved** the right label gutter (dead unused canvas beside truncated labels) and could under-budget unusual strings. Reservation and truncation are now exact on the client; SSR keeps the 0.6em heuristic fallback. The #375 overlap-invariant specs still pass unchanged.

## Tests (negative-controlled)

Specs first ran against the unfixed components: pie-crowded overlaps FAIL, tooltip left-edge clamp FAIL, bottom-flip FAIL (the right-edge test also asserts the degenerate skinny-column shape away). After the fix: **new specs 6/6, full integration suite 118/118**, lint green, no svelte-check regressions (only the pre-existing `lottie-web` optional-peer errors).

- `tests/tooltip-action-clamping.spec.ts` — left-edge clamp + arrow-on-trigger, right-edge clamp + natural bubble shape, bottom-edge flip.
- `tests/pie-label-engine.spec.ts` — crowded pie: zero overlapping labels, all inside the chart box, engine selective (some labels dropped); all-zero → empty state, no `NaN` paths; sparse pie keeps every label untruncated (defaults-unchanged guard).

## Demos

- PieChart: "Crowded — 24 sources with long labels and sliver slices", "All-zero values".
- Tooltip: "Edge clamping" section with edge-hugging triggers.

## Docs

- `docs/Tooltip.md` — clamping/flip/anchored-arrow behaviour on the action.
- `docs/PieChart.md` — new "Label overflow & collisions" section.
- `docs/SankeyChart.md` — measurement wording updated (estimates → measured).
