### PR TITLE
style: wrap DeltaIndicator trend-arrow svg to satisfy prettier

### DIFF
--- a/src/lib/DeltaIndicator/DeltaIndicator.svelte
+++ b/src/lib/DeltaIndicator/DeltaIndicator.svelte
@@ -40,7 +40,9 @@
 >
   {#if !hideArrow && direction !== 'neutral'}
     <span class="delta-indicator-arrow delta-arrow-{direction}" aria-hidden="true">
-      <svg viewBox="0 0 24 24"><path d="M22 7L13.5 15.5L8.5 10.5L2 17" /><path d="M16 7H22V13" /></svg>
+      <svg viewBox="0 0 24 24"
+        ><path d="M22 7L13.5 15.5L8.5 10.5L2 17" /><path d="M16 7H22V13" /></svg
+      >
     </span>
   {/if}
   <span class="delta-indicator-text">{text}</span>


### PR DESCRIPTION
Follow-up to #396: the two-path trend-arrow SVG was on one line, exceeding prettier's print width, so the release lint step failed and the publish never ran (npm is still at 2.100.0, without the trend-arrow fix). Reflow via `prettier --write`; `prettier --check` now passes. No behavioural change — the rendered arrow is identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted the delta indicator’s arrow markup without changing its appearance or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->