### PR TITLE
feat(Table): opt-in column highlight via TableColumn.highlighted

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -98,13 +98,13 @@ const rows: TableRow[] = [
 
 ### Per-Column Header Metadata
 
-Keyed columns carry their own header behavior: `tooltip` (hover text on the label), `align` (`'left' | 'center' | 'right'`, applied to header and body cells), `maxWidth` (caps the column; overflowing scalar cells ellipsize with the full value on the native title tooltip), and `filter` (a header dropdown — Table renders the Menu mechanics, the consumer owns options/selection/filtering; re-selecting the active option clears to `null`):
+Keyed columns carry their own header behavior: `tooltip` (hover text on the label), `align` (`'left' | 'center' | 'right'`, applied to header and body cells), `maxWidth` (caps the column; overflowing scalar cells ellipsize with the full value on the native title tooltip), `highlighted` (paints the column's header and body cells with the highlight wash — see `--table-col-highlight-background`; row hover and row selection still paint over it), and `filter` (a header dropdown — Table renders the Menu mechanics, the consumer owns options/selection/filtering; re-selecting the active option clears to `null`):
 
 ```svelte
 const columns: TableColumn[] = [
   { id: 'id', label: 'Order', maxWidth: '120px' },
   { id: 'name', label: 'Name', tooltip: 'Customer display name' },
-  { id: 'amount', label: 'Amount', align: 'right' },
+  { id: 'amount', label: 'Amount', align: 'right', highlighted: true },
   {
     id: 'status', label: 'Status',
     filter: {
@@ -482,6 +482,8 @@ Override these custom properties to theme the component.
 | `--table-content-font-size`   | `14px`    | font-size        | Font size of data cells.                                                        |
 | `--table-content-font-family` | `-`       | font-family      | Font family of data cells.                                                      |
 | `--table-content-color`       | `#111827` | color            | Text color of data cells. Falls back to `--table-content-font-color`.           |
+| `--table-col-highlight-background` | `#f3f9ff` | background-color | Background of a `highlighted: true` column's body cells. Row hover/selection paint over it. |
+| `--table-col-highlight-header-background` | falls back to `--table-col-highlight-background` | background-color | Background of a `highlighted: true` column's header cell. |
 
 ### Rows
 

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -669,6 +669,7 @@
                 <th
                   class="table-header"
                   class:table-header-sticky={isStickyHeader}
+                  class:table-col-highlighted={headerColumn?.highlighted === true}
                   data-pw={headerColumn?.testId ?? null}
                   style:text-align={headerColumn?.align ?? null}
                   style:max-width={headerColumn?.maxWidth ?? null}
@@ -848,6 +849,7 @@
                       typeof cellValue === 'boolean'}
                     <td
                       class="table-content"
+                      class:table-col-highlighted={keyedColumn?.highlighted === true}
                       data-pw={typeof getCellTestId === 'function'
                         ? getCellTestId(row, cellValue, rowIndex)
                         : null}
@@ -1178,6 +1180,20 @@
     font-size: var(--table-content-font-size, 14px);
     font-family: var(--table-content-font-family);
     color: var(--table-content-color, var(--table-content-font-color, #111827));
+  }
+
+  /* Column highlight (TableColumn.highlighted). Row hover keeps higher
+     specificity and row selection is declared later at equal specificity, so
+     both row states paint over the column wash. */
+  .table-header.table-col-highlighted {
+    background-color: var(
+      --table-col-highlight-header-background,
+      var(--table-col-highlight-background, #f3f9ff)
+    );
+  }
+
+  .table-content.table-col-highlighted {
+    background-color: var(--table-col-highlight-background, #f3f9ff);
   }
 
   .table-row {

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -232,6 +232,14 @@ export type TableColumn = {
    * ellipsizes with the full value available on the native title tooltip.
    */
   maxWidth?: string;
+  /**
+   * Paints this column's header and body cells with the highlight wash —
+   * `--table-col-highlight-background` (body) and
+   * `--table-col-highlight-header-background` (header; falls back to the body
+   * wash). Use to emphasize a selected/pivot column. Row hover and row
+   * selection still paint over the wash.
+   */
+  highlighted?: boolean;
   /** Opt-in header filter dropdown (see TableColumnFilterConfig). */
   filter?: TableColumnFilterConfig;
   /**

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -127,7 +127,7 @@
     { id: 'state', label: 'State', type: 'tag' },
     { id: 'channels', label: 'Channels', type: 'tag-array' },
     { id: 'owners', label: 'Owners', type: 'avatar-stack' },
-    { id: 'revenue', label: 'Revenue', type: 'compare', align: 'right' },
+    { id: 'revenue', label: 'Revenue', type: 'compare', align: 'right', highlighted: true },
     {
       id: 'active',
       label: 'Active',


### PR DESCRIPTION
## What

Adds `highlighted?: boolean` to `TableColumn` — paints that column's header and body cells with a highlight wash:

- `--table-col-highlight-background` (body cells, default `#f3f9ff`)
- `--table-col-highlight-header-background` (header cell, falls back to the body wash)

Row hover keeps higher specificity and row selection is declared later at equal specificity, so both row states still paint over the column wash.

## Why

The Breeze dashboard Figma spec ("All Cell Variants", Breeze Dashboard Design System) shows a highlighted/selected column state (Blue/50 wash) that consumers currently can only approximate with `classes` + nth-child CSS. This makes it first-class on the keyed column model.

## Demo

`/components/table` — the built-in renderers example now highlights the `compare` Revenue column (the exact Figma use case).

## Gates

`check` ✓ · `lint` ✓ · `test:unit` 94 passed ✓