### PR TITLE
fix(Menu): add usePortal so the dropdown escapes overflow-clipping ancestors

### DIFF
--- a/src/lib/Menu/Menu.svelte
+++ b/src/lib/Menu/Menu.svelte
@@ -2,6 +2,7 @@
   import { tick, onMount } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import Img from '../Img/Img.svelte';
+  import { computeMenuDropdownPosition } from './dropdownPosition';
   import type { MenuProperties, MenuItem, MenuPlacement } from './properties';
 
   let {
@@ -17,7 +18,8 @@
     role: menuRole = 'menu',
     ariaLabel: menuAriaLabel,
     id: menuId,
-    placement = 'bottom-left'
+    placement = 'bottom-left',
+    usePortal = false
   }: MenuProperties = $props();
 
   let itemRole = $derived(menuRole === 'listbox' ? 'option' : 'menuitem');
@@ -25,6 +27,11 @@
   let menuContainerEl: HTMLDivElement | null = $state(null);
   let menuListEl: HTMLDivElement | null = $state(null);
   let triggerEl: HTMLDivElement | null = $state(null);
+  let dropdownWidth = $state(0);
+  let dropdownHeight = $state(0);
+  // Portal placement reads untracked DOM (container rect, viewport); bump on
+  // scroll/resize so the derived style re-runs while the menu is open.
+  let portalTick = $state(0);
   let focusedIndex: number = $state(-1);
   let typeaheadQuery: string = $state('');
   let typeaheadTimer: ReturnType<typeof setTimeout> | null = $state(null);
@@ -64,6 +71,82 @@
 
     return `${vertical}-${horizontal}`;
   }
