### PR TITLE
feat: BarChartRenderContext.bars — per-bar geometry for overlay annotations

### DIFF
--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -641,7 +641,25 @@
       right: dims.margin.right,
       bottom: dims.margin.bottom,
       left: dims.margin.left
-    }
+    },
+    bars: bars.map((bar, index) => {
+      // barLabels is index-aligned with bars (both derive from the same list);
+      // fall back to the bar's top-centre when value labels are hidden.
+      const barLabel = barLabels[index];
+      return {
+        index,
+        seriesIndex: bar.si,
+        pointIndex: bar.pi,
+        x: bar.x,
+        y: bar.y,
+        width: bar.width,
+        height: bar.height,
+        value: bar.dataPoint.value,
+        label: bar.dataPoint.label ?? '',
+        labelX: barLabel ? barLabel.p.x : bar.x + bar.width / 2,
+        labelY: barLabel ? barLabel.p.y : bar.y
+      };
+    })
   });
 
   // ── Interactions ───────────────────────────────────────────────

--- a/src/lib/BarChart/properties.ts
+++ b/src/lib/BarChart/properties.ts
@@ -60,6 +60,37 @@ export type BarChartSeries = {
 
 // ── Render-overlay escape hatch (A1-4) ───────────────────────
 
+/**
+ * Geometry for a single rendered bar, in inner (post-margin) coordinates — the
+ * same space the overlay `<g>` draws in, so values map 1:1 without re-applying
+ * the margin. `labelX`/`labelY` are the value-label anchor when `showValues` is
+ * on, otherwise the bar's top-centre.
+ */
+export type BarChartBarPosition = {
+  /** Zero-based index in render order. */
+  index: number;
+  /** Series index (0-based). */
+  seriesIndex: number;
+  /** Category / point index (0-based). */
+  pointIndex: number;
+  /** Bar rectangle x (left edge). */
+  x: number;
+  /** Bar rectangle y (top edge). */
+  y: number;
+  /** Bar rectangle width. */
+  width: number;
+  /** Bar rectangle height. */
+  height: number;
+  /** The datum's numeric value. */
+  value: number;
+  /** The datum's category label. */
+  label: string;
+  /** Value-label anchor x. */
+  labelX: number;
+  /** Value-label anchor y. */
+  labelY: number;
+};
+
 export type BarChartRenderContext = {
   /** Inner drawing width (pixels) */
   innerWidth: number;
@@ -73,6 +104,12 @@ export type BarChartRenderContext = {
    * a bottom-edge connector in a funnel overlay).
    */
   margin: { top: number; right: number; bottom: number; left: number };
+  /**
+   * Per-bar geometry in render order. Lets an overlay anchor annotations
+   * (e.g. an icon above the first funnel step's value) to a specific bar
+   * without re-deriving the band scale from innerWidth.
+   */
+  bars: BarChartBarPosition[];
 };
 
 // ── Component property types ──────────────────────────────────


### PR DESCRIPTION
## What

Adds a `bars` array to the `BarChartRenderContext` that `renderOverlay` receives, exposing per-bar geometry so consumers can anchor overlay annotations to a specific bar.

Each entry is a new exported `BarChartBarPosition`:

```ts
type BarChartBarPosition = {
  index: number;        // zero-based, render order
  seriesIndex: number;  // 0-based series
  pointIndex: number;   // 0-based category/point
  x: number; y: number; width: number; height: number;  // bar rect, inner coords
  value: number;        // datum value
  label: string;        // datum category label
  labelX: number; labelY: number;  // value-label anchor (top-centre fallback when values hidden)
};
```

All coordinates are in inner (post-margin) space — the same `<g>` the overlay draws in — so they map 1:1 without re-applying the margin.

## Why

`renderOverlay` already exposes `innerWidth` / `innerHeight` / `margin`, but not where individual bars land. To place an annotation on a specific bar today, a consumer has to re-derive the d3 band scale from `innerWidth` (fragile, and it breaks on responsive resize).

Concrete use case: a conversion **funnel** whose first step should show a small icon above its count (`460`). With `context.bars[0].labelX/labelY` the consumer positions the icon exactly above the first bar's value label, no scale math:

```svelte
<BarChart {series}>
  {#snippet renderOverlay(ctx)}
    {@const first = ctx.bars[0]}
    {#if first}
      <image href={sessionsIcon} x={first.labelX - 8} y={first.labelY - 22} width="16" height="16" />
    {/if}
  {/snippet}
</BarChart>
```

## Notes

- Purely additive — no behaviour change to existing charts; `renderOverlay` consumers that ignore `bars` are unaffected.
- Works for vertical + horizontal orientation and stacked mode (geometry comes from the same `bars`/`barLabels` the chart already computes).
- `svelte-check` clean (0 errors); `build` + `publint` pass; the type ships in `dist/BarChart/properties.d.ts` via the existing `export type *`.
