### PR TITLE
fix(sankey): reserve a left gutter so first-column source labels render in full

### DIFF
--- a/src/lib/SankeyChart/SankeyChart.svelte
+++ b/src/lib/SankeyChart/SankeyChart.svelte
@@ -95,7 +95,35 @@
     return Math.max(0, Math.min(chartWidth * 0.25, wanted));
   });
 
-  let plotWidth = $derived(Math.max(0, chartWidth - MARGIN * 2 - lastColumnLabelGutter));
+  // First-column labels render to the LEFT of their node, anchored `end` into the
+  // left margin. The bare 40px margin is nowhere near enough for real source labels
+  // ("SESSIONS", "Source A", "START") — they truncate to a few characters and, once
+  // the room falls below an ellipsis, vanish entirely. Mirror the sink gutter:
+  // reserve a capped left gutter sized from the source-node labels (sources are what
+  // land in the first column) and shift the diagram right by it.
+  let firstColumnLabelGutter = $derived.by(() => {
+    if (!showLabels || nodes.length === 0 || chartWidth <= 0) {
+      return 0;
+    }
+    const targetIds = new Set(links.map((link) => link.target));
+    const sourceLabels = nodes
+      .filter((node) => !targetIds.has(node.id))
+      .map((node) => node.label ?? node.id);
+    if (sourceLabels.length === 0) {
+      return 0;
+    }
+    const longestPx =
+      Math.max(...sourceLabels.map((label) => measureText(label, labelFont).width)) +
+      (showValues ? measureText(' (999,999)', labelFont).width : 0);
+    const wanted = longestPx + 10 + dataLabelOffsetX;
+    // Same 25% cap and 0 floor as the sink gutter so the two together can never
+    // starve the diagram, and a negative dataLabelOffsetX can't push past the margin.
+    return Math.max(0, Math.min(chartWidth * 0.25, wanted));
+  });
+
+  let plotWidth = $derived(
+    Math.max(0, chartWidth - MARGIN * 2 - firstColumnLabelGutter - lastColumnLabelGutter)
+  );
   let layout = $derived(
     computeSankeyLayout(
       nodes,
@@ -151,12 +179,13 @@
     // node.x + nodeWidth + 6 + dataLabelOffsetX, so the room before the next
     // column's bar shrinks by the same offset. Omitting it let "fitting"
     // labels run under the neighbouring column's node rect.
-    // First-column labels anchor `end` at node.x - 6 - offset with node.x = 0,
-    // so their room is exactly the left margin minus that inset — budgeting
-    // more pushes long labels past the SVG's left edge, where they clip.
+    // First-column labels anchor `end` at node.x - 6 - offset with node.x = 0.
+    // The diagram is shifted right by firstColumnLabelGutter, so the room to the
+    // SVG's left edge is that gutter plus the base margin, minus the inset —
+    // symmetric with the last column's sink-gutter budget below.
     const available =
       column === 0
-        ? Math.max(0, MARGIN - 6 - dataLabelOffsetX)
+        ? Math.max(0, firstColumnLabelGutter + MARGIN - 6 - dataLabelOffsetX)
         : column === columnCount - 1
           ? Math.max(0, lastColumnLabelGutter + MARGIN - 6 - dataLabelOffsetX)
           : Math.max(0, colWidth - nodeWidth - 12 - dataLabelOffsetX);
@@ -396,7 +425,7 @@
     <div class="chart-empty">{@render empty()}</div>
   {:else}
     <ChartContainer bind:width={chartWidth} bind:height={chartHeight} {aspectRatio} {maxHeight}>
-      <g transform="translate({MARGIN}, {MARGIN})">
+      <g transform="translate({MARGIN + firstColumnLabelGutter}, {MARGIN})">
         {#if columnLabels != null && columnLabels.length > 0}
           {#each columnLabels.slice(0, columnCount) as label, ci (ci)}
             <text

--- a/tests/sankey-label-engine.spec.ts
+++ b/tests/sankey-label-engine.spec.ts
@@ -20,7 +20,10 @@ test.describe('SankeyChart label engine', () => {
       // Shrink each box by 1px per side so antialiasing/rounding can never
       // count touching neighbours as an overlap.
       const intersects = (a: DOMRect, b: DOMRect) =>
-        a.left < b.right - 1 && b.left < a.right - 1 && a.top < b.bottom - 1 && b.top < a.bottom - 1;
+        a.left < b.right - 1 &&
+        b.left < a.right - 1 &&
+        a.top < b.bottom - 1 &&
+        b.top < a.bottom - 1;
 
       const labels = boxesOf('.sankey-label');
       const nodes = boxesOf('.sankey-node');
@@ -67,5 +70,43 @@ test.describe('SankeyChart label engine', () => {
     });
 
     expect(overflowing).toBe(0);
+  });
+
+  // First-column (source) labels anchor `end` into the left margin. Historically
+  // they were budgeted only the bare 40px margin, so any real source label
+  // ("SESSIONS (12.2K)") truncated to "SES…" — or, once the room fell below an
+  // ellipsis, vanished entirely — at every width. A left gutter, symmetric with
+  // the sink gutter, must now give them full room. A clipped label still fits
+  // inside the chart box, so the edge test above cannot catch this.
+  test('first-column source labels render their full text (not clipped)', async ({ page }) => {
+    await page.goto('/components/sankey-chart');
+
+    const chart = page.getByTestId('sankey-crowded-chart');
+    await expect(chart.locator('.sankey-label').first()).toBeVisible();
+
+    const sources = await chart.evaluate((root) => {
+      // Source labels are the ones anchored `end` (rendered left of their node).
+      return Array.from(root.querySelectorAll('.sankey-label'))
+        .filter((el) => el.getAttribute('text-anchor') === 'end')
+        .map((el) => {
+          const visible = Array.from(el.childNodes)
+            .filter((node) => node.nodeType === Node.TEXT_NODE)
+            .map((node) => node.nodeValue ?? '')
+            .join('')
+            .trim();
+          const full = el.querySelector('title')?.textContent?.trim() ?? '';
+          return { visible, full };
+        });
+    });
+
+    // The engine must be exercised (the crowded funnel has a "SESSIONS" source).
+    expect(sources.length).toBeGreaterThan(0);
+    for (const source of sources) {
+      // Not truncated to an ellipsis, and not squeezed away to nothing.
+      expect(source.visible).not.toContain('…');
+      expect(source.visible.length).toBeGreaterThan(0);
+      // The full, untruncated label is what actually renders.
+      expect(source.visible).toBe(source.full);
+    }
   });
 });


### PR DESCRIPTION
## Problem

First-column (source) labels in `SankeyChart` anchor `end` into the left margin, but were budgeted only the bare **40px** left margin (`MARGIN - 6 = 34px`). Any real source label truncated to a few characters — and once the remaining room fell below an ellipsis, the label **vanished entirely**. This happens at **every width**, not just narrow ones, because the budget is a fixed constant.

The right (sink) column, by contrast, already reserves a *computed* gutter sized from its labels. The asymmetry is the bug: sink labels render in full, source labels clip.

This is what made the analytics **User-Journey funnel** look distorted/squeezed (downstream ticket BZ-4599): the "START"/"SESSIONS" source label rendered as "STA…"/"SES…" or disappeared.

## Root cause (verified)

Rendering the shipped demo (`/components/sankey-chart`) at any viewport, first-column source labels clip:

| chart | source label | before |
|---|---|---|
| Simple Flow | `Source A` | ✂ `Sou…` |
| Website Traffic | `Google` / `Direct` / `Social` | ✂ `Goo…` / `Dire…` / `Soc…` |
| Payment (showValues) | `Card (828)` | ✂ `Car…` |
| Crowded funnel | `SESSIONS (12.2K)` | ✂ `SES…` |

## Fix

Mirror the existing `lastColumnLabelGutter`: reserve a capped (25%) **`firstColumnLabelGutter`** sized from the source-node labels, shift the diagram right by it, and budget the first-column label at `gutter + margin`. The two gutters share the same 25% cap and 0 floor so they can never together starve the plot.

## Proof

After the fix, every previously-clipped source label renders in full (same demo, same widths):

| source label | after |
|---|---|
| `Source A`, `Google`, `Direct`, `Social`, `Card (828)`, `SESSIONS (12.2K)` | ✔ full text |

**Discriminating regression test** added to `tests/sankey-label-engine.spec.ts`:
- **Without the fix** it fails: `Received string: "SES…"` (proving it catches the real bug; the pre-existing edge-overflow test cannot — a clipped label still fits inside the box).
- **With the fix** all 3 tests pass.

## Checks
- `pnpm run check` — 0 errors
- `pnpm exec vitest run src/lib/_chart` — 54/54 pass (geometry/labels/measure unchanged)
- `pnpm exec playwright test tests/sankey-label-engine.spec.ts` — 3/3 pass
- eslint + prettier clean

Scope is intentionally tight to the confirmed root cause (source-label clipping). Middle-column labels still truncate to their column pitch with a `<title>` tooltip — that is the existing, correct anti-collision behavior, not part of this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sankey chart layout by reserving space for first-column labels.
  * Prevented source labels from being unnecessarily truncated or hidden.
  * Refined label overlap handling so labels that only touch are not treated as overlapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->