### PR TITLE
fix: donut centre label fits the hole; StatCard breakdown delta sits inline

### DIFF
--- a/src/lib/PieChart/PieChart.svelte
+++ b/src/lib/PieChart/PieChart.svelte
@@ -227,7 +227,13 @@
     return visible;
   });
 
-  let centerBoxSize = $derived(innerR > 0 ? Math.max(0, innerR * 1.3) : 0);
+  // The centre snippet (e.g. a currency total like "₹31.24k") is clipped by the
+  // foreignObject bounds, so the box must be wide enough for it. The inner hole
+  // has diameter 2*innerR; a square of side ~1.9*innerR keeps every edge inside
+  // the hole at the text's mid-line while giving the label the room a plain
+  // "innerR*1.3" (≈2/3 of the hole) did not — the old value cut the ₹/k off the
+  // sides and forced the caption onto two lines.
+  let centerBoxSize = $derived(innerR > 0 ? Math.max(0, innerR * 1.9) : 0);
 
   // The foreignObject for the center snippet is positioned relative to the <g>
   // origin (which is at cx, cy in SVG space). The box is always centred on

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -201,13 +201,15 @@
                     : null}
                 >
                   <div class="statcard-breakdown-label">{breakdownItem.label}</div>
-                  <div class="statcard-breakdown-value">{breakdownItem.value}</div>
-                  {#if typeof breakdownItem.change === 'number'}
-                    <DeltaIndicator
-                      value={breakdownItem.change}
-                      invertColors={breakdownItem.invertChangeColors ?? false}
-                    />
-                  {/if}
+                  <div class="statcard-breakdown-value-line">
+                    <div class="statcard-breakdown-value">{breakdownItem.value}</div>
+                    {#if typeof breakdownItem.change === 'number'}
+                      <DeltaIndicator
+                        value={breakdownItem.change}
+                        invertColors={breakdownItem.invertChangeColors ?? false}
+                      />
+                    {/if}
+                  </div>
                 </div>
               {/each}
             </div>
@@ -486,6 +488,16 @@
     display: flex;
     flex-direction: column;
     gap: var(--statcard-breakdown-item-gap, 2px);
+  }
+
+  /* The metric value and its change indicator share one line (label sits above
+     as the caption). Previously the delta was a third stacked child, so it
+     rendered on its own line beneath the number. */
+  .statcard-breakdown-value-line {
+    display: flex;
+    align-items: baseline;
+    gap: var(--statcard-breakdown-value-gap, 6px);
+    flex-wrap: wrap;
   }
 
   .statcard-breakdown-label {


### PR DESCRIPTION
## What

Two small, independent component fixes surfaced while bringing Lighthouse's analytics route to Figma parity. Both are appearance-preserving structural fixes with sensible defaults; no public prop/API changes.

### 1. `PieChart` — centre label no longer clips

The centre-snippet `<foreignObject>` was sized `innerR * 1.3` — only ~⅔ of the inner-hole **diameter**. `foreignObject` clips its content to those bounds, so a currency total like **`₹31.24k`** was cut off on both sides and a two-word caption (`Total Sales`) wrapped to two lines.

Widened the box to `innerR * 1.9`. Every edge still stays **inside** the hole at the text's horizontal mid-line (half-width `0.95·innerR < innerR`), so short/centred content is unaffected, but the label now gets the room it needs.

| centre value | before (box 50px) | after (box 73px) |
|---|---|---|
| `₹1.33k` | clipped (56px) | fits |
| `₹31.24k` | clipped | **fits** (68px) |
| `₹12.34L` / `₹1.23Cr` | clipped | fits |

Values physically wider than the hole diameter (e.g. `₹999.9Cr`) still can't fit at small donut sizes — that needs font-shrink-to-fit, out of scope here.

### 2. `StatCard` — breakdown value + change indicator share one line

A breakdown item rendered `label`, `value` and the `DeltaIndicator` as three stacked column children, so the change % sat on its own line **beneath** the number:

```
New Customer        New Customer
1m 46s        →     1m 46s  0%
0%
```

Wrapped the value + delta in a flex row (`.statcard-breakdown-value-line`); the label stays the caption above. The new gap is tokenised (`--statcard-breakdown-value-gap`, default 6px).

## Why here (not in the consumer)

These are the two structural/geometry issues that can't be fixed from the app via CSS variables — the clip is a `foreignObject` bound and the delta placement is DOM order. The remaining analytics-parity tweaks (legend spacing, chart-header alignment, card width) stay in Lighthouse.

## Verification

Built and overlaid into the Lighthouse mock `/analytics` page; verified in **light + dark** with computed-style measurements and screenshots:
- donut `foreignObject` width 50 → 73px, `clipped: false` for `₹31.24k` / `₹12.34L` / `₹1.23Cr`;
- long centre caption (`Total Sales`) drops from 2 lines to 1;
- StatCard breakdown delta renders inline (`deltaBelowValue: false`) on the Prepaid Share / Median Checkout Time cards.

Rebased onto `release` (2.98.1); the two files were untouched upstream since 2.97.2, so it applies cleanly. Single commit, per the rebase-merge policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pie chart center captions from being clipped or wrapping unexpectedly.
  * Improved breakdown displays in statistic cards by aligning metric values and change indicators on the same line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->