### PR TITLE
fix(Select): add usePortal so the dropdown escapes overflow-clipping ancestors

### DIFF
--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -3,6 +3,7 @@
   import type { SelectItem, SelectProperties } from './properties';
   import Pill from '$lib/Pill/Pill.svelte';
   import Img from '$lib/Img/Img.svelte';
+  import { computeSelectDropdownPosition } from './dropdownPosition';
   import chevronDownSvg from '$lib/assets/chevron-down.svg?raw';
   import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
 
@@ -29,7 +30,8 @@
     dropdownAlign = 'left',
     hierarchy = 'default',
     leftIcon,
-    leftIconTestId
+    leftIconTestId,
+    usePortal = false
   }: SelectProperties = $props();
 
   function normalizeItems(source: SelectItem[] | string[]): SelectItem[] {
@@ -42,6 +44,16 @@
   let containerEl: HTMLDivElement | null = $state(null);
   let searchInputEl: HTMLInputElement | null = $state(null);
   let triggerEl: HTMLDivElement | null = $state(null);
+  let dropdownEl: HTMLDivElement | null = $state(null);
+  let dropdownWidth = $state(0);
+  let dropdownHeight = $state(0);
+  // Portal placement reads untracked DOM (trigger rect, viewport size); bump on
+  // scroll/resize so the derived style re-runs while the dropdown is open.
+  let portalTick = $state(0);
+
+  // Gap between trigger and portaled panel, matching the --select-dropdown-gap
+  // default. The in-flow panel still honours the CSS var via its margin-top.
+  const PORTAL_DROPDOWN_GAP = 4;
 
   const listboxId = `select-listbox-${Math.random().toString(36).slice(2, 9)}`;
 
@@ -94,6 +106,77 @@
   );
 
   let searchPlaceholder = $derived(open && displayText.length > 0 ? displayText : placeholder);
