### PR TITLE
feat(Table): leading icon for input cells via TableInputCellData.iconUrl

### DIFF
--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -37,6 +37,7 @@
     onKeyDown = () => {},
     classes,
     role,
+    ariaLabel,
     ariaExpanded,
     ariaAutocomplete,
     ariaControls,
@@ -256,6 +257,7 @@
       <textarea
         {value}
         {placeholder}
+        aria-label={ariaLabel}
         autocomplete={autoComplete}
         inputmode={inputMode}
         {name}
@@ -287,6 +289,7 @@
         type={dataType}
         {value}
         {placeholder}
+        aria-label={ariaLabel}
         autocomplete={autoComplete}
         inputmode={inputMode}
         {name}

--- a/src/lib/Input/properties.ts
+++ b/src/lib/Input/properties.ts
@@ -57,6 +57,8 @@ export type OptionalInputProperties = {
   testId?: string;
   classes?: string;
   role?: string;
+  /** Accessible name applied to the native input/textarea (aria-label). */
+  ariaLabel?: string | null;
   ariaExpanded?: boolean;
   ariaAutocomplete?: 'none' | 'inline' | 'list' | 'both';
   ariaControls?: string | null;

--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -274,6 +274,9 @@
 {:else if column.type === 'input'}
   {@const inputData = asInputCellData(value)}
   {#if inputData}
+    {#snippet inputLeadingIcon()}
+      <img class="builtin-input-icon" src={inputData.iconUrl} alt="" />
+    {/snippet}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <span
       class="builtin-interactive"
@@ -283,6 +286,7 @@
       <Input
         value={inputData.value ?? ''}
         placeholder={inputData.placeholder ?? ''}
+        ariaLabel={inputData.ariaLabel ?? null}
         disable={inputData.disabled ?? false}
         testId={inputData.testId ?? ''}
         dataType={asInputDataType(inputData.dataType ?? null)}
@@ -292,6 +296,7 @@
         onErrorMessage={inputData.onErrorMessage ?? null}
         actionInput={false}
         onInput={(newValue) => column.onInput?.(rowIndex, newValue, originalIndex)}
+        {...inputData.iconUrl ? { leftIcon: inputLeadingIcon } : {}}
       />
     </span>
   {:else}
@@ -587,6 +592,12 @@
     align-items: center;
     min-width: 0;
     width: var(--table-interactive-width, auto);
+  }
+
+  .builtin-input-icon {
+    display: block;
+    width: var(--table-cell-input-icon-size, 16px);
+    height: var(--table-cell-input-icon-size, 16px);
   }
 
   .builtin-action-group {

--- a/src/lib/Table/cell-data.test.ts
+++ b/src/lib/Table/cell-data.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   asAvatarStackData,
   asCompareCellData,
+  asInputCellData,
   asLinkCellData,
   asTagArrayItems,
   asTagCellData,
@@ -47,6 +48,22 @@ describe('cell narrowing', () => {
     expect(asLinkCellData('https://x.test')).toEqual({ url: 'https://x.test' });
     expect(asLinkCellData('')).toBeNull();
     expect(asLinkCellData({ href: 'https://x.test' })).toBeNull();
+  });
+
+  it('asInputCellData carries string iconUrl/ariaLabel and drops non-string values', () => {
+    expect(
+      asInputCellData({
+        placeholder: 'Amount',
+        iconUrl: 'data:image/svg+xml;utf8,x',
+        ariaLabel: 'Amount in rupees'
+      })
+    ).toEqual({
+      placeholder: 'Amount',
+      ariaLabel: 'Amount in rupees',
+      iconUrl: 'data:image/svg+xml;utf8,x'
+    });
+    expect(asInputCellData({ iconUrl: 42, ariaLabel: false })).toEqual({});
+    expect(asInputCellData('amount')).toBeNull();
   });
 
   it('cellValueToText renders scalars, dashes empty/object values', () => {

--- a/src/lib/Table/cellData.ts
+++ b/src/lib/Table/cellData.ts
@@ -185,6 +185,12 @@ export const asInputCellData = (value: TableCellValue): TableInputCellData | nul
   if (typeof record.testId === 'string') {
     inputData.testId = record.testId;
   }
+  if (typeof record.ariaLabel === 'string') {
+    inputData.ariaLabel = record.ariaLabel;
+  }
+  if (typeof record.iconUrl === 'string') {
+    inputData.iconUrl = record.iconUrl;
+  }
   if (typeof record.dataType === 'string') {
     inputData.dataType = record.dataType;
   }

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -133,6 +133,17 @@ export type TableInputCellData = {
   placeholder?: string;
   disabled?: boolean;
   testId?: string;
+  /**
+   * Accessible name forwarded to the rendered Input's native element
+   * (aria-label). Recommended whenever the cell has no visible label —
+   * required in practice for icon-bearing inputs.
+   */
+  ariaLabel?: string;
+  /**
+   * URL of a passive leading icon rendered inside the input field (e.g. a
+   * currency glyph). Sized via `--table-cell-input-icon-size` (default 16px).
+   */
+  iconUrl?: string;
   /** Input dataType forwarded to the rendered Input ('text' | 'tel' | 'number' | …). */
   dataType?: string;
   /**

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -191,6 +191,9 @@
   let interactiveLog = $state('none');
   let rowClickLog = $state('none');
 
+  const demoDotIcon =
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='8' fill='%2394a3b8'/></svg>";
+
   const interactiveColumns: TableColumn[] = [
     { id: 'name', label: 'Name' },
     {
@@ -283,7 +286,9 @@
         placeholder: 'Add note',
         testId: 'demo-note-1',
         validationPattern: '^\\d+$',
-        onErrorMessage: 'Digits only'
+        onErrorMessage: 'Digits only',
+        ariaLabel: 'Note for Starter Annual',
+        iconUrl: demoDotIcon
       },
       action: { text: 'Renew', disabled: true, testId: 'demo-renew-1' },
       manage: { menuItems: [{ id: 'delete', label: 'Delete', danger: true }] },
@@ -396,9 +401,6 @@
   }));
 
   // ── Media cell renderers demo (icon-label, image-two-line-text) ─────────────
-  const demoDotIcon =
-    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='8' fill='%2394a3b8'/></svg>";
-
   const mediaColumns: TableColumn[] = [
     { id: 'gateway', label: 'Gateway', type: 'icon-label', sortable: false },
     { id: 'product', label: 'Product', type: 'image-two-line-text', sortable: false }


### PR DESCRIPTION
## What

Adds `iconUrl?: string` to `TableInputCellData` — a JSON-safe way to render a passive leading icon inside a `type: 'input'` cell (e.g. a currency glyph), riding `Input`'s existing `leftIcon` snippet. Icon sizes via `--table-cell-input-icon-size` (default 16px).

- `asInputCellData` narrows the new field field-by-field (string only), with unit coverage added in `cell-data.test.ts` (the input decoder previously had none).
- Demo: the interactive-cells example's note input now renders a leading icon.

## Why

The Breeze dashboard Figma Table spec shows currency inputs with a leading ₹ glyph inside table cells; cell data must stay JSON-serializable, so the snippet bridge lives in BuiltinCell.

## Gates

`check` ✓ · `lint` ✓ · `test:unit` ✓ (95 passed, incl. the new decoder test)

Note: the interactive cell shapes (input/select/button) are currently undocumented in docs/Table.md — pre-existing gap, left for a docs pass.