### PR TITLE
feat(Table): align-aware builtin cells and horizontal-scroll edge scrims

### DIFF
--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -42,6 +42,20 @@
     originalIndex: number;
   } = $props();
 
+  // The td applies column.align as text-align, which flex containers ignore:
+  // column-flex builtins stretch their children and row-flex builtins pack to
+  // flex-start, so an aligned column's builtin cells stayed left. Mirror the
+  // column alignment as a modifier class the flex builtins translate into
+  // align-items / justify-content (same idiom as the header's
+  // justify-content mapping).
+  const alignmentClass = $derived(
+    column.align === 'right'
+      ? 'builtin-align-end'
+      : column.align === 'center'
+        ? 'builtin-align-center'
+        : ''
+  );
+
   let copied = $state(false);
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -99,7 +113,7 @@
 {:else if column.type === 'text-tag'}
   {@const data = asJsonObject(value) ?? {}}
   {@const tag = asTagCellData(data.tag ?? null)}
-  <div class="builtin-text-tag">
+  <div class="builtin-text-tag {alignmentClass}">
     <span class="builtin-primary-text"
       >{typeof data.text === 'string' ? data.text : cellValueToText(value)}</span
     >
@@ -114,7 +128,7 @@
   </div>
 {:else if column.type === 'two-line-text'}
   {@const data = asJsonObject(value) ?? {}}
-  <div class="builtin-two-line">
+  <div class="builtin-two-line {alignmentClass}">
     <span class="builtin-primary-text">{typeof data.text1 === 'string' ? data.text1 : '-'}</span>
     <span class="builtin-secondary-text">{typeof data.text2 === 'string' ? data.text2 : '-'}</span>
   </div>
@@ -123,7 +137,7 @@
   {@const icons = Array.isArray(data.icons)
     ? data.icons.filter((iconSrc) => typeof iconSrc === 'string')
     : []}