+
+  // Keep the portaled panel anchored to its trigger while the page scrolls or
+  // resizes. Mirrors the chart-tooltip portal pattern; $effect is the sanctioned
+  // reactive escape hatch here for untracked window listeners. Reposition work is
+  // coalesced into one animation frame so fast/inertial scrolling can't thrash
+  // layout with a getBoundingClientRect on every event.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (!usePortal || !open || typeof window === 'undefined') {
+      return;
+    }
+    let frame: number | null = null;
+    const bump = (): void => {
+      if (frame !== null) {
+        return;
+      }
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        portalTick += 1;
+      });
+    };
+    window.addEventListener('scroll', bump, { capture: true, passive: true });
+    window.addEventListener('resize', bump);
+    return () => {
+      window.removeEventListener('scroll', bump, { capture: true });
+      window.removeEventListener('resize', bump);
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  });
+
+  /**
+   * Svelte action: relocates the dropdown to document.body when usePortal is set,
+   * so a position:fixed panel is never clipped by an overflow/scroll ancestor
+   * (e.g. a table cell). No-op otherwise; `use:` actions never run during SSR.
+   */
+  const portalToBody = (node: HTMLElement) => {
+    if (!usePortal) {
+      return;
+    }
+    document.body.appendChild(node);
+    return { destroy: () => node.remove() };
+  };
+
+  let portalStyle = $derived.by(() => {
+    if (!usePortal || !open || triggerEl === null) {
+      return '';
+    }
+    void portalTick;
+    const rect = triggerEl.getBoundingClientRect();
+    const viewport =
+      typeof window === 'undefined'
+        ? { width: Number.POSITIVE_INFINITY, height: Number.POSITIVE_INFINITY }
+        : { width: window.innerWidth, height: window.innerHeight };
+    const placement = computeSelectDropdownPosition({
+      trigger: {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+        width: rect.width
+      },
+      dropdown: { width: dropdownWidth, height: dropdownHeight },
+      viewport,
+      align: dropdownAlign,
+      gap: PORTAL_DROPDOWN_GAP
+    });
+    const widthRule = placement.width === null ? '' : `width:${placement.width}px;`;
+    return `top:${placement.top}px;left:${placement.left}px;min-width:${placement.minWidth}px;${widthRule}`;
+  });
 
   async function openDropdown(): Promise<void> {
     if (disabled || open) {
@@ -173,8 +256,10 @@
     }
     highlightedIndex = next;
     await tick();
-    if (containerEl !== null) {
-      const el = containerEl.querySelector('.select-option.highlighted');
+    // Query the dropdown node itself, not containerEl, so highlight-scrolling
+    // keeps working once the panel is portaled out to <body>.
+    if (dropdownEl !== null) {
+      const el = dropdownEl.querySelector('.select-option.highlighted');
       if (el instanceof HTMLElement) {
         el.scrollIntoView({ block: 'nearest' });
       }
@@ -275,10 +360,14 @@
   }
 
   function handleClickOutside(event: Event): void {
+    // A portaled dropdown lives outside containerEl, so a click on an option is
+    // not contained by it — treat the dropdown node as "inside" too, otherwise a
+    // multi-select would close on every pick.
     if (
       event.target instanceof Node &&
       containerEl !== null &&
-      !containerEl.contains(event.target)
+      !containerEl.contains(event.target) &&
+      !(dropdownEl !== null && dropdownEl.contains(event.target))
     ) {
       close();
     }
@@ -393,9 +482,15 @@
     <div
       class="select-dropdown"
       class:select-dropdown-right={dropdownAlign === 'right'}
+      class:select-dropdown-portal={usePortal}
+      bind:this={dropdownEl}
+      bind:clientWidth={dropdownWidth}
+      bind:clientHeight={dropdownHeight}
       role="listbox"
       id={listboxId}
       aria-multiselectable={multiple}
+      style={portalStyle}
+      use:portalToBody
     >
       {#if filteredItems.length === 0}
         <div class="select-empty">No results</div>
@@ -624,6 +719,19 @@
     min-width: var(--select-dropdown-min-width, 100%);
     max-width: var(--select-dropdown-max-width, none);
     width: var(--select-dropdown-width, max-content);
+  }
+
+  .select-dropdown.select-dropdown-portal {
+    /* Portaled to <body>: fixed positioning escapes overflow/scroll ancestors
+       (e.g. a table cell). Placement (top/left/width/min-width) is set inline
+       from the trigger rect, so neutralise the in-flow anchoring here. */
+    position: fixed;
+    right: auto;
+    margin-top: 0;
+    /* In the root stacking context the panel competes with modals/sheets rather
+       than painting above same-container siblings, so default it into the
+       top-layer band (consumers still override via --select-dropdown-z-index). */
+    z-index: var(--select-dropdown-z-index, 1000);
   }
 
   .select-option {

--- a/src/lib/Select/dropdownPosition.test.ts
+++ b/src/lib/Select/dropdownPosition.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { computeSelectDropdownPosition } from './dropdownPosition';
+
+const trigger = { left: 100, right: 300, top: 200, bottom: 240, width: 200 };
+const viewport = { width: 1000, height: 800 };
+
+describe('computeSelectDropdownPosition', () => {
+  it('anchors a left-aligned panel to the trigger left edge and matches its width', () => {
+    const placement = computeSelectDropdownPosition({
+      trigger,
+      dropdown: { width: 200, height: 120 },
+      viewport,
+      align: 'left',
+      gap: 4
+    });
+    expect(placement.left).toBe(100);
+    expect(placement.top).toBe(244); // bottom (240) + gap (4)
+    expect(placement.width).toBe(200);
+    expect(placement.minWidth).toBe(200);
+    expect(placement.flippedUp).toBe(false);
+  });
+
+  it('hangs a wider right-aligned panel leftward from the trigger right edge', () => {
+    // trigger right edge at 600; a 320px panel therefore starts at 280 — left of
+    // the trigger's own left edge (400), i.e. it hangs leftward.
+    const rightTrigger = { left: 400, right: 600, top: 200, bottom: 240, width: 200 };
+    const placement = computeSelectDropdownPosition({
+      trigger: rightTrigger,
+      dropdown: { width: 320, height: 120 },
+      viewport,
+      align: 'right',
+      gap: 4
+    });
+    expect(placement.left).toBe(600 - 320); // right edge minus measured width → 280
+    expect(placement.left).toBeLessThan(rightTrigger.left); // hangs leftward
+    expect(placement.width).toBeNull(); // right-aligned panels keep their content width
+    expect(placement.minWidth).toBe(200);
+  });
+
+  it('clamps a right-aligned panel to the left viewport margin when it would overflow', () => {
+    const placement = computeSelectDropdownPosition({
+      trigger,
+      dropdown: { width: 320, height: 120 },
+      viewport,
+      align: 'right',
+      gap: 4
+    });
+    // right edge 300 minus 320 = -20 → clamped to the 8px margin
+    expect(placement.left).toBe(8);
+  });
+
+  it('flips above the trigger when there is no room below and more room above', () => {
+    const lowTrigger = { left: 100, right: 300, top: 700, bottom: 740, width: 200 };
+    const placement = computeSelectDropdownPosition({
+      trigger: lowTrigger,
+      dropdown: { width: 200, height: 200 },
+      viewport,
+      align: 'left',
+      gap: 4
+    });
+    expect(placement.flippedUp).toBe(true);
+    expect(placement.top).toBe(700 - 4 - 200); // trigger top - gap - height
+  });
+
+  it('does not flip when the panel height is unmeasured (0)', () => {
+    const lowTrigger = { left: 100, right: 300, top: 700, bottom: 740, width: 200 };
+    const placement = computeSelectDropdownPosition({
+      trigger: lowTrigger,
+      dropdown: { width: 200, height: 0 },
+      viewport,
+      align: 'left',
+      gap: 4
+    });
+    expect(placement.flippedUp).toBe(false);
+    expect(placement.top).toBe(744);
+  });
+
+  it('clamps a panel to the right viewport margin instead of overflowing', () => {
+    const rightTrigger = { left: 900, right: 990, top: 200, bottom: 240, width: 90 };
+    const placement = computeSelectDropdownPosition({
+      trigger: rightTrigger,
+      dropdown: { width: 300, height: 120 },
+      viewport,
+      align: 'left',
+      gap: 4
+    });
+    // left-aligned width matches the 90px trigger, so it fits: left stays at the trigger left
+    expect(placement.left).toBe(900);
+    expect(placement.width).toBe(90);
+  });
+});

--- a/src/lib/Select/dropdownPosition.ts
+++ b/src/lib/Select/dropdownPosition.ts
@@ -1,0 +1,65 @@
+type TriggerRect = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+};
+
+type Size = { width: number; height: number };
+
+export type SelectDropdownPlacement = {
+  left: number;
+  top: number;
+  /** Floor width for the panel — always at least the trigger width. */
+  minWidth: number;
+  /**
+   * Explicit width (px) for a left-aligned panel so it matches the trigger,
+   * reproducing the in-flow `left:0; right:0` default. `null` for a
+   * right-aligned panel, which keeps its content/`max-content` width.
+   */
+  width: number | null;
+  /** True when the panel was flipped above the trigger for lack of room below. */
+  flippedUp: boolean;
+};
+
+/**
+ * Pure placement for a portaled Select dropdown. Coordinates are viewport
+ * coordinates for a `position: fixed` panel anchored to `trigger`. Left-aligned
+ * panels match the trigger width; right-aligned panels hang leftward from the
+ * trigger's right edge using their measured content width. The panel flips above
+ * the trigger only when it cannot fit below and there is more room above, and is
+ * clamped horizontally to a viewport margin.
+ */
+export function computeSelectDropdownPosition(opts: {
+  trigger: TriggerRect;
+  dropdown: Size;
+  viewport: Size;
+  align: 'left' | 'right';
+  gap: number;
+  margin?: number;
+}): SelectDropdownPlacement {
+  const margin = opts.margin ?? 8;
+  const { trigger, dropdown, viewport, align, gap } = opts;
+
+  const minWidth = trigger.width;
+  const width = align === 'left' ? trigger.width : null;
+  const effectiveWidth = Math.max(
+    align === 'right' ? dropdown.width : trigger.width,
+    trigger.width
+  );
+
+  let left = align === 'right' ? trigger.right - effectiveWidth : trigger.left;
+  if (Number.isFinite(viewport.width)) {
+    const maxLeft = viewport.width - effectiveWidth - margin;
+    left = Math.max(margin, Math.min(left, maxLeft));
+  }
+
+  const spaceBelow = viewport.height - trigger.bottom;
+  const spaceAbove = trigger.top;
+  const flippedUp =
+    dropdown.height > 0 && spaceBelow < dropdown.height + gap && spaceAbove > spaceBelow;
+  const top = flippedUp ? trigger.top - gap - dropdown.height : trigger.bottom + gap;
+
+  return { left, top, minWidth, width, flippedUp };
+}

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -67,6 +67,19 @@ export type OptionalSelectProperties = {
   leftIcon?: string;
   /** `data-pw` test id forwarded to the leading icon `<Img>` element. */
   leftIconTestId?: string;
+  /**
+   * When `true`, the dropdown panel is portaled to `document.body` and positioned
+   * `fixed` relative to the trigger, so an ancestor with `overflow: hidden` or a
+   * scroll container (e.g. a table cell) cannot clip it. Placement follows the
+   * trigger on scroll/resize and flips above the trigger when there is no room
+   * below. Defaults to `false` (in-flow `position: absolute`), which preserves the
+   * existing behaviour — including any consumer CSS that targets `.select-dropdown`
+   * via an ancestor selector, since that only resolves while the panel stays inside
+   * the `.select` container. Opt in for Selects rendered inside clipping containers.
+   * When portaled the panel defaults to `z-index: 1000` (top-layer band); raise
+   * `--select-dropdown-z-index` if it must sit above an even higher overlay.
+   */
+  usePortal?: boolean;
 };
 
 export type SelectEventProperties = {

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -52,6 +52,8 @@
   let ghostValue: string[] = $state([]);
   let openEventLog: string[] = $state([]);
   let leftIconValue: string[] = $state([]);
+  let portalValue: string[] = $state([]);
+  let inflowValue: string[] = $state([]);
 
   // Inline SVG data URI — a simple globe icon, no external asset needed
   const globeIconSrc =
@@ -296,7 +298,60 @@
   {/if}
 </div>
 
+<h3>usePortal — escape a clipping container</h3>
+<p>
+  Inside an <code>overflow: hidden</code> ancestor (like a table cell), the default in-flow panel is
+  clipped. Set <code>usePortal</code> to portal the panel to <code>&lt;body&gt;</code> and position
+  it
+  <code>fixed</code> against the trigger so it renders in full.
+</p>
+<div class="overflow-demo-grid">
+  <div class="clipper" data-pw="select-inflow-clipper">
+    <span class="clipper-label">Default (clipped)</span>
+    <Select
+      items={fruits}
+      bind:value={inflowValue}
+      placeholder="In-flow"
+      testId="select-inflow-demo"
+    />
+  </div>
+  <div class="clipper" data-pw="select-portal-clipper">
+    <span class="clipper-label">usePortal (escapes)</span>
+    <Select
+      items={fruits}
+      bind:value={portalValue}
+      placeholder="Portaled"
+      usePortal
+      testId="select-portal-demo"
+    />
+  </div>
+</div>
+
 <style>
+  /* Small, fixed-height, overflow-clipping boxes to demonstrate the difference
+     between the in-flow and portaled dropdown. */
+  .overflow-demo-grid {
+    display: flex;
+    gap: 32px;
+    flex-wrap: wrap;
+  }
+
+  .clipper {
+    width: 220px;
+    height: 90px;
+    overflow: hidden;
+    border: 1px dashed #bbb;
+    border-radius: 6px;
+    padding: 12px;
+  }
+
+  .clipper-label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 12px;
+    color: #888;
+  }
+
   .demo-info {
     margin: 8px 0 0;
     font-size: 13px;

--- a/tests/select-portal-overflow.test.ts
+++ b/tests/select-portal-overflow.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Select — usePortal escapes clipping containers', () => {
+  // The demo wraps two Selects in 90px-tall overflow:hidden boxes. The default
+  // in-flow panel is clipped by that box; the usePortal panel is relocated to
+  // <body> and fixed-positioned against the trigger so it renders in full.
+  test('portals the dropdown to <body> so an overflow:hidden ancestor cannot clip it', async ({
+    page
+  }) => {
+    await page.goto('/components/select');
+
+    const portalSelect = page.locator('[data-pw="select-portal-demo"]');
+    await expect(portalSelect).toBeVisible();
+    await portalSelect.getByRole('combobox').click();
+
+    // The panel is portaled: its listbox is a top-level child of <body>, not a
+    // descendant of the .select container inside the clipper.
+    const portaledListbox = page.locator('body > [role="listbox"]');
+    await expect(portaledListbox).toHaveCount(1);
+    await expect(portaledListbox).toBeVisible();
+    await expect(portaledListbox).toHaveCSS('position', 'fixed');
+
+    // It extends below the 90px clipper box (would be cut off in-flow).
+    const clipperBox = await page.locator('[data-pw="select-portal-clipper"]').boundingBox();
+    const listboxBox = await portaledListbox.boundingBox();
+    expect(clipperBox).not.toBeNull();
+    expect(listboxBox).not.toBeNull();
+    if (clipperBox !== null && listboxBox !== null) {
+      expect(listboxBox.y + listboxBox.height).toBeGreaterThan(clipperBox.y + clipperBox.height);
+    }
+
+    // The last option is fully reachable and selectable.
+    await portaledListbox.getByRole('option', { name: 'Grape', exact: true }).click();
+    await expect(portalSelect.getByText('Grape')).toBeVisible();
+  });
+
+  test('the default (in-flow) dropdown stays inside the .select container', async ({ page }) => {
+    await page.goto('/components/select');
+
+    const inflowSelect = page.locator('[data-pw="select-inflow-demo"]');
+    await inflowSelect.getByRole('combobox').click();
+
+    // Not portaled: no listbox is a direct child of <body>; it lives in .select.
+    await expect(page.locator('body > [role="listbox"]')).toHaveCount(0);
+    await expect(inflowSelect.getByRole('listbox')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Problem

The `Select` dropdown renders **in-flow** — `position: absolute` inside `.select` (which is `position: relative`). Any ancestor with `overflow: hidden` or a scroll container therefore **clips the panel**. This bites hardest for a `Select` inside a table cell: the table's horizontal-scroll container (`overflow-x: auto`, which forces `overflow-y: auto`) cuts off the bottom of the dropdown.

Downstream repro (Breeze/Lighthouse, BZ-4585): an in-cell Rate-Type `Select` in the RTO config table — the option popover (measured `top 690 → bottom 765`) is clipped at `y=711` by the scroll container. There is no pure-CSS escape, because CSS collapses `overflow-y: visible` → `auto` whenever `overflow-x` scrolls, so relaxing the container's overflow would break its horizontal scroll instead.

## Fix

Add an opt-in **`usePortal`** prop (default `false`). When set, the dropdown is relocated to `document.body` and positioned `fixed` against the trigger, so no overflow/scroll ancestor can clip it — mirroring the library's existing **chart-tooltip portal pattern** (`_chart/ChartTooltip.svelte`): a `use:` action to move the node, a scroll/resize `$effect` (via the sanctioned `no-restricted-syntax` escape hatch) to keep it anchored, and a pure placement helper.

- Placement follows the trigger on scroll/resize and **flips above** the trigger when there's no room below.
- Left-aligned panels match the trigger width (parity with the in-flow `left:0; right:0` default); right-aligned panels keep their content width and hang leftward.
- Placement math lives in a pure, unit-tested helper (`Select/dropdownPosition.ts`), mirroring `_chart/tooltipPosition.ts`.

### Why opt-in (default `false`)

Portaling unconditionally would be a breaking change: once the panel leaves `.select`, any consumer CSS that styles `.select-dropdown` via an **ancestor selector** (e.g. `.some-wrapper .select-dropdown { … }`) stops resolving, and existing tests that query `select.getByRole('listbox')` as a descendant would break. Defaulting to `false` preserves 100% of current behaviour; consumers rendering a `Select` inside a clipping container opt in. This matches the library's existing `usePortal` (Modal) / `portal` (ChartTooltip) convention.

### Portal-safety details handled

- **Click-outside** now also treats the portaled dropdown node as "inside", so a multi-select doesn't close on every pick.
- **Arrow-key highlight scrolling** queries the dropdown node (not `.select`), so it keeps working once portaled.
- **Width parity**: fixed positioning loses the `left:0; right:0` sizing, so `min-width`/`width` are set explicitly from the trigger rect.
- **z-index / margin** anchoring is neutralised on the portal class; gap + placement come from JS.

## Verification

- `pnpm run lint` — 0 errors (prettier + eslint)
- `pnpm run check` (svelte-check) — 0 errors
- `pnpm run test:unit` (vitest) — 6/6 for the new placement helper
- `pnpm run build` (vite + svelte-package + publint) — success
- `pnpm run test:integration` (playwright) — 12/12: **2 new** overflow-escape specs (`tests/select-portal-overflow.test.ts`) + all existing Select/Menu specs still green (`menu-placement`, `select-multi-indicator`, `select-select-all`)
- New demo section on `/components/select` ("usePortal — escape a clipping container").

## Follow-up (not in this PR)

`Menu` has the same in-flow-absolute clipping class of bug, but it recently gained a `placement` prop with pixel-exact placement tests; giving it the same portal treatment means reworking its four CSS corner-anchoring cases into JS, so it's better as its own focused PR rather than risking a regression here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional portal mode for Select dropdowns, allowing them to escape overflow-clipping containers.
  * Portal dropdowns remain correctly positioned during scrolling and resizing, with automatic viewport-aware placement.
  * Dropdowns can flip above the trigger when there is insufficient space below.
  * Added a documentation demo showing standard and portal-based Select behavior.

* **Bug Fixes**
  * Improved keyboard navigation and option selection for portaled dropdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->