### PR TITLE
fix: paginator page-size dropdown clipping + image-cell placeholder initials

### DIFF
--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -165,7 +165,10 @@
       <span
         class="builtin-thumb builtin-thumb-placeholder"
         data-pw={column.testId ? `${column.testId}-thumb-placeholder` : null}
-      ></span>
+        >{typeof data.text1 === 'string' && data.text1
+          ? data.text1.charAt(0).toUpperCase()
+          : ''}</span
+      >
     {/if}
     <div class="builtin-two-line {alignmentClass}">
       <span class="builtin-primary-text">{typeof data.text1 === 'string' ? data.text1 : '-'}</span>
@@ -600,7 +603,15 @@
   }
 
   .builtin-thumb-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background-color: var(--table-cell-thumb-placeholder-background, #f3f4f6);
+    color: var(--table-cell-thumb-placeholder-color, #6b7280);
+    font-size: var(--table-cell-thumb-placeholder-font-size, 14px);
+    font-weight: 600;
+    line-height: 1;
+    text-transform: uppercase;
   }
 
   .builtin-tag-array {

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -919,6 +919,7 @@
                 }))}
                 value={[String(effectivePageSize)]}
                 disabled={pagination.isLoading ?? false}
+                usePortal
                 testId={pagination.testId && `${pagination.testId}-page-size`}
                 onchange={(selectedSizes) => {
                   if (selectedSizes.length > 0) {


### PR DESCRIPTION
## What

Two small `Table` built-in fixes (consumed together by the Lighthouse dashboard).

### BZ-4623 — paginator page-size dropdown clipped behind the footer
The built-in paginator's page-size `Select` sits at the very bottom of `.table-container` (`overflow: hidden`) and opens downward, so its options were clipped behind the table footer — impossible to change page size. It is internal chrome a consumer can't reach, so it now uses `usePortal` **unconditionally** (consistent with the in-cell selects added in the earlier RTO work): it portals to `document.body` with fixed, collision-aware positioning and escapes the container's clip. **No consumer change required** beyond consuming this version.

### BZ-4620 — image-two-line-text cell showed a blank placeholder
When a line item had no `imageUrl`, the cell rendered an empty grey box. It now renders the **first letter of `text1`** (uppercased, centered) in the placeholder, so line-item tables show product-name initials like the rest of the app — for every image-cell consumer at once.

## Verify
- `npm run check` — 0 errors (547 files)
- `prettier --check` / `eslint` — clean

Placeholder colour/size are tokenised (`--table-cell-thumb-placeholder-color/-font-size`) with sensible defaults.