### PR TITLE
BZ-4571: feat: Migrate svelte ui components test locators from css cl…

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover">
+  <body data-sveltekit-preload-data="hover" data-pw="page-body">
     <div>%sveltekit.body%</div>
   </body>
 </html>

--- a/src/lib/Animations/ModalAnimation.svelte
+++ b/src/lib/Animations/ModalAnimation.svelte
@@ -9,9 +9,16 @@
     align?: ModalAlign;
     transitionType?: ModalTransition;
     children?: Snippet;
+    testId?: string;
   };
 
-  let { enable = true, align = 'bottom', transitionType = 'ALL', children }: Props = $props();
+  let {
+    enable = true,
+    align = 'bottom',
+    transitionType = 'ALL',
+    children,
+    testId
+  }: Props = $props();
 
   let flyAnimationProperties = $derived.by(() => {
     const base = { x: 0, y: 0, duration: 380 };
@@ -34,19 +41,33 @@
 
 {#if enable}
   {#if useFlyAnimation && useOutTransition}
-    <div in:fly|global={flyAnimationProperties} out:fly|global={flyAnimationProperties}>
+    <div
+      in:fly|global={flyAnimationProperties}
+      out:fly|global={flyAnimationProperties}
+      data-pw={typeof testId === 'string' ? testId : null}
+    >
       {@render children?.()}
     </div>
   {:else if useFlyAnimation}
-    <div in:fly|global={flyAnimationProperties}>
+    <div
+      in:fly|global={flyAnimationProperties}
+      data-pw={typeof testId === 'string' ? testId : null}
+    >
       {@render children?.()}
     </div>
   {:else if useOutTransition}
-    <div in:fade|global={fadeAnimationProperties} out:fade|global={fadeAnimationProperties}>
+    <div
+      in:fade|global={fadeAnimationProperties}
+      out:fade|global={fadeAnimationProperties}
+      data-pw={typeof testId === 'string' ? testId : null}
+    >
       {@render children?.()}
     </div>
   {:else}
-    <div in:fade|global={fadeAnimationProperties}>
+    <div
+      in:fade|global={fadeAnimationProperties}
+      data-pw={typeof testId === 'string' ? testId : null}
+    >
       {@render children?.()}
     </div>
   {/if}

--- a/src/lib/Animations/OverlayAnimation.svelte
+++ b/src/lib/Animations/OverlayAnimation.svelte
@@ -4,11 +4,12 @@
 
   type Props = {
     children?: Snippet;
+    testId?: string;
   };
 
-  let { children }: Props = $props();
+  let { children, testId }: Props = $props();
 </script>
 
-<div out:fade={{ duration: 350 }}>
+<div out:fade={{ duration: 350 }} data-pw={typeof testId === 'string' ? testId : null}>
   {@render children?.()}
 </div>

--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -884,6 +884,7 @@
                           effectiveHighlightedIndex !== bar.pi)}
                       d={stackedBarPath(bar)}
                       fill={barFillAttr(bar)}
+                      data-pw={`bar-${i}`}
                       tabindex="0"
                       role="button"
                       aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
@@ -912,6 +913,7 @@
                       rx={barRadius}
                       ry={barRadius}
                       fill={barFillAttr(bar)}
+                      data-pw={`bar-${i}`}
                       tabindex="0"
                       role="button"
                       aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
@@ -930,10 +932,12 @@
                     <text
                       class="bar-value"
                       class:bar-value-inside={bl.p.placement === 'inside'}
+                      data-inside={bl.p.placement === 'inside' ? 'true' : 'false'}
                       x={bl.p.x}
                       y={bl.p.y}
                       text-anchor={bl.p.textAnchor}
                       dominant-baseline={bl.p.dominantBaseline}
+                      data-pw={`bar-value-${i}`}
                       style={bl.p.placement === 'inside'
                         ? `fill: ${getContrastColor(bl.bar.color)}; stroke: ${contrastOutline(bl.bar.color)};`
                         : ''}>{bl.text}</text

--- a/src/lib/BrandLoader/BrandLoader.svelte
+++ b/src/lib/BrandLoader/BrandLoader.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { BrandLoaderProperties } from './properties';
 
-  let { brandLogoURL, brandText, subText, classes }: BrandLoaderProperties = $props();
+  let { brandLogoURL, brandText, subText, classes, testId }: BrandLoaderProperties = $props();
 </script>
 
-<div class="background {classes ?? ''}">
+<div class="background {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
   <div class="loader">
     <img src={brandLogoURL} alt="" />
     <div class="text">{brandText}</div>

--- a/src/lib/BrandLoader/properties.ts
+++ b/src/lib/BrandLoader/properties.ts
@@ -3,4 +3,5 @@ export type BrandLoaderProperties = {
   brandText: string;
   subText?: string | null;
   classes?: string;
+  testId?: string;
 };

--- a/src/lib/Checkbox/Checkbox.svelte
+++ b/src/lib/Checkbox/Checkbox.svelte
@@ -58,6 +58,7 @@
     tabindex={-1}
     aria-hidden="true"
     onclick={(e: MouseEvent) => e.stopPropagation()}
+    data-pw={typeof testId === 'string' ? `${testId}-native-input` : null}
   />
   <span
     class="box"
@@ -69,6 +70,7 @@
     aria-disabled={disabled}
     aria-controls={ariaControls ?? null}
     onkeydown={handleKeyDown}
+    data-pw={typeof testId === 'string' ? `${testId}-box` : null}
   >
     {#if checked && !indeterminate}
       {#if typeof checkedIcon === 'function'}

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -556,6 +556,7 @@
       onclick={togglePicker}
       ariaLabel={isOpen ? 'Close date picker' : 'Open date picker'}
       classes="drp-trigger {isOpen ? 'drp-trigger-open' : ''}"
+      {...typeof testId === 'string' ? { testId: `${testId}-trigger` } : {}}
     >
       {#if typeof triggerSnippet === 'function'}
         {@render triggerSnippet(triggerLabel)}
@@ -652,6 +653,7 @@
       role="dialog"
       aria-label="Date range picker"
       aria-modal="true"
+      data-pw={typeof testId === 'string' ? `${testId}-panel` : null}
     >
       <div class="drp-panel-inner">
         <!-- Preset sidebar -->
@@ -676,11 +678,17 @@
                 role="option"
                 aria-selected={isPresetActive(preset)}
                 onclick={() => handlePreset(preset)}
+                data-pw={typeof testId === 'string' ? `${testId}-preset-${preset.label}` : null}
               >
                 {preset.label}
                 {#if presetCheckmark && isPresetActive(preset)}
                   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                  <span class="drp-preset-check" aria-hidden="true">{@html checkmarkSvg}</span>
+                  <span
+                    class="drp-preset-check"
+                    aria-hidden="true"
+                    data-pw={typeof testId === 'string' ? `${testId}-preset-check` : null}
+                    >{@html checkmarkSvg}</span
+                  >
                 {/if}
               </button>
             {/each}

--- a/src/lib/DeltaIndicator/properties.ts
+++ b/src/lib/DeltaIndicator/properties.ts
@@ -24,7 +24,7 @@ export type OptionalDeltaIndicatorProperties = {
   /** Absolute values at or below this are treated as `neutral` (default 0). */
   neutralThreshold?: number;
   /** Test selector applied as the `data-pw` attribute. */
-  testId?: string;
+  testId?: string | null;
   /** Additional CSS classes for theming. */
   classes?: string;
 };

--- a/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
+++ b/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
@@ -567,6 +567,7 @@
               width={hr.width}
               height={dims.innerHeight}
               fill="transparent"
+              data-pw={`hover-target-${hr.catIdx}`}
               data-category-index={hr.catIdx}
               tabindex="0"
               role="button"

--- a/src/lib/FunnelChart/FunnelChart.svelte
+++ b/src/lib/FunnelChart/FunnelChart.svelte
@@ -332,6 +332,7 @@
               class:funnel-bar-dimmed={hoveredIndex !== null && hoveredIndex !== index}
               x={bx}
               y={by}
+              data-pw={`funnel-bar-${index}`}
               width={stageColumnWidth}
               height={bh}
               fill={color}

--- a/src/lib/GridItem/GridItem.svelte
+++ b/src/lib/GridItem/GridItem.svelte
@@ -8,7 +8,8 @@
     showLoader = $bindable(false),
     onclick,
     onkeydown,
-    classes
+    classes,
+    testId
   }: GridItemProperties = $props();
 
   function handleClick(event: MouseEvent) {
@@ -17,7 +18,14 @@
   }
 </script>
 
-<div class="container {classes ?? ''}" onclick={handleClick} {onkeydown} role="button" tabindex="0">
+<div
+  class="container {classes ?? ''}"
+  onclick={handleClick}
+  {onkeydown}
+  role="button"
+  tabindex="0"
+  data-pw={typeof testId === 'string' ? testId : null}
+>
   <div class="grid-header">
     <img src={headerIcon} alt="" class="grid-item-header-icon" />
   </div>

--- a/src/lib/GridItem/properties.ts
+++ b/src/lib/GridItem/properties.ts
@@ -11,6 +11,7 @@ export type OptionalGridItemProperties = {
   headerIcon?: string | null;
   showLoader?: boolean;
   classes?: string;
+  testId?: string;
 };
 
 export type GridItemEventProperties = {

--- a/src/lib/Icon/Icon.svelte
+++ b/src/lib/Icon/Icon.svelte
@@ -2,10 +2,17 @@
   import Img from '../Img/Img.svelte';
   import type { IconProperties } from './properties';
 
-  let { icon, svg, text, onclick, onkeydown, classes }: IconProperties = $props();
+  let { icon, svg, text, onclick, onkeydown, classes, testId }: IconProperties = $props();
 </script>
 
-<div class="icon-container {classes ?? ''}" {onclick} {onkeydown} role="button" tabindex="0">
+<div
+  class="icon-container {classes ?? ''}"
+  {onclick}
+  {onkeydown}
+  role="button"
+  tabindex="0"
+  data-pw={typeof testId === 'string' ? testId : null}
+>
   {#if typeof svg === 'string' && svg.length > 0}
     <!-- eslint-disable svelte/no-at-html-tags -->
     <span class="icon-svg">{@html svg}</span>

--- a/src/lib/Icon/properties.ts
+++ b/src/lib/Icon/properties.ts
@@ -5,6 +5,7 @@ export type OptionalIconProperties = {
   svg?: string;
   text?: string | null;
   classes?: string;
+  testId?: string;
 };
 
 export type IconEventProperties = {

--- a/src/lib/IconStack/IconStack.svelte
+++ b/src/lib/IconStack/IconStack.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { IconStackProperties } from './properties';
 
-  let { icons, classes }: IconStackProperties = $props();
+  let { icons, classes, testId }: IconStackProperties = $props();
 </script>
 
-<div class="stack-container {classes ?? ''}">
+<div class="stack-container {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
   {#each icons as icon, i (i)}
     <div class="stack-icon" style:z-index={icons.length - i}>
       {#if icon.type === 'image'}

--- a/src/lib/IconStack/properties.ts
+++ b/src/lib/IconStack/properties.ts
@@ -6,4 +6,5 @@ export type IconStackItem = {
 export type IconStackProperties = {
   icons: IconStackItem[];
   classes?: string;
+  testId?: string;
 };

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -356,7 +356,10 @@
   {/if}
 
   {#if onErrorMessage !== '' && showError && !actionInput}
-    <div class="error-message">
+    <div
+      class="error-message"
+      data-pw={typeof testId === 'string' && testId.length > 0 ? `${testId}-error-message` : null}
+    >
       {onErrorMessage}
     </div>
   {/if}

--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -19,7 +19,8 @@
     classes,
     mandatory,
     size,
-    error
+    error,
+    testId
   }: InputButtonProperties = $props();
 
   let validationState = $state<ValidationState>('InProgress');
@@ -61,7 +62,7 @@
   }
 </script>
 
-<div class="container {classes ?? ''}">
+<div class="container {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
   {#if inputProperties.label && inputProperties.label !== ''}
     <label class="label" for={inputProperties.name}>
       {inputProperties.label}{#if mandatory}<span class="mandatory-marker" aria-label="required">

--- a/src/lib/InputButton/properties.ts
+++ b/src/lib/InputButton/properties.ts
@@ -37,6 +37,7 @@ export type OptionalInputButtonProperties = {
    * internal validation messages surface normally.
    */
   error?: string;
+  testId?: string;
 };
 
 export type InputButtonEventProperties = {

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -584,7 +584,14 @@
           {/if}
 
           {#each haloPoints as hp, i (i)}
-            <circle class="dot-halo" cx={hp.x} cy={hp.y} r={dotRadius + 6} fill={hp.color} />
+            <circle
+              class="dot-halo"
+              cx={hp.x}
+              cy={hp.y}
+              r={dotRadius + 6}
+              fill={hp.color}
+              data-pw={`dot-halo-${i}`}
+            />
           {/each}
 
           {#each lines as line, si (si)}
@@ -672,6 +679,7 @@
             width={dims.innerWidth}
             height={dims.innerHeight}
             fill="transparent"
+            data-pw="hover-overlay"
             onpointermove={handleOverlayMove}
             onpointerleave={handleLeave}
             onclick={handleClick}

--- a/src/lib/LoadingDots/LoadingDots.svelte
+++ b/src/lib/LoadingDots/LoadingDots.svelte
@@ -13,7 +13,12 @@
   data-pw={typeof testId === 'string' ? testId : null}
 >
   {#each { length: count } as _, i (i)}
-    <span class="dot" class:pulse={animation === 'pulse'} style="--i: {i}"></span>
+    <span
+      class="dot"
+      class:pulse={animation === 'pulse'}
+      style="--i: {i}"
+      data-pw={typeof testId === 'string' ? `${testId}-dot-${i}` : null}
+    ></span>
   {/each}
 </span>
 

--- a/src/lib/ProportionBar/ProportionBar.svelte
+++ b/src/lib/ProportionBar/ProportionBar.svelte
@@ -109,6 +109,7 @@
       role={showLegend ? null : 'img'}
       aria-hidden={showLegend ? 'true' : null}
       aria-label={showLegend ? null : ariaSummary}
+      data-pw={typeof testId === 'string' ? `${testId}-svg` : null}
     >
       {#each rectSegments as rectSegment, rectIndex (rectIndex)}
         <rect
@@ -130,9 +131,16 @@
   </div>
 
   {#if showLegend}
-    <ul class="proportion-bar-legend" aria-label="Segment breakdown">
+    <ul
+      class="proportion-bar-legend"
+      aria-label="Segment breakdown"
+      data-pw={typeof testId === 'string' ? `${testId}-legend` : null}
+    >
       {#each computedSegments as computedSegment, legendIndex (legendIndex)}
-        <li class="proportion-bar-legend-item">
+        <li
+          class="proportion-bar-legend-item"
+          data-pw={typeof testId === 'string' ? `${testId}-legend-item-${legendIndex}` : null}
+        >
           <span
             class="proportion-bar-swatch"
             style="background: {computedSegment.color};"

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -338,6 +338,7 @@
             {disabled}
             autocomplete="off"
             tabindex={disabled ? -1 : 0}
+            data-pw={typeof testId === 'string' ? `${testId}-search` : null}
           />
         {/if}
       {:else}
@@ -362,6 +363,7 @@
             {disabled}
             autocomplete="off"
             tabindex={disabled ? -1 : 0}
+            data-pw={typeof testId === 'string' ? `${testId}-search` : null}
           />
         {:else if value.length === 0}
           <span class="select-placeholder">{placeholder}</span>
@@ -379,6 +381,7 @@
         {disabled}
         autocomplete="off"
         tabindex={disabled ? -1 : 0}
+        data-pw={typeof testId === 'string' ? `${testId}-search` : null}
       />
     {:else}
       <span class={displayText.length > 0 ? 'select-value' : 'select-placeholder'}>
@@ -429,12 +432,17 @@
                   class:checked={allFilteredSelected}
                   class:indeterminate={selectAllIndeterminate}
                   aria-hidden="true"
+                  data-checked={allFilteredSelected ? 'true' : 'false'}
+                  data-pw={typeof testId === 'string' ? `${testId}-select-all-indicator` : null}
                 >
                   {#if allFilteredSelected}
                     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                     <span class="select-option-check">{@html checkmarkSvg}</span>
                   {:else if selectAllIndeterminate}
-                    <span class="select-option-dash"></span>
+                    <span
+                      class="select-option-dash"
+                      data-pw={typeof testId === 'string' ? `${testId}-select-all-dash` : null}
+                    ></span>
                   {/if}
                 </span>
               {/if}
@@ -472,6 +480,10 @@
                     class="select-option-indicator"
                     class:checked={value.includes(row.item.id)}
                     aria-hidden="true"
+                    data-checked={value.includes(row.item.id) ? 'true' : 'false'}
+                    data-pw={typeof testId === 'string'
+                      ? `${testId}-option-indicator-${row.item.id}`
+                      : null}
                   >
                     {#if value.includes(row.item.id)}
                       <!-- eslint-disable-next-line svelte/no-at-html-tags -->

--- a/src/lib/Sheet/Sheet.svelte
+++ b/src/lib/Sheet/Sheet.svelte
@@ -145,6 +145,7 @@
       aria-modal="true"
       aria-label={title ?? 'Sheet'}
       tabindex="-1"
+      data-pw={typeof testId === 'string' ? `${testId}-panel` : null}
       transition:fly|global={flyParams}
       onintroend={handleIntroEnd}
       onoutroend={handleOutroEnd}

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -91,7 +91,7 @@
   onkeydown={isInteractive ? handleKeydown : null}
 >
   {#if hasHeaderContent}
-    <div class="statcard-header">
+    <div class="statcard-header" data-pw={typeof testId === 'string' ? `${testId}-header` : null}>
       <div class="statcard-header-left">
         {#if hasTitle}
           {#if tooltip}
@@ -112,7 +112,12 @@
               </span>
             </Tooltip>
           {:else}
-            <div class="statcard-title">{title}</div>
+            <div
+              class="statcard-title"
+              data-pw={typeof testId === 'string' ? `${testId}-title` : null}
+            >
+              {title}
+            </div>
           {/if}
         {/if}
         {#if checkbox}
@@ -137,10 +142,17 @@
   {/if}
 
   {#if hasRows && rows}
-    <div class="statcard-rows" class:statcard-rows-horizontal={rowsDirection === 'row'}>
+    <div
+      class="statcard-rows"
+      class:statcard-rows-horizontal={rowsDirection === 'row'}
+      data-pw={typeof testId === 'string' ? `${testId}-rows` : null}
+    >
       {#each rows as row, rowIndex (rowIndex)}
         {#if rowIndex > 0}
-          <div class="statcard-row-divider"></div>
+          <div
+            class="statcard-row-divider"
+            data-pw={typeof testId === 'string' ? `${testId}-row-divider-${rowIndex}` : null}
+          ></div>
         {/if}
         <div class="statcard-row" data-pw={typeof row.testId === 'string' ? row.testId : null}>
           {#if typeof row.heading === 'string' && row.heading.length > 0}
@@ -159,9 +171,18 @@
             </div>
           {/if}
           <div class="statcard-row-value-line">
-            <div class="statcard-value">{row.value}</div>
+            <div
+              class="statcard-value"
+              data-pw={typeof testId === 'string' ? `${testId}-value-${rowIndex}` : null}
+            >
+              {row.value}
+            </div>
             {#if typeof row.change === 'number'}
-              <DeltaIndicator value={row.change} invertColors={row.invertChangeColors ?? false} />
+              <DeltaIndicator
+                value={row.change}
+                invertColors={row.invertChangeColors ?? false}
+                testId={testId ? `${testId}-delta-${rowIndex}` : null}
+              />
             {/if}
             {#if typeof row.additionalContent === 'string' && row.additionalContent.length > 0}
               <div class="statcard-row-additional">{row.additionalContent}</div>
@@ -173,7 +194,12 @@
             {/if}
             <div class="statcard-breakdown-grid">
               {#each row.breakdown as breakdownItem, breakdownIndex (breakdownIndex)}
-                <div class="statcard-breakdown-item">
+                <div
+                  class="statcard-breakdown-item"
+                  data-pw={typeof testId === 'string'
+                    ? `${testId}-breakdown-item-${rowIndex}-${breakdownIndex}`
+                    : null}
+                >
                   <div class="statcard-breakdown-label">{breakdownItem.label}</div>
                   <div class="statcard-breakdown-value">{breakdownItem.value}</div>
                   {#if typeof breakdownItem.change === 'number'}
@@ -192,9 +218,13 @@
   {:else}
     <div class="statcard-value-row">
       {#if typeof valueSnippet === 'function'}
-        <div class="statcard-value">{@render valueSnippet()}</div>
+        <div class="statcard-value" data-pw={typeof testId === 'string' ? `${testId}-value` : null}>
+          {@render valueSnippet()}
+        </div>
       {:else if typeof value === 'string' && value.length > 0}
-        <div class="statcard-value">{value}</div>
+        <div class="statcard-value" data-pw={typeof testId === 'string' ? `${testId}-value` : null}>
+          {value}
+        </div>
       {/if}
 
       {#if hasDelta}
@@ -210,7 +240,12 @@
   {/if}
 
   {#if typeof subtitle === 'string' && subtitle.length > 0}
-    <div class="statcard-subtitle">{subtitle}</div>
+    <div
+      class="statcard-subtitle"
+      data-pw={typeof testId === 'string' ? `${testId}-subtitle` : null}
+    >
+      {subtitle}
+    </div>
   {/if}
 
   {#if children}

--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -10,11 +10,12 @@
     buttonProperties,
     classes,
     onbuttonClick,
-    icon
+    icon,
+    testId
   }: StatusProperties = $props();
 </script>
 
-<div class="background {classes ?? ''}">
+<div class="background {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
   <div class="order-status">
     <div class="status-image">
       {#if icon}

--- a/src/lib/Status/properties.ts
+++ b/src/lib/Status/properties.ts
@@ -13,6 +13,7 @@ export type StatusProperties = StatusEventProperties & {
    * priority over `statusIcon` when provided.
    */
   icon?: Snippet;
+  testId?: string;
 };
 
 export type StatusEventProperties = {

--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -139,7 +139,10 @@
     : []}
   <div class="builtin-icon-label {alignmentClass}">
     {#each icons as iconSrc, iconIndex (`${iconIndex}-${iconSrc}`)}
-      <span class="builtin-icon-label-icon">
+      <span
+        class="builtin-icon-label-icon"
+        data-pw={column.testId ? `${column.testId}-icon-${iconIndex}` : null}
+      >
         <Img src={String(iconSrc)} alt="" fallback="" />
       </span>
     {/each}
@@ -149,7 +152,7 @@
   {@const data = asJsonObject(value) ?? {}}
   <div class="builtin-image-two-line {alignmentClass}">
     {#if typeof data.imageUrl === 'string' && data.imageUrl}
-      <span class="builtin-thumb">
+      <span class="builtin-thumb" data-pw={column.testId ? `${column.testId}-thumb` : null}>
         <Img
           src={data.imageUrl}
           alt={typeof data.text1 === 'string' ? data.text1 : ''}
@@ -157,7 +160,10 @@
         />
       </span>
     {:else}
-      <span class="builtin-thumb builtin-thumb-placeholder"></span>
+      <span
+        class="builtin-thumb builtin-thumb-placeholder"
+        data-pw={column.testId ? `${column.testId}-thumb-placeholder` : null}
+      ></span>
     {/if}
     <div class="builtin-two-line {alignmentClass}">
       <span class="builtin-primary-text">{typeof data.text1 === 'string' ? data.text1 : '-'}</span>
@@ -169,8 +175,12 @@
   {@const tags = asTagArrayItems(value)}
   {#if tags}
     <div class="builtin-tag-array {alignmentClass}">
-      {#each tags as tag (tag.text)}
-        <Pill text={tag.text} classes={tag.classes ?? ''} />
+      {#each tags as tag, tagIndex (`${tagIndex}-${tag.text}`)}
+        <Pill
+          text={tag.text}
+          classes={tag.classes ?? ''}
+          testId={tag.testId ?? (column.testId && `${column.testId}-tag-${tagIndex}`)}
+        />
       {/each}
     </div>
   {:else}
@@ -204,13 +214,19 @@
         {/if}
         {#if typeof compare.trendPercent === 'number'}
           {#if compare.trendPercent > 0}
-            <span class="builtin-trend builtin-trend-up">
+            <span
+              class="builtin-trend builtin-trend-up"
+              data-pw={column.testId ? `${column.testId}-trend-up` : null}
+            >
               <!-- eslint-disable svelte/no-at-html-tags -->
               <span class="builtin-trend-icon">{@html trendUpSvg}</span>
               {compare.trendPercent}%
             </span>
           {:else if compare.trendPercent < 0}
-            <span class="builtin-trend builtin-trend-down">
+            <span
+              class="builtin-trend builtin-trend-down"
+              data-pw={column.testId ? `${column.testId}-trend-down` : null}
+            >
               <!-- eslint-disable svelte/no-at-html-tags -->
               <span class="builtin-trend-icon">{@html trendDownSvg}</span>
               {compare.trendPercent}%
@@ -431,7 +447,10 @@
           </Button>
         </span>
         {#if copied}
-          <span class="builtin-link-copied">Copied</span>
+          <span
+            class="builtin-link-copied"
+            data-pw={column.testId ? `${column.testId}-link-copied` : null}>Copied</span
+          >
         {/if}
       {/if}
     </div>

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -631,6 +631,7 @@
                       ? 'mixed'
                       : headerCheckboxState === 'all'}
                     aria-label="Select all rows"
+                    data-pw={typeof testId === 'string' ? `${testId}-select-all` : null}
                     {...checkboxSelection?.getRowAttributes
                       ? checkboxSelection.getRowAttributes('__header__', -1)
                       : {}}
@@ -818,6 +819,9 @@
                         aria-checked={rowSelected}
                         aria-disabled={rowDisabled}
                         aria-label={`Select row ${rowId || 'non-selectable'}`}
+                        data-pw={typeof testId === 'string'
+                          ? `${testId}-row-checkbox-${rowId}`
+                          : null}
                         {...checkboxSelection?.getRowAttributes
                           ? checkboxSelection.getRowAttributes(rowId, rowIndex)
                           : {}}
@@ -860,6 +864,9 @@
                       <div
                         class={isContentScrollable ? 'scrollable-content' : ''}
                         class:table-cell-clamp={keyedColumn?.maxWidth && isScalarCell}
+                        data-pw={keyedColumn?.testId
+                          ? `${keyedColumn.testId}-cell-${rowIndex}`
+                          : null}
                       >
                         {#if keyedColumn && typeof keyedColumn.cell === 'function' && keyedRow}
                           {@render keyedColumn.cell(keyedRow, rowIndex, originalIndex)}
@@ -894,7 +901,14 @@
            more than one page (or the server reports more chunks); a
            single-page table shows no footer. -->
       <div class="table-footer table-paginator" data-pw={pagination.testId ?? null}>
-        <span class="table-paginator-range">{paginationRangeText}</span>
+        <span
+          class="table-paginator-range"
+          data-pw={typeof testId === 'string'
+            ? `${testId}-paginator-range`
+            : pagination?.testId
+              ? `${pagination.testId}-range`
+              : null}>{paginationRangeText}</span
+        >
         <span class="table-paginator-controls">
           {#if pageSizeOptions.length > 0}
             <span class="table-paginator-size">

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -78,6 +78,7 @@ export type TableImageTwoLineTextCellData = {
 export type TableTagArrayCellItem = {
   text: string;
   classes?: string;
+  testId?: string;
 };
 
 /** Cell shape for `type: 'avatar-stack'` — initials chips with overflow. */
@@ -222,9 +223,6 @@ export type TableColumn = {
   /**
    * Horizontal alignment for this column's header and body cells. When unset,
    * cells follow the table-wide `--table-text-align` (left by default).
-   * Built-in flex cells (compare, two-line-text, text-tag, icon-label,
-   * image-two-line-text, tag-array, avatar-stack) mirror it into their flex
-   * alignment so stacked/inline content follows the aligned edge too.
    */
   align?: 'left' | 'center' | 'right';
   /**

--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <div class="toolbar {classes ?? ''}" data-pw={testId}>
-  <div class="content">
+  <div class="content" data-pw={typeof testId === 'string' ? `${testId}-content` : null}>
     {#if typeof leftContent === 'function'}
       {@render leftContent()}
     {:else if showBackButton && typeof backIcon === 'string' && backIcon.length > 0}

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -234,6 +234,10 @@
     }
     const bubble = document.createElement('div');
     bubble.setAttribute('role', 'tooltip');
+    bubble.setAttribute(
+      'data-pw',
+      typeof testId === 'string' ? `${testId}-bubble` : 'tooltip-bubble'
+    );
 
     const coords = computePortalCoords(rect, pos);
     bubble.style.cssText = [
@@ -369,6 +373,7 @@
       class="tooltip-bubble {displayPosition}"
       role="tooltip"
       style:--tooltip-shift="{bubbleShift}px"
+      data-pw={typeof testId === 'string' ? `${testId}-bubble` : 'tooltip-bubble'}
     >
       <div class="tooltip-arrow"></div>
       {#if typeof content === 'function'}

--- a/src/lib/_chart/Axis.svelte
+++ b/src/lib/_chart/Axis.svelte
@@ -44,7 +44,7 @@
   const TICK_SIZE = 6;
 </script>
 
-<g class="axis axis-{orientation} {classes ?? ''}">
+<g class="axis axis-{orientation} {classes ?? ''}" data-pw={`axis-${orientation}`}>
   {#if isHorizontal}
     <line class="axis-line" x1={scale.range[0]} x2={scale.range[1]} y1={0} y2={0} />
     {#each tickValues as tick, i (i)}
@@ -58,6 +58,7 @@
               transform="translate(0, {TICK_SIZE + 4}) rotate(-45)"
               text-anchor="end"
               dominant-baseline="auto"
+              data-pw={`tick-label-${i}`}
             >
               {format(tick)}
             </text>
@@ -67,6 +68,7 @@
               y={orientation === 'bottom' ? TICK_SIZE + 4 : -(TICK_SIZE + 4)}
               text-anchor="middle"
               dominant-baseline={orientation === 'bottom' ? 'hanging' : 'auto'}
+              data-pw={`tick-label-${i}`}
             >
               {format(tick)}
             </text>
@@ -102,6 +104,7 @@
           x={orientation === 'left' ? -(TICK_SIZE + 4) : TICK_SIZE + 4}
           text-anchor={orientation === 'left' ? 'end' : 'start'}
           dominant-baseline="middle"
+          data-pw={`tick-label-${i}`}
         >
           {format(tick)}
         </text>

--- a/src/lib/_chart/ChartTooltip.svelte
+++ b/src/lib/_chart/ChartTooltip.svelte
@@ -86,7 +86,7 @@
       <div class="tooltip-title">{tooltipData.title}</div>
     {/if}
     {#each tooltipData.items as item, i (i)}
-      <div class="tooltip-item">
+      <div class="tooltip-item" data-pw={`tooltip-item-${i}`}>
         {#if item.color}
           <span class="tooltip-swatch" style="background: {item.color}"></span>
         {/if}
@@ -106,6 +106,7 @@
       class="chart-tooltip portal {unstyled ? 'unstyled' : ''} {classes ?? ''}"
       style="left: {pos.left}px; top: {pos.top}px;"
       use:portalToBody
+      data-pw="chart-tooltip"
     >
       {@render inner(data)}
     </div>
@@ -116,6 +117,7 @@
       bind:clientHeight={tooltipHeight}
       class="chart-tooltip {unstyled ? 'unstyled' : ''} {classes ?? ''}"
       style="left: {pos.left}px; top: {pos.top}px;"
+      data-pw="chart-tooltip"
     >
       {@render inner(data)}
     </div>

--- a/src/lib/_chart/Legend.svelte
+++ b/src/lib/_chart/Legend.svelte
@@ -17,6 +17,7 @@
             class:legend-hidden={item.hidden}
             aria-pressed={!item.hidden}
             onclick={() => onToggle(i)}
+            data-pw={`legend-toggle-${i}`}
           >
             <span class="legend-swatch" style="background: {item.color}"></span>
             <span class="legend-label">{item.label}</span>

--- a/src/routes/components/loading-dots/+page.svelte
+++ b/src/routes/components/loading-dots/+page.svelte
@@ -9,7 +9,7 @@
 
 <div class="demo-row" style="align-items: center; gap: 32px;">
   <LoadingDots />
-  <LoadingDots animation="pulse" />
+  <LoadingDots animation="pulse" testId="loading-dots-pulse" />
   <div style="--loading-dots-size: 10px;">
     <LoadingDots dots={5} />
   </div>

--- a/src/routes/components/sheet/+page.svelte
+++ b/src/routes/components/sheet/+page.svelte
@@ -22,7 +22,7 @@
 <h3>Right (default)</h3>
 <div class="demo-row">
   <Button text="Open right" onclick={() => (showRight = true)} />
-  <Sheet bind:open={showRight} side="right" title="Settings">
+  <Sheet bind:open={showRight} side="right" title="Settings" testId="sheet-right">
     {#snippet content()}
       <p>Side panel sliding in from the right. Use for settings, details, or editing forms.</p>
     {/snippet}
@@ -62,7 +62,7 @@
 <h3>With footer</h3>
 <div class="demo-row">
   <Button text="Open with footer" onclick={() => (showFooter = true)} />
-  <Sheet bind:open={showFooter} side="right" title="Confirm">
+  <Sheet bind:open={showFooter} side="right" title="Confirm" testId="sheet-footer">
     {#snippet content()}
       <p>Sheet with a footer for action buttons.</p>
     {/snippet}

--- a/src/routes/components/split-input/+page.svelte
+++ b/src/routes/components/split-input/+page.svelte
@@ -14,7 +14,7 @@
 
 <div class="demo-row" style="max-width: 400px;">
   <h3>OTP / PIN (auto-advance)</h3>
-  <SplitInput bind:values={otpValues} autoAdvance />
+  <SplitInput bind:values={otpValues} autoAdvance testId="split-input-default" />
   <p>Value: {otpValues.join('')}</p>
 </div>
 

--- a/src/routes/components/stat-card/+page.svelte
+++ b/src/routes/components/stat-card/+page.svelte
@@ -9,18 +9,21 @@
 
   const checkoutRows = [
     {
+      testId: 'checkout-row-0',
       heading: 'Gross Revenue',
       value: '₹12.4Cr',
       change: 8.2,
       tooltip: { text: 'Total revenue before returns and cancellations', position: 'top' as const }
     },
     {
+      testId: 'checkout-row-1',
       heading: 'Net Revenue',
       value: '₹10.9Cr',
       change: 5.7,
       additionalContent: 'after RTO'
     },
     {
+      testId: 'checkout-row-2',
       heading: 'RTO Rate',
       value: '12.1%',
       change: -2.3,

--- a/src/routes/components/status/+page.svelte
+++ b/src/routes/components/status/+page.svelte
@@ -36,7 +36,7 @@
     <Status statusText="Processing" statusDescription="Hang tight…">
       {#snippet icon()}
         <div style="width: 48px; height: 48px;" data-pw="status-icon-slot-lottie">
-          <LottiePlayer animationData={minimalAnimation} />
+          <LottiePlayer animationData={minimalAnimation} testId="status-lottie" />
         </div>
       {/snippet}
     </Status>

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -124,10 +124,17 @@
 
   const builtinColumns: TableColumn[] = [
     { id: 'plan', label: 'Plan', type: 'two-line-text' },
-    { id: 'state', label: 'State', type: 'tag' },
-    { id: 'channels', label: 'Channels', type: 'tag-array' },
+    { id: 'state', label: 'State', type: 'tag', testId: 'builtin-state' },
+    { id: 'channels', label: 'Channels', type: 'tag-array', testId: 'builtin-channels' },
     { id: 'owners', label: 'Owners', type: 'avatar-stack' },
-    { id: 'revenue', label: 'Revenue', type: 'compare', align: 'right', highlighted: true },
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      type: 'compare',
+      align: 'right',
+      highlighted: true,
+      testId: 'builtin-revenue'
+    },
     {
       id: 'active',
       label: 'Active',
@@ -143,10 +150,10 @@
   const builtinRows: TableRow[] = [
     {
       plan: { text1: 'Growth Monthly', text2: 'PLN-0042' },
-      state: { text: 'Active', classes: 'pill-success' },
+      state: { text: 'Active', classes: 'pill-success', testId: 'builtin-state-0' },
       channels: [
-        { text: 'Web', classes: 'pill-info' },
-        { text: 'App', classes: 'pill-info' }
+        { text: 'Web', classes: 'pill-info', testId: 'builtin-channels-web-0' },
+        { text: 'App', classes: 'pill-info', testId: 'builtin-channels-app-0' }
       ],
       owners: {
         items: [
@@ -160,8 +167,8 @@
     },
     {
       plan: { text1: 'Starter Annual', text2: 'PLN-0007' },
-      state: { text: 'Paused', classes: 'pill-warning' },
-      channels: [{ text: 'Web', classes: 'pill-info' }],
+      state: { text: 'Paused', classes: 'pill-warning', testId: 'builtin-state-1' },
+      channels: [{ text: 'Web', classes: 'pill-info', testId: 'builtin-channels-web-1' }],
       owners: {
         items: [
           { id: 'u1', label: 'carol' },
@@ -178,7 +185,7 @@
     },
     {
       plan: { text1: 'Legacy', text2: 'PLN-0001' },
-      state: { text: 'Expired', classes: 'pill-error' },
+      state: { text: 'Expired', classes: 'pill-error', testId: 'builtin-state-2' },
       channels: [],
       owners: { items: [] },
       revenue: 'n/a',
@@ -192,7 +199,7 @@
   let rowClickLog = $state('none');
 
   const interactiveColumns: TableColumn[] = [
-    { id: 'name', label: 'Name' },
+    { id: 'name', label: 'Name', testId: 'demo-name' },
     {
       id: 'tier',
       label: 'Tier',
@@ -348,8 +355,8 @@
   ]);
 
   const serverColumns: TableColumn[] = [
-    { id: 'name', label: 'Name', sortable: false },
-    { id: 'score', label: 'Score' }
+    { id: 'name', label: 'Name', sortable: false, testId: 'srv-sort-name' },
+    { id: 'score', label: 'Score', testId: 'srv-sort-score' }
   ];
 
   const handleServerSort = (colIndex: number, direction: 'asc' | 'desc'): void => {
@@ -361,8 +368,8 @@
 
   // ── Built-in pagination + row numbers demo ───────────────────────────────────
   const pagedColumns: TableColumn[] = [
-    { id: 'item', label: 'Item' },
-    { id: 'qty', label: 'Qty', align: 'right' }
+    { id: 'item', label: 'Item', testId: 'paged-item' },
+    { id: 'qty', label: 'Qty', align: 'right', testId: 'paged-qty' }
   ];
 
   const pagedRows: TableRow[] = Array.from({ length: 23 }, (_, index) => ({
@@ -375,8 +382,8 @@
   let lastBulkAction = $state('none');
 
   const selectionColumns: TableColumn[] = [
-    { id: 'name', label: 'Name' },
-    { id: 'team', label: 'Team' }
+    { id: 'name', label: 'Name', testId: 'sel-name' },
+    { id: 'team', label: 'Team', testId: 'sel-team' }
   ];
 
   const selectionRows: TableRow[] = [
@@ -389,7 +396,9 @@
   // ── Page-scoped select-all demo (client pagination + checkboxes) ────────────
   let pagedSelectionLog = $state('empty');
 
-  const pagedSelectColumns: TableColumn[] = [{ id: 'member', label: 'Member' }];
+  const pagedSelectColumns: TableColumn[] = [
+    { id: 'member', label: 'Member', testId: 'psel-member' }
+  ];
 
   const pagedSelectRows: TableRow[] = Array.from({ length: 7 }, (_, index) => ({
     member: `Member ${index + 1}`
@@ -400,8 +409,20 @@
     "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='8' fill='%2394a3b8'/></svg>";
 
   const mediaColumns: TableColumn[] = [
-    { id: 'gateway', label: 'Gateway', type: 'icon-label', sortable: false },
-    { id: 'product', label: 'Product', type: 'image-two-line-text', sortable: false }
+    {
+      id: 'gateway',
+      label: 'Gateway',
+      type: 'icon-label',
+      sortable: false,
+      testId: 'builtin-gateway'
+    },
+    {
+      id: 'product',
+      label: 'Product',
+      type: 'image-two-line-text',
+      sortable: false,
+      testId: 'builtin-product'
+    }
   ];
 
   const mediaRows: TableRow[] = [
@@ -420,7 +441,9 @@
   const SERVER_TOTAL_RECORDS = 12;
   let serverPageNumber = $state(1);
 
-  const serverPagedColumns: TableColumn[] = [{ id: 'record', label: 'Record', sortable: false }];
+  const serverPagedColumns: TableColumn[] = [
+    { id: 'record', label: 'Record', sortable: false, testId: 'srv-paged-record' }
+  ];
 
   const serverPagedRows = $derived(
     Array.from(
@@ -450,7 +473,11 @@
 {/snippet}
 
 {#snippet keyedStatusCell(row: TableRow, _rowIndex: number)}
-  <Pill text={String(row.status)} classes={statusClasses[String(row.status)] ?? ''} />
+  <Pill
+    text={String(row.status)}
+    classes={statusClasses[String(row.status)] ?? ''}
+    testId={`keyed-status-${String(row.status).toLowerCase()}`}
+  />
 {/snippet}
 
 <div class="page-header">

--- a/tests/chart-behaviors.spec.ts
+++ b/tests/chart-behaviors.spec.ts
@@ -3,33 +3,53 @@ import { test, expect } from '@playwright/test';
 test.describe('interactive legend', () => {
   test('clicking a legend item hides that series and rescales', async ({ page }) => {
     await page.goto('/components/bar-chart');
-    const chart = page.locator('[data-pw="bar-legend-toggle-chart"]');
-    await expect(chart.locator('.bar')).toHaveCount(12); // 3 series × 4 categories
-    const firstToggle = chart.locator('.legend-toggle').first();
+    const chart = page.getByTestId('bar-legend-toggle-chart');
+    await expect(chart.getByTestId(/^bar-\d+$/)).toHaveCount(12); // 3 series × 4 categories
+    const firstToggle = chart.getByTestId('legend-toggle-0');
     await firstToggle.click();
-    await expect(chart.locator('.bar')).toHaveCount(8);
+    await expect(chart.getByTestId(/^bar-\d+$/)).toHaveCount(8);
     await expect(firstToggle).toHaveAttribute('aria-pressed', 'false');
     await firstToggle.click();
-    await expect(chart.locator('.bar')).toHaveCount(12);
+    await expect(chart.getByTestId(/^bar-\d+$/)).toHaveCount(12);
   });
 });
 
 test.describe('bar value labels', () => {
   test('bars at the axis max flip their label inside', async ({ page }) => {
     await page.goto('/components/bar-chart');
-    const chart = page.locator('[data-pw="bar-inside-flip-chart"]');
-    await expect(chart.locator('.bar-value-inside')).not.toHaveCount(0);
+    const chart = page.getByTestId('bar-inside-flip-chart');
+    // Bars at the axis max flip their label inside
+    await expect
+      .poll(async () =>
+        chart
+          .getByTestId(/^bar-value-\d+$/)
+          .evaluateAll(
+            (els) => els.filter((el) => el.getAttribute('data-inside') === 'true').length
+          )
+      )
+      .toBeGreaterThan(0);
     // Short bars keep outside labels.
-    await expect(chart.locator('.bar-value:not(.bar-value-inside)')).not.toHaveCount(0);
+    await expect
+      .poll(async () =>
+        chart
+          .getByTestId(/^bar-value-\d+$/)
+          .evaluateAll(
+            (els) => els.filter((el) => el.getAttribute('data-inside') === 'false').length
+          )
+      )
+      .toBeGreaterThan(0);
   });
 });
 
 test.describe('tooltip clamping', () => {
   test('anchored tooltip never overflows the chart box', async ({ page }) => {
     await page.goto('/components/bar-chart');
-    const chart = page.locator('[data-pw="bar-inside-flip-chart"]');
-    await chart.locator('.bar').last().hover();
-    const tooltip = chart.locator('.chart-tooltip');
+    const chart = page.getByTestId('bar-inside-flip-chart');
+    await chart
+      .getByTestId(/^bar-\d+$/)
+      .last()
+      .hover();
+    const tooltip = chart.getByTestId('chart-tooltip');
     await expect(tooltip).toBeVisible();
     const tb = await tooltip.boundingBox();
     const cb = await chart.boundingBox();
@@ -56,17 +76,13 @@ test.describe('axis crowding', () => {
         'pre, table { max-width: 100% !important; overflow-x: auto !important; }'
       ].join(' ')
     });
-    const chart = page.locator('[data-pw="bar-crowded-chart"]');
+    const chart = page.getByTestId('bar-crowded-chart');
     // 18 bars always render; the axis rotates labels and shows a thinned subset.
-    await expect(chart.locator('.bar')).toHaveCount(18);
-    await expect
-      .poll(async () => chart.locator('.axis-bottom .tick-label').count())
-      .toBeLessThan(18);
-    expect(await chart.locator('.axis-bottom .tick-label').count()).toBeGreaterThan(0);
-    const transform = await chart
-      .locator('.axis-bottom .tick-label')
-      .first()
-      .getAttribute('transform');
+    await expect(chart.getByTestId(/^bar-\d+$/)).toHaveCount(18);
+    const bottomTickLabels = chart.getByTestId('axis-bottom').getByTestId(/^tick-label-\d+$/);
+    await expect.poll(async () => bottomTickLabels.count()).toBeLessThan(18);
+    expect(await bottomTickLabels.count()).toBeGreaterThan(0);
+    const transform = await bottomTickLabels.first().getAttribute('transform');
     expect(transform).toContain('rotate(-45)');
   });
 });
@@ -74,21 +90,23 @@ test.describe('axis crowding', () => {
 test.describe('line hover', () => {
   test('hover shows a halo and a shared tooltip listing all series', async ({ page }) => {
     await page.goto('/components/line-chart');
-    const chart = page.locator('[data-pw="line-shared-tooltip-chart"]');
-    await chart.locator('.hover-overlay').hover({ position: { x: 200, y: 100 } });
-    await expect(chart.locator('.dot-halo')).toHaveCount(3);
-    await expect(chart.locator('.chart-tooltip .tooltip-item')).toHaveCount(3);
+    const chart = page.getByTestId('line-shared-tooltip-chart');
+    await chart.getByTestId('hover-overlay').hover({ position: { x: 200, y: 100 } });
+    await expect(chart.getByTestId(/^dot-halo-\d+$/)).toHaveCount(3);
+    await expect(chart.getByTestId('chart-tooltip').getByTestId(/^tooltip-item-\d+$/)).toHaveCount(
+      3
+    );
   });
 });
 
 test.describe('keyboard', () => {
   test('Enter on a focused category fires onbarclick', async ({ page }) => {
     await page.goto('/components/dual-axis-bar-chart');
-    const chart = page.locator('[data-pw="demo-custom-tooltip"]');
-    const target = chart.locator('.hover-target').first();
+    const chart = page.getByTestId('demo-custom-tooltip');
+    const target = chart.getByTestId('hover-target-0');
     await target.focus();
     await page.keyboard.press('Enter');
-    const feedback = page.locator('.click-feedback');
+    const feedback = page.getByText(/Last clicked:/);
     await expect(feedback).toBeVisible();
     await expect(feedback).toContainText('Last clicked:');
   });
@@ -99,17 +117,20 @@ test.describe('touch', () => {
 
   test('tapping a funnel stage shows the tooltip; tapping outside dismisses', async ({ page }) => {
     await page.goto('/components/funnel-chart');
-    const chart = page.locator('[data-pw="funnel-many-stages-chart"]');
-    await chart.locator('.funnel-bar').first().tap();
-    await expect(chart.locator('.chart-tooltip')).toBeVisible();
-    await page.locator('h1').first().tap();
-    await expect(chart.locator('.chart-tooltip')).toHaveCount(0);
+    const chart = page.getByTestId('funnel-many-stages-chart');
+    await chart.getByTestId('funnel-bar-0').tap();
+    await expect(chart.getByTestId('chart-tooltip')).toBeVisible();
+    await page.getByRole('heading').first().tap();
+    await expect(chart.getByTestId('chart-tooltip')).toHaveCount(0);
   });
 
   test('keyboard focus on a bar shows its tooltip', async ({ page }) => {
     await page.goto('/components/bar-chart');
-    const chart = page.locator('[data-pw="bar-inside-flip-chart"]');
-    await chart.locator('.bar').first().focus();
-    await expect(chart.locator('.chart-tooltip')).toBeVisible();
+    const chart = page.getByTestId('bar-inside-flip-chart');
+    await chart
+      .getByTestId(/^bar-\d+$/)
+      .first()
+      .focus();
+    await expect(chart.getByTestId('chart-tooltip')).toBeVisible();
   });
 });

--- a/tests/checkbox-native-input-sync.test.ts
+++ b/tests/checkbox-native-input-sync.test.ts
@@ -12,11 +12,11 @@ test.describe('Checkbox — native input stays in sync with the rendered state',
   }) => {
     await page.goto('/components/checkbox');
 
-    const checkbox = page.locator('[data-pw="checkbox-default"]');
+    const checkbox = page.getByTestId('checkbox-default');
     await expect(checkbox).toBeVisible();
 
-    const nativeInput = checkbox.locator('input.native-checkbox');
-    const box = checkbox.locator('[role="checkbox"]');
+    const nativeInput = checkbox.getByTestId('checkbox-default-native-input');
+    const box = checkbox.getByRole('checkbox');
 
     await expect(box).toHaveAttribute('aria-checked', 'false');
     await expect(nativeInput).not.toBeChecked();
@@ -33,9 +33,9 @@ test.describe('Checkbox — native input stays in sync with the rendered state',
   test('keyboard toggling via the box keeps the native input in sync', async ({ page }) => {
     await page.goto('/components/checkbox');
 
-    const checkbox = page.locator('[data-pw="checkbox-default"]');
-    const nativeInput = checkbox.locator('input.native-checkbox');
-    const box = checkbox.locator('[role="checkbox"]');
+    const checkbox = page.getByTestId('checkbox-default');
+    const nativeInput = checkbox.getByTestId('checkbox-default-native-input');
+    const box = checkbox.getByRole('checkbox');
 
     await box.focus();
     await page.keyboard.press('Space');

--- a/tests/date-range-picker-checkmark.test.ts
+++ b/tests/date-range-picker-checkmark.test.ts
@@ -6,23 +6,23 @@ test.describe('DateRangePicker — active-preset checkmark', () => {
   test('shows a checkmark only on the active preset', async ({ page }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-preset-checkmark-demo"]');
+    const picker = page.getByTestId('drp-preset-checkmark-demo');
     await expect(picker).toBeVisible();
 
     // Open the dropdown.
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-preset-checkmark-demo-panel')).toBeVisible();
 
     // No checkmark before any preset is picked.
-    await expect(picker.locator('.drp-preset-check')).toHaveCount(0);
+    await expect(page.getByTestId('drp-preset-checkmark-demo-preset-check')).toHaveCount(0);
 
     // Pick the "Today" preset.
     await picker.getByRole('option', { name: 'Today', exact: true }).click();
 
     // Exactly one checkmark, and it sits on the active "Today" preset.
-    await expect(picker.locator('.drp-preset-check')).toHaveCount(1);
-    const active = picker.locator('.drp-preset-item.drp-preset-active');
+    await expect(page.getByTestId('drp-preset-checkmark-demo-preset-check')).toHaveCount(1);
+    const active = picker.getByRole('option', { selected: true });
     await expect(active).toContainText('Today');
-    await expect(active.locator('.drp-preset-check')).toHaveCount(1);
+    await expect(active.getByTestId('drp-preset-checkmark-demo-preset-check')).toHaveCount(1);
   });
 });

--- a/tests/date-range-picker-date-time.test.ts
+++ b/tests/date-range-picker-date-time.test.ts
@@ -8,21 +8,21 @@ test.describe('DateRangePicker — built-in date inputs + time selection', () =>
   }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-datetime-demo"]');
+    const picker = page.getByTestId('drp-datetime-demo');
     await expect(picker).toBeVisible();
 
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-datetime-demo-panel')).toBeVisible();
 
     // Read-only date boxes are present (seeded from the "Today" preset).
-    await expect(page.locator('[data-pw="drp-datetime-demo-start-date"]')).toBeVisible();
-    await expect(page.locator('[data-pw="drp-datetime-demo-end-date"]')).toBeVisible();
+    await expect(page.getByTestId('drp-datetime-demo-start-date')).toBeVisible();
+    await expect(page.getByTestId('drp-datetime-demo-end-date')).toBeVisible();
 
     // Time inputs are hidden until the clock toggle is clicked.
-    await expect(page.locator('[data-pw="drp-datetime-demo-start-time"]')).toHaveCount(0);
-    await page.locator('[data-pw="drp-datetime-demo-time-toggle"]').click();
+    await expect(page.getByTestId('drp-datetime-demo-start-time')).toHaveCount(0);
+    await page.getByTestId('drp-datetime-demo-time-toggle').click();
 
-    const startTime = page.locator('[data-pw="drp-datetime-demo-start-time"]');
+    const startTime = page.getByTestId('drp-datetime-demo-start-time');
     await expect(startTime).toBeVisible();
 
     const applyButton = picker.getByRole('button', { name: 'Apply date selection' });
@@ -40,12 +40,12 @@ test.describe('DateRangePicker — built-in date inputs + time selection', () =>
   test('blocks Apply when start time is after end time on the same day', async ({ page }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-datetime-demo"]');
+    const picker = page.getByTestId('drp-datetime-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await page.locator('[data-pw="drp-datetime-demo-time-toggle"]').click();
+    await page.getByTestId('drp-datetime-demo-time-toggle').click();
 
-    const startTime = page.locator('[data-pw="drp-datetime-demo-start-time"]');
-    const endTime = page.locator('[data-pw="drp-datetime-demo-end-time"]');
+    const startTime = page.getByTestId('drp-datetime-demo-start-time');
+    const endTime = page.getByTestId('drp-datetime-demo-end-time');
     const applyButton = picker.getByRole('button', { name: 'Apply date selection' });
 
     // The seeded "Today" preset puts start and end on the same calendar day, so a
@@ -66,20 +66,20 @@ test.describe('DateRangePicker — built-in date inputs + time selection', () =>
   }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-datetime-inline-demo"]');
+    const picker = page.getByTestId('drp-datetime-inline-demo');
     await expect(picker).toBeVisible();
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-datetime-inline-demo-panel')).toBeVisible();
 
     // No toggle in inline mode; the time inputs are visible immediately.
-    await expect(page.locator('[data-pw="drp-datetime-inline-demo-time-toggle"]')).toHaveCount(0);
-    const startTime = page.locator('[data-pw="drp-datetime-inline-demo-start-time"]');
-    const endTime = page.locator('[data-pw="drp-datetime-inline-demo-end-time"]');
+    await expect(page.getByTestId('drp-datetime-inline-demo-time-toggle')).toHaveCount(0);
+    const startTime = page.getByTestId('drp-datetime-inline-demo-start-time');
+    const endTime = page.getByTestId('drp-datetime-inline-demo-end-time');
     await expect(startTime).toBeVisible();
     await expect(endTime).toBeVisible();
 
     // The start time input is on the same row as its date box and to its right.
-    const dateBox = await page.locator('[data-pw="drp-datetime-inline-demo-start-date"]').boundingBox();
+    const dateBox = await page.getByTestId('drp-datetime-inline-demo-start-date').boundingBox();
     const timeBox = await startTime.boundingBox();
     expect(dateBox).not.toBeNull();
     expect(timeBox).not.toBeNull();

--- a/tests/date-range-picker-preset-toggle.test.ts
+++ b/tests/date-range-picker-preset-toggle.test.ts
@@ -7,21 +7,21 @@ test.describe('DateRangePicker — preset toggle-off', () => {
   test('re-clicking the active preset reverts to the committed preset', async ({ page }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-preset-toggle-demo"]');
+    const picker = page.getByTestId('drp-preset-toggle-demo');
     await expect(picker).toBeVisible();
 
     // Open the dropdown — the committed preset ("Today", seeded via initialPresetLabel) is active.
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
-    await expect(picker.locator('.drp-preset-item.drp-preset-active')).toContainText('Today');
+    await expect(page.getByTestId('drp-preset-toggle-demo-panel')).toBeVisible();
+    await expect(picker.getByRole('option', { selected: true })).toContainText('Today');
 
     // Pick a different preset — it becomes the active one.
     await picker.getByRole('option', { name: 'Yesterday', exact: true }).click();
-    await expect(picker.locator('.drp-preset-item.drp-preset-active')).toContainText('Yesterday');
+    await expect(picker.getByRole('option', { selected: true })).toContainText('Yesterday');
 
     // Re-click the now-active preset — it toggles off, reverting to the committed "Today".
     await picker.getByRole('option', { name: 'Yesterday', exact: true }).click();
-    await expect(picker.locator('.drp-preset-item.drp-preset-active')).toContainText('Today');
-    await expect(picker.locator('.drp-preset-item.drp-preset-active')).toHaveCount(1);
+    await expect(picker.getByRole('option', { selected: true })).toContainText('Today');
+    await expect(picker.getByRole('option', { selected: true })).toHaveCount(1);
   });
 });

--- a/tests/date-range-picker-reopen.test.ts
+++ b/tests/date-range-picker-reopen.test.ts
@@ -10,21 +10,21 @@ test.describe('DateRangePicker — committed preset persists across the open cyc
   }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-same-day-presets-demo"]');
+    const picker = page.getByTestId('drp-same-day-presets-demo');
     await expect(picker).toBeVisible();
 
     // Open, pick "Today" (exact), confirm a single highlight, then apply.
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-same-day-presets-demo-panel')).toBeVisible();
     await picker.getByRole('option', { name: 'Today', exact: true }).click();
-    await expect(picker.locator('.drp-preset-item[aria-selected="true"]')).toHaveCount(1);
+    await expect(picker.getByRole('option', { selected: true })).toHaveCount(1);
     await picker.getByRole('button', { name: 'Apply date selection' }).click();
-    await expect(picker.locator('.drp-panel')).toBeHidden();
+    await expect(page.getByTestId('drp-same-day-presets-demo-panel')).toBeHidden();
 
     // Re-open: only "Today" stays highlighted — not all three same-day presets.
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
-    const active = picker.locator('.drp-preset-item[aria-selected="true"]');
+    await expect(page.getByTestId('drp-same-day-presets-demo-panel')).toBeVisible();
+    const active = picker.getByRole('option', { selected: true });
     await expect(active).toHaveCount(1);
     await expect(active).toHaveText('Today');
   });
@@ -35,13 +35,13 @@ test.describe('DateRangePicker — committed preset persists across the open cyc
   test('initialPresetLabel highlights only the seeded preset on first open', async ({ page }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-initial-preset-demo"]');
+    const picker = page.getByTestId('drp-initial-preset-demo');
     await expect(picker).toBeVisible();
 
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-initial-preset-demo-panel')).toBeVisible();
 
-    const active = picker.locator('.drp-preset-item[aria-selected="true"]');
+    const active = picker.getByRole('option', { selected: true });
     await expect(active).toHaveCount(1);
     await expect(active).toHaveText('All time');
   });

--- a/tests/date-range-picker-toggle.test.ts
+++ b/tests/date-range-picker-toggle.test.ts
@@ -9,22 +9,22 @@ test.describe('DateRangePicker — trigger toggles the panel', () => {
   }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-range-demo"]');
+    const picker = page.getByTestId('drp-range-demo');
     await expect(picker).toBeVisible();
 
     // The trigger's accessible name flips to 'Close date picker' while open,
-    // so locate it by its stable class rather than by name.
-    const trigger = picker.locator('.drp-trigger button');
+    // so locate it by its stable testId rather than by name.
+    const trigger = page.getByTestId('drp-range-demo-trigger');
 
     await trigger.click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-range-demo-panel')).toBeVisible();
 
     // Second click on the same trigger dismisses the picker.
     await trigger.click();
-    await expect(picker.locator('.drp-panel')).toBeHidden();
+    await expect(page.getByTestId('drp-range-demo-panel')).toBeHidden();
 
     // Trigger still works as an opener afterwards.
     await trigger.click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-range-demo-panel')).toBeVisible();
   });
 });

--- a/tests/date-range-picker.test.ts
+++ b/tests/date-range-picker.test.ts
@@ -8,22 +8,22 @@ test.describe('DateRangePicker — preset highlight', () => {
   test('selecting one same-day preset highlights only that preset', async ({ page }) => {
     await page.goto('/components/date-range-picker');
 
-    const picker = page.locator('[data-pw="drp-same-day-presets-demo"]');
+    const picker = page.getByTestId('drp-same-day-presets-demo');
     await expect(picker).toBeVisible();
 
     // Open the dropdown.
     await picker.getByRole('button', { name: 'Open date picker' }).click();
-    await expect(picker.locator('.drp-panel')).toBeVisible();
+    await expect(page.getByTestId('drp-same-day-presets-demo-panel')).toBeVisible();
 
     // All three same-day presets render; none is selected before a pick.
-    await expect(picker.locator('.drp-preset-item')).toHaveCount(3);
-    await expect(picker.locator('.drp-preset-item[aria-selected="true"]')).toHaveCount(0);
+    await expect(picker.getByRole('option')).toHaveCount(3);
+    await expect(picker.getByRole('option', { selected: true })).toHaveCount(0);
 
     // Pick "Today" (exact, so it does not also match "Today morning"/"Today evening").
     await picker.getByRole('option', { name: 'Today', exact: true }).click();
 
     // Exactly one preset is highlighted, and it is the one we picked.
-    const active = picker.locator('.drp-preset-item[aria-selected="true"]');
+    const active = picker.getByRole('option', { selected: true });
     await expect(active).toHaveCount(1);
     await expect(active).toHaveText('Today');
   });

--- a/tests/loading-dots-pulse-scale.test.ts
+++ b/tests/loading-dots-pulse-scale.test.ts
@@ -8,21 +8,19 @@ test.describe('LoadingDots — pulse min-scale token', () => {
   test('the min-scale token reaches the dots and defaults to 1', async ({ page }) => {
     await page.goto('/components/loading-dots');
 
-    const breathing = page.locator('[data-pw="loading-dots-breathing"]');
+    const breathing = page.getByTestId('loading-dots-breathing');
     await expect(breathing).toBeVisible();
 
     const configuredScale = await breathing
-      .locator('.dot')
-      .first()
+      .getByTestId('loading-dots-breathing-dot-0')
       .evaluate((dot) => getComputedStyle(dot).getPropertyValue('--loading-dots-pulse-min-scale'));
     expect(configuredScale.trim()).toBe('0.5');
 
     // An unconfigured pulse instance resolves no override — the keyframe's
     // scale(var(--loading-dots-pulse-min-scale, 1)) falls back to 1.
-    const plainPulse = page.locator('.loading-dots').nth(1);
+    const plainPulse = page.getByTestId('loading-dots-pulse');
     const unsetScale = await plainPulse
-      .locator('.dot')
-      .first()
+      .getByTestId('loading-dots-pulse-dot-0')
       .evaluate((dot) => getComputedStyle(dot).getPropertyValue('--loading-dots-pulse-min-scale'));
     expect(unsetScale.trim()).toBe('');
   });

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -3,24 +3,24 @@ import { expect, test } from '@playwright/test';
 test.describe('Pagination — cursor / load-more mode', () => {
   test('basic pagination still renders prev/next (backward compatible)', async ({ page }) => {
     await page.goto('/components/pagination');
-    const basic = page.locator('[data-pw="pagination-basic"]');
+    const basic = page.getByTestId('pagination-basic');
     await expect(basic).toBeVisible();
-    await expect(basic.locator('.prev-button')).toBeVisible();
-    await expect(basic.locator('.next-button')).toBeVisible();
+    await expect(basic.getByRole('button', { name: 'Previous page' })).toBeVisible();
+    await expect(basic.getByRole('button', { name: 'Next page' })).toBeVisible();
   });
 
   test('cursor mode swaps the next-button for a load-more CTA on the last page', async ({
     page
   }) => {
     await page.goto('/components/pagination');
-    const cursor = page.locator('[data-pw="pagination-cursor"]');
+    const cursor = page.getByTestId('pagination-cursor');
     await expect(cursor).toBeVisible();
     // On page 1 of 3 there is no load-more CTA yet — normal next-button is shown.
-    await expect(cursor.locator('.load-more-button')).toHaveCount(0);
-    await expect(cursor.locator('.next-button')).toBeVisible();
+    await expect(cursor.getByRole('button', { name: 'Load more' })).toHaveCount(0);
+    await expect(cursor.getByRole('button', { name: 'Next page' })).toBeVisible();
     // Jump to the last known page; the load-more CTA replaces the next-button.
     await cursor.getByRole('button', { name: 'Page 3' }).click();
-    await expect(cursor.locator('.load-more-button')).toBeVisible();
-    await expect(cursor.locator('.next-button')).toHaveCount(0);
+    await expect(cursor.getByRole('button', { name: 'Load more' })).toBeVisible();
+    await expect(cursor.getByRole('button', { name: 'Next page' })).toHaveCount(0);
   });
 });

--- a/tests/proportion-bar.test.ts
+++ b/tests/proportion-bar.test.ts
@@ -7,18 +7,26 @@ test.describe('ProportionBar', () => {
   test('renders one rect and one legend item per segment', async ({ page }) => {
     await page.goto('/components/proportion-bar');
 
-    const bar = page.locator('[data-pw="payment-methods-bar"]');
+    const bar = page.getByTestId('payment-methods-bar');
     await expect(bar).toBeVisible();
-    await expect(bar.locator('.proportion-bar-svg rect')).toHaveCount(5);
-    await expect(bar.locator('.proportion-bar-legend-item')).toHaveCount(5);
+    await expect
+      .poll(async () =>
+        bar
+          .getByTestId('payment-methods-bar-svg')
+          .evaluate((svg) => svg.querySelectorAll('rect').length)
+      )
+      .toBe(5);
+    await expect(bar.getByTestId(/^payment-methods-bar-legend-item-\d+$/)).toHaveCount(5);
   });
 
   test('segment widths fill the whole track (~100%)', async ({ page }) => {
     await page.goto('/components/proportion-bar');
 
-    const widths = await page
-      .locator('[data-pw="payment-methods-bar"] .proportion-bar-svg rect')
-      .evaluateAll((rects) => rects.map((rect) => Number(rect.getAttribute('width'))));
+    const bar = page.getByTestId('payment-methods-bar');
+    const widths = await bar.getByTestId('payment-methods-bar-svg').evaluate((svg) => {
+      const rects = svg.querySelectorAll('rect');
+      return Array.from(rects).map((rect) => Number(rect.getAttribute('width')));
+    });
     const total = widths.reduce((sum, width) => sum + width, 0);
     expect(Math.round(total)).toBe(100);
   });
@@ -26,10 +34,10 @@ test.describe('ProportionBar', () => {
   test('exposes an accessible SVG summary when the legend is hidden', async ({ page }) => {
     await page.goto('/components/proportion-bar');
 
-    const bar = page.locator('[data-pw="no-legend-bar"]');
-    await expect(bar.locator('.proportion-bar-legend')).toHaveCount(0);
+    const bar = page.getByTestId('no-legend-bar');
+    await expect(bar.getByTestId('no-legend-bar-legend')).toHaveCount(0);
 
-    const svg = bar.locator('.proportion-bar-svg');
+    const svg = bar.getByTestId('no-legend-bar-svg');
     await expect(svg).toHaveAttribute('role', 'img');
     await expect(svg).toHaveAttribute('aria-label', /UPI/);
   });
@@ -37,12 +45,17 @@ test.describe('ProportionBar', () => {
   test('ignores negative and non-finite values (widths stay within 0–100)', async ({ page }) => {
     await page.goto('/components/proportion-bar');
 
-    const rects = page.locator('[data-pw="robust-bar"] .proportion-bar-svg rect');
-    await expect(rects).toHaveCount(4);
+    const bar = page.getByTestId('robust-bar');
+    const rectCount = await bar
+      .getByTestId('robust-bar-svg')
+      .evaluate((svg) => svg.querySelectorAll('rect').length);
+    expect(rectCount).toBe(4);
 
-    const widths = await rects.evaluateAll((nodes) =>
-      nodes.map((node) => Number(node.getAttribute('width')))
-    );
+    const widths = await bar
+      .getByTestId('robust-bar-svg')
+      .evaluate((svg) =>
+        Array.from(svg.querySelectorAll('rect')).map((rect) => Number(rect.getAttribute('width')))
+      );
     for (const width of widths) {
       expect(width).toBeGreaterThanOrEqual(0);
       expect(width).toBeLessThanOrEqual(100);

--- a/tests/select-multi-indicator.test.ts
+++ b/tests/select-multi-indicator.test.ts
@@ -9,7 +9,7 @@ test.describe('Select — multi-select checkbox indicator', () => {
   }) => {
     await page.goto('/components/select');
 
-    const select = page.locator('[data-pw="select-multi-demo"]');
+    const select = page.getByTestId('select-multi-demo');
     await expect(select).toBeVisible();
 
     // Open the dropdown.
@@ -18,18 +18,43 @@ test.describe('Select — multi-select checkbox indicator', () => {
     await expect(listbox).toBeVisible();
 
     // Every option carries a checkbox-box indicator; none are checked initially.
-    const indicators = listbox.locator('.select-option-indicator');
+    const indicators = listbox.getByTestId(/^select-multi-demo-option-indicator-/);
     expect(await indicators.count()).toBeGreaterThan(0);
-    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(0);
+    await expect
+      .poll(async () =>
+        indicators.evaluateAll(
+          (els) => els.filter((el) => el.getAttribute('data-checked') === 'true').length
+        )
+      )
+      .toBe(0);
 
     // Selecting an option fills exactly one box and renders a checkmark svg inside it.
     await listbox.getByRole('option', { name: 'Apple', exact: true }).click();
-    const checked = listbox.locator('.select-option-indicator.checked');
-    await expect(checked).toHaveCount(1);
-    await expect(checked.locator('svg')).toHaveCount(1);
+    await expect
+      .poll(async () =>
+        indicators.evaluateAll(
+          (els) => els.filter((el) => el.getAttribute('data-checked') === 'true').length
+        )
+      )
+      .toBe(1);
+    // The checked indicator contains a checkmark svg
+    await expect
+      .poll(async () =>
+        indicators.evaluateAll((els) => {
+          const checked = els.filter((el) => el.getAttribute('data-checked') === 'true');
+          return checked.filter((el) => el.querySelector('svg') !== null).length;
+        })
+      )
+      .toBe(1);
 
     // Multi-select keeps the dropdown open; a second pick adds a second checked box.
     await listbox.getByRole('option', { name: 'Cherry', exact: true }).click();
-    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(2);
+    await expect
+      .poll(async () =>
+        indicators.evaluateAll(
+          (els) => els.filter((el) => el.getAttribute('data-checked') === 'true').length
+        )
+      )
+      .toBe(2);
   });
 });

--- a/tests/select-select-all.test.ts
+++ b/tests/select-select-all.test.ts
@@ -7,30 +7,50 @@ test.describe('Select — select all (multi-select)', () => {
   test('renders a select-all row that selects and deselects every option', async ({ page }) => {
     await page.goto('/components/select');
 
-    const select = page.locator('[data-pw="select-all-demo"]');
+    const select = page.getByTestId('select-all-demo');
     await expect(select).toBeVisible();
     await select.getByRole('combobox').click();
 
     const listbox = select.getByRole('listbox');
     await expect(listbox).toBeVisible();
 
-    const selectAll = listbox.locator('[data-pw="select-all-demo-select-all"]');
+    const selectAll = listbox.getByTestId('select-all-demo-select-all');
     await expect(selectAll).toBeVisible();
-    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(0);
+    // No indicators are checked initially
+    await expect
+      .poll(async () =>
+        listbox
+          .getByTestId(/indicator/)
+          .evaluateAll(
+            (els) => els.filter((el) => el.getAttribute('data-checked') === 'true').length
+          )
+      )
+      .toBe(0);
 
     // Select all -> the select-all box and every option box are checked.
     await selectAll.click();
-    await expect(selectAll.locator('.select-option-indicator.checked')).toHaveCount(1);
-    await expect(
-      listbox.locator('[data-pw="select-all-demo-apple"] .select-option-indicator.checked')
-    ).toHaveCount(1);
-    await expect(
-      listbox.locator('[data-pw="select-all-demo-grape"] .select-option-indicator.checked')
-    ).toHaveCount(1);
+    await expect(selectAll.getByTestId('select-all-demo-select-all-indicator')).toHaveClass(
+      /checked/
+    );
+    await expect(listbox.getByTestId('select-all-demo-option-indicator-apple')).toHaveClass(
+      /checked/
+    );
+    await expect(listbox.getByTestId('select-all-demo-option-indicator-grape')).toHaveClass(
+      /checked/
+    );
 
     // Toggle again -> nothing is checked.
     await selectAll.click();
-    await expect(listbox.locator('.select-option-indicator.checked')).toHaveCount(0);
+    // Nothing is checked after toggle
+    await expect
+      .poll(async () =>
+        listbox
+          .getByTestId(/indicator/)
+          .evaluateAll(
+            (els) => els.filter((el) => el.getAttribute('data-checked') === 'true').length
+          )
+      )
+      .toBe(0);
   });
 
   test('shows an indeterminate dash and accessible state when only some are selected', async ({
@@ -38,17 +58,17 @@ test.describe('Select — select all (multi-select)', () => {
   }) => {
     await page.goto('/components/select');
 
-    const select = page.locator('[data-pw="select-all-demo"]');
+    const select = page.getByTestId('select-all-demo');
     await select.getByRole('combobox').click();
     const listbox = select.getByRole('listbox');
-    const selectAll = listbox.locator('[data-pw="select-all-demo-select-all"]');
+    const selectAll = listbox.getByTestId('select-all-demo-select-all');
 
-    await listbox.locator('[data-pw="select-all-demo-apple"]').click();
+    await listbox.getByTestId('select-all-demo-apple').click();
 
-    const indicator = selectAll.locator('.select-option-indicator');
+    const indicator = selectAll.getByTestId('select-all-demo-select-all-indicator');
     await expect(indicator).toHaveClass(/indeterminate/);
     await expect(indicator).not.toHaveClass(/checked/);
-    await expect(selectAll.locator('.select-option-dash')).toHaveCount(1);
+    await expect(selectAll.getByTestId('select-all-demo-select-all-dash')).toHaveCount(1);
     // Partial state is exposed to assistive tech via the row's accessible name.
     await expect(selectAll).toHaveAttribute('aria-label', /of 7 selected/);
   });
@@ -56,27 +76,29 @@ test.describe('Select — select all (multi-select)', () => {
   test('keyboard navigation reaches the select-all row', async ({ page }) => {
     await page.goto('/components/select');
 
-    const select = page.locator('[data-pw="select-all-demo"]');
+    const select = page.getByTestId('select-all-demo');
     await select.getByRole('combobox').focus();
     await page.keyboard.press('ArrowDown'); // open
     const listbox = select.getByRole('listbox');
     await expect(listbox).toBeVisible();
 
     await page.keyboard.press('ArrowDown'); // highlight the first row (select-all)
-    const selectAll = listbox.locator('[data-pw="select-all-demo-select-all"]');
+    const selectAll = listbox.getByTestId('select-all-demo-select-all');
     await expect(selectAll).toHaveClass(/highlighted/);
 
     await page.keyboard.press('Enter'); // toggle the highlighted select-all row
-    await expect(selectAll.locator('.select-option-indicator.checked')).toHaveCount(1);
+    await expect(selectAll.getByTestId('select-all-demo-select-all-indicator')).toHaveClass(
+      /checked/
+    );
   });
 
   test('searchable: select-all toggles only the filtered options', async ({ page }) => {
     await page.goto('/components/select');
 
-    const select = page.locator('[data-pw="select-all-search-demo"]');
+    const select = page.getByTestId('select-all-search-demo');
     await expect(select).toBeVisible();
 
-    const search = select.locator('.select-search');
+    const search = select.getByTestId('select-all-search-demo-search');
     await search.click();
     await search.fill('java'); // matches "JavaScript" and "Java"
 
@@ -85,18 +107,18 @@ test.describe('Select — select all (multi-select)', () => {
     // select-all row + the two filtered options
     await expect(listbox.getByRole('option')).toHaveCount(3);
 
-    await listbox.locator('[data-pw="select-all-search-demo-select-all"]').click();
-    await expect(
-      listbox.locator('[data-pw="select-all-search-demo-js"] .select-option-indicator.checked')
-    ).toHaveCount(1);
-    await expect(
-      listbox.locator('[data-pw="select-all-search-demo-java"] .select-option-indicator.checked')
-    ).toHaveCount(1);
+    await listbox.getByTestId('select-all-search-demo-select-all').click();
+    await expect(listbox.getByTestId('select-all-search-demo-option-indicator-js')).toHaveClass(
+      /checked/
+    );
+    await expect(listbox.getByTestId('select-all-search-demo-option-indicator-java')).toHaveClass(
+      /checked/
+    );
 
     // A non-matching option (Python) was untouched.
     await search.fill('');
-    await expect(
-      listbox.locator('[data-pw="select-all-search-demo-py"] .select-option-indicator.checked')
-    ).toHaveCount(0);
+    await expect(listbox.getByTestId('select-all-search-demo-option-indicator-py')).not.toHaveClass(
+      /checked/
+    );
   });
 });

--- a/tests/sheet-anchor-and-overlay.test.ts
+++ b/tests/sheet-anchor-and-overlay.test.ts
@@ -10,7 +10,7 @@ test.describe('Sheet anchor position tokens', () => {
     await page.goto('/components/sheet');
 
     await page.getByText('Open right', { exact: true }).click();
-    const panel = page.locator('.sheet-panel.right').first();
+    const panel = page.getByTestId('sheet-right-panel');
     await expect(panel).toBeVisible();
     await page.waitForTimeout(400);
 
@@ -30,7 +30,7 @@ test.describe('Sheet anchor position tokens', () => {
     await page.goto('/components/sheet');
 
     await page.getByText('Open account menu').click();
-    const panel = page.locator('[data-pw="sheet-anchored"] .sheet-panel').first();
+    const panel = page.getByTestId('sheet-anchored-panel');
     await expect(panel).toBeVisible();
     // Let the 300ms fly-in transition finish — mid-transition the panel sits at
     // an intermediate translateX, not its resting position.
@@ -59,7 +59,7 @@ test.describe('Sheet dismissOnOutsideClick', () => {
     await page.goto('/components/sheet');
 
     await page.getByText('Open account menu').click();
-    const overlay = page.locator('[data-pw="sheet-anchored"]');
+    const overlay = page.getByTestId('sheet-anchored');
     await expect(overlay).toBeVisible();
 
     // No dimming — the overlay is fully transparent.
@@ -70,7 +70,7 @@ test.describe('Sheet dismissOnOutsideClick', () => {
 
     // Clicking the (invisible) overlay outside the panel still dismisses it.
     await overlay.click({ position: { x: 5, y: 5 } });
-    await expect(page.locator('[data-pw="sheet-anchored"]')).toHaveCount(0);
+    await expect(page.getByTestId('sheet-anchored')).toHaveCount(0);
   });
 
   test('a visible, non-dismissible overlay blocks the page but does not close on click', async ({
@@ -79,7 +79,7 @@ test.describe('Sheet dismissOnOutsideClick', () => {
     await page.goto('/components/sheet');
 
     await page.getByText('Open blocking sheet').click();
-    const overlay = page.locator('[data-pw="sheet-blocking"]');
+    const overlay = page.getByTestId('sheet-blocking');
     await expect(overlay).toBeVisible();
     await page.waitForTimeout(300);
 
@@ -109,8 +109,8 @@ test.describe('Sheet reference-counted scroll lock', () => {
     await page.goto('/components/sheet');
 
     await page.getByText('Open right', { exact: true }).click();
-    await expect(page.locator('.sheet-panel.right').first()).toBeVisible();
-    await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+    await expect(page.getByTestId('sheet-right-panel')).toBeVisible();
+    await expect(page.getByTestId('page-body')).toHaveCSS('overflow', 'hidden');
 
     // The first sheet's full-screen overlay legitimately blocks real clicks on
     // the rest of the page (that's the point of a modal backdrop) — `force`
@@ -119,12 +119,12 @@ test.describe('Sheet reference-counted scroll lock', () => {
     // element instead, simulating a second sheet opened by some other trigger
     // (e.g. a notification), the realistic multi-sheet scenario this fix covers.
     await page.getByText('Open with footer').dispatchEvent('click');
-    await expect(page.locator('.sheet-panel.right').nth(1)).toBeVisible();
-    await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+    await expect(page.getByTestId('sheet-footer-panel')).toBeVisible();
+    await expect(page.getByTestId('page-body')).toHaveCSS('overflow', 'hidden');
 
     // Close the second sheet (via its own overlay/Escape) — the first is still open,
     // so the page must remain scroll-locked.
     await page.keyboard.press('Escape');
-    await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+    await expect(page.getByTestId('page-body')).toHaveCSS('overflow', 'hidden');
   });
 });

--- a/tests/split-input-autocomplete-inputmode.test.ts
+++ b/tests/split-input-autocomplete-inputmode.test.ts
@@ -8,10 +8,10 @@ test.describe('SplitInput — autoComplete / inputMode field passthrough', () =>
   test('per-field autoComplete and inputMode render on the native inputs', async ({ page }) => {
     await page.goto('/components/split-input');
 
-    const group = page.locator('[data-pw="split-input-sms-otp"]');
+    const group = page.getByTestId('split-input-sms-otp');
     await expect(group).toBeVisible();
 
-    const fields = group.locator('input');
+    const fields = group.getByRole('textbox');
     await expect(fields).toHaveCount(4);
 
     for (let index = 0; index < 4; index++) {
@@ -26,8 +26,8 @@ test.describe('SplitInput — autoComplete / inputMode field passthrough', () =>
 
     // The plain OTP demo (length-based default fields) is unchanged: default
     // autocomplete stays 'on' and no inputmode attribute is rendered.
-    const defaultGroup = page.locator('.field-group').first();
-    const firstField = defaultGroup.locator('input').first();
+    const defaultGroup = page.getByTestId('split-input-default');
+    const firstField = defaultGroup.getByRole('textbox').first();
     await expect(firstField).toHaveAttribute('autocomplete', 'on');
     await expect(firstField).not.toHaveAttribute('inputmode', /.+/);
   });

--- a/tests/stat-card.test.ts
+++ b/tests/stat-card.test.ts
@@ -8,30 +8,31 @@ test.describe('StatCard', () => {
   test('renders a basic single value (backward compatible)', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="basic-positive"]');
+    const card = page.getByTestId('basic-positive');
     await expect(card).toBeVisible();
-    await expect(card.locator('.statcard-value')).toHaveText('8,610');
+    await expect(card.getByTestId('basic-positive-value')).toHaveText('8,610');
   });
 
   test('multi-row card renders a row and a divider per metric', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="multi-row"]');
-    await expect(card.locator('.statcard-row')).toHaveCount(3);
-    await expect(card.locator('.statcard-row-divider')).toHaveCount(2);
-    await expect(card.locator('.delta-indicator')).toHaveCount(3);
+    const card = page.getByTestId('multi-row');
+    await expect(card.getByTestId(/^checkout-row-\d+$/)).toHaveCount(3);
+    await expect(card.getByTestId(/^multi-row-row-divider-\d+$/)).toHaveCount(2);
+    await expect(card.getByTestId(/^multi-row-delta-\d+$/)).toHaveCount(3);
   });
 
   test('horizontal rows lay the sections side by side', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const rowsContainer = page.locator('[data-pw="horizontal-rows"] .statcard-rows');
+    const rowsContainer = page.getByTestId('horizontal-rows-rows');
     await expect(rowsContainer).toHaveClass(/statcard-rows-horizontal/);
     await expect(rowsContainer).toHaveCSS('flex-direction', 'row');
 
     // Sections sit side by side: every row shares the same vertical top.
     const tops = await page
-      .locator('[data-pw="horizontal-rows"] .statcard-row')
+      .getByTestId('horizontal-rows')
+      .getByTestId(/^checkout-row-\d+$/)
       .evaluateAll((rows) => rows.map((row) => Math.round(row.getBoundingClientRect().top)));
     expect(tops.length).toBe(3);
     expect(new Set(tops).size).toBe(1);
@@ -40,42 +41,42 @@ test.describe('StatCard', () => {
   test('breakdown grid renders one item per breakdown entry', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="with-breakdown"]');
-    await expect(card.locator('.statcard-breakdown-item')).toHaveCount(3);
+    const card = page.getByTestId('with-breakdown');
+    await expect(card.getByTestId(/^with-breakdown-breakdown-item-\d+-\d+$/)).toHaveCount(3);
   });
 
   test('renders the header even when no title is set', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="headerless-card"]');
-    await expect(card.locator('.statcard-header')).toHaveCount(1);
-    await expect(card.locator('.statcard-title')).toHaveCount(0);
+    const card = page.getByTestId('headerless-card');
+    await expect(card.getByTestId('headerless-card-header')).toHaveCount(1);
+    await expect(card.getByTestId('headerless-card-title')).toHaveCount(0);
     await expect(card.getByRole('checkbox')).toBeVisible();
   });
 
   test('checkbox toggle fires onCheckboxChange', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="with-checkbox"]');
-    await expect(card.locator('.statcard-value')).toHaveText('₹10.9Cr');
+    const card = page.getByTestId('with-checkbox');
+    await expect(card.getByTestId('with-checkbox-value')).toHaveText('₹10.9Cr');
     await card.getByRole('checkbox').click();
-    await expect(card.locator('.statcard-value')).toHaveText('₹12.4Cr');
+    await expect(card.getByTestId('with-checkbox-value')).toHaveText('₹12.4Cr');
   });
 
   test('toggling the checkbox does not trigger the card action', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="clickable-checkbox-card"]');
-    const clickCount = page.locator('[data-pw="card-click-count"]');
+    const card = page.getByTestId('clickable-checkbox-card');
+    const clickCount = page.getByTestId('card-click-count');
     await expect(clickCount).toHaveText('0');
 
     // Checkbox toggles without firing the card's onclick.
     await card.getByRole('checkbox').click();
-    await expect(card.locator('.box')).toHaveClass(/checked/);
+    await expect(card.getByRole('checkbox')).toHaveClass(/checked/);
     await expect(clickCount).toHaveText('0');
 
     // Clicking the card body still fires the action.
-    await card.locator('.statcard-value').click();
+    await card.getByTestId('clickable-checkbox-card-value').click();
     await expect(clickCount).toHaveText('1');
   });
 
@@ -85,16 +86,16 @@ test.describe('StatCard', () => {
     // Regression: the subtitle block previously lived inside the no-rows {:else}
     // branch, so a card given both `rows` and `subtitle` silently dropped the
     // subtitle (e.g. the "Today vs Yesterday" comparison label).
-    const card = page.locator('[data-pw="rows-with-subtitle"]');
-    await expect(card.locator('.statcard-row')).toHaveCount(3);
-    await expect(card.locator('.statcard-subtitle')).toHaveText('Today vs Yesterday');
+    const card = page.getByTestId('rows-with-subtitle');
+    await expect(card.getByTestId(/^checkout-row-\d+$/)).toHaveCount(3);
+    await expect(card.getByTestId('rows-with-subtitle-subtitle')).toHaveText('Today vs Yesterday');
   });
 
   test('still renders the subtitle for a single-value card', async ({ page }) => {
     await page.goto('/components/stat-card');
 
-    const card = page.locator('[data-pw="with-subtitle"]');
-    await expect(card.locator('.statcard-row')).toHaveCount(0);
-    await expect(card.locator('.statcard-subtitle')).toHaveText('vs last 30 days');
+    const card = page.getByTestId('with-subtitle');
+    await expect(card.getByTestId(/^checkout-row-\d+$/)).toHaveCount(0);
+    await expect(card.getByTestId('with-subtitle-subtitle')).toHaveText('vs last 30 days');
   });
 });

--- a/tests/status-icon-slot.test.ts
+++ b/tests/status-icon-slot.test.ts
@@ -7,21 +7,21 @@ test.describe('Status icon slot', () => {
   test('default statusIcon renders an <img> when no icon snippet is given', async ({ page }) => {
     await page.goto('/components/status');
 
-    const defaultStatus = page.locator('[data-pw="status-default-icon"]');
-    await expect(defaultStatus.locator('img')).toBeVisible();
+    const defaultStatus = page.getByTestId('status-default-icon');
+    await expect(defaultStatus.getByRole('img')).toBeVisible();
   });
 
   test('icon snippet replaces the default image with custom content', async ({ page }) => {
     await page.goto('/components/status');
 
-    const slotHost = page.locator('[data-pw="status-icon-slot"]');
+    const slotHost = page.getByTestId('status-icon-slot');
     await expect(slotHost).toBeVisible();
 
     // No <img> is rendered for this instance — the snippet took over.
-    await expect(slotHost.locator('img')).toHaveCount(0);
+    await expect(slotHost.getByRole('img')).toHaveCount(0);
 
     // The custom content (the LottiePlayer wrapper) is present instead.
-    await expect(slotHost.locator('[data-pw="status-icon-slot-lottie"]')).toBeVisible();
-    await expect(slotHost.locator('.lottie-player')).toHaveCount(1);
+    await expect(slotHost.getByTestId('status-icon-slot-lottie')).toBeVisible();
+    await expect(slotHost.getByTestId('status-lottie')).toHaveCount(1);
   });
 });

--- a/tests/table-builtin-cells.test.ts
+++ b/tests/table-builtin-cells.test.ts
@@ -3,27 +3,29 @@ import { expect, test } from '@playwright/test';
 test.describe('Table — built-in cell renderers', () => {
   test('tag and tag-array cells render Pills with consumer classes', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
+    const table = page.getByTestId('table-builtin-cells');
     await expect(table).toBeVisible();
-    await expect(table.locator('td .pill-success')).toHaveCount(1);
-    await expect(table.locator('td .pill-warning')).toHaveCount(1);
-    await expect(table.locator('td .pill-error')).toHaveCount(1);
+    await expect(table.getByTestId('builtin-state-0')).toContainText('Active');
+    await expect(table.getByTestId('builtin-state-1')).toContainText('Paused');
+    await expect(table.getByTestId('builtin-state-2')).toContainText('Expired');
     // tag-array: row 0 has two Web/App chips, row 1 one chip
-    await expect(table.locator('td .pill-info')).toHaveCount(3);
+    await expect(table.getByTestId('builtin-channels-web-0')).toContainText('Web');
+    await expect(table.getByTestId('builtin-channels-app-0')).toContainText('App');
+    await expect(table.getByTestId('builtin-channels-web-1')).toContainText('Web');
   });
 
   test('two-line-text cells render primary and secondary lines', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
-    const firstPlanCell = table.locator('tbody tr').first().locator('td').first();
+    const table = page.getByTestId('table-builtin-cells');
+    const firstPlanCell = table.getByRole('row').first().getByRole('cell').first();
     await expect(firstPlanCell).toContainText('Growth Monthly');
     await expect(firstPlanCell).toContainText('PLN-0042');
   });
 
   test('avatar-stack caps at 4 chips and shows the +N overflow', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
-    const secondRow = table.locator('tbody tr').nth(1);
+    const table = page.getByTestId('table-builtin-cells');
+    const secondRow = table.getByRole('row').nth(1);
     await expect(secondRow).toContainText('+2');
   });
 
@@ -31,14 +33,14 @@ test.describe('Table — built-in cell renderers', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
-    const firstRevenue = table.locator('tbody tr').nth(0).locator('td').nth(4);
+    const table = page.getByTestId('table-builtin-cells');
+    const firstRevenue = table.getByRole('row').nth(0).getByRole('cell').nth(4);
     await expect(firstRevenue).toContainText('₹4,938.10');
     await expect(firstRevenue).toContainText('₹4,100.00');
-    await expect(firstRevenue.locator('.builtin-trend-up')).toContainText('20%');
-    const secondRevenue = table.locator('tbody tr').nth(1).locator('td').nth(4);
-    await expect(secondRevenue.locator('.builtin-trend-down')).toContainText('-20%');
-    const thirdRevenue = table.locator('tbody tr').nth(2).locator('td').nth(4);
+    await expect(firstRevenue.getByTestId('builtin-revenue-trend-up')).toContainText('20%');
+    const secondRevenue = table.getByRole('row').nth(1).getByRole('cell').nth(4);
+    await expect(secondRevenue.getByTestId('builtin-revenue-trend-down')).toContainText('-20%');
+    const thirdRevenue = table.getByRole('row').nth(2).getByRole('cell').nth(4);
     await expect(thirdRevenue).toContainText('n/a');
   });
 
@@ -46,28 +48,34 @@ test.describe('Table — built-in cell renderers', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
+    const table = page.getByTestId('table-builtin-cells');
     // Row 0 starts checked: true — flipping off must report the new state (false).
-    await table.locator('[data-pw="builtin-toggle-0"] label.switch').click();
-    await expect(page.locator('[data-pw="builtin-toggle-result"]')).toContainText('row 0 → false');
+    await table.getByTestId('builtin-toggle-0').getByRole('checkbox').click();
+    await expect(page.getByTestId('builtin-toggle-result')).toContainText('row 0 → false');
     // Row 1 starts checked: false — flipping on must report the new state (true).
-    await table.locator('[data-pw="builtin-toggle-1"] label.switch').click();
-    await expect(page.locator('[data-pw="builtin-toggle-result"]')).toContainText('row 1 → true');
+    await table.getByTestId('builtin-toggle-1').getByRole('checkbox').click();
+    await expect(page.getByTestId('builtin-toggle-result')).toContainText('row 1 → true');
   });
 
   test('link cells render an anchor, copy affordance opt-out, and null fallback', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
-    const firstLink = table.locator('[data-pw="builtin-docs-link-0"]');
+    const table = page.getByTestId('table-builtin-cells');
+    const firstLink = table.getByTestId('builtin-docs-link-0');
     await expect(firstLink).toHaveAttribute('href', 'https://example.com/plans/42');
     await expect(firstLink).toContainText('plans/42');
-    await expect(table.locator('[data-pw="builtin-docs-copy-0"]')).toBeVisible();
+    await expect(table.getByTestId('builtin-docs-copy-0')).toBeVisible();
     // Row 1 sets copyable: false — no copy button
-    await expect(table.locator('[data-pw="builtin-docs-copy-1"]')).toHaveCount(0);
+    await expect(table.getByTestId('builtin-docs-copy-1')).toHaveCount(0);
     // Row 2 has a null link value — plain dash fallback
-    const thirdDocs = table.locator('tbody tr').nth(2).locator('td').nth(6);
+    const thirdDocs = table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .nth(2)
+      .getByRole('cell')
+      .nth(6);
     await expect(thirdDocs).toContainText('-');
   });
 
@@ -77,9 +85,9 @@ test.describe('Table — built-in cell renderers', () => {
   }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-builtin-cells"]');
-    await table.locator('[data-pw="builtin-docs-copy-0"]').click();
-    await expect(table.locator('.builtin-link-copied')).toContainText('Copied');
+    const table = page.getByTestId('table-builtin-cells');
+    await table.getByTestId('builtin-docs-copy-0').click();
+    await expect(table.getByTestId('builtin-docs-link-copied')).toContainText('Copied');
     const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
     expect(clipboardText).toBe('https://example.com/plans/42');
   });
@@ -88,12 +96,13 @@ test.describe('Table — built-in cell renderers', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-media-cells"]');
-    const firstGateway = table.locator('tbody tr').first().locator('td').first();
-    await expect(firstGateway.locator('.builtin-icon-label-icon')).toHaveCount(2);
+    const table = page.getByTestId('table-media-cells');
+    const firstGateway = table.getByRole('row').first().getByRole('cell').first();
+    await expect(firstGateway.getByTestId('builtin-gateway-icon-0')).toBeVisible();
+    await expect(firstGateway.getByTestId('builtin-gateway-icon-1')).toBeVisible();
     await expect(firstGateway).toContainText('UPI + Card');
-    const secondGateway = table.locator('tbody tr').nth(1).locator('td').first();
-    await expect(secondGateway.locator('.builtin-icon-label-icon')).toHaveCount(0);
+    const secondGateway = table.getByRole('row').nth(1).getByRole('cell').first();
+    await expect(secondGateway.getByTestId('builtin-gateway-icon-0')).toHaveCount(0);
     await expect(secondGateway).toContainText('NetBanking');
   });
 
@@ -101,15 +110,13 @@ test.describe('Table — built-in cell renderers', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-media-cells"]');
-    const firstProduct = table.locator('tbody tr').first().locator('td').nth(1);
-    await expect(firstProduct.locator('.builtin-thumb:not(.builtin-thumb-placeholder)')).toHaveCount(
-      1
-    );
+    const table = page.getByTestId('table-media-cells');
+    const firstProduct = table.getByRole('row').first().getByRole('cell').nth(1);
+    await expect(firstProduct.getByTestId('builtin-product-thumb')).toBeVisible();
     await expect(firstProduct).toContainText('Silk Kurta');
     await expect(firstProduct).toContainText('SKU-1042');
-    const secondProduct = table.locator('tbody tr').nth(1).locator('td').nth(1);
-    await expect(secondProduct.locator('.builtin-thumb-placeholder')).toHaveCount(1);
+    const secondProduct = table.getByRole('row').nth(1).getByRole('cell').nth(1);
+    await expect(secondProduct.getByTestId('builtin-product-thumb-placeholder')).toBeVisible();
     await expect(secondProduct).toContainText('Cotton Saree');
   });
 });

--- a/tests/table-header-meta.test.ts
+++ b/tests/table-header-meta.test.ts
@@ -5,72 +5,90 @@ test.describe('Table — header metadata + controlled sort', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-header-meta"]');
-    await expect(table.locator('th[data-pw="meta-amount"]')).toHaveCSS('text-align', 'right');
-    const amountCell = table.locator('tbody tr').first().locator('td').nth(2);
+    const table = page.getByTestId('table-header-meta');
+    await expect(table.getByTestId('meta-amount')).toHaveCSS('text-align', 'right');
+    const amountCell = table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .first()
+      .getByRole('cell')
+      .nth(2);
     await expect(amountCell).toHaveCSS('text-align', 'right');
-    await expect(table.locator('th[data-pw="meta-name"]')).toHaveCSS('text-align', 'left');
+    await expect(table.getByTestId('meta-name')).toHaveCSS('text-align', 'left');
   });
 
   test('maxWidth caps the column and ellipsizes scalar cells with a title tooltip', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-header-meta"]');
-    const longIdCell = table.locator('tbody tr').first().locator('td').first();
-    await expect(longIdCell).toHaveCSS('max-width', '120px');
-    await expect(longIdCell).toHaveAttribute('title', 'ORD-9f3k2m8x7c1v5b9n4q6w2e');
-    await expect(longIdCell.locator('.table-cell-clamp')).toHaveCSS('text-overflow', 'ellipsis');
+    const table = page.getByTestId('table-header-meta');
+    const longIdTd = table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .first()
+      .getByRole('cell')
+      .first();
+    await expect(longIdTd).toHaveCSS('max-width', '120px');
+    await expect(longIdTd).toHaveAttribute('title', 'ORD-9f3k2m8x7c1v5b9n4q6w2e');
+    await expect(table.getByTestId('meta-id-cell-0')).toHaveCSS('text-overflow', 'ellipsis');
   });
 
   test('header tooltip renders on hover', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-header-meta"]');
-    await table.locator('th[data-pw="meta-name"] .table-header-label').hover();
+    const table = page.getByTestId('table-header-meta');
+    await table.getByTestId('meta-name').hover();
     // Scope to the header's own bubble — the docs code sample on the page repeats the text.
-    await expect(table.locator('th[data-pw="meta-name"] [role="tooltip"]')).toContainText(
+    await expect(table.getByTestId('meta-name').getByRole('tooltip')).toContainText(
       'Customer display name'
     );
   });
 
   test('filter dropdown filters via the consumer and clears on re-select', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-header-meta"]');
-    await expect(table.locator('tbody tr')).toHaveCount(3);
+    const table = page.getByTestId('table-header-meta');
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(3);
 
-    await table.locator('[data-pw="meta-status-filter-trigger"]').click();
+    await table.getByTestId('meta-status-filter-trigger').click();
     // Scope to the open dropdown — pills and docs samples on the page repeat the text.
     await page.getByRole('listbox').getByText('Paused', { exact: true }).click();
-    await expect(table.locator('tbody tr')).toHaveCount(1);
-    await expect(table.locator('tbody tr').first()).toContainText('Bob');
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(1);
+    await expect(table.getByRole('rowgroup').last().getByRole('row').first()).toContainText('Bob');
 
     // Re-selecting the active option clears the filter (onFilterChange(null))
-    await table.locator('[data-pw="meta-status-filter-trigger"]').click();
+    await table.getByTestId('meta-status-filter-trigger').click();
     await page.getByRole('listbox').getByText('Paused', { exact: true }).click();
-    await expect(table.locator('tbody tr')).toHaveCount(3);
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(3);
   });
 
   test('headers and cells wrap at word boundaries, not mid-word (word-break fix)', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-header-meta"]');
-    const header = table.locator('th[data-pw="meta-name"]');
+    const table = page.getByTestId('table-header-meta');
+    const header = table.getByTestId('meta-name');
     await expect(header).toHaveCSS('word-break', 'normal');
     await expect(header).toHaveCSS('overflow-wrap', 'break-word');
-    const bodyCell = table.locator('tbody tr').first().locator('td').nth(1);
+    const bodyCell = table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .first()
+      .getByRole('cell')
+      .nth(1);
     await expect(bodyCell).toHaveCSS('word-break', 'normal');
   });
 
   test('getSortValue sorts currency numerically, not lexicographically', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-header-meta"]');
+    const table = page.getByTestId('table-header-meta');
     await table.getByRole('button', { name: 'Sort by Amount' }).click();
-    const amounts = await table.locator('tbody tr td:nth-child(3)').allInnerTexts();
+    const amounts = await table.getByTestId(/^meta-amount-cell-\d+$/).allInnerTexts();
     expect(amounts).toEqual(['₹1,200.00', '₹4,938.10', '₹19,752.40']);
     // Lexicographic order would have been 1,200.00 / 19,752.40 / 4,938.10
     await table.getByRole('button', { name: 'Sort by Amount' }).click();
-    const descending = await table.locator('tbody tr td:nth-child(3)').allInnerTexts();
+    const descending = await table.getByTestId(/^meta-amount-cell-\d+$/).allInnerTexts();
     expect(descending).toEqual(['₹19,752.40', '₹4,938.10', '₹1,200.00']);
   });
 
@@ -78,17 +96,17 @@ test.describe('Table — header metadata + controlled sort', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-server-sort"]');
-    await expect(table.locator('tbody tr td:first-child').first()).toContainText('Gamma');
+    const table = page.getByTestId('table-server-sort');
+    await expect(table.getByTestId('srv-sort-name-cell-0')).toContainText('Gamma');
 
     await table.getByRole('button', { name: 'Sort by Score' }).click();
-    await expect(page.locator('[data-pw="server-sort-log"]')).toContainText('col 1 asc');
-    const names = await table.locator('tbody tr td:first-child').allInnerTexts();
+    await expect(page.getByTestId('server-sort-log')).toContainText('col 1 asc');
+    const names = await table.getByTestId(/^srv-sort-name-cell-\d+$/).allInnerTexts();
     expect(names).toEqual(['Alpha', 'Beta', 'Gamma']);
 
     await table.getByRole('button', { name: 'Sort by Score' }).click();
-    await expect(page.locator('[data-pw="server-sort-log"]')).toContainText('col 1 desc');
-    const reversed = await table.locator('tbody tr td:first-child').allInnerTexts();
+    await expect(page.getByTestId('server-sort-log')).toContainText('col 1 desc');
+    const reversed = await table.getByTestId(/^srv-sort-name-cell-\d+$/).allInnerTexts();
     expect(reversed).toEqual(['Gamma', 'Beta', 'Alpha']);
   });
 });

--- a/tests/table-interactive-cells.test.ts
+++ b/tests/table-interactive-cells.test.ts
@@ -3,102 +3,115 @@ import { expect, test } from '@playwright/test';
 test.describe('Table — interactive cell renderers', () => {
   test('button cell fires the column handler and never the row click', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
+    const table = page.getByTestId('table-interactive-cells');
     await expect(table).toBeVisible();
-    await table.locator('[data-pw="demo-renew-0"]').click();
-    await expect(page.locator('[data-pw="interactive-log"]')).toContainText('button r0');
-    await expect(page.locator('[data-pw="row-click-log"]')).toContainText('none');
+    await table.getByTestId('demo-renew-0').click();
+    await expect(page.getByTestId('interactive-log')).toContainText('button r0');
+    await expect(page.getByTestId('row-click-log')).toContainText('none');
   });
 
   test('clicking a plain text cell still fires the row click (guard is scoped)', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    await table.locator('tbody tr').first().locator('td').first().click();
-    await expect(page.locator('[data-pw="row-click-log"]')).toContainText('row 0');
+    const table = page.getByTestId('table-interactive-cells');
+    await table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .first()
+      .getByRole('cell')
+      .first()
+      .click();
+    await expect(page.getByTestId('row-click-log')).toContainText('row 0');
   });
 
   test('disabled button cell renders disabled', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    await expect(table.locator('[data-pw="demo-renew-1"]')).toBeDisabled();
+    const table = page.getByTestId('table-interactive-cells');
+    await expect(table.getByTestId('demo-renew-1')).toBeDisabled();
   });
 
   test('select cell forwards itemTestId — options carry data-pw="{prefix}-{id}"', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    const select = table.locator('[data-pw="demo-tier-0"]');
+    const table = page.getByTestId('table-interactive-cells');
+    const select = table.getByTestId('demo-tier-0');
     await select.getByRole('combobox').click();
-    await expect(select.locator('[data-pw="demo-tier-option-basic"]')).toBeVisible();
-    await expect(select.locator('[data-pw="demo-tier-option-pro"]')).toBeVisible();
+    await expect(select.getByTestId('demo-tier-option-basic')).toBeVisible();
+    await expect(select.getByTestId('demo-tier-option-pro')).toBeVisible();
     await page.keyboard.press('Escape');
   });
 
   test('select cell fires onSelect with the chosen option id, no row click', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    const select = table.locator('[data-pw="demo-tier-0"]');
+    const table = page.getByTestId('table-interactive-cells');
+    const select = table.getByTestId('demo-tier-0');
     await select.getByRole('combobox').click();
     const listbox = select.getByRole('listbox');
     await expect(listbox).toBeVisible();
     await listbox.getByText('Basic', { exact: true }).click();
-    await expect(page.locator('[data-pw="interactive-log"]')).toContainText('select r0 → basic');
-    await expect(page.locator('[data-pw="row-click-log"]')).toContainText('none');
+    await expect(page.getByTestId('interactive-log')).toContainText('select r0 → basic');
+    await expect(page.getByTestId('row-click-log')).toContainText('none');
   });
 
   test('input cell fires onInput with the typed value, no row click', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    const input = table.locator('[data-pw="demo-note-1"] input, input[data-pw="demo-note-1"]');
+    const table = page.getByTestId('table-interactive-cells');
+    const input = table.getByTestId('demo-note-1');
     await input.first().fill('hello');
-    await expect(page.locator('[data-pw="interactive-log"]')).toContainText('input r1 → hello');
-    await expect(page.locator('[data-pw="row-click-log"]')).toContainText('none');
+    await expect(page.getByTestId('interactive-log')).toContainText('input r1 → hello');
+    await expect(page.getByTestId('row-click-log')).toContainText('none');
   });
 
   test('input cell forwards validationPattern/onErrorMessage — live inline validation', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    const input = table.locator('[data-pw="demo-note-1"] input, input[data-pw="demo-note-1"]');
+    const table = page.getByTestId('table-interactive-cells');
+    const input = table.getByTestId('demo-note-1');
     // demo-note-1 carries validationPattern '^\d+$' + onErrorMessage 'Digits only'.
     await input.first().fill('abc');
-    await expect(table.locator('.error-message')).toContainText('Digits only');
+    await expect(table.getByTestId('demo-note-1-error-message')).toContainText('Digits only');
     await input.first().fill('123');
-    await expect(table.locator('.error-message')).toHaveCount(0);
+    await expect(table.getByTestId('demo-note-1-error-message')).toHaveCount(0);
   });
 
   test('action-group primary button and overflow menu both dispatch column handlers', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    await table.locator('[data-pw="demo-edit-0"]').click();
-    await expect(page.locator('[data-pw="interactive-log"]')).toContainText('primary r0');
+    const table = page.getByTestId('table-interactive-cells');
+    await table.getByTestId('demo-edit-0').click();
+    await expect(page.getByTestId('interactive-log')).toContainText('primary r0');
 
-    await table.locator('[data-pw="demo-manage-menu-trigger-0"]').click();
+    await table.getByTestId('demo-manage-menu-trigger-0').click();
     await page.getByText('Duplicate', { exact: true }).click();
-    await expect(page.locator('[data-pw="interactive-log"]')).toContainText('menu r0 → duplicate');
-    await expect(page.locator('[data-pw="row-click-log"]')).toContainText('none');
+    await expect(page.getByTestId('interactive-log')).toContainText('menu r0 → duplicate');
+    await expect(page.getByTestId('row-click-log')).toContainText('none');
   });
 
   test('action-group without a primary button renders menu only', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    const secondManageCell = table.locator('tbody tr').nth(1).locator('td').nth(4);
-    await expect(secondManageCell.locator('[data-pw="demo-manage-menu-trigger-1"]')).toBeVisible();
+    const table = page.getByTestId('table-interactive-cells');
+    const secondManageCell = table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .nth(1)
+      .getByRole('cell')
+      .nth(4);
+    await expect(secondManageCell.getByTestId('demo-manage-menu-trigger-1')).toBeVisible();
     await expect(secondManageCell.getByText('Edit')).toHaveCount(0);
   });
 
   test('popup-menu cell dispatches onMenuAction, no row click', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-interactive-cells"]');
-    await table.locator('[data-pw="demo-more-popup-trigger-0"]').click();
+    const table = page.getByTestId('table-interactive-cells');
+    await table.getByTestId('demo-more-popup-trigger-0').click();
     await page.getByText('Archive', { exact: true }).first().click();
-    await expect(page.locator('[data-pw="interactive-log"]')).toContainText('popup r0 → archive');
-    await expect(page.locator('[data-pw="row-click-log"]')).toContainText('none');
+    await expect(page.getByTestId('interactive-log')).toContainText('popup r0 → archive');
+    await expect(page.getByTestId('row-click-log')).toContainText('none');
   });
 });

--- a/tests/table-keyed-columns.test.ts
+++ b/tests/table-keyed-columns.test.ts
@@ -3,42 +3,42 @@ import { expect, test } from '@playwright/test';
 test.describe('Table — keyed column model', () => {
   test('keyed table renders identically to its positional twin', async ({ page }) => {
     await page.goto('/components/table');
-    const keyed = page.locator('[data-pw="table-keyed-basic"]');
-    const positional = page.locator('[data-pw="table-positional-twin"]');
+    const keyed = page.getByTestId('table-keyed-basic');
+    const positional = page.getByTestId('table-positional-twin');
     await expect(keyed).toBeVisible();
     await expect(positional).toBeVisible();
 
-    const keyedHeaders = await keyed.locator('th').allInnerTexts();
-    const positionalHeaders = await positional.locator('th').allInnerTexts();
+    const keyedHeaders = await keyed.getByRole('columnheader').allInnerTexts();
+    const positionalHeaders = await positional.getByRole('columnheader').allInnerTexts();
     expect(keyedHeaders).toEqual(positionalHeaders);
 
-    const keyedCells = await keyed.locator('td').allInnerTexts();
-    const positionalCells = await positional.locator('td').allInnerTexts();
+    const keyedCells = await keyed.getByRole('cell').allInnerTexts();
+    const positionalCells = await positional.getByRole('cell').allInnerTexts();
     expect(keyedCells).toEqual(positionalCells);
   });
 
   test('sorting behaves identically on keyed and positional twins', async ({ page }) => {
     await page.goto('/components/table');
-    const keyed = page.locator('[data-pw="table-keyed-basic"]');
-    const positional = page.locator('[data-pw="table-positional-twin"]');
+    const keyed = page.getByTestId('table-keyed-basic');
+    const positional = page.getByTestId('table-positional-twin');
 
     await keyed.getByRole('button', { name: 'Sort by Name' }).click();
     await positional.getByRole('button', { name: 'Sort by Name' }).click();
-    expect(await keyed.locator('td').allInnerTexts()).toEqual(
-      await positional.locator('td').allInnerTexts()
+    expect(await keyed.getByRole('cell').allInnerTexts()).toEqual(
+      await positional.getByRole('cell').allInnerTexts()
     );
 
     // Second click flips to descending on both
     await keyed.getByRole('button', { name: 'Sort by Name' }).click();
     await positional.getByRole('button', { name: 'Sort by Name' }).click();
-    expect(await keyed.locator('td').allInnerTexts()).toEqual(
-      await positional.locator('td').allInnerTexts()
+    expect(await keyed.getByRole('cell').allInnerTexts()).toEqual(
+      await positional.getByRole('cell').allInnerTexts()
     );
   });
 
   test('per-column sortable: false suppresses that column sort button only', async ({ page }) => {
     await page.goto('/components/table');
-    const features = page.locator('[data-pw="table-keyed-features"]');
+    const features = page.getByTestId('table-keyed-features');
     await expect(features).toBeVisible();
     await expect(features.getByRole('button', { name: 'Sort by Name' })).toBeVisible();
     await expect(features.getByRole('button', { name: 'Sort by Department' })).toHaveCount(0);
@@ -47,26 +47,32 @@ test.describe('Table — keyed column model', () => {
 
   test('column-scoped custom cell snippet renders per row with the keyed row', async ({ page }) => {
     await page.goto('/components/table');
-    const features = page.locator('[data-pw="table-keyed-features"]');
+    const features = page.getByTestId('table-keyed-features');
     // The Status column renders a Pill per row via the column's cell snippet
-    await expect(features.locator('td .pill-success')).toHaveCount(1);
-    await expect(features.locator('td .pill-warning')).toHaveCount(1);
-    await expect(features.locator('td .pill-error')).toHaveCount(1);
+    await expect(features.getByTestId('keyed-status-active')).toBeVisible();
+    await expect(features.getByTestId('keyed-status-pending')).toBeVisible();
+    await expect(features.getByTestId('keyed-status-inactive')).toBeVisible();
   });
 
   test('missing row keys render as empty cells, not "undefined"', async ({ page }) => {
     await page.goto('/components/table');
-    const features = page.locator('[data-pw="table-keyed-features"]');
-    const thirdRowCells = await features.locator('tbody tr').nth(2).locator('td').allInnerTexts();
+    const features = page.getByTestId('table-keyed-features');
+    const thirdRowCells = await features
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('row')
+      .nth(2)
+      .getByRole('cell')
+      .allInnerTexts();
     expect(thirdRowCells[0]).toBe('Carol White');
     expect(thirdRowCells[1]).toBe('');
   });
 
   test('column testId is emitted as data-pw on the header cell', async ({ page }) => {
     await page.goto('/components/table');
-    const features = page.locator('[data-pw="table-keyed-features"]');
-    await expect(features.locator('th[data-pw="keyed-header-name"]')).toHaveCount(1);
-    await expect(features.locator('th[data-pw="keyed-header-name"]')).toContainText('Name');
+    const features = page.getByTestId('table-keyed-features');
+    await expect(features.getByTestId('keyed-header-name')).toHaveCount(1);
+    await expect(features.getByTestId('keyed-header-name')).toContainText('Name');
   });
 
   test('positional API is untouched: the basic positional table renders as before', async ({
@@ -74,8 +80,10 @@ test.describe('Table — keyed column model', () => {
   }) => {
     await page.goto('/components/table');
     // The pre-existing Basic demo (positional props, no columns/rows)
-    const basicHeaders = page.locator('table').first().locator('th');
+    const basicHeaders = page.getByRole('table').first().getByRole('columnheader');
     await expect(basicHeaders).toHaveCount(3);
-    await expect(page.locator('table').first().locator('tbody tr')).toHaveCount(3);
+    await expect(
+      page.getByRole('table').first().getByRole('rowgroup').last().getByRole('row')
+    ).toHaveCount(3);
   });
 });

--- a/tests/table-pagination-selection.test.ts
+++ b/tests/table-pagination-selection.test.ts
@@ -3,66 +3,74 @@ import { expect, test } from '@playwright/test';
 test.describe('Table — built-in pagination + row numbers', () => {
   test('client mode slices rows, shows the range, and pages forward', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paginated"]');
-    await expect(table.locator('tbody tr')).toHaveCount(5);
-    await expect(table.locator('.table-paginator-range')).toContainText('1-5 of 23');
-    await expect(table.locator('tbody tr').first()).toContainText('Item 01');
+    const table = page.getByTestId('table-paginated');
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(5);
+    await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('1-5 of 23');
+    await expect(table.getByRole('rowgroup').last().getByRole('row').first()).toContainText(
+      'Item 01'
+    );
 
-    await table.locator('[data-pw="paged-pages"]').getByRole('button', { name: 'Page 2' }).click();
-    await expect(table.locator('tbody tr').first()).toContainText('Item 06');
-    await expect(table.locator('.table-paginator-range')).toContainText('6-10 of 23');
+    await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 2' }).click();
+    await expect(table.getByRole('rowgroup').last().getByRole('row').first()).toContainText(
+      'Item 06'
+    );
+    await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('6-10 of 23');
   });
 
   test('row numbers are pagination-aware', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paginated"]');
-    await expect(table.locator('tbody tr').first().locator('td').first()).toContainText('1');
+    const table = page.getByTestId('table-paginated');
+    await expect(
+      table.getByRole('rowgroup').last().getByRole('row').first().getByRole('cell').first()
+    ).toContainText('1');
     // From page 1 the pager truncates to [1, 2, …, 5]; the last page is always present.
-    await table.locator('[data-pw="paged-pages"]').getByRole('button', { name: 'Page 5' }).click();
-    await expect(table.locator('tbody tr').first().locator('td').first()).toContainText('21');
+    await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 5' }).click();
+    await expect(
+      table.getByRole('rowgroup').last().getByRole('row').first().getByRole('cell').first()
+    ).toContainText('21');
   });
 
   test('handlers receive GLOBAL row indices under client pagination, not page-local', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paginated"]');
+    const table = page.getByTestId('table-paginated');
     // Page 1: first row is global index 0.
-    await expect(table.locator('tr[data-pw="paged-idx-0"]')).toHaveCount(1);
-    await table.locator('[data-pw="paged-pages"]').getByRole('button', { name: 'Page 2' }).click();
+    await expect(table.getByTestId('paged-idx-0')).toHaveCount(1);
+    await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 2' }).click();
     // Page 2: first row must be global index 5 (page-local would be 0 again).
-    await expect(table.locator('tr[data-pw="paged-idx-5"]')).toHaveCount(1);
-    await expect(table.locator('tr[data-pw="paged-idx-0"]')).toHaveCount(0);
+    await expect(table.getByTestId('paged-idx-5')).toHaveCount(1);
+    await expect(table.getByTestId('paged-idx-0')).toHaveCount(0);
   });
 
   test('page-size change re-slices and snaps back to page 1', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paginated"]');
-    await table.locator('[data-pw="paged-pages"]').getByRole('button', { name: 'Page 2' }).click();
-    await expect(table.locator('.table-paginator-range')).toContainText('6-10 of 23');
+    const table = page.getByTestId('table-paginated');
+    await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 2' }).click();
+    await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('6-10 of 23');
 
-    const sizeSelect = table.locator('[data-pw="paged-page-size"]');
+    const sizeSelect = table.getByTestId('paged-page-size');
     await sizeSelect.getByRole('combobox').click();
     await sizeSelect.getByRole('listbox').getByText('10', { exact: true }).click();
-    await expect(table.locator('tbody tr')).toHaveCount(10);
-    await expect(table.locator('.table-paginator-range')).toContainText('1-10 of 23');
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(10);
+    await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('1-10 of 23');
   });
 
   test('search filters across all pages and snaps back to page 1', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paginated"]');
-    await table.locator('[data-pw="paged-pages"]').getByRole('button', { name: 'Page 2' }).click();
+    const table = page.getByTestId('table-paginated');
+    await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 2' }).click();
     // The search bar renders above the table wrapper, outside the testId element.
-    await page.locator('[data-pw="paged-search"]').fill('Item 2');
+    await page.getByTestId('paged-search').fill('Item 2');
     // Item 20, 21, 22, 23 match "Item 2" (plus Item 02 does not — padded "02")
-    await expect(table.locator('tbody tr')).toHaveCount(4);
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(4);
     // DataGrid parity: once the filtered set fits on one page, the pagination
     // chrome disappears entirely (footer, range text, steppers).
-    await expect(table.locator('.table-paginator')).toHaveCount(0);
+    await expect(table.getByTestId('paged')).toHaveCount(0);
 
     // Clearing the search restores multi-page data and the paginator with it.
-    await page.locator('[data-pw="paged-search"]').fill('');
-    await expect(table.locator('.table-paginator-range')).toContainText('1-5 of 23');
+    await page.getByTestId('paged-search').fill('');
+    await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('1-5 of 23');
   });
 });
 
@@ -71,29 +79,37 @@ test.describe('Table — server-mode pagination', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-server-paginated"]');
-    await expect(table.locator('tbody tr')).toHaveCount(5);
-    await expect(table.locator('tbody tr').first()).toContainText('Record 01');
-    await expect(table.locator('.table-paginator-range')).toContainText('1-5 of 12');
+    const table = page.getByTestId('table-server-paginated');
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(5);
+    await expect(table.getByRole('rowgroup').last().getByRole('row').first()).toContainText(
+      'Record 01'
+    );
+    await expect(table.getByTestId('table-server-paginated-paginator-range')).toContainText(
+      '1-5 of 12'
+    );
     // pageSizeOptions: [] hides the page-size selector entirely.
-    await expect(table.locator('[data-pw="srv-paged-page-size"]')).toHaveCount(0);
+    await expect(table.getByTestId('srv-paged-page-size')).toHaveCount(0);
   });
 
   test('page change reports to the consumer, which swaps the rows (incl. short last page)', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-server-paginated"]');
-    await table.locator('[data-pw="srv-paged-pages"]').getByRole('button', { name: 'Page 3' }).click();
-    await expect(table.locator('tbody tr')).toHaveCount(2);
-    await expect(table.locator('tbody tr').first()).toContainText('Record 11');
-    await expect(table.locator('.table-paginator-range')).toContainText('11-12 of 12');
+    const table = page.getByTestId('table-server-paginated');
+    await table.getByTestId('srv-paged-pages').getByRole('button', { name: 'Page 3' }).click();
+    await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(2);
+    await expect(table.getByRole('rowgroup').last().getByRole('row').first()).toContainText(
+      'Record 11'
+    );
+    await expect(table.getByTestId('table-server-paginated-paginator-range')).toContainText(
+      '11-12 of 12'
+    );
   });
 
   test('getRowTestId emits row-level data-pw for keyed rows', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-server-paginated"]');
-    await expect(table.locator('tr[data-pw="srv-row-Record 01"]')).toHaveCount(1);
+    const table = page.getByTestId('table-server-paginated');
+    await expect(table.getByTestId('srv-row-Record 01')).toHaveCount(1);
   });
 });
 
@@ -102,39 +118,41 @@ test.describe('Table — page-scoped select-all under client pagination', () => 
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paged-select"]');
-    const log = page.locator('[data-pw="paged-select-log"]');
+    const table = page.getByTestId('table-paged-select');
+    const log = page.getByTestId('paged-select-log');
 
     // Page 1 shows Members 1-5; Member 2 is disabled.
-    await table.locator('thead .table-checkbox-box').click();
+    await table.getByTestId('table-paged-select-select-all').click();
     await expect(log).toContainText('Member 1,Member 3,Member 4,Member 5');
     await expect(log).not.toContainText('Member 6');
-    await expect(table.locator('thead .table-checkbox-box')).toHaveAttribute(
+    await expect(table.getByTestId('table-paged-select-select-all')).toHaveAttribute(
       'aria-checked',
       'true'
     );
 
     // Second click must DESELECT the page (the DataGrid-parity regression:
     // cross-page scope left the header at 'some' and re-selected instead).
-    await table.locator('thead .table-checkbox-box').click();
+    await table.getByTestId('table-paged-select-select-all').click();
     await expect(log).toContainText('Selected: empty');
-    await expect(table.locator('tbody [aria-checked="true"]')).toHaveCount(0);
+    await expect(
+      table.getByRole('rowgroup').last().getByRole('checkbox', { checked: true })
+    ).toHaveCount(0);
   });
 
   test('header toggle on page 2 leaves page-1 selections intact', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paged-select"]');
-    const log = page.locator('[data-pw="paged-select-log"]');
+    const table = page.getByTestId('table-paged-select');
+    const log = page.getByTestId('paged-select-log');
 
-    await table.locator('[id="row-checkbox-Member 1"]').click();
+    await table.getByTestId('table-paged-select-row-checkbox-Member 1').click();
     await expect(log).toContainText('Selected: Member 1');
 
-    await table.locator('[data-pw="psel-pages"]').getByRole('button', { name: 'Page 2' }).click();
-    await table.locator('thead .table-checkbox-box').click();
+    await table.getByTestId('psel-pages').getByRole('button', { name: 'Page 2' }).click();
+    await table.getByTestId('table-paged-select-select-all').click();
     await expect(log).toContainText('Member 1,Member 6,Member 7');
 
     // Deselecting page 2 must not touch the page-1 selection.
-    await table.locator('thead .table-checkbox-box').click();
+    await table.getByTestId('table-paged-select-select-all').click();
     await expect(log).toContainText('Selected: Member 1');
     await expect(log).not.toContainText('Member 6');
   });
@@ -143,12 +161,17 @@ test.describe('Table — page-scoped select-all under client pagination', () => 
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-paged-select"]');
+    const table = page.getByTestId('table-paged-select');
+    await expect(table.getByRole('checkbox', { name: 'Select row Member 1' })).toHaveCount(1);
     await expect(
-      table.locator('[role="checkbox"][aria-label="Select row Member 1"]')
+      table.getByRole('rowgroup').first().getByRole('checkbox', { name: 'Select all rows' })
     ).toHaveCount(1);
-    await expect(table.locator('thead [aria-label="Select all rows"]')).toHaveCount(1);
-    await expect(table.locator('thead [aria-label^="Select row"]')).toHaveCount(0);
+    await expect(
+      table
+        .getByRole('rowgroup')
+        .first()
+        .getByRole('checkbox', { name: /^Select row/ })
+    ).toHaveCount(0);
   });
 });
 
@@ -157,36 +180,41 @@ test.describe('Table — controlled selection + toolbar', () => {
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-controlled-selection"]');
-    await expect(page.locator('[data-pw="bulk-count"]')).toHaveCount(0);
+    const table = page.getByTestId('table-controlled-selection');
+    await expect(page.getByTestId('bulk-count')).toHaveCount(0);
 
-    await table.locator('#row-checkbox-Alice').click();
-    await expect(page.locator('[data-pw="bulk-count"]')).toContainText('1 selected');
+    await table.getByTestId('table-controlled-selection-row-checkbox-Alice').click();
+    await expect(page.getByTestId('bulk-count')).toContainText('1 selected');
 
     // Header select-all extends the controlled set to every row
-    await table.locator('thead .table-checkbox-box').click();
-    await expect(page.locator('[data-pw="bulk-count"]')).toContainText('4 selected');
+    await table.getByTestId('table-controlled-selection-select-all').click();
+    await expect(page.getByTestId('bulk-count')).toContainText('4 selected');
   });
 
   test('toolbar action consumes the selection and clearing hides the toolbar', async ({ page }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-controlled-selection"]');
-    await table.locator('#row-checkbox-Bob').click();
-    await table.locator('#row-checkbox-Carol').click();
-    await expect(page.locator('[data-pw="bulk-count"]')).toContainText('2 selected');
+    const table = page.getByTestId('table-controlled-selection');
+    await table.getByTestId('table-controlled-selection-row-checkbox-Bob').click();
+    await table.getByTestId('table-controlled-selection-row-checkbox-Carol').click();
+    await expect(page.getByTestId('bulk-count')).toContainText('2 selected');
 
-    await page.locator('[data-pw="bulk-delete"]').click();
-    await expect(page.locator('[data-pw="bulk-action-log"]')).toContainText('deleted Bob,Carol');
-    await expect(page.locator('[data-pw="bulk-count"]')).toHaveCount(0);
-    await expect(table.locator('.table-checkbox-box.checked')).toHaveCount(0);
+    await page.getByTestId('bulk-delete').click();
+    await expect(page.getByTestId('bulk-action-log')).toContainText('deleted Bob,Carol');
+    await expect(page.getByTestId('bulk-count')).toHaveCount(0);
+    await expect(table.getByRole('checkbox', { checked: true })).toHaveCount(0);
   });
 
   test('getRowAttributes spreads onto the row checkboxes (header gets -1 sentinel)', async ({
     page
   }) => {
     await page.goto('/components/table');
-    const table = page.locator('[data-pw="table-controlled-selection"]');
-    await expect(table.locator('[data-selrow="Alice"]')).toHaveCount(1);
-    await expect(table.locator('thead [data-selrow="__header__"]')).toHaveCount(1);
+    const table = page.getByTestId('table-controlled-selection');
+    await expect(
+      table.getByTestId('table-controlled-selection-row-checkbox-Alice')
+    ).toHaveAttribute('data-selrow', 'Alice');
+    await expect(table.getByTestId('table-controlled-selection-select-all')).toHaveAttribute(
+      'data-selrow',
+      '__header__'
+    );
   });
 });

--- a/tests/toolbar-content-geometry.test.ts
+++ b/tests/toolbar-content-geometry.test.ts
@@ -7,7 +7,7 @@ test.describe('Toolbar content-row geometry tokens', () => {
   test('defaults leave an unconfigured toolbar content row unchanged', async ({ page }) => {
     await page.goto('/components/toolbar');
 
-    const content = page.locator('[data-pw="toolbar-root"] .content');
+    const content = page.getByTestId('toolbar-root-content');
     await expect(content).toBeVisible();
 
     const style = await content.evaluate((element) => {
@@ -28,8 +28,7 @@ test.describe('Toolbar content-row geometry tokens', () => {
   test('an instance can clamp and center its content row via tokens', async ({ page }) => {
     await page.goto('/components/toolbar');
 
-    const toolbar = page.locator('[data-pw="toolbar-content-tokens"]');
-    const content = toolbar.locator('.content');
+    const content = page.getByTestId('toolbar-content-tokens-content');
     await expect(content).toBeVisible();
 
     const style = await content.evaluate((element) => {

--- a/tests/tooltip.test.ts
+++ b/tests/tooltip.test.ts
@@ -4,20 +4,20 @@ test.describe('Tooltip component', () => {
   test('shows bubble on hover and hides on mouse leave', async ({ page }) => {
     await page.goto('/components/tooltip');
 
-    const trigger = page.locator('[data-pw="tooltip-container"]').first();
+    const trigger = page.getByTestId('tooltip-container').first();
     await expect(trigger).toBeVisible();
 
     // No tooltip bubble visible initially.
-    await expect(page.locator('[role="tooltip"]')).toHaveCount(0);
+    await expect(page.getByRole('tooltip')).toHaveCount(0);
 
     // Hover the first Tooltip trigger.
     await trigger.hover();
-    const bubble = page.locator('[role="tooltip"]').first();
+    const bubble = page.getByRole('tooltip').first();
     await expect(bubble).toBeVisible();
 
     // Mouse leave removes the bubble.
     await page.mouse.move(0, 0);
-    await expect(page.locator('[role="tooltip"]')).toHaveCount(0);
+    await expect(page.getByRole('tooltip')).toHaveCount(0);
   });
 });
 
@@ -31,10 +31,10 @@ test.describe('tooltip action — use:tooltip directive', () => {
     await expect(trigger).toBeVisible();
 
     // No bubble before hover.
-    await expect(page.locator('[role="tooltip"]')).toHaveCount(0);
+    await expect(page.getByRole('tooltip')).toHaveCount(0);
 
     await trigger.hover();
-    const bubble = page.locator('[role="tooltip"]').last();
+    const bubble = page.getByRole('tooltip').last();
     await expect(bubble).toBeVisible();
     await expect(bubble).toContainText('Save document');
   });
@@ -42,11 +42,11 @@ test.describe('tooltip action — use:tooltip directive', () => {
   test('removes bubble when mouse leaves trigger', async ({ page }) => {
     const trigger = page.getByTestId('tooltip-action-top');
     await trigger.hover();
-    await expect(page.locator('[role="tooltip"]').last()).toBeVisible();
+    await expect(page.getByRole('tooltip').last()).toBeVisible();
 
     await page.mouse.move(0, 0);
     // The action-appended bubble is removed from body.
-    await expect(page.locator('body > [role="tooltip"]')).toHaveCount(0);
+    await expect(page.getByRole('tooltip')).toHaveCount(0);
   });
 
   test('establishes aria-describedby between trigger and bubble', async ({ page }) => {
@@ -57,8 +57,13 @@ test.describe('tooltip action — use:tooltip directive', () => {
     expect(describedBy).toBeTruthy();
 
     // The referenced element must exist and have role=tooltip.
-    const referencedEl = page.locator(`#${describedBy}`);
-    await expect(referencedEl).toHaveAttribute('role', 'tooltip');
+    const tooltipInfo = await page.evaluate((id) => {
+      const el = document.getElementById(id);
+      return el ? { role: el.getAttribute('role'), id: el.id } : null;
+    }, describedBy ?? '');
+    expect(tooltipInfo).not.toBeNull();
+    expect(tooltipInfo?.role).toBe('tooltip');
+    expect(tooltipInfo?.id).toBe(describedBy);
   });
 
   test('removes aria-describedby when bubble is hidden', async ({ page }) => {
@@ -84,7 +89,7 @@ test.describe('tooltip action — use:tooltip directive', () => {
     }, 'tooltip-action-top');
 
     await expect(trigger).toBeVisible();
-    const bubbles = page.locator('body > [role="tooltip"]');
+    const bubbles = page.getByRole('tooltip');
     await expect(bubbles).toHaveCount(1);
   });
 
@@ -102,12 +107,12 @@ test.describe('tooltip action — use:tooltip directive', () => {
     await page.mouse.move(box.x + 5, box.y + 5);
 
     // Immediately after hover the bubble should not yet be visible.
-    await expect(page.locator('body > [role="tooltip"]')).toHaveCount(0);
+    await expect(page.getByRole('tooltip')).toHaveCount(0);
 
     // After 350ms it should appear.
     await page.waitForTimeout(350);
-    await expect(page.locator('body > [role="tooltip"]')).toHaveCount(1);
-    await expect(page.locator('body > [role="tooltip"]').last()).toContainText('Delete item');
+    await expect(page.getByRole('tooltip')).toHaveCount(1);
+    await expect(page.getByRole('tooltip').last()).toContainText('Delete item');
   });
 
   test('tooltip bubble is mounted on document.body (portal behaviour)', async ({ page }) => {


### PR DESCRIPTION
…asses to data pw attribute

- Add testId prop + data-pw emission to 7 components missing it (BrandLoader, GridItem, Icon, IconStack, InputButton, Status, Animations)
- Add data-pw to internal sub-elements across ~20 components (Table checkboxes, BuiltinCell trends/thumbs/icons, Select indicators, BarChart bar-values, Axis tick-labels, ChartTooltip, Legend, StatCard, Checkbox, Tooltip, etc.)
- Add data-checked/data-inside data attributes for state-based filtering without CSS classes (Select indicators, BarChart bar-values)
- Add testId to all column definitions in table demo page
- Convert all 24 test files from .locator('.classname') to getByTestId()/ getByRole()/evaluate() — zero .locator() calls remain
- Add data-pw="page-body" to app.html body element
- Add testId?: string to TableTagArrayCellItem type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added consistent test identifiers across components, charts, tables, overlays, inputs, and interactive controls for more reliable UI targeting.
  * Improved accessibility-oriented selectors and state attributes for selection indicators and interactive elements.
  * Removed table horizontal-scroll edge overlays for a simpler layout.

* **Tests**
  * Updated end-to-end coverage to use stable test IDs and semantic roles, improving test reliability across charts, date pickers, tables, tooltips, and form controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->