### PR TITLE
fix(Table): thread usePortal to in-cell Select/Menu so they escape the table's overflow

### DIFF
--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -34,12 +34,14 @@
     column,
     value,
     rowIndex,
-    originalIndex
+    originalIndex,
+    usePortal = false
   }: {
     column: TableColumn;
     value: TableCellValue;
     rowIndex: number;
     originalIndex: number;
+    usePortal?: boolean;
   } = $props();
 
   // The td applies column.align as text-align, which flex containers ignore:
@@ -261,6 +263,7 @@
         disabled={selectData.disabled ?? false}
         testId={selectData.testId}
         itemTestId={selectData.itemTestId}
+        {usePortal}
         onchange={(selectedIds) => {
           if (selectedIds.length > 0) {
             column.onSelect?.(rowIndex, selectedIds[0], originalIndex);
@@ -389,6 +392,7 @@
             separator: item.separator
           }))}
           testId={column.testId && `${column.testId}-menu-${rowIndex}`}
+          {usePortal}
           onselect={(menuItem) => column.onMenuAction?.(rowIndex, menuItem.value, originalIndex)}
         >
           {#snippet trigger()}
@@ -427,6 +431,7 @@
           separator: item.separator
         }))}
         testId={column.testId && `${column.testId}-popup-${rowIndex}`}
+        {usePortal}
         onselect={(menuItem) => column.onMenuAction?.(rowIndex, menuItem.value, originalIndex)}
       >
         {#snippet trigger()}

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -50,7 +50,8 @@
     rowNumberColumn = false,
     rowNumberLabel = '#',
     headerTooltipIcon,
-    headerTooltipPosition
+    headerTooltipPosition,
+    usePortal = false
   }: TableProperties = $props();
 
   // ─── Keyed column model → positional projection ─────────────────────────────
@@ -867,6 +868,7 @@
                             value={cellValue}
                             {rowIndex}
                             {originalIndex}
+                            {usePortal}
                           />
                         {:else if typeof cell === 'function'}
                           {@render cell(cellValue, rowIndex, colIndex)}

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -444,6 +444,14 @@ export type OptionalTableProperties = {
   headerTooltipIcon?: Snippet;
   /** Placement of every header tooltip bubble. Defaults to `'top'`. */
   headerTooltipPosition?: TooltipPosition;
+  /**
+   * When `true`, in-cell `Select` dropdowns (`type: 'select'` columns) and in-cell
+   * `Menu` popovers (`type: 'action-group'` / `'popup-menu'` columns) are portaled
+   * to `document.body` and positioned `fixed`, so the table's own scroll/overflow
+   * container cannot clip them. Set this on tables whose rows can be near a scroll
+   * edge. Defaults to `false` (in-flow rendering, unchanged).
+   */
+  usePortal?: boolean;
   sortable?: boolean;
   sortableColumns?: number[];
   stickyHeader?: boolean;

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -444,6 +444,26 @@
       })
     )
   );
