### PR TITLE
feat: fill component gaps (Accordion disabled, Button style, Select/Tabs per-item icon+status)

### DIFF
--- a/src/lib/Accordion/Accordion.svelte
+++ b/src/lib/Accordion/Accordion.svelte
@@ -8,10 +8,14 @@
     ontoggle,
     triggerClasses,
     classes,
-    testId
+    testId,
+    disabled = false
   }: AccordionProperties = $props();
 
   function handleTriggerClick(): void {
+    if (disabled) {
+      return;
+    }
     expand = !expand;
     ontoggle?.(expand);
   }
@@ -20,9 +24,11 @@
 {#if trigger}
   <div
     class="accordion-trigger {triggerClasses ?? ''}"
+    class:disabled
     role="button"
-    tabindex="0"
+    tabindex={disabled ? -1 : 0}
     aria-expanded={expand}
+    aria-disabled={disabled}
     onclick={handleTriggerClick}
     onkeydown={(event) => {
       if (event.key === 'Enter' || event.key === ' ') {
@@ -48,6 +54,10 @@
 <style>
   .accordion-trigger {
     cursor: var(--accordion-trigger-cursor, pointer);
+  }
+
+  .accordion-trigger.disabled {
+    cursor: var(--accordion-trigger-disabled-cursor, not-allowed);
   }
 
   .accordion {

--- a/src/lib/Accordion/properties.ts
+++ b/src/lib/Accordion/properties.ts
@@ -9,6 +9,14 @@ export type OptionalAccordionProperties = {
   triggerClasses?: string;
   classes?: string;
   testId?: string;
+  /**
+   * Disables the built-in trigger: clicks and Enter/Space no longer toggle,
+   * the trigger is removed from the tab order, and `aria-disabled="true"` is
+   * emitted. The trigger element also gets a `disabled` class so consumers can
+   * style the locked state. `expand` is still honoured, so a disabled accordion
+   * can be shown open or closed under external (controlled) state.
+   */
+  disabled?: boolean;
 };
 
 export type AccordionEventProperties = {

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -34,7 +34,8 @@
     ontouchend,
     icon,
     children,
-    classes
+    classes,
+    style
   }: ButtonProperties = $props();
 
   // `loading` and the legacy Circular loaderType both render the spinner and disable the button.
@@ -65,6 +66,7 @@
   class="button-container variant-{variant} size-{size} {classes ?? ''}"
   class:icon-only={iconOnly}
   class:full-width={fullWidth}
+  style={style ?? null}
 >
   {#if showProgressBar}
     <div class="button-progress-bar"></div>

--- a/src/lib/Button/properties.ts
+++ b/src/lib/Button/properties.ts
@@ -61,6 +61,13 @@ export type OptionalButtonProperties = {
   role?: string;
   disabled?: boolean;
   classes?: string;
+  /**
+   * Inline style applied to the outer `.button-container`. Use for per-instance
+   * dynamic values a static class can't express — e.g. a CSS custom property
+   * driven by runtime state (`--offset: {n}px`). Prefer `classes` / `--button-*`
+   * tokens for anything static.
+   */
+  style?: string;
 };
 
 export type ButtonEventProperties = {

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -587,6 +587,9 @@
                   </span>
                 {/if}
               {/if}
+              {#if typeof row.item.icon === 'string' && row.item.icon.length > 0}
+                <Img src={row.item.icon} alt="" fallback="" classes="select-option-icon" />
+              {/if}
               <span class="select-option-label">{row.item.label}</span>
               {#if showSelectedTick && !multiple && value.includes(row.item.id)}
                 <!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -752,6 +755,17 @@
     font-size: var(--select-option-font-size, inherit);
     cursor: pointer;
     transition: background 0.1s;
+  }
+
+  /* Per-option leading icon (SelectItem.icon). Kept inline + vertically centred so
+     it needs no change to the option's display and can't regress icon-less lists. */
+  .select-option :global(.select-option-icon) {
+    --image-width: var(--select-option-icon-size, 16px);
+    --image-height: var(--select-option-icon-size, 16px);
+    --image-object-fit: contain;
+
+    vertical-align: middle;
+    margin-right: var(--select-option-icon-gap, 8px);
   }
 
   .select-option.multi {

--- a/src/lib/Select/properties.ts
+++ b/src/lib/Select/properties.ts
@@ -9,6 +9,14 @@ export type SelectItem = {
   label: string;
   /** Optional per-option test id, emitted as `data-pw` on the option element. */
   testId?: string;
+  /**
+   * Optional image src (URL or data URI) rendered at the left of the option row,
+   * before the label — for icon pickers and any list whose options carry a glyph.
+   * Size is controlled by the `--select-option-icon-size` CSS variable (default 16px).
+   * Pair with the trigger's `leftIcon` (driven by the selected option's icon) to show
+   * the current selection in the closed trigger.
+   */
+  icon?: string;
 };
 
 export type MandatorySelectProperties = {

--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TabItem, TabsProperties } from './properties';
+  import Img from '../Img/Img.svelte';
   import chevronLeftSvg from '$lib/assets/chevron-left.svg?raw';
   import chevronRightSvg from '$lib/assets/chevron-right.svg?raw';
 
@@ -191,9 +192,22 @@
         onkeydown={(event) => handleKeydown(event, index)}
       >
         {#if typeof tab === 'function'}
-          {@render tab({ label, index, active: isActiveItem(index), subtitle: tabItem?.subtitle })}
+          {@render tab({
+            label,
+            index,
+            active: isActiveItem(index),
+            subtitle: tabItem?.subtitle,
+            icon: tabItem?.icon,
+            status: tabItem?.status
+          })}
         {:else}
+          {#if typeof tabItem?.icon === 'string' && tabItem.icon.length > 0}
+            <Img src={tabItem.icon} alt="" fallback="" classes="tabs-item-icon" />
+          {/if}
           {label}
+          {#if tabItem?.status && tabItem.status !== 'none'}
+            <span class="tabs-item-status status-{tabItem.status}" aria-hidden="true"></span>
+          {/if}
         {/if}
       </div>
     {/each}
@@ -327,6 +341,7 @@
   .tabs-item {
     display: flex;
     align-items: center;
+    gap: var(--tabs-item-gap, 8px);
     position: relative;
     padding: var(--tabs-item-padding, 12px 16px);
     font-size: var(--tabs-item-font-size, 14px);
@@ -342,6 +357,38 @@
     flex-shrink: 0;
     user-select: none;
     transition: var(--tabs-transition, color 0.2s ease, background 0.2s ease);
+  }
+
+  .tabs-item :global(.tabs-item-icon) {
+    --image-width: var(--tabs-item-icon-size, 16px);
+    --image-height: var(--tabs-item-icon-size, 16px);
+    --image-object-fit: contain;
+
+    flex-shrink: 0;
+  }
+
+  /* Trailing status dot for nav/menu tabs. margin-left:auto pushes it to the row's
+     end (e.g. a settings menu); harmless on a normal tab bar where the item shrinks
+     to content. */
+  .tabs-item-status {
+    width: var(--tabs-item-status-size, 8px);
+    height: var(--tabs-item-status-size, 8px);
+    margin-left: auto;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--tabs-item-status-default-color, transparent);
+  }
+
+  .tabs-item-status.status-pending {
+    background: var(--tabs-item-status-pending-color, #f59e0b);
+  }
+
+  .tabs-item-status.status-error {
+    background: var(--tabs-item-status-error-color, #e7000b);
+  }
+
+  .tabs-item-status.status-success {
+    background: var(--tabs-item-status-success-color, #16a34a);
   }
 
   .tabs-item:hover:not(.active):not([aria-disabled]) {

--- a/src/lib/Tabs/properties.ts
+++ b/src/lib/Tabs/properties.ts
@@ -5,6 +5,18 @@ export type TabItem = {
   label: string;
   testId?: string;
   subtitle?: string;
+  /**
+   * Optional image src (URL or data URI) rendered before the label in the default
+   * tab layout. Size is controlled by the `--tabs-item-icon-size` CSS variable
+   * (default 16px). Also forwarded to the `tab` snippet for custom layouts.
+   */
+  icon?: string;
+  /**
+   * Optional status dot rendered after the label — for nav/menu tabs that flag
+   * per-item state. `'none'` (default) renders nothing. Colours are themeable via
+   * `--tabs-item-status-{pending,error,success}-color`.
+   */
+  status?: 'none' | 'pending' | 'error' | 'success';
 };
 
 export type TabsProperties = MandatoryTabsProperties & OptionalTabsProperties & TabsEventProperties;
@@ -20,7 +32,18 @@ export type OptionalTabsProperties = {
   testId?: string;
   scrollLeftIcon?: Snippet;
   scrollRightIcon?: Snippet;
-  tab?: Snippet<[{ label: string; index: number; active: boolean; subtitle?: string }]>;
+  tab?: Snippet<
+    [
+      {
+        label: string;
+        index: number;
+        active: boolean;
+        subtitle?: string;
+        icon?: string;
+        status?: TabItem['status'];
+      }
+    ]
+  >;
   classes?: string;
 };
 


### PR DESCRIPTION
## What

Adds the capabilities that currently force consumers (Lighthouse, specifically) to hand-roll raw `<button>` / dropdowns / accordions instead of using these components. Each is additive and backward-compatible.

- **Accordion — `disabled`**: suppresses the built-in trigger's toggle (click + Enter/Space), removes it from the tab order, emits `aria-disabled`, and adds a `disabled` trigger class + a `not-allowed` cursor. `expand` is still honoured, so a locked accordion can be shown open/closed under controlled state.
- **Button — `style`**: an inline `style` on the outer `.button-container`, for per-instance dynamic values a static class can't express (e.g. a runtime-driven CSS custom property for positioning).
- **Select — per-option `icon`**: `SelectItem.icon` renders an `<Img>` before each option label (icon pickers). Inline + vertically centred so icon-less lists are unaffected; sized via `--select-option-icon-size`.
- **Tabs — per-tab `icon` + `status`**: `TabItem.icon` (leading image) + `TabItem.status` (`'none'|'pending'|'error'|'success'` trailing dot) in the default layout, both also forwarded to the `tab` snippet. Themeable via `--tabs-item-{icon-size, status-*-color}`.

## Why

These four gaps are what block a set of Lighthouse screens from dropping bespoke raw-`<button>` implementations (an icon picker, a lockable step accordion, an icon+status settings nav, and dynamically-positioned icon buttons) in favour of the library components.

## Verification

`pnpm run check` ✅ · `pnpm run lint` ✅ · `pnpm run build` ✅. All four verified rendering in the local demo (Accordion locked, Button offset via `style`, Select options with colour icons, Tabs with per-tab icons + pending/error status dots).

## Notes

Backward-compatible — all additions are optional. Follow-up: consuming migrations land in Lighthouse once this is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disabled-state support for accordion triggers, including accessibility indicators and non-interactive behavior.
  * Added inline style customization for buttons.
  * Added optional icons to select options.
  * Added optional icons and status indicators to tabs, including pending, error, and success states.
  * Extended tab customization data with icon and status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->