### PR TITLE
fix(Toast): click-through by default — stop swallowing clicks meant for content beneath

### DIFF
--- a/src/lib/Toast/Toast.svelte
+++ b/src/lib/Toast/Toast.svelte
@@ -178,6 +178,14 @@
     background-color: var(--toast-background-color, #87ceeb);
     opacity: var(--toast-opacity, 1);
     box-sizing: var(--toast-box-sizing);
+
+    /* A toast is a transient status overlay, not a click target: it floats
+       above page content (often over drawer/footer CTAs) and used to swallow
+       clicks meant for the controls beneath it for its whole duration.
+       Click-through by default; the close button re-enables its own hit
+       area below, and consumers with actionable bottomContent can opt the
+       whole toast back in via --toast-pointer-events: auto. */
+    pointer-events: var(--toast-pointer-events, none);
   }
 
   .no-page-overlap {
@@ -213,6 +221,7 @@
   }
 
   .close-button {
+    pointer-events: auto;
     width: var(--toast-close-button-width, 20px);
     height: var(--toast-close-button-height, 20px);
     cursor: var(--toast-close-button-cursor, pointer);


### PR DESCRIPTION
## What

A toast is a transient status overlay positioned above page content — often directly over drawer/footer CTAs. Its whole box was a hit target for its entire duration, so clicks aimed at controls beneath it silently died. Surfaced in Lighthouse as broken e2e flows (a save-success toast covering the cross-sell drawer's **Add products** button swallowed the click that should have opened the product picker) — and the same dead clicks hit real users.

## Fix

- `.toast` root defaults to `pointer-events: none` via the new `--toast-pointer-events` token.
- The close button (`rightIcon`) re-enables its own hit area with `pointer-events: auto`.
- Consumers rendering actionable `bottomContent` opt the whole toast back in with `--toast-pointer-events: auto`.

## Verification

- 94/94 unit tests, svelte-check 0 errors, prettier clean.
- Live demo probe: the toast computes `pointer-events: none` and `document.elementFromPoint` at the toast's own center resolves to the **button beneath it** — the exact control the bug was swallowing.

Companion to [#377](https://github.com/juspay/svelte-ui-components/pull/377); both feed the next Lighthouse bump ([lighthouse PR #6190 follow-up](https://bitbucket.juspay.net/projects/BZ/repos/lighthouse/pull-requests/6190)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications no longer block clicks on content behind them.
  * Toast close buttons remain fully interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->