### PR TITLE
feat(BarChart): marginX inset override + value-end-only bar rounding

### DIFF
--- a/docs/BarChart.md
+++ b/docs/BarChart.md
@@ -167,6 +167,7 @@ Render axes, gridlines, and legend without drawing any bar rectangles — useful
 | stackNormalize        | `boolean`                              | No       | `false`       | Normalises stacked values to 100%. Applies only when `groupMode="stacked"`. Appends `%` to value labels unless `valueFormat` is supplied.                                                                                                                                    |
 | scrollable            | `boolean`                              | No       | `false`       | Wraps the chart in a horizontally-scrollable container. Use with `minBandWidth` to keep bars readable.                                                                                                                                                                        |
 | minBandWidth          | `number`                               | No       | `48`          | Minimum pixel width per category band when `scrollable` is `true`.                                                                                                                                                                                                            |
+| marginX               | `number`                               | No       | auto          | Fixed horizontal inset (px) between the svg edges and the plot, overriding the auto layout's left/right margins. Use for edge-to-edge funnels where tick-label padding leaves dead space beside the first/last bars; short category labels recommended (long edge labels may clip). |
 | onChartReady          | `(api: ChartHighlightAPI) => void`     | No       | `-`           | Called once on mount with an imperative highlight handle. Use `api.highlight(index)` to emphasise a bar; `api.highlight(null)` clears. `api.getCategories()` returns the ordered label list. `api.type` is always `'bar-chart'`.                                              |
 | highlightedIndex      | `number \| null`                       | No       | `null`        | Declarative highlight: the bar at this zero-based index is shown at full opacity; all others are dimmed. Overrides any index set via `onChartReady`. Set to `null` to show all bars normally.                                                                                 |
 | normaliseToFirstPoint | `boolean`                              | No       | `false`       | When `true`, each series' values are expressed as a percentage of that series' own first data point (baseline = 100). Series whose first point is zero are left unchanged.                                                                                                    |
@@ -181,6 +182,14 @@ Render axes, gridlines, and legend without drawing any bar rectangles — useful
 | interactiveLegend | `boolean` | No | `false` | Legend items become click/keyboard toggles for series visibility; hidden series are removed from the plot and the scales rescale to the remaining data. |
 | hideLegendBelow | `number` | No | `360` | Hide the legend when the measured chart width is below this pixel value; `0` disables the behavior. |
 | tooltipPortal | `boolean` | No | `false` | Render the tooltip into `document.body` (`position: fixed`) so scroll/overflow ancestors never clip it. |
+
+### Bar corner rounding
+
+Grouped and single bars round only their **value end** (per the design-system bar spec): a vertical
+bar rounds its top corners (bottom when the value is negative), a horizontal bar its right corners
+(left when negative), and floating `[low, high]` range bars round both ends. This keeps a backdrop
+or track bar behind the value bar from peeking through notches at the baseline corners (the old
+all-corner `rx` rounding). Stacked bars keep their existing outer-end-only rounding.
 
 ## Events
 

--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -78,6 +78,7 @@
     stackNormalize = false,
     scrollable = false,
     minBandWidth = 48,
+    marginX,
     tooltipSnippet,
     empty,
     renderOverlay,
@@ -309,7 +310,19 @@
       base: { top: 20, left: showYAxis ? 50 : 28, right: 28, bottom: showXAxis ? 40 : 8 }
     });
   });
-  let dims = $derived(layout);
+  let dims = $derived.by(() => {
+    if (marginX == null) {
+      return layout;
+    }
+    // Fixed horizontal inset: overrides the auto layout's tick-label padding
+    // so the plot (and its edge bars) runs to the requested inset.
+    const inset = Math.max(0, marginX);
+    return {
+      ...layout,
+      margin: { ...layout.margin, left: inset, right: inset },
+      innerWidth: Math.max(0, chartWidth - inset * 2)
+    };
+  });
 
   let catScale = $derived(
     createBandScale(labels, isVertical ? [0, dims.innerWidth] : [0, dims.innerHeight], barPadding)
@@ -608,6 +621,38 @@
       const br = isLast ? barRadius : 0;
       return roundedRectPath(bar.x, bar.y, bar.width, bar.height, tl, tr, br, bl);
     }
