### PR TITLE
feat: BarChartDataPoint.valueLabel — restore per-bar value-label override to release

### DIFF
--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -246,6 +246,9 @@
   let isStackedMode = $derived(isMulti && groupMode === 'stacked');
 
   function getDisplayValue(bar: BarRect): string {
+    if (typeof bar.dataPoint.valueLabel === 'string' && bar.dataPoint.valueLabel.length > 0) {
+      return bar.dataPoint.valueLabel;
+    }
     if (isNormalized && bar.normalizedValue != null) {
       return normalizedFormat(bar.normalizedValue);
     }

--- a/src/lib/BarChart/properties.ts
+++ b/src/lib/BarChart/properties.ts
@@ -49,6 +49,12 @@ export type BarChartDataPoint = {
   range?: [number, number];
   /** Per-bar fill: plain color, pattern, or gradient. Overrides series color. */
   color?: BarFill;
+  /**
+   * Custom text for this bar's value label, rendered verbatim instead of the
+   * `valueFormat(value)` output. Lets a caller label a single bar differently —
+   * e.g. a funnel baseline showing a raw count while the rest show a percentage.
+   */
+  valueLabel?: string;
 };
 
 export type BarChartSeries = {


### PR DESCRIPTION
Re-lands `BarChartDataPoint.valueLabel` (per-bar value-label override — e.g. a funnel baseline showing a raw count while later steps show a percentage) on `release`.

This override was published in 2.100.1 from a side branch but never merged to `release`, so 2.100.2 / 2.101.0 dropped it — regressing consumers (e.g. the lighthouse conversion funnel) that pin a newer version to get the `BarChartRenderContext.bars` overlay geometry. Merging this makes `release` carry **both** `valueLabel` and `bars` so a single version has the full funnel-annotation surface.

Purely additive; `svelte-check` 0 errors, build + publint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom value labels on individual bars.
  * Custom labels display exactly as provided, overriding automatic value formatting.
  * Existing percentage, range, and value formatting remain available when no custom label is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->