### PR TITLE
fix(fileinput): open the picker on click of the whole drop zone

### DIFF
--- a/src/lib/FileInput/FileInput.svelte
+++ b/src/lib/FileInput/FileInput.svelte
@@ -15,11 +15,22 @@
 
   let dragOver = $state(false);
   let inputEl: HTMLInputElement | null = $state(null);
+  let pickerBusy = false;
 
   export const openFilePicker = (): void => {
-    if (!disabled) {
-      inputEl?.click();
+    if (disabled || pickerBusy) {
+      return;
     }
+    // Idempotent within one click dispatch: if an inner trigger control wires
+    // openFilePicker AND the wrapper's own onclick fires for the same user click,
+    // the second call is a no-op (guarding against a double-open). Released on the
+    // next microtask — after the whole click has finished bubbling — so a genuinely
+    // separate later click still opens the picker.
+    pickerBusy = true;
+    inputEl?.click();
+    queueMicrotask(() => {
+      pickerBusy = false;
+    });
   };
 
   function isAccepted(file: File): boolean {
@@ -107,6 +118,20 @@
       openFilePicker();
     }
   }
+
+  function handleClick(event: MouseEvent): void {
+    if (disabled) {
+      return;
+    }
+    // openFilePicker() calls inputEl.click(), whose click bubbles back up to this
+    // wrapper — ignore it so we don't re-enter openFilePicker in a loop. Consumers
+    // whose trigger already wires openFilePicker on an inner control should NOT also
+    // rely on this handler (it would double-open); clicking the trigger is enough.
+    if (event.target === inputEl) {
+      return;
+    }
+    openFilePicker();
+  }
 </script>
 
 <div
@@ -121,6 +146,7 @@
   ondragleave={handleDragLeave}
   ondrop={handleDrop}
   onkeydown={handleKeyDown}
+  onclick={handleClick}
 >
   <input
     bind:this={inputEl}

--- a/src/routes/components/file-input/+page.svelte
+++ b/src/routes/components/file-input/+page.svelte
@@ -77,6 +77,20 @@
   {/if}
 </div>
 
+<h3>Card trigger (click-to-open via the wrapper — no inner button)</h3>
+<div class="demo-row" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+  <FileInput testId="file-input-card" onfiles={(files) => (acceptedFiles = files)}>
+    {#snippet trigger({ dragOver })}
+      <div
+        class="card-trigger"
+        style="border: 1px dashed #cccccc; border-radius: 8px; padding: 24px 48px;"
+      >
+        {dragOver ? 'Drop files here' : 'A plain card — click anywhere to open'}
+      </div>
+    {/snippet}
+  </FileInput>
+</div>
+
 <h3>Disabled</h3>
 <div class="demo-row">
   <FileInput disabled testId="file-input-disabled">


### PR DESCRIPTION
## What

`FileInput`'s wrapper is `role="button"` and opened the native picker on **keyboard** (Enter/Space) and **drag-drop**, but **not on a plain click**. So a non-button trigger — e.g. a `Card` drop zone — couldn't open the picker without the consumer wiring `openFilePicker` onto an inner control. This adds `onclick` to the wrapper: clicking anywhere in the drop zone now opens the picker.

## Safety (no double-open, no re-entrancy)

- **Double-open guard:** `openFilePicker` is idempotent within a single click dispatch (a busy flag released on the next microtask). A trigger that *also* wires `openFilePicker` on an inner `<button>` — plus this wrapper's new `onclick` — for the same user click opens the picker exactly **once**.
- **Re-entrancy guard:** `openFilePicker()` calls `inputEl.click()`, whose click bubbles back to the wrapper; a `event.target === inputEl` check ignores it so we don't loop.

## Proof

Counted hidden-input clicks per user click on the demo:
- Card trigger (no inner handler): **1** — click-to-open works.
- Button trigger (inner `onclick={openFilePicker}` + wrapper `onclick`): **1** — no double-fire regression.

`svelte-check` 0 errors, `eslint` clean, `svelte-package` + `publint` clean. Demo (`/components/file-input`) extended with a Card-style trigger.

## Why

Unblocks the Lighthouse shipping-COD CSV upload migration (a `Card` drop zone) to library `FileInput` (BZ-4233).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening the file picker by clicking a styled card or wrapper area.
  * Added a card-style file input demonstration with drag-and-drop prompt updates.

* **Bug Fixes**
  * Prevented duplicate file picker launches from repeated or nested click events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->