### PR TITLE
fix(LineChart): gap-resilient paths for sparse series + 6-tick x-axis cap

### DIFF
--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -174,6 +174,38 @@ Hovering anywhere over the plot area finds the nearest point and shows a crossha
 </LineChart>
 ```
 
+### Sparse Series — Gap Points
+
+A data point with a non-finite y (`NaN`) marks a **gap**: the line breaks around it and resumes
+at the next finite point, instead of one poisoned SVG path (a single `NaN` coordinate makes the
+browser drop everything after it, visually cutting the line mid-chart). Gap points render no
+marker, no data label, are skipped by hover/crosshair/tooltip, and are excluded from the
+auto-computed axis domains.
+
+```svelte
+<script>
+  const series = [
+    {
+      name: 'Sales',
+      // Jun 3 had no data — the line gaps over x=3 and resumes at x=4.
+      data: [
+        { x: 1, y: 120 },
+        { x: 2, y: 180 },
+        { x: 3, y: NaN },
+        { x: 4, y: 150 }
+      ]
+    }
+  ];
+</script>
+
+<LineChart {series} />
+```
+
+### X-Axis Tick Density
+
+The x-axis renders at most **6 ticks** (per the design-system line-chart spec), thinning further
+on narrow charts. Y-axis ticks were already capped at 6.
+
 ## Props
 
 | Prop              | Type                                                         | Required | Default      | Description                                                                                                                                                                                                                         |

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -131,9 +131,12 @@
     if (xDomain) {
       return xDomain;
     }
+    // Non-finite coordinates mark gap points in sparse series; they must not
+    // poison the auto-domain (Math.min/max propagate NaN).
     const allX = series
       .filter((_, si) => !hiddenSeries.has(si))
-      .flatMap((s) => s.data.map((d) => d.x));
+      .flatMap((s) => s.data.map((d) => d.x))
+      .filter((x) => Number.isFinite(x));
     if (allX.length === 0) {
       return [0, 1];
     }
@@ -145,7 +148,8 @@
     }
     const allY = series
       .filter((_, si) => !hiddenSeries.has(si))
-      .flatMap((s) => s.data.map((d) => d.y));
+      .flatMap((s) => s.data.map((d) => d.y))
+      .filter((y) => Number.isFinite(y));
     if (allY.length === 0) {
       return [0, 1];
     }
@@ -170,7 +174,8 @@
   });
 
   let yTickCount = $derived(Math.max(2, Math.min(6, Math.floor(chartHeight / 70))));
-  let xTickCount = $derived(Math.max(2, Math.min(8, Math.floor(chartWidth / 90))));
+  // Capped at 6 per the design-system line-chart spec ("Max no. of ticks should be 6").
+  let xTickCount = $derived(Math.max(2, Math.min(6, Math.floor(chartWidth / 90))));
   // Category positions are whole numbers — fractional tick steps would repeat labels.
   let xIntegerTicks = $derived(Boolean(xAxisCategories && xAxisCategories.length > 0));
 
@@ -222,9 +227,14 @@
     hovered === null ? null : (series[hovered.si]?.data[hovered.pi] ?? null)
   );
 
-  let hoverLineX = $derived(
-    hovered === null ? null : (lines[hovered.si]?.points[hovered.pi]?.x ?? null)
-  );
+  let hoverLineX = $derived.by<number | null>(() => {
+    if (hovered === null) {
+      return null;
+    }
+    const x = lines[hovered.si]?.points[hovered.pi]?.x ?? null;
+    // A gap point (non-finite) anchors no crosshair.
+    return x !== null && Number.isFinite(x) ? x : null;
+  });
 
   // When a highlight index is active (imperative or prop), show the vertical
   // crosshair at that point even without a mouse hover.
@@ -238,7 +248,7 @@
         continue;
       }
       const point = line.points[effectiveHighlight];
-      if (point) {
+      if (point && Number.isFinite(point.x)) {
         return point.x;
       }
     }
@@ -280,7 +290,9 @@
           ({ si }) =>
             !hiddenSeries.has(si) &&
             (shared || si === hovered?.si) &&
-            series[si]?.data[hovered!.pi] != null
+            series[si]?.data[hovered!.pi] != null &&
+            // A gap point (non-finite y) has nothing to report in the tooltip.
+            Number.isFinite(series[si].data[hovered!.pi].y)
         )
         .map(({ p }) => ({ label: p.name, value: formatNumber(p.y), color: p.color }))
     };
@@ -296,7 +308,10 @@
         return [];
       }
       const p = line.points[hovered!.pi];
-      return p ? [{ x: p.x, y: p.y, color: line.color }] : [];
+      // A gap point (non-finite) has no marker, so it gets no halo either.
+      return p && Number.isFinite(p.x) && Number.isFinite(p.y)
+        ? [{ x: p.x, y: p.y, color: line.color }]
+        : [];
     });
   });
 
@@ -408,6 +423,11 @@
     let nearestPi = 0;
     let nearestXDist = Infinity;
     for (let i = 0; i < reference.length; i++) {
+      // Gap points (non-finite) are not hoverable — NaN distances would never
+      // win the comparison, but skipping keeps nearestPi from defaulting to one.
+      if (!Number.isFinite(reference[i].x) || !Number.isFinite(reference[i].y)) {
+        continue;
+      }
       const px = xScale(reference[i].x);
       const dist = Math.abs(px - plotX);
       if (dist < nearestXDist) {
@@ -619,7 +639,7 @@
                 stroke-width={strokeWidth}
                 fill="none"
               />
-              {#if line.points.length === 1 && !showDots}
+              {#if line.points.length === 1 && !showDots && Number.isFinite(line.points[0].x) && Number.isFinite(line.points[0].y)}
                 <circle
                   class="single-point"
                   class:dimmed={isLineDimmed(si)}
@@ -631,21 +651,24 @@
               {/if}
               {#if showDots}
                 {#each line.points as point, pi (pi)}
-                  <circle
-                    class="dot"
-                    class:dimmed={isDotDimmed(si, pi)}
-                    class:highlighted={isHighlightedDot(si, pi)}
-                    cx={point.x}
-                    cy={point.y}
-                    r={isHighlightedDot(si, pi) ? dotRadius * 1.5 : dotRadius}
-                    fill={line.color}
-                  />
+                  <!-- Gap points (non-finite) render no marker. -->
+                  {#if Number.isFinite(point.x) && Number.isFinite(point.y)}
+                    <circle
+                      class="dot"
+                      class:dimmed={isDotDimmed(si, pi)}
+                      class:highlighted={isHighlightedDot(si, pi)}
+                      cx={point.x}
+                      cy={point.y}
+                      r={isHighlightedDot(si, pi) ? dotRadius * 1.5 : dotRadius}
+                      fill={line.color}
+                    />
+                  {/if}
                 {/each}
               {/if}
               {#if showValues && pointLabelPlacements[si]}
                 {#each line.points as _point, pi (pi)}
                   {@const pl = pointLabelPlacements[si][pi]}
-                  {#if pl?.visible}
+                  {#if pl?.visible && Number.isFinite(pl.x) && Number.isFinite(pl.y)}
                     <text
                       class="point-value"
                       x={pl.x}

--- a/src/lib/_chart/paths.test.ts
+++ b/src/lib/_chart/paths.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { linePath, areaPath } from './paths';
+
+const finiteRun = [
+  { x: 0, y: 10 },
+  { x: 10, y: 20 },
+  { x: 20, y: 5 }
+];
+
+describe('linePath — gap (non-finite) segmentation', () => {
+  it('never emits NaN into the path data', () => {
+    const points = [
+      { x: 0, y: 10 },
+      { x: 10, y: NaN },
+      { x: 20, y: 5 }
+    ];
+    for (const curve of ['linear', 'monotone', 'step'] as const) {
+      expect(linePath(points, curve)).not.toContain('NaN');
+    }
+  });
+
+  it('breaks the line into one subpath per finite run', () => {
+    const points = [
+      { x: 0, y: 10 },
+      { x: 10, y: 20 },
+      { x: 20, y: NaN },
+      { x: 30, y: 5 },
+      { x: 40, y: 8 }
+    ];
+    const d = linePath(points, 'linear');
+    expect(d.match(/M /g)).toHaveLength(2);
+    expect(d).toBe('M 0 10 L 10 20 M 30 5 L 40 8');
+  });
+
+  it('is unchanged for fully-finite input', () => {
+    expect(linePath(finiteRun, 'linear')).toBe('M 0 10 L 10 20 L 20 5');
+  });
+
+  it('renders an isolated finite point between gaps as a bare moveto', () => {
+    const points = [
+      { x: 0, y: NaN },
+      { x: 10, y: 7 },
+      { x: 20, y: NaN }
+    ];
+    expect(linePath(points, 'linear')).toBe('M 10 7');
+  });
+
+  it('returns an empty string when every point is a gap', () => {
+    const points = [
+      { x: 0, y: NaN },
+      { x: 10, y: NaN }
+    ];
+    expect(linePath(points, 'monotone')).toBe('');
+  });
+});
+
+describe('areaPath — gap (non-finite) segmentation', () => {
+  it('closes one area per finite run and never emits NaN', () => {
+    const points = [
+      { x: 0, y: 10 },
+      { x: 10, y: 20 },
+      { x: 20, y: NaN },
+      { x: 30, y: 5 },
+      { x: 40, y: 8 }
+    ];
+    const d = areaPath(points, 100, 'linear');
+    expect(d).not.toContain('NaN');
+    expect(d.match(/Z/g)).toHaveLength(2);
+    expect(d).toBe('M 0 10 L 10 20 L 10 100 L 0 100 Z M 30 5 L 40 8 L 40 100 L 30 100 Z');
+  });
+
+  it('is unchanged for fully-finite input', () => {
+    expect(areaPath(finiteRun, 100, 'linear')).toBe('M 0 10 L 10 20 L 20 5 L 20 100 L 0 100 Z');
+  });
+});

--- a/src/lib/_chart/paths.ts
+++ b/src/lib/_chart/paths.ts
@@ -50,6 +50,31 @@ export function arcPath(
   return `M ${cx} ${cy}` + `L ${x1} ${y1}` + `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2}Z`;
 }
 
+/**
+ * Splits a point run into finite sub-runs. A non-finite coordinate (NaN /
+ * Infinity — typically a missing value in a sparse series) acts as a break:
+ * the line renders as separate segments with a gap at the missing point
+ * instead of one poisoned path — a single NaN coordinate in `d` makes the
+ * browser drop everything from that command onward, visually cutting the
+ * line mid-chart.
+ */
+function finiteSegments(points: Point[]): Point[][] {
+  const segments: Point[][] = [];
+  let current: Point[] = [];
+  for (const point of points) {
+    if (Number.isFinite(point.x) && Number.isFinite(point.y)) {
+      current.push(point);
+    } else if (current.length > 0) {
+      segments.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) {
+    segments.push(current);
+  }
+  return segments;
+}
+
 function linearPath(points: Point[]): string {
   if (points.length === 0) {
     return '';
@@ -143,7 +168,7 @@ function monotonePath(points: Point[]): string {
   return d;
 }
 
-export function linePath(points: Point[], curve: CurveType = 'linear'): string {
+function linePathSegment(points: Point[], curve: CurveType): string {
   if (points.length < 2) {
     return points.length === 1 ? `M ${points[0].x} ${points[0].y}` : '';
   }
@@ -159,14 +184,28 @@ export function linePath(points: Point[], curve: CurveType = 'linear'): string {
   }
 }
 
-export function areaPath(points: Point[], baseline: number, curve: CurveType = 'linear'): string {
+export function linePath(points: Point[], curve: CurveType = 'linear'): string {
+  return finiteSegments(points)
+    .map((segment) => linePathSegment(segment, curve))
+    .filter((d) => d !== '')
+    .join(' ');
+}
+
+function areaPathSegment(points: Point[], baseline: number, curve: CurveType): string {
   if (points.length === 0) {
     return '';
   }
-  const topPath = linePath(points, curve);
+  const topPath = linePathSegment(points, curve);
   const lastPoint = points[points.length - 1];
   const firstPoint = points[0];
   return topPath + ` L ${lastPoint.x} ${baseline} L ${firstPoint.x} ${baseline} Z`;
+}
+
+export function areaPath(points: Point[], baseline: number, curve: CurveType = 'linear'): string {
+  return finiteSegments(points)
+    .map((segment) => areaPathSegment(segment, baseline, curve))
+    .filter((d) => d !== '')
+    .join(' ');
 }
 
 /**


### PR DESCRIPTION
## Problem

A single non-finite `y` (`NaN` — a missing value in a sparse/partial series) poisons the entire SVG path: the browser drops every path command after the first NaN coordinate, **visually cutting the line mid-chart**. Real analytics data hits this constantly (days with no sales, partial current-day windows).

## Fix

- `linePath` / `areaPath` split the point run into **finite segments** and emit one subpath per segment — the line gaps over missing points and resumes at the next finite one (Highcharts-style gap semantics).
- Gap points render no marker, no halo, no crosshair anchor, no data label, no tooltip row, and are excluded from the auto-computed x/y domains.
- X-axis ticks capped at **6** per the design-system line-chart spec sticky note ("Max no. of tiks should be 6"); y-axis was already capped at 6.

## Tests

`src/lib/_chart/paths.test.ts` — 7 unit tests: no-NaN guarantee across curves, per-run subpath splitting, unchanged finite behaviour, isolated-point and all-gap edge cases, per-run closed areas.

## Consumer

Lighthouse analytics line charts (Sales/Orders/Conversions tabs) — the "line cut in between" defect on smaller/sparse datasets.