### PR TITLE
feat(LineChart): add yIntegerTicks to snap Y-axis ticks to whole numbers

### DIFF
--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -48,6 +48,7 @@
     xAxisCategories,
     xTickFormat,
     yTickFormat,
+    yIntegerTicks = false,
     aspectRatio = 16 / 9,
     minHeight = 0,
     maxHeight = DEFAULT_CHART_MAX_HEIGHT,
@@ -561,6 +562,7 @@
               orientation="left"
               scale={yScale}
               tickCount={yTickCount}
+              integerTicks={yIntegerTicks}
               {showGridlines}
               gridlineLength={dims.innerWidth}
               label={yAxisLabel}

--- a/src/lib/LineChart/properties.ts
+++ b/src/lib/LineChart/properties.ts
@@ -97,6 +97,13 @@ export type OptionalLineChartProperties = {
   xTickFormat?: (value: number | string) => string;
   /** Formatter for Y axis tick labels. */
   yTickFormat?: (value: number | string) => string;
+  /**
+   * Snap Y-axis ticks to whole numbers (mirrors the X axis' category
+   * behaviour). Use for count-style series (orders, items) where a small
+   * domain would otherwise produce fractional ticks (0, 0.5, 1, 1.5, 2) —
+   * `yTickFormat` only changes label text, not tick placement.
+   */
+  yIntegerTicks?: boolean;
   /** Width-to-height ratio for the chart. */
   aspectRatio?: number;
   /** Minimum chart height in pixels, regardless of computed aspect-ratio height. */

--- a/src/lib/_chart/scales.test.ts
+++ b/src/lib/_chart/scales.test.ts
@@ -20,4 +20,12 @@ describe('computeLinearTicks — integer mode (category axes)', () => {
   it('still produces fractional steps when integer mode is off', () => {
     expect(computeLinearTicks([1, 6], 8)).toContain(1.5);
   });
+
+  it('snaps count-style y domains to whole ticks', () => {
+    // Regression: a low-volume order-count chart with y domain [0, 2] rendered
+    // ticks 0, 0.5, 1, 1.5, 2 — fractional values for a discrete count. With
+    // integer mode (the new yIntegerTicks prop) the axis shows 0, 1, 2.
+    expect(computeLinearTicks([0, 2], 5)).toContain(0.5);
+    expect(computeLinearTicks([0, 2], 5, true)).toEqual([0, 1, 2]);
+  });
 });


### PR DESCRIPTION
## Problem

Count-style series (orders, items) with small domains render **fractional Y-axis ticks**: a `[0, 2]` order-count domain picks step 0.5, showing `0, 0.5, 1, 1.5, 2` for a discrete count.

Reported downstream as Lighthouse **BZ-4696** (Orders analytics tab, low-volume day: today=2, yesterday=0 → Y axis 0/0.5/1/1.5/2).

## Why the consumer can't fix it

`yTickFormat` only changes tick **label text**, not tick **placement** — rounding labels just prints duplicates (`0, 1, 1, 2, 2`) at the same fractional pixel positions.

## Fix

The integer-tick machinery already exists — `computeLinearTicks(domain, count, integer)` clamps sub-1 steps to 1, and `Axis` accepts `integerTicks` (the X axis uses it for category domains). The Y axis just never wired it and exposed no public prop.

- `LineChartProperties.yIntegerTicks?: boolean` (default `false` — zero behaviour change for existing consumers), doc'd next to `yTickFormat`
- Forwarded to the Y-axis `<Axis integerTicks={yIntegerTicks}>`, exactly mirroring the `xIntegerTicks` pattern
- Unit test for the count-style `[0, 2]` domain in `scales.test.ts` (fractional without the flag, `[0, 1, 2]` with it)

## Gates
- `npm run check` — 0 errors
- `npx vitest run src/lib/_chart/scales.test.ts` — 5/5 pass
- `npm run lint` — 0 errors (3 pre-existing warnings in unrelated `Table/cell-data.test.ts`)

## Follow-up (downstream)
Once released, Lighthouse passes `yIntegerTicks` for its ORDERS analytics chart and bumps the dependency — tracked on Plane BZ-4696.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to display whole-number tick marks on line chart Y-axes.
  * Updated chart configuration documentation to clarify integer tick behavior.

* **Bug Fixes**
  * Improved Y-axis tick calculation for count-based data when integer ticks are enabled.

* **Tests**
  * Added coverage for whole-number and fractional Y-axis tick scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->