+
+  // Gap between trigger and portaled panel, matching the --menu-margin default.
+  const PORTAL_MENU_GAP = 4;
+
+  // Keep the portaled panel anchored to its trigger while the page scrolls or
+  // resizes. Mirrors the chart-tooltip portal pattern; $effect is the sanctioned
+  // reactive escape hatch here for untracked window listeners. Reposition work is
+  // coalesced into one animation frame so fast/inertial scrolling can't thrash
+  // layout with a getBoundingClientRect on every event.
+  // eslint-disable-next-line no-restricted-syntax
+  $effect(() => {
+    if (!usePortal || !open || typeof window === 'undefined') {
+      return;
+    }
+    let frame: number | null = null;
+    const bump = (): void => {
+      if (frame !== null) {
+        return;
+      }
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        portalTick += 1;
+      });
+    };
+    window.addEventListener('scroll', bump, { capture: true, passive: true });
+    window.addEventListener('resize', bump);
+    return () => {
+      window.removeEventListener('scroll', bump, { capture: true });
+      window.removeEventListener('resize', bump);
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  });
+
+  /**
+   * Svelte action: relocates the dropdown to document.body when usePortal is set,
+   * so a position:fixed panel is never clipped by an overflow/scroll ancestor
+   * (e.g. a table cell). No-op otherwise; `use:` actions never run during SSR.
+   */
+  const portalToBody = (node: HTMLElement) => {
+    if (!usePortal) {
+      return;
+    }
+    document.body.appendChild(node);
+    return { destroy: () => node.remove() };
+  };
+
+  let portalStyle = $derived.by(() => {
+    if (!usePortal || !open || menuContainerEl === null) {
+      return '';
+    }
+    void portalTick;
+    const containerRect = menuContainerEl.getBoundingClientRect();
+    const viewport =
+      typeof window === 'undefined'
+        ? { width: Number.POSITIVE_INFINITY, height: Number.POSITIVE_INFINITY }
+        : { width: window.innerWidth, height: window.innerHeight };
+    const { left, top } = computeMenuDropdownPosition({
+      container: {
+        left: containerRect.left,
+        right: containerRect.right,
+        top: containerRect.top,
+        bottom: containerRect.bottom
+      },
+      dropdown: { width: dropdownWidth, height: dropdownHeight },
+      placement: resolvedPlacement,
+      gap: PORTAL_MENU_GAP,
+      viewport
+    });
+    // Inline wins over the corner-class anchoring, so the portaled panel is
+    // driven entirely by these fixed coordinates. Default into the top-layer
+    // z-index band (root stacking context competes with modals/sheets); consumers
+    // still override via --menu-z-index.
+    return `position:fixed;left:${left}px;top:${top}px;right:auto;bottom:auto;margin:0;z-index:var(--menu-z-index,1000);`;
+  });
 
   let selectableItems: MenuItem[] = $derived(
     items.filter((item) => item.separator !== true && item.disabled !== true)
@@ -231,11 +314,15 @@
   }
 
   function handleClickOutside(event: Event) {
+    // A portaled panel lives outside menuContainerEl, so a click on a separator
+    // or padding inside it is not contained — treat the panel node as "inside"
+    // too, matching the in-flow behaviour of not closing on such clicks.
     if (
       open &&
       event.target instanceof Node &&
       menuContainerEl !== null &&
-      !menuContainerEl.contains(event.target)
+      !menuContainerEl.contains(event.target) &&
+      !(menuListEl !== null && menuListEl.contains(event.target))
     ) {
       close();
     }
@@ -277,11 +364,15 @@
       class="menu-dropdown menu-dropdown-{placement === 'auto' ? resolvedPlacement : placement}"
       class:menu-dropdown-measuring={measuringPlacement}
       bind:this={menuListEl}
+      bind:clientWidth={dropdownWidth}
+      bind:clientHeight={dropdownHeight}
       role={menuRole}
       id={menuId}
       aria-label={menuAriaLabel}
       tabindex="-1"
+      style={portalStyle}
       onkeydown={handleMenuKeydown}
+      use:portalToBody
     >
       {#each items as item (item.value)}
         {#if item.separator === true}

--- a/src/lib/Menu/dropdownPosition.test.ts
+++ b/src/lib/Menu/dropdownPosition.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { computeMenuDropdownPosition } from './dropdownPosition';
+
+const viewport = { width: 1000, height: 800 };
+const dropdown = { width: 160, height: 200 };
+
+describe('computeMenuDropdownPosition', () => {
+  it('bottom-left: panel left edge to container left, below the container', () => {
+    const container = { left: 100, right: 180, top: 200, bottom: 230 };
+    const pos = computeMenuDropdownPosition({
+      container,
+      dropdown,
+      placement: 'bottom-left',
+      gap: 4,
+      viewport
+    });
+    expect(pos).toEqual({ left: 100, top: 234 });
+  });
+
+  it('bottom-right: panel right edge to container right, below the container', () => {
+    const container = { left: 100, right: 180, top: 200, bottom: 230 };
+    const pos = computeMenuDropdownPosition({
+      container,
+      dropdown,
+      placement: 'bottom-right',
+      gap: 4,
+      viewport
+    });
+    expect(pos).toEqual({ left: 180 - 160, top: 234 });
+  });
+
+  it('top-left: panel left edge to container left, above the container', () => {
+    const container = { left: 100, right: 180, top: 400, bottom: 430 };
+    const pos = computeMenuDropdownPosition({
+      container,
+      dropdown,
+      placement: 'top-left',
+      gap: 4,
+      viewport
+    });
+    expect(pos).toEqual({ left: 100, top: 400 - 200 - 4 });
+  });
+
+  it('top-right: panel right edge to container right, above the container', () => {
+    const container = { left: 300, right: 400, top: 400, bottom: 430 };
+    const pos = computeMenuDropdownPosition({
+      container,
+      dropdown,
+      placement: 'top-right',
+      gap: 4,
+      viewport
+    });
+    expect(pos).toEqual({ left: 400 - 160, top: 400 - 200 - 4 });
+  });
+
+  it('clamps to the viewport margin when a corner would overflow', () => {
+    // Trigger pinned to the bottom-right corner: both axes overflow.
+    const container = { left: 960, right: 995, top: 760, bottom: 790 };
+    const pos = computeMenuDropdownPosition({
+      container,
+      dropdown,
+      placement: 'bottom-right',
+      gap: 4,
+      viewport
+    });
+    // left 995 - 160 = 835 > maxLeft (1000 - 160 - 8 = 832) → clamp to 832
+    expect(pos.left).toBe(viewport.width - dropdown.width - 8);
+    // top 790 + 4 = 794 > maxTop (800 - 200 - 8 = 592) → clamp to 592
+    expect(pos.top).toBe(viewport.height - dropdown.height - 8);
+  });
+});

--- a/src/lib/Menu/dropdownPosition.ts
+++ b/src/lib/Menu/dropdownPosition.ts
@@ -1,0 +1,37 @@
+type Rect = { left: number; right: number; top: number; bottom: number };
+type Size = { width: number; height: number };
+
+export type MenuDropdownCorner = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
+
+/**
+ * Pure placement for a portaled Menu dropdown. Returns viewport coordinates for
+ * a `position: fixed` panel anchored to `container` at the resolved corner,
+ * reproducing the in-flow CSS anchoring: `*-left` aligns the panel's left edge
+ * to the container's left, `*-right` aligns its right edge to the container's
+ * right; `bottom-*` sits below the container, `top-*` above it. A `gap` is added
+ * between panel and container, and the result is clamped to a viewport margin.
+ */
+export function computeMenuDropdownPosition(opts: {
+  container: Rect;
+  dropdown: Size;
+  placement: MenuDropdownCorner;
+  gap: number;
+  viewport: Size;
+  margin?: number;
+}): { left: number; top: number } {
+  const margin = opts.margin ?? 8;
+  const { container, dropdown, placement, gap, viewport } = opts;
+  const anchorsRight = placement === 'bottom-right' || placement === 'top-right';
+  const anchorsTop = placement === 'top-left' || placement === 'top-right';
+
+  let left = anchorsRight ? container.right - dropdown.width : container.left;
+  let top = anchorsTop ? container.top - dropdown.height - gap : container.bottom + gap;
+
+  if (Number.isFinite(viewport.width)) {
+    left = Math.max(margin, Math.min(left, viewport.width - dropdown.width - margin));
+  }
+  if (Number.isFinite(viewport.height)) {
+    top = Math.max(margin, Math.min(top, viewport.height - dropdown.height - margin));
+  }
+  return { left, top };
+}

--- a/src/lib/Menu/properties.ts
+++ b/src/lib/Menu/properties.ts
@@ -43,6 +43,19 @@ export type OptionalMenuProperties = {
    * / `--menu-dropdown-left` consumer tokens). Fixed corners anchor statically;
    * `'auto'` resolves the best-fitting corner against the viewport on open. */
   placement?: MenuPlacement;
+  /**
+   * When `true`, the dropdown panel is portaled to `document.body` and positioned
+   * `fixed` at the resolved `placement` corner, so an ancestor with
+   * `overflow: hidden` or a scroll container (e.g. a table cell) cannot clip it.
+   * Placement follows the trigger on scroll/resize. Defaults to `false` (in-flow
+   * `position: absolute`), which preserves the existing behaviour — including any
+   * consumer CSS that targets `.menu-dropdown` via an ancestor selector, since
+   * that only resolves while the panel stays inside the `.menu-container`. Opt in
+   * for Menus rendered inside clipping containers. When portaled the panel defaults
+   * to `z-index: 1000` (top-layer band); raise `--menu-z-index` if it must sit
+   * above an even higher overlay.
+   */
+  usePortal?: boolean;
 };
 
 export type MenuEventProperties = {

--- a/src/routes/components/menu/+page.svelte
+++ b/src/routes/components/menu/+page.svelte
@@ -72,10 +72,78 @@
   </Menu>
 </div>
 
+<h3>usePortal — escape a clipping container</h3>
+<p>
+  Inside an <code>overflow: hidden</code> ancestor (like a table cell), the default in-flow panel is
+  clipped. Set <code>usePortal</code> to portal the panel to <code>&lt;body&gt;</code> and position
+  it
+  <code>fixed</code> at the resolved corner so it renders in full.
+</p>
+<div class="overflow-demo-grid">
+  <div class="clipper" data-pw="menu-inflow-clipper">
+    <span class="clipper-label">Default (clipped)</span>
+    <Menu
+      items={[
+        { label: 'Edit', value: 'edit' },
+        { label: 'Duplicate', value: 'duplicate' },
+        { label: 'Archive', value: 'archive', separator: true },
+        { label: 'Delete', value: 'delete', danger: true }
+      ]}
+      testId="menu-inflow-demo"
+    >
+      {#snippet trigger()}
+        <Button text="In-flow" />
+      {/snippet}
+    </Menu>
+  </div>
+  <div class="clipper" data-pw="menu-portal-clipper">
+    <span class="clipper-label">usePortal (escapes)</span>
+    <Menu
+      items={[
+        { label: 'Edit', value: 'edit' },
+        { label: 'Duplicate', value: 'duplicate' },
+        { label: 'Archive', value: 'archive', separator: true },
+        { label: 'Delete', value: 'delete', danger: true }
+      ]}
+      usePortal
+      testId="menu-portal-demo"
+    >
+      {#snippet trigger()}
+        <Button text="Portaled" />
+      {/snippet}
+    </Menu>
+  </div>
+</div>
+
 <style>
   .corner-pinned-demo {
     position: fixed;
     right: 16px;
     bottom: 16px;
+  }
+
+  /* Small, fixed-height, overflow-clipping boxes to contrast the in-flow and
+     portaled dropdown. */
+  .overflow-demo-grid {
+    display: flex;
+    gap: 32px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+  }
+
+  .clipper {
+    width: 220px;
+    height: 90px;
+    overflow: hidden;
+    border: 1px dashed #bbb;
+    border-radius: 6px;
+    padding: 12px;
+  }
+
+  .clipper-label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 12px;
+    color: #888;
   }
 </style>

--- a/tests/menu-portal-overflow.test.ts
+++ b/tests/menu-portal-overflow.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Menu — usePortal escapes clipping containers', () => {
+  // The demo wraps two Menus in 90px-tall overflow:hidden boxes. The default
+  // in-flow panel is clipped by that box; the usePortal panel is relocated to
+  // <body> and fixed-positioned at the resolved corner so it renders in full.
+  test('portals the dropdown to <body> so an overflow:hidden ancestor cannot clip it', async ({
+    page
+  }) => {
+    await page.goto('/components/menu');
+
+    const portalMenu = page.locator('[data-pw="menu-portal-demo"]');
+    await expect(portalMenu).toBeVisible();
+    await portalMenu.locator('.menu-trigger').click();
+
+    // The panel is portaled: the menu-dropdown is a descendant of <body>, not of
+    // the .menu-container inside the clipper.
+    const portaledDropdown = page.locator('body > .menu-dropdown');
+    await expect(portaledDropdown).toHaveCount(1);
+    await expect(portaledDropdown).toBeVisible();
+    await expect(portaledDropdown).toHaveCSS('position', 'fixed');
+
+    // It extends below the 90px clipper box (would be cut off in-flow).
+    const clipperBox = await page.locator('[data-pw="menu-portal-clipper"]').boundingBox();
+    const dropdownBox = await portaledDropdown.boundingBox();
+    expect(clipperBox).not.toBeNull();
+    expect(dropdownBox).not.toBeNull();
+    if (clipperBox !== null && dropdownBox !== null) {
+      expect(dropdownBox.y + dropdownBox.height).toBeGreaterThan(clipperBox.y + clipperBox.height);
+    }
+
+    // The last item is fully reachable and selectable.
+    await portaledDropdown.getByText('Delete', { exact: true }).click();
+    await expect(portaledDropdown).toHaveCount(0); // selecting closes the menu
+  });
+
+  test('the default (in-flow) dropdown stays inside the .menu-container', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const inflowMenu = page.locator('[data-pw="menu-inflow-demo"]');
+    await inflowMenu.locator('.menu-trigger').click();
+
+    // Not portaled: no menu-dropdown is a direct child of <body>; it lives in
+    // the container.
+    await expect(page.locator('body > .menu-dropdown')).toHaveCount(0);
+    await expect(inflowMenu.locator('.menu-dropdown')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Problem

Follow-up to #386 (Select). The `Menu` dropdown has the same class of bug: it renders **in-flow** — `position: absolute` inside `.menu-container` — so any ancestor with `overflow: hidden` or a scroll container (e.g. a table row-actions cell) **clips the panel**. The recent `placement="auto"` logic flips corners against the viewport but is still CSS-anchored, so it inherits the identical clipping.

## Fix

Add an opt-in **`usePortal`** prop (default `false`). When set, the dropdown is relocated to `document.body` and positioned `fixed` at the resolved `placement` corner, so no overflow/scroll ancestor can clip it — mirroring the library's `ChartTooltip` portal pattern (and matching the `Select` fix in #386): a `use:` action to move the node, a scroll/resize `$effect` (via the sanctioned `no-restricted-syntax` escape hatch), and a pure placement helper.

Because the CSS corner anchoring (`top:100%` / `bottom:100%` / `left:0` / `right:0`) is meaningless once the node leaves `.menu-container`, all four corners (and `auto`) are computed in JS from the trigger rect. `resolveAutoPlacement()` still picks the corner (it reads panel *dimensions*, which are correct regardless of portal position), then the panel is placed at that corner in viewport coordinates.

### Why opt-in (default `false`)

Same reasoning as #386: portaling unconditionally would break consumer CSS that targets `.menu-dropdown` via an ancestor selector, and would break the existing pixel-exact `menu-placement.test.ts` assertions that query `.menu-dropdown` as a descendant of the container. Defaulting to `false` preserves 100% of current behaviour; consumers opt in for Menus inside clipping containers.

### Portal-safety details handled

- **Click-outside** now also treats the portaled panel node as "inside", so clicking a separator or padding doesn't wrongly close the menu (matching in-flow behaviour).
- **`focusItem()`** already queries `menuListEl` (the panel node), so keyboard focus keeps working once portaled.
- **z-index / margin** anchoring is neutralised inline; gap + corner placement come from JS.
- `placement="auto"` measuring pass still works: the panel measures its dimensions (hidden) before the corner is resolved.

## Verification

- `pnpm run lint` — 0 errors (prettier + eslint)
- `pnpm run check` (svelte-check) — 0 errors
- `pnpm run test:unit` (vitest) — 5/5 for the new corner-placement helper
- `pnpm run build` (vite + svelte-package + publint) — success
- `pnpm run test:integration` (playwright) — 12/12: **2 new** overflow-escape specs (`tests/menu-portal-overflow.test.ts`) + all existing Menu/Select specs still green, including the **pixel-exact `menu-placement` suite** (no regression)
- New demo section on `/components/menu` ("usePortal — escape a clipping container").

## Relationship to #386

Independent of #386 (touches only `Menu` files), so the two can merge in any order. Together they give both overlay primitives a consistent `usePortal` opt-in for use inside tables/scroll containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional portal mode for menus, allowing dropdowns to escape clipped containers and remain aligned during scrolling and resizing.
  * Added viewport-aware positioning for dropdowns, including support for four placement options and edge clamping.
  * Preserved existing in-flow dropdown behavior by default.

* **Documentation**
  * Added interactive examples demonstrating portal and default menu behavior.

* **Tests**
  * Added coverage for positioning, viewport clamping, portal rendering, and overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->