+  }
+
+  // Grouped/single bars round only their value end (design-system bar spec):
+  // a vertical bar rounds its top (bottom when the value is negative), a
+  // horizontal bar its right (left when negative). The old all-corner rect
+  // rounding let the backdrop/track behind a bar peek through the notches at
+  // its baseline corners. Floating [low, high] range bars round both ends.
+  function valueEndBarPath(bar: BarRect): string {
+    if (barRadius <= 0) {
+      return roundedRectPath(bar.x, bar.y, bar.width, bar.height, 0, 0, 0, 0);
+    }
+    if (bar.isFloating) {
+      return roundedRectPath(
+        bar.x,
+        bar.y,
+        bar.width,
+        bar.height,
+        barRadius,
+        barRadius,
+        barRadius,
+        barRadius
+      );
+    }
+    const isNegative = (bar.dataPoint.value ?? 0) < 0;
+    if (isVertical) {
+      return isNegative
+        ? roundedRectPath(bar.x, bar.y, bar.width, bar.height, 0, 0, barRadius, barRadius)
+        : roundedRectPath(bar.x, bar.y, bar.width, bar.height, barRadius, barRadius, 0, 0);
+    }
+    return isNegative
+      ? roundedRectPath(bar.x, bar.y, bar.width, bar.height, barRadius, 0, 0, barRadius)
+      : roundedRectPath(bar.x, bar.y, bar.width, bar.height, 0, barRadius, barRadius, 0);
   }
 
   // ── Fill attribute helper ──────────────────────────────────────
@@ -918,7 +963,7 @@
                       onclick={() => handleClick(bar)}
                     />
                   {:else}
-                    <rect
+                    <path
                       class="bar"
                       class:hovered={hovered?.si === bar.si && hovered?.pi === bar.pi}
                       class:highlighted={effectiveHighlightedIndex !== null &&
@@ -927,12 +972,7 @@
                         (hovered.si !== bar.si || hovered.pi !== bar.pi)) ||
                         (effectiveHighlightedIndex !== null &&
                           effectiveHighlightedIndex !== bar.pi)}
-                      x={bar.x}
-                      y={bar.y}
-                      width={bar.width}
-                      height={bar.height}
-                      rx={barRadius}
-                      ry={barRadius}
+                      d={valueEndBarPath(bar)}
                       fill={barFillAttr(bar)}
                       data-pw={`bar-${i}`}
                       tabindex="0"

--- a/src/lib/BarChart/properties.ts
+++ b/src/lib/BarChart/properties.ts
@@ -174,6 +174,14 @@ export type OptionalBarChartProperties = {
    * is `false`. Default is `48`.
    */
   minBandWidth?: number;
+  /**
+   * Fixed horizontal inset (px) between the svg edges and the plot, overriding
+   * the auto-computed left/right margins. Use for edge-to-edge funnels where
+   * the auto layout's tick-label padding leaves dead space beside the first and
+   * last bars. Category tick labels near the edges may clip if they are wider
+   * than their band, so pair small values with short labels.
+   */
+  marginX?: number;
   tooltipSnippet?: Snippet<[BarChartDataPoint, number]>;
   empty?: Snippet;
   /**


### PR DESCRIPTION
## What

1. **`marginX` prop** — fixed horizontal inset (px) between the svg edges and the plot, overriding the auto layout's computed left/right margins. The auto layout's tick-label padding left ~28px/72px of dead space beside the first/last bars of Lighthouse's edge-to-edge conversion funnel. Documented caveat: long edge category labels may clip at tiny insets.
2. **Value-end-only bar rounding** (design-system bar spec) — grouped/single bars round only their value end: vertical bars round the top corners (bottom when the value is negative), horizontal bars the right (left when negative); floating `[low, high]` range bars round both ends. The old all-corner `rx`/`ry` rect rounding let a track/backdrop bar behind the value bar peek through the notches at its baseline corners. Stacked bars keep their existing outer-end rounding (untouched).

## Consumer

Lighthouse analytics conversion funnel (filled-track pattern: a 100% track chart behind the value chart) — track edges visibly poked out around every bar's bottom corners, and the funnel had large dead margins instead of the Figma's edge-to-edge composition.

## Checks

`svelte-check` 0 errors; existing unit tests pass (rounding reuses the tested `roundedRectPath`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `marginX` option to set a fixed horizontal inset between the chart edges and plot area.
  * Improved bar corner rounding for positive, negative, range, grouped, and stacked bars.
* **Documentation**
  * Documented the new horizontal margin option and bar corner-rounding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->