-  <div class="builtin-icon-label">
+  <div class="builtin-icon-label {alignmentClass}">
     {#each icons as iconSrc, iconIndex (`${iconIndex}-${iconSrc}`)}
       <span class="builtin-icon-label-icon">
         <Img src={String(iconSrc)} alt="" fallback="" />
@@ -133,7 +147,7 @@
   </div>
 {:else if column.type === 'image-two-line-text'}
   {@const data = asJsonObject(value) ?? {}}
-  <div class="builtin-image-two-line">
+  <div class="builtin-image-two-line {alignmentClass}">
     {#if typeof data.imageUrl === 'string' && data.imageUrl}
       <span class="builtin-thumb">
         <Img
@@ -145,7 +159,7 @@
     {:else}
       <span class="builtin-thumb builtin-thumb-placeholder"></span>
     {/if}
-    <div class="builtin-two-line">
+    <div class="builtin-two-line {alignmentClass}">
       <span class="builtin-primary-text">{typeof data.text1 === 'string' ? data.text1 : '-'}</span>
       <span class="builtin-secondary-text">{typeof data.text2 === 'string' ? data.text2 : '-'}</span
       >
@@ -154,7 +168,7 @@
 {:else if column.type === 'tag-array'}
   {@const tags = asTagArrayItems(value)}
   {#if tags}
-    <div class="builtin-tag-array">
+    <div class="builtin-tag-array {alignmentClass}">
       {#each tags as tag (tag.text)}
         <Pill text={tag.text} classes={tag.classes ?? ''} />
       {/each}
@@ -166,7 +180,7 @@
   {@const stackData = asAvatarStackData(value)}
   {#if stackData}
     {@const stack = buildAvatarStack(stackData)}
-    <div class="builtin-avatar-stack">
+    <div class="builtin-avatar-stack {alignmentClass}">
       <IconStack icons={stack.icons} />
       {#if stack.rest > 0}
         <span class="builtin-avatar-rest">+{stack.rest}</span>
@@ -181,7 +195,7 @@
   {:else}
     {@const compare = asCompareCellData(value)}
     {#if compare}
-      <div class="builtin-compare">
+      <div class="builtin-compare {alignmentClass}">
         {#if typeof compare.primary === 'string'}
           <span class="builtin-primary-text">{compare.primary}</span>
         {/if}
@@ -446,6 +460,35 @@
     display: flex;
     flex-direction: column;
     gap: var(--table-cell-line-gap, 2px);
+  }
+
+  /* column.align lands on the td as text-align, which flex layouts ignore.
+     Column-flex builtins follow it via align-items… */
+  .builtin-two-line.builtin-align-end,
+  .builtin-compare.builtin-align-end {
+    align-items: flex-end;
+  }
+
+  .builtin-two-line.builtin-align-center,
+  .builtin-compare.builtin-align-center {
+    align-items: center;
+  }
+
+  /* …and row-flex builtins follow it via justify-content. */
+  .builtin-text-tag.builtin-align-end,
+  .builtin-icon-label.builtin-align-end,
+  .builtin-image-two-line.builtin-align-end,
+  .builtin-tag-array.builtin-align-end,
+  .builtin-avatar-stack.builtin-align-end {
+    justify-content: flex-end;
+  }
+
+  .builtin-text-tag.builtin-align-center,
+  .builtin-icon-label.builtin-align-center,
+  .builtin-image-two-line.builtin-align-center,
+  .builtin-tag-array.builtin-align-center,
+  .builtin-avatar-stack.builtin-align-center {
+    justify-content: center;
   }
 
   .builtin-text-tag {

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -133,6 +133,37 @@
   let isRowClickable = $derived(typeof onRowClick === 'function');
   let isStickyHeader = $derived(stickyHeader || isTableScrollable);
 
+  // ─── Horizontal-scroll affordance ────────────────────────────────────────
+  // The table clips columns behind an internal horizontal scroll on narrow
+  // viewports, but a bare scroll container gives no visual hint that more
+  // columns exist. Track whether either edge has hidden content and surface
+  // it as edge scrims (see .table-scroll-shell styles).
+  let canScrollLeft = $state(false);
+  let canScrollRight = $state(false);
+
+  const trackHorizontalScroll = (scrollNode: HTMLElement) => {
+    const updateScrollHints = () => {
+      canScrollLeft = scrollNode.scrollLeft > 2;
+      canScrollRight = scrollNode.scrollLeft + scrollNode.clientWidth < scrollNode.scrollWidth - 2;
+    };
+    updateScrollHints();
+    scrollNode.addEventListener('scroll', updateScrollHints, { passive: true });
+    // Both the container resizing (viewport changes) and the table resizing
+    // (async rows/columns arriving) change scrollWidth, so observe both.
+    const hintResizeObserver = new ResizeObserver(updateScrollHints);
+    hintResizeObserver.observe(scrollNode);
+    const tableElement = scrollNode.querySelector('table');
+    if (tableElement) {
+      hintResizeObserver.observe(tableElement);
+    }
+    return {
+      destroy: () => {
+        scrollNode.removeEventListener('scroll', updateScrollHints);
+        hintResizeObserver.disconnect();
+      }
+    };
+  };
+
   // ─── C2-3: Search ─────────────────────────────────────────────────────────
   let searchTerm = $state('');
   let hasSearchConfig = $derived(!!searchConfig);
@@ -572,263 +603,286 @@
     class="table-container {isTableScrollable ? 'scrollable-table' : ''} {classes ?? ''}"
     data-pw={testId}
   >
-    <table>
-      {#if caption}
-        <caption class="sr-only">{caption}</caption>
-      {/if}
-      <thead>
-        <tr>
-          {#if isCheckboxMode && !isSingleSelect}
-            <th class="table-header table-checkbox-col" class:table-header-sticky={isStickyHeader}>
-              <!-- Header tri-state checkbox -->
-              <span
-                class="table-checkbox-box"
-                class:checked={headerCheckboxState === 'all'}
-                class:indeterminate={headerCheckboxState === 'some'}
-                role="checkbox"
-                tabindex={0}
-                aria-checked={headerCheckboxState === 'some'
-                  ? 'mixed'
-                  : headerCheckboxState === 'all'}
-                aria-label="Select all rows"
-                {...checkboxSelection?.getRowAttributes
-                  ? checkboxSelection.getRowAttributes('__header__', -1)
-                  : {}}
-                aria-controls={selectableRowIds.map((rowId) => `row-checkbox-${rowId}`).join(' ')}
-                onclick={toggleAllSelection}
-                onkeydown={(keyboardEvent) =>
-                  handleCheckboxKeydown(keyboardEvent, toggleAllSelection)}
-              >
-                {#if headerCheckboxState === 'all'}
-                  <!-- eslint-disable svelte/no-at-html-tags -->
-                  <span class="table-checkbox-icon">{@html checkmarkSvg}</span>
-                {:else if headerCheckboxState === 'some'}
-                  <!-- eslint-disable svelte/no-at-html-tags -->
-                  <span class="table-checkbox-icon">{@html minusSvg}</span>
-                {/if}
-              </span>
-            </th>
-          {:else if isCheckboxMode && isSingleSelect}
-            <!-- In single-select mode the header cell is an empty spacer -->
-            <th class="table-header table-checkbox-col" class:table-header-sticky={isStickyHeader}>
-            </th>
+    <div
+      class="table-scroll-shell"
+      class:scrollable-left={canScrollLeft}
+      class:scrollable-right={canScrollRight}
+    >
+      <div class="table-scroll" use:trackHorizontalScroll>
+        <table>
+          {#if caption}
+            <caption class="sr-only">{caption}</caption>
           {/if}
-          {#if rowNumberColumn}
-            <th class="table-header table-row-number-col" class:table-header-sticky={isStickyHeader}
-              >{rowNumberLabel}</th
-            >
-          {/if}
-          {#each effectiveHeaders as header, colIndex (colIndex)}
-            {@const headerColumn = columns?.[colIndex]}
-            <th
-              class="table-header"
-              class:table-header-sticky={isStickyHeader}
-              data-pw={headerColumn?.testId ?? null}
-              style:text-align={headerColumn?.align ?? null}
-              style:max-width={headerColumn?.maxWidth ?? null}
-            >
-              <span
-                class="table-header-content"
-                style:justify-content={headerColumn?.align === 'right'
-                  ? 'flex-end'
-                  : headerColumn?.align === 'center'
-                    ? 'center'
-                    : null}
-              >
-                {#if headerColumn?.tooltip}
-                  <Tooltip
-                    text={headerColumn.tooltip}
-                    position={headerTooltipPosition}
-                    icon={headerTooltipIcon}
-                    iconPosition="trailing"
-                  >
-                    <span
-                      class="table-header-label"
-                      class:table-header-label-plain={headerTooltipIcon}>{header}</span
-                    >
-                  </Tooltip>
-                {:else}
-                  {header}
-                {/if}
-                {#if headerColumn?.filter}
-                  {@const filter = headerColumn.filter}
-                  <span class="table-header-filter">
-                    <Menu
-                      items={filter.options.map((option) => ({
-                        value: option.value,
-                        label: option.label
-                      }))}
-                      selectedValue={filter.selectedValue ?? null}
-                      role="listbox"
-                      testId={headerColumn.testId && `${headerColumn.testId}-filter`}
-                      onselect={(menuItem) =>
-                        filter.onFilterChange?.(
-                          menuItem.value === filter.selectedValue ? null : menuItem.value
-                        )}
-                    >
-                      {#snippet trigger()}
-                        <span
-                          class="table-header-filter-trigger"
-                          class:table-header-filter-active={typeof filter.selectedValue ===
-                            'string'}
-                        >
-                          <Button
-                            ariaLabel="Filter by {header}"
-                            testId={headerColumn.testId && `${headerColumn.testId}-filter-trigger`}
-                          >
-                            {#snippet icon()}
-                              <!-- eslint-disable svelte/no-at-html-tags -->
-                              <span class="table-header-filter-icon">{@html chevronDownSmSvg}</span>
-                            {/snippet}
-                          </Button>
-                        </span>
-                      {/snippet}
-                    </Menu>
-                  </span>
-                {/if}
-                {#if isColumnSortable(colIndex)}
-                  <div class="sort-button">
-                    <Button onclick={() => handleSort(colIndex)} ariaLabel="Sort by {header}">
-                      {#if sortColumn === colIndex && sortDirection === 'asc'}
-                        {#if typeof sortAscIcon === 'function'}
-                          {@render sortAscIcon()}
-                        {:else}
-                          <span class="sort-icon">
-                            <!-- eslint-disable svelte/no-at-html-tags -->
-                            {@html chevronUpSvg}
-                          </span>
-                        {/if}
-                      {:else if sortColumn === colIndex && sortDirection === 'desc'}
-                        {#if typeof sortDescIcon === 'function'}
-                          {@render sortDescIcon()}
-                        {:else}
-                          <span class="sort-icon">
-                            <!-- eslint-disable svelte/no-at-html-tags -->
-                            {@html chevronDownSvg}
-                          </span>
-                        {/if}
-                      {:else if typeof sortDefaultIcon === 'function'}
-                        {@render sortDefaultIcon()}
-                      {:else}
-                        <span class="sort-icon sort-icon-idle">
-                          <!-- eslint-disable svelte/no-at-html-tags -->
-                          {@html sortDefaultSvg}
-                        </span>
-                      {/if}
-                    </Button>
-                  </div>
-                {/if}
-              </span>
-            </th>
-          {/each}
-        </tr>
-      </thead>
-      <tbody>
-        {#if filteredTableData.length === 0 && typeof empty === 'function'}
-          <tr>
-            <td
-              class="table-empty"
-              colspan={effectiveHeaders.length +
-                (isCheckboxMode ? 1 : 0) +
-                (rowNumberColumn ? 1 : 0)}
-            >
-              {@render empty()}
-            </td>
-          </tr>
-        {:else}
-          {#each paginatedTableData as row, pageRowIndex (rowIdByRow.get(row) ?? pageRowIndex)}
-            {@const rowIndex = pageRowIndex + rowIndexOffset}
-            {@const originalIndex = originalIndexByRow.get(row) ?? rowIndex}
-            {@const rowId = rowIdByRow.get(row) ?? String(rowIndex)}
-            {@const rowDisabled = isCheckboxMode && isRowDisabled(rowId)}
-            {@const rowSelected = isCheckboxMode && isRowSelected(rowId)}
-            <tr
-              class="table-row"
-              class:table-row-clickable={isRowClickable}
-              class:table-row-selected={rowSelected}
-              data-pw={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
-              onclick={isRowClickable ? () => handleRowClick(rowIndex, row, originalIndex) : null}
-              onkeydown={isRowClickable
-                ? (keyboardEvent) => handleRowKeydown(keyboardEvent, rowIndex, row, originalIndex)
-                : null}
-              tabindex={isRowClickable ? 0 : null}
-            >
-              {#if isCheckboxMode}
-                <td class="table-content table-checkbox-col">
+          <thead>
+            <tr>
+              {#if isCheckboxMode && !isSingleSelect}
+                <th
+                  class="table-header table-checkbox-col"
+                  class:table-header-sticky={isStickyHeader}
+                >
+                  <!-- Header tri-state checkbox -->
                   <span
                     class="table-checkbox-box"
-                    class:checked={rowSelected}
-                    class:disabled={rowDisabled}
+                    class:checked={headerCheckboxState === 'all'}
+                    class:indeterminate={headerCheckboxState === 'some'}
                     role="checkbox"
-                    id={`row-checkbox-${rowId}`}
-                    tabindex={rowDisabled ? -1 : 0}
-                    aria-checked={rowSelected}
-                    aria-disabled={rowDisabled}
-                    aria-label={`Select row ${rowId || 'non-selectable'}`}
+                    tabindex={0}
+                    aria-checked={headerCheckboxState === 'some'
+                      ? 'mixed'
+                      : headerCheckboxState === 'all'}
+                    aria-label="Select all rows"
                     {...checkboxSelection?.getRowAttributes
-                      ? checkboxSelection.getRowAttributes(rowId, rowIndex)
+                      ? checkboxSelection.getRowAttributes('__header__', -1)
                       : {}}
-                    onclick={(mouseEvent) => {
-                      mouseEvent.stopPropagation();
-                      toggleRowSelection(rowId);
-                    }}
-                    onkeydown={(keyboardEvent) => {
-                      keyboardEvent.stopPropagation();
-                      handleCheckboxKeydown(keyboardEvent, () => toggleRowSelection(rowId));
-                    }}
+                    aria-controls={selectableRowIds
+                      .map((rowId) => `row-checkbox-${rowId}`)
+                      .join(' ')}
+                    onclick={toggleAllSelection}
+                    onkeydown={(keyboardEvent) =>
+                      handleCheckboxKeydown(keyboardEvent, toggleAllSelection)}
                   >
-                    {#if rowSelected}
+                    {#if headerCheckboxState === 'all'}
                       <!-- eslint-disable svelte/no-at-html-tags -->
                       <span class="table-checkbox-icon">{@html checkmarkSvg}</span>
+                    {:else if headerCheckboxState === 'some'}
+                      <!-- eslint-disable svelte/no-at-html-tags -->
+                      <span class="table-checkbox-icon">{@html minusSvg}</span>
                     {/if}
                   </span>
-                </td>
+                </th>
+              {:else if isCheckboxMode && isSingleSelect}
+                <!-- In single-select mode the header cell is an empty spacer -->
+                <th
+                  class="table-header table-checkbox-col"
+                  class:table-header-sticky={isStickyHeader}
+                >
+                </th>
               {/if}
               {#if rowNumberColumn}
-                <td class="table-content table-row-number-col">{rowNumberFor(pageRowIndex)}</td>
-              {/if}
-              {#each row as cellValue, colIndex (colIndex)}
-                {@const keyedColumn = columns?.[colIndex]}
-                {@const keyedRow = keyedRowByProjected?.get(row)}
-                {@const isScalarCell =
-                  typeof cellValue === 'string' ||
-                  typeof cellValue === 'number' ||
-                  typeof cellValue === 'boolean'}
-                <td
-                  class="table-content"
-                  data-pw={typeof getCellTestId === 'function'
-                    ? getCellTestId(row, cellValue, rowIndex)
-                    : null}
-                  style:text-align={keyedColumn?.align ?? null}
-                  style:max-width={keyedColumn?.maxWidth ?? null}
-                  title={keyedColumn?.maxWidth && isScalarCell ? String(cellValue) : null}
+                <th
+                  class="table-header table-row-number-col"
+                  class:table-header-sticky={isStickyHeader}>{rowNumberLabel}</th
                 >
-                  <div
-                    class={isContentScrollable ? 'scrollable-content' : ''}
-                    class:table-cell-clamp={keyedColumn?.maxWidth && isScalarCell}
+              {/if}
+              {#each effectiveHeaders as header, colIndex (colIndex)}
+                {@const headerColumn = columns?.[colIndex]}
+                <th
+                  class="table-header"
+                  class:table-header-sticky={isStickyHeader}
+                  data-pw={headerColumn?.testId ?? null}
+                  style:text-align={headerColumn?.align ?? null}
+                  style:max-width={headerColumn?.maxWidth ?? null}
+                >
+                  <span
+                    class="table-header-content"
+                    style:justify-content={headerColumn?.align === 'right'
+                      ? 'flex-end'
+                      : headerColumn?.align === 'center'
+                        ? 'center'
+                        : null}
                   >
-                    {#if keyedColumn && typeof keyedColumn.cell === 'function' && keyedRow}
-                      {@render keyedColumn.cell(keyedRow, rowIndex, originalIndex)}
-                    {:else if keyedColumn?.type && keyedColumn.type !== 'text' && keyedColumn.type !== 'custom'}
-                      <BuiltinCell
-                        column={keyedColumn}
-                        value={cellValue}
-                        {rowIndex}
-                        {originalIndex}
-                      />
-                    {:else if typeof cell === 'function'}
-                      {@render cell(cellValue, rowIndex, colIndex)}
+                    {#if headerColumn?.tooltip}
+                      <Tooltip
+                        text={headerColumn.tooltip}
+                        position={headerTooltipPosition}
+                        icon={headerTooltipIcon}
+                        iconPosition="trailing"
+                      >
+                        <span
+                          class="table-header-label"
+                          class:table-header-label-plain={headerTooltipIcon}>{header}</span
+                        >
+                      </Tooltip>
                     {:else}
-                      {cellValue}
+                      {header}
                     {/if}
-                  </div>
-                </td>
+                    {#if headerColumn?.filter}
+                      {@const filter = headerColumn.filter}
+                      <span class="table-header-filter">
+                        <Menu
+                          items={filter.options.map((option) => ({
+                            value: option.value,
+                            label: option.label
+                          }))}
+                          selectedValue={filter.selectedValue ?? null}
+                          role="listbox"
+                          testId={headerColumn.testId && `${headerColumn.testId}-filter`}
+                          onselect={(menuItem) =>
+                            filter.onFilterChange?.(
+                              menuItem.value === filter.selectedValue ? null : menuItem.value
+                            )}
+                        >
+                          {#snippet trigger()}
+                            <span
+                              class="table-header-filter-trigger"
+                              class:table-header-filter-active={typeof filter.selectedValue ===
+                                'string'}
+                            >
+                              <Button
+                                ariaLabel="Filter by {header}"
+                                testId={headerColumn.testId &&
+                                  `${headerColumn.testId}-filter-trigger`}
+                              >
+                                {#snippet icon()}
+                                  <!-- eslint-disable svelte/no-at-html-tags -->
+                                  <span class="table-header-filter-icon"
+                                    >{@html chevronDownSmSvg}</span
+                                  >
+                                {/snippet}
+                              </Button>
+                            </span>
+                          {/snippet}
+                        </Menu>
+                      </span>
+                    {/if}
+                    {#if isColumnSortable(colIndex)}
+                      <div class="sort-button">
+                        <Button onclick={() => handleSort(colIndex)} ariaLabel="Sort by {header}">
+                          {#if sortColumn === colIndex && sortDirection === 'asc'}
+                            {#if typeof sortAscIcon === 'function'}
+                              {@render sortAscIcon()}
+                            {:else}
+                              <span class="sort-icon">
+                                <!-- eslint-disable svelte/no-at-html-tags -->
+                                {@html chevronUpSvg}
+                              </span>
+                            {/if}
+                          {:else if sortColumn === colIndex && sortDirection === 'desc'}
+                            {#if typeof sortDescIcon === 'function'}
+                              {@render sortDescIcon()}
+                            {:else}
+                              <span class="sort-icon">
+                                <!-- eslint-disable svelte/no-at-html-tags -->
+                                {@html chevronDownSvg}
+                              </span>
+                            {/if}
+                          {:else if typeof sortDefaultIcon === 'function'}
+                            {@render sortDefaultIcon()}
+                          {:else}
+                            <span class="sort-icon sort-icon-idle">
+                              <!-- eslint-disable svelte/no-at-html-tags -->
+                              {@html sortDefaultSvg}
+                            </span>
+                          {/if}
+                        </Button>
+                      </div>
+                    {/if}
+                  </span>
+                </th>
               {/each}
             </tr>
-          {/each}
-        {/if}
-      </tbody>
-    </table>
+          </thead>
+          <tbody>
+            {#if filteredTableData.length === 0 && typeof empty === 'function'}
+              <tr>
+                <td
+                  class="table-empty"
+                  colspan={effectiveHeaders.length +
+                    (isCheckboxMode ? 1 : 0) +
+                    (rowNumberColumn ? 1 : 0)}
+                >
+                  {@render empty()}
+                </td>
+              </tr>
+            {:else}
+              {#each paginatedTableData as row, pageRowIndex (rowIdByRow.get(row) ?? pageRowIndex)}
+                {@const rowIndex = pageRowIndex + rowIndexOffset}
+                {@const originalIndex = originalIndexByRow.get(row) ?? rowIndex}
+                {@const rowId = rowIdByRow.get(row) ?? String(rowIndex)}
+                {@const rowDisabled = isCheckboxMode && isRowDisabled(rowId)}
+                {@const rowSelected = isCheckboxMode && isRowSelected(rowId)}
+                <tr
+                  class="table-row"
+                  class:table-row-clickable={isRowClickable}
+                  class:table-row-selected={rowSelected}
+                  data-pw={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
+                  onclick={isRowClickable
+                    ? () => handleRowClick(rowIndex, row, originalIndex)
+                    : null}
+                  onkeydown={isRowClickable
+                    ? (keyboardEvent) =>
+                        handleRowKeydown(keyboardEvent, rowIndex, row, originalIndex)
+                    : null}
+                  tabindex={isRowClickable ? 0 : null}
+                >
+                  {#if isCheckboxMode}
+                    <td class="table-content table-checkbox-col">
+                      <span
+                        class="table-checkbox-box"
+                        class:checked={rowSelected}
+                        class:disabled={rowDisabled}
+                        role="checkbox"
+                        id={`row-checkbox-${rowId}`}
+                        tabindex={rowDisabled ? -1 : 0}
+                        aria-checked={rowSelected}
+                        aria-disabled={rowDisabled}
+                        aria-label={`Select row ${rowId || 'non-selectable'}`}
+                        {...checkboxSelection?.getRowAttributes
+                          ? checkboxSelection.getRowAttributes(rowId, rowIndex)
+                          : {}}
+                        onclick={(mouseEvent) => {
+                          mouseEvent.stopPropagation();
+                          toggleRowSelection(rowId);
+                        }}
+                        onkeydown={(keyboardEvent) => {
+                          keyboardEvent.stopPropagation();
+                          handleCheckboxKeydown(keyboardEvent, () => toggleRowSelection(rowId));
+                        }}
+                      >
+                        {#if rowSelected}
+                          <!-- eslint-disable svelte/no-at-html-tags -->
+                          <span class="table-checkbox-icon">{@html checkmarkSvg}</span>
+                        {/if}
+                      </span>
+                    </td>
+                  {/if}
+                  {#if rowNumberColumn}
+                    <td class="table-content table-row-number-col">{rowNumberFor(pageRowIndex)}</td>
+                  {/if}
+                  {#each row as cellValue, colIndex (colIndex)}
+                    {@const keyedColumn = columns?.[colIndex]}
+                    {@const keyedRow = keyedRowByProjected?.get(row)}
+                    {@const isScalarCell =
+                      typeof cellValue === 'string' ||
+                      typeof cellValue === 'number' ||
+                      typeof cellValue === 'boolean'}
+                    <td
+                      class="table-content"
+                      data-pw={typeof getCellTestId === 'function'
+                        ? getCellTestId(row, cellValue, rowIndex)
+                        : null}
+                      style:text-align={keyedColumn?.align ?? null}
+                      style:max-width={keyedColumn?.maxWidth ?? null}
+                      title={keyedColumn?.maxWidth && isScalarCell ? String(cellValue) : null}
+                    >
+                      <div
+                        class={isContentScrollable ? 'scrollable-content' : ''}
+                        class:table-cell-clamp={keyedColumn?.maxWidth && isScalarCell}
+                      >
+                        {#if keyedColumn && typeof keyedColumn.cell === 'function' && keyedRow}
+                          {@render keyedColumn.cell(keyedRow, rowIndex, originalIndex)}
+                        {:else if keyedColumn?.type && keyedColumn.type !== 'text' && keyedColumn.type !== 'custom'}
+                          <BuiltinCell
+                            column={keyedColumn}
+                            value={cellValue}
+                            {rowIndex}
+                            {originalIndex}
+                          />
+                        {:else if typeof cell === 'function'}
+                          {@render cell(cellValue, rowIndex, colIndex)}
+                        {:else}
+                          {cellValue}
+                        {/if}
+                      </div>
+                    </td>
+                  {/each}
+                </tr>
+              {/each}
+            {/if}
+          </tbody>
+        </table>
+      </div>
+    </div>
     {#if typeof paginatorSlot === 'function'}
       <div class="table-footer">
         {@render paginatorSlot()}
@@ -966,6 +1020,57 @@
   .scrollable-table {
     height: var(--table-container-height, 143px);
     overflow-y: auto;
+  }
+
+  .table-scroll-shell {
+    position: relative;
+    min-width: 0;
+  }
+
+  /* Edge scrims: fade the clipped side of the table into its background so
+     hidden columns read as "more content this way". Class-driven from live
+     scroll state — never shown when the table fits. pointer-events: none
+     keeps cells under the fade clickable; z-index 2 paints above sticky
+     headers (z-index 1). */
+  .table-scroll-shell::before,
+  .table-scroll-shell::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--table-scroll-scrim-width, 32px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 2;
+  }
+
+  .table-scroll-shell::before {
+    left: 0;
+    border-radius: var(--table-border-radius, var(--radius, 4px)) 0 0
+      var(--table-border-radius, var(--radius, 4px));
+    background: linear-gradient(to right, var(--table-scroll-scrim-color, #ffffff), transparent);
+  }
+
+  .table-scroll-shell::after {
+    right: 0;
+    border-radius: 0 var(--table-border-radius, var(--radius, 4px))
+      var(--table-border-radius, var(--radius, 4px)) 0;
+    background: linear-gradient(to left, var(--table-scroll-scrim-color, #ffffff), transparent);
+  }
+
+  .table-scroll-shell.scrollable-left::before {
+    opacity: 1;
+  }
+
+  .table-scroll-shell.scrollable-right::after {
+    opacity: 1;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+    min-width: 0;
+    scrollbar-width: thin;
   }
 
   table {

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -222,6 +222,9 @@ export type TableColumn = {
   /**
    * Horizontal alignment for this column's header and body cells. When unset,
    * cells follow the table-wide `--table-text-align` (left by default).
+   * Built-in flex cells (compare, two-line-text, text-tag, icon-label,
+   * image-two-line-text, tag-array, avatar-stack) mirror it into their flex
+   * alignment so stacked/inline content follows the aligned edge too.
    */
   align?: 'left' | 'center' | 'right';
   /**

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -127,7 +127,7 @@
     { id: 'state', label: 'State', type: 'tag' },
     { id: 'channels', label: 'Channels', type: 'tag-array' },
     { id: 'owners', label: 'Owners', type: 'avatar-stack' },
-    { id: 'revenue', label: 'Revenue', type: 'compare' },
+    { id: 'revenue', label: 'Revenue', type: 'compare', align: 'right' },
     {
       id: 'active',
       label: 'Active',


### PR DESCRIPTION
## What

Two Table upgrades that close consumer-side workaround gaps found during the Lighthouse DataGrid→Table migration ([lighthouse PR #6190](https://bitbucket.juspay.net/projects/BZ/repos/lighthouse/pull-requests/6190)):

### 1. Builtin cells follow `column.align`

`column.align` lands on the td as `text-align`, which flex layouts ignore — an aligned column's builtin cells stayed pinned left: column-flex builtins (`compare`, `two-line-text`) stretch their children, row-flex builtins (`text-tag`, `icon-label`, `image-two-line-text`, `tag-array`, `avatar-stack`) pack to flex-start. Most visible defect: a right-aligned compare column right-aligned its numbers but left-pinned the trend pill.

`BuiltinCell` now mirrors the column alignment as a modifier class (`builtin-align-end` / `builtin-align-center`): column-flex containers translate it into `align-items`, row-flex containers into `justify-content` — the same idiom the header already uses for its `justify-content` mapping. Consumers currently carrying `[style*='text-align: right']` CSS overrides (Lighthouse does) can delete them.

### 2. First-class horizontal-scroll edge scrims

On narrow viewports columns clip behind a horizontal scroll with no visual hint that more exist. The table body now renders inside `.table-scroll` (an `overflow-x: auto` scroller) wrapped by `.table-scroll-shell`, whose edge scrims fade in/out from live scroll state (`scrollable-left` / `scrollable-right` classes driven by a scroll+resize-tracked action). This ports the scroll-affordance fix Lighthouse shipped inside its (now deleted) DataGrid to its first-class home.

- Tokens: `--table-scroll-scrim-width` (32px), `--table-scroll-scrim-color` (#fff base).
- `pointer-events: none` keeps cells under the fade clickable; `z-index: 2` paints above sticky headers (z-index 1).
- Scrims sit on the shell — full table height inside a vertical scroller — so `isTableScrollable` consumers keep their exact scroll behavior, and the paginator footer (outside the shell) never gets tinted.
- DOM note: `<table>` gains two wrapper divs inside `.table-container`. Descendant selectors are unaffected; only direct-child selectors (`.table-container > table`) need to relax to descendant.

## Verification

- 51/51 unit tests, svelte-check 0 errors (pre-existing warnings untouched), prettier/publint clean.
- Demo probe (Playwright, computed styles): aligned compare cell reports `align-items: flex-end` with the trend pill flush to the primary line (0px right gap); scrim cycle reads right-only → both → left-only at scroll start/mid/end with matching `::before`/`::after` opacities.
- Demo: the builtin-renderers table's Revenue compare column now demonstrates `align: 'right'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added horizontal scroll indicators for tables with clipped columns, making additional content easier to discover.
  * Built-in table cell layouts now respect the configured column alignment, including right-aligned content.
* **Documentation**
  * Clarified that supported built-in cell renderers mirror their column’s alignment setting.
* **Style**
  * Improved table scrolling behavior with edge visual cues and streamlined scrollbar support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->