### PR TITLE
fix(choicebox): keep the selected look while hovering a selected card

### DIFF
--- a/src/lib/Choicebox/Choicebox.svelte
+++ b/src/lib/Choicebox/Choicebox.svelte
@@ -68,7 +68,11 @@
     box-shadow: var(--choicebox-focus-ring, 0 0 0 3px rgba(33, 150, 243, 0.3));
   }
 
-  .choicebox:not(.disabled):hover {
+  /* Exclude the selected state from hover: without :not(.selected) this rule
+     (specificity 0,3,0) outranks .choicebox.selected (0,2,0), so hovering a
+     selected card repaints it with the neutral hover border/fill until the
+     cursor leaves. Excluding selected lets .choicebox.selected show through. */
+  .choicebox:not(.disabled):not(.selected):hover {
     border-color: var(--choicebox-hover-border-color, #9e9e9e);
     background: var(--choicebox-hover-background, var(--choicebox-background, #ffffff));
   }

--- a/tests/choicebox-selected-hover.spec.ts
+++ b/tests/choicebox-selected-hover.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+// The library's own `.choicebox:hover` rule (specificity 0,3,0) outranked
+// `.choicebox.selected` (0,2,0), so hovering a selected card repainted it with
+// the neutral hover border/fill until the cursor left. Excluding the selected
+// state from the hover rule lets the selected look show through on hover.
+// Selected border default = #2196f3 (rgb(33,150,243)); hover border default =
+// #9e9e9e (rgb(158,158,158)). The demo's first radio card is selected on load.
+test.describe('Choicebox selected + hover', () => {
+  test('a selected card keeps its selected border while hovered', async ({ page }) => {
+    await page.goto('/components/choicebox');
+
+    const selected = page.locator('.choicebox.selected').first();
+    await expect(selected).toBeVisible();
+
+    const borderOf = () =>
+      selected.evaluate((el) => getComputedStyle(el as HTMLElement).borderTopColor);
+
+    const restingBorder = await borderOf();
+    expect(restingBorder).toBe('rgb(33, 150, 243)'); // selected blue, not hovered
+
+    await selected.hover();
+    // Give :hover a frame to apply.
+    await page.waitForTimeout(100);
+
+    const hoveredBorder = await borderOf();
+    // Must stay the selected blue — NOT the neutral hover grey rgb(158, 158, 158).
+    expect(hoveredBorder).toBe('rgb(33, 150, 243)');
+  });
+});


### PR DESCRIPTION
## Problem

`Choicebox`'s own hover rule outranks its selected rule:

- `.choicebox:not(.disabled):hover` → specificity **(0,3,0)**
- `.choicebox.selected` → specificity **(0,2,0)**

So when a card is **selected** and the pointer is over it, the hover rule wins and repaints it with the neutral hover border/fill — the card only flips back to its selected look once the cursor leaves. Every consumer hits this bare (lighthouse currently works around it with a `.choicebox.selected` token-remap in its own theme.css, which this makes unnecessary).

## Fix

Exclude the selected state from the hover rule:

```css
.choicebox:not(.disabled):not(.selected):hover { … }
```

A selected card no longer matches `:hover`, so `.choicebox.selected` shows through by default. No token juggling, no consumer class — correct out of the box for everyone.

## Proof

Added `tests/choicebox-selected-hover.spec.ts` (the demo's first radio card is selected on load; selected border default `#2196f3` = `rgb(33,150,243)`, hover border default `#9e9e9e`):

- **Without the fix** it fails — the hovered selected card's border drifts off the selected blue toward the neutral hover grey (`Received: rgb(133, 156, 175)`).
- **With the fix** it stays `rgb(33, 150, 243)` on hover.

## Checks
- `pnpm run check` — 0 errors
- `pnpm exec playwright test tests/choicebox-selected-hover.spec.ts` — passes (and fails on the pre-fix rule)
- eslint + prettier clean

## Follow-up
Once published, the lighthouse `.choicebox.selected` hover-remap in `static/style/theme.css` (PR #6320, BZ-4597) should be deleted and the dependency bumped — the central fix makes it dead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected styling when hovering over a selected choice, preventing it from changing to the neutral hover appearance.

* **Tests**
  * Added coverage to verify selected choices retain their highlighted border color during hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->