### PR TITLE
fix: DeltaIndicator renders the trend-line arrow, not a filled triangle

### DIFF
--- a/src/lib/DeltaIndicator/DeltaIndicator.svelte
+++ b/src/lib/DeltaIndicator/DeltaIndicator.svelte
@@ -40,7 +40,7 @@
 >
   {#if !hideArrow && direction !== 'neutral'}
     <span class="delta-indicator-arrow delta-arrow-{direction}" aria-hidden="true">
-      <svg viewBox="0 0 10 10"><path d="M5 1 L9 8 L1 8 Z" /></svg>
+      <svg viewBox="0 0 24 24"><path d="M22 7L13.5 15.5L8.5 10.5L2 17" /><path d="M16 7H22V13" /></svg>
     </span>
   {/if}
   <span class="delta-indicator-text">{text}</span>
@@ -50,7 +50,7 @@
   .delta-indicator {
     display: inline-flex;
     align-items: center;
-    gap: var(--delta-indicator-gap, 2px);
+    gap: var(--delta-indicator-gap, 4px);
     font-size: var(--delta-indicator-font-size, 13px);
     font-weight: var(--delta-indicator-font-weight, 600);
     line-height: 1;
@@ -78,18 +78,25 @@
 
   .delta-indicator-arrow {
     display: inline-flex;
-    width: var(--delta-indicator-arrow-size, 9px);
-    height: var(--delta-indicator-arrow-size, 9px);
+    width: var(--delta-indicator-arrow-size, 16px);
+    height: var(--delta-indicator-arrow-size, 16px);
     flex-shrink: 0;
   }
 
   .delta-indicator-arrow svg {
     width: 100%;
     height: 100%;
-    fill: currentColor;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: var(--delta-indicator-arrow-stroke-width, 2);
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
+  /* Down-trend mirrors the up-trend glyph vertically (line falling to the
+     lower-right, arrowhead at the bottom-right) — the Untitled UI trend-down-01
+     shape. A 180deg rotation would instead point down-left. */
   .delta-arrow-down {
-    transform: rotate(180deg);
+    transform: scaleY(-1);
   }
 </style>


### PR DESCRIPTION
## What

The `DeltaIndicator` arrow was a **filled triangle** (`M5 1 L9 8 L1 8 Z`, rotated 180° for the down state). The Breeze dashboard design — and the Untitled UI icon set it's built on — uses the **`trend-up-01` / `trend-down-01`** glyph: a stroked line that trends up/down to an arrowhead.

- Swap the SVG to the trend path (`M22 7L13.5 15.5L8.5 10.5L2 17` + arrowhead `M16 7H22V13`), stroked (`fill:none; stroke:currentColor; round joins`).
- Size to the design's **16px** with a **4px** gap.
- **Down** = `scaleY(-1)` of the up glyph (falls to the lower-right), not `rotate(180deg)` (which points down-left).
- New `--delta-indicator-arrow-stroke-width` token; colours/size/weight stay token-driven.

## Before → After

| | before | after |
|---|---|---|
| glyph | filled triangle ▲ / ▼ | trend-up-01 / trend-down-01 line-arrow |
| down state | 180° rotation (points down-**left**) | vertical mirror (falls down-**right**) |

## Verification

Built and rendered on the Lighthouse `/analytics` page across every metric card — KPIs, Prepaid Share, Conversion Rate, Median Checkout Time — up-trends green, down-trends red, matching the Figma. Full before/after screenshots in the consuming PR: **[bz/lighthouse#6336](https://bitbucket.juspay.net/projects/BZ/repos/lighthouse/pull-requests/6336)**.

Driven by the analytics Figma-parity pass (design file: Breeze Dashboard, Overview section).