+
+  // usePortal demo — a select column inside an overflow-clipping container.
+  const portalColumns: TableColumn[] = [
+    { id: 'name', label: 'Name' },
+    { id: 'tier', label: 'Tier', type: 'select', sortable: false }
+  ];
+  const portalRows: TableRow[] = [
+    {
+      name: 'Row one',
+      tier: {
+        options: [
+          { id: 'basic', label: 'Basic' },
+          { id: 'pro', label: 'Pro' },
+          { id: 'enterprise', label: 'Enterprise' }
+        ],
+        selectedId: 'pro',
+        testId: 'portal-tier-0'
+      }
+    }
+  ];
 </script>
 
 {#snippet bulkToolbar({ selectedIds }: { selectedIds: Set<string> })}
@@ -930,7 +950,28 @@
   </div>
 </div>
 
+<!-- usePortal: in-cell select escapes an overflow-clipping ancestor -->
+<h3>usePortal — in-cell dropdown escapes a clipping container</h3>
+<p>
+  With <code>usePortal</code>, a <code>type: 'select'</code> cell's dropdown (and in-cell menus) are
+  portaled to <code>&lt;body&gt;</code> so the table's own <code>overflow</code> can't clip them.
+</p>
+<div class="table-portal-clipper" data-pw="table-portal-clipper">
+  <Table columns={portalColumns} rows={portalRows} usePortal testId="table-portal-cells" />
+</div>
+
 <style>
+  /* Fixed-height, overflow-clipping frame to demonstrate the portaled dropdown
+     rendering in full instead of being cut off. */
+  .table-portal-clipper {
+    max-width: 420px;
+    height: 120px;
+    overflow: hidden;
+    border: 1px dashed #bbb;
+    border-radius: 6px;
+    padding: 12px;
+  }
+
   :global(.custom-cell-table th:nth-child(1)),
   :global(.custom-cell-table td:nth-child(1)) {
     width: 180px;

--- a/tests/table-cell-portal.test.ts
+++ b/tests/table-cell-portal.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Table — usePortal escapes clipping containers for in-cell dropdowns', () => {
+  // The demo wraps a usePortal table (a type:'select' column) in a 120px-tall
+  // overflow:hidden frame. Without portaling the dropdown would be clipped; with
+  // it, the panel is relocated to <body> and fixed-positioned.
+  test('an in-cell select dropdown portals to <body> instead of being clipped', async ({
+    page
+  }) => {
+    await page.goto('/components/table');
+
+    const table = page.locator('[data-pw="table-portal-cells"]');
+    await expect(table).toBeVisible();
+
+    // Open the in-cell tier select.
+    await page.locator('[data-pw="portal-tier-0"]').getByRole('combobox').click();
+
+    // The dropdown is portaled: a top-level child of <body>, fixed-positioned.
+    const portaled = page.locator('body > [role="listbox"]');
+    await expect(portaled).toHaveCount(1);
+    await expect(portaled).toBeVisible();
+    await expect(portaled).toHaveCSS('position', 'fixed');
+
+    // It extends beyond the 120px clipper (would be cut off in-flow).
+    const clipperBox = await page.locator('[data-pw="table-portal-clipper"]').boundingBox();
+    const dropdownBox = await portaled.boundingBox();
+    expect(clipperBox).not.toBeNull();
+    expect(dropdownBox).not.toBeNull();
+    if (clipperBox !== null && dropdownBox !== null) {
+      expect(dropdownBox.y + dropdownBox.height).toBeGreaterThan(clipperBox.y + clipperBox.height);
+    }
+
+    // The last option is reachable and selectable.
+    await portaled.getByRole('option', { name: 'Enterprise', exact: true }).click();
+    await expect(portaled).toHaveCount(0); // single-select closes on pick
+  });
+
+  test('without usePortal the in-cell select dropdown stays in the table', async ({ page }) => {
+    await page.goto('/components/table');
+
+    // The interactive demo table (no usePortal) keeps its dropdown in-flow.
+    await page
+      .locator('[data-pw="table-interactive-cells"] [data-pw="demo-tier-0"]')
+      .getByRole('combobox')
+      .click();
+    await expect(page.locator('body > [role="listbox"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Problem

Third and final library piece for the downstream table-cell dropdown clipping (Breeze/Lighthouse BZ-4585). #386 (Select) and #387 (Menu) added `usePortal` to those components — but tables render their in-cell dropdowns *themselves*: a `type: 'select'` column renders a `<Select>` inside `BuiltinCell`, and `type: 'action-group'` / `'popup-menu'` columns render `<Menu>`. Consumers have no handle on those instances, so they still get clipped by the table's own scroll/overflow container.

## Fix

Add a **`usePortal`** prop to `Table` (default `false`), threaded through `BuiltinCell` to:
- the in-cell `<Select>` (`type: 'select'`)
- the in-cell `<Menu>` (`type: 'action-group'` action menu, and `type: 'popup-menu'`)

When set, those dropdowns portal to `document.body` and position `fixed` (using the `usePortal` support shipped in `2.96.1`), so the table's `overflow` can't clip them. One prop on the table opts in every in-cell dropdown at once, which matches the use case — a table inside a scroll container wants all of them to escape.

Default `false` keeps in-flow rendering and every existing table behaviour unchanged.

## Verification

- `pnpm run lint` — 0 errors · `pnpm run check` — 0 errors · `pnpm run build` — success
- `pnpm run test:integration` (playwright) — 12/12: **2 new** specs (`tests/table-cell-portal.test.ts`) — the in-cell select dropdown portals to `<body>` and escapes a 120px `overflow:hidden` frame; a control confirms the default (non-portal) table keeps its dropdown in-flow — plus the existing `table-interactive-cells` suite, no regression.
- New demo section on `/components/table` ("usePortal — in-cell dropdown escapes a clipping container").

## Chain

1. `fix(Select): usePortal` — #386 ✅ (2.96.1)
2. `fix(Menu): usePortal` — #387 ✅ (2.96.1)
3. **`fix(Table): usePortal passthrough`** — this PR
4. Consumer (Lighthouse): set `usePortal` on the RTO config tables → the in-cell Rate-Type Select and row-action menus stop clipping (BZ-4585).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `usePortal` table setting for rendering in-cell dropdowns and menus outside clipped containers.
  - Added a documentation demo showing portal-rendered controls in an overflow-constrained table.

- **Bug Fixes**
  - Prevented table dropdowns and menus from being clipped by scroll or overflow boundaries when portal rendering is enabled.

- **Tests**
  - Added coverage for portal and standard in-table dropdown behavior, including selecting options beyond the clipped area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->