### PR TITLE
fix(SankeyChart): single global px-per-value scale so ribbons stay flush inside node bars

### DIFF
--- a/docs/SankeyChart.md
+++ b/docs/SankeyChart.md
@@ -1,6 +1,6 @@
 # SankeyChart
 
-A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Link widths are proportional to flow values. Hovering highlights all connected nodes and dims unrelated ones (opt-out via `disableDimOnHover`). Supports a configurable minimum link/node thickness (`minLinkWidth`) so tiny flows remain visible, and a horizontal label offset (`dataLabelOffsetX`) for fine-grained spacing between node bars and their text labels.
+A responsive SVG Sankey diagram for visualizing flows between nodes. Automatically positions nodes into columns via topological ordering and iterative relaxation. Node heights and link widths share one global px-per-value scale (set by the tightest column), so equal values render equally tall in every column and each node's ribbon stack sits flush inside its bar — ribbons never spill past a bar's bottom edge. Hovering highlights all connected nodes and dims unrelated ones (opt-out via `disableDimOnHover`). Supports a configurable minimum link/node thickness (`minLinkWidth`) so tiny flows remain visible, and a horizontal label offset (`dataLabelOffsetX`) for fine-grained spacing between node bars and their text labels.
 
 ## Usage
 

--- a/src/lib/_chart/geometry.test.ts
+++ b/src/lib/_chart/geometry.test.ts
@@ -1,6 +1,68 @@
 import { describe, expect, it } from 'vitest';
 import { computeAutoLayout, computeSankeyLayout } from './geometry';
 
+// Real-shaped payment funnel (7 columns, mid-funnel exits, wide value spread) —
+// shared by the drift and ribbon-flushness regressions below.
+const paymentFunnelNodes = [
+  { id: 'START' },
+  { id: 'ENTERED MOBILE NUMBER' },
+  { id: 'MOBILE NUMBER SKIPPED' },
+  { id: 'EXIT AT MOBILE NUMBER' },
+  { id: 'ENTERED OTP' },
+  { id: 'OTP SKIPPED' },
+  { id: 'EXIT AT OTP' },
+  { id: 'ADDED PROFILE DETAILS' },
+  { id: 'PROFILE DETAILS SKIPPED' },
+  { id: 'EXIT AT PROFILE DETAILS' },
+  { id: 'ADDED ADDRESS' },
+  { id: 'ADDRESS SKIPPED' },
+  { id: 'EXIT AT ADDRESS' },
+  { id: 'CASH' },
+  { id: 'UPI' },
+  { id: 'DEBIT CARD' },
+  { id: 'NB' },
+  { id: 'WALLET' },
+  { id: 'PAGE EXPIRED' },
+  { id: 'EXIT AT PAYMENT PAGE' },
+  { id: 'EXIT AT PREVIOUS STAGE' },
+  { id: 'SUCCESS' },
+  { id: 'PENDING' },
+  { id: 'FAILED' }
+];
+const paymentFunnelLinks = [
+  { source: 'START', target: 'ENTERED MOBILE NUMBER', value: 400 },
+  { source: 'START', target: 'MOBILE NUMBER SKIPPED', value: 500 },
+  { source: 'START', target: 'EXIT AT MOBILE NUMBER', value: 150 },
+  { source: 'ENTERED MOBILE NUMBER', target: 'ENTERED OTP', value: 350 },
+  { source: 'ENTERED MOBILE NUMBER', target: 'EXIT AT OTP', value: 50 },
+  { source: 'MOBILE NUMBER SKIPPED', target: 'OTP SKIPPED', value: 450 },
+  { source: 'MOBILE NUMBER SKIPPED', target: 'EXIT AT OTP', value: 50 },
+  { source: 'ENTERED OTP', target: 'ADDED PROFILE DETAILS', value: 300 },
+  { source: 'ENTERED OTP', target: 'EXIT AT PROFILE DETAILS', value: 50 },
+  { source: 'OTP SKIPPED', target: 'PROFILE DETAILS SKIPPED', value: 400 },
+  { source: 'OTP SKIPPED', target: 'EXIT AT PROFILE DETAILS', value: 50 },
+  { source: 'ADDED PROFILE DETAILS', target: 'ADDED ADDRESS', value: 250 },
+  { source: 'ADDED PROFILE DETAILS', target: 'EXIT AT ADDRESS', value: 50 },
+  { source: 'PROFILE DETAILS SKIPPED', target: 'ADDRESS SKIPPED', value: 350 },
+  { source: 'PROFILE DETAILS SKIPPED', target: 'EXIT AT ADDRESS', value: 50 },
+  { source: 'ADDED ADDRESS', target: 'CASH', value: 20 },
+  { source: 'ADDED ADDRESS', target: 'UPI', value: 60 },
+  { source: 'ADDED ADDRESS', target: 'DEBIT CARD', value: 100 },
+  { source: 'ADDED ADDRESS', target: 'EXIT AT PAYMENT PAGE', value: 70 },
+  { source: 'ADDRESS SKIPPED', target: 'NB', value: 30 },
+  { source: 'ADDRESS SKIPPED', target: 'WALLET', value: 40 },
+  { source: 'ADDRESS SKIPPED', target: 'PAGE EXPIRED', value: 30 },
+  { source: 'ADDRESS SKIPPED', target: 'EXIT AT PAYMENT PAGE', value: 250 },
+  { source: 'CASH', target: 'SUCCESS', value: 18 },
+  { source: 'UPI', target: 'SUCCESS', value: 50 },
+  { source: 'DEBIT CARD', target: 'SUCCESS', value: 70 },
+  { source: 'DEBIT CARD', target: 'PENDING', value: 20 },
+  { source: 'NB', target: 'SUCCESS', value: 20 },
+  { source: 'WALLET', target: 'SUCCESS', value: 30 },
+  { source: 'PAGE EXPIRED', target: 'FAILED', value: 30 },
+  { source: 'EXIT AT PAYMENT PAGE', target: 'EXIT AT PREVIOUS STAGE', value: 320 }
+];
+
 describe('computeSankeyLayout', () => {
   it('produces finite node positions when every link weight is zero (no NaN collapse)', () => {
     // Real-world "store with no funnel completions" case: every transition has
@@ -67,67 +129,17 @@ describe('computeSankeyLayout', () => {
     // Regression for the multi-stage funnel that progressively drifted downward
     // and overflowed its own height budget column-to-column.
     const height = 527;
-    const nodes = [
-      { id: 'START' },
-      { id: 'ENTERED MOBILE NUMBER' },
-      { id: 'MOBILE NUMBER SKIPPED' },
-      { id: 'EXIT AT MOBILE NUMBER' },
-      { id: 'ENTERED OTP' },
-      { id: 'OTP SKIPPED' },
-      { id: 'EXIT AT OTP' },
-      { id: 'ADDED PROFILE DETAILS' },
-      { id: 'PROFILE DETAILS SKIPPED' },
-      { id: 'EXIT AT PROFILE DETAILS' },
-      { id: 'ADDED ADDRESS' },
-      { id: 'ADDRESS SKIPPED' },
-      { id: 'EXIT AT ADDRESS' },
-      { id: 'CASH' },
-      { id: 'UPI' },
-      { id: 'DEBIT CARD' },
-      { id: 'NB' },
-      { id: 'WALLET' },
-      { id: 'PAGE EXPIRED' },
-      { id: 'EXIT AT PAYMENT PAGE' },
-      { id: 'EXIT AT PREVIOUS STAGE' },
-      { id: 'SUCCESS' },
-      { id: 'PENDING' },
-      { id: 'FAILED' }
-    ];
-    const links = [
-      { source: 'START', target: 'ENTERED MOBILE NUMBER', value: 400 },
-      { source: 'START', target: 'MOBILE NUMBER SKIPPED', value: 500 },
-      { source: 'START', target: 'EXIT AT MOBILE NUMBER', value: 150 },
-      { source: 'ENTERED MOBILE NUMBER', target: 'ENTERED OTP', value: 350 },
-      { source: 'ENTERED MOBILE NUMBER', target: 'EXIT AT OTP', value: 50 },
-      { source: 'MOBILE NUMBER SKIPPED', target: 'OTP SKIPPED', value: 450 },
-      { source: 'MOBILE NUMBER SKIPPED', target: 'EXIT AT OTP', value: 50 },
-      { source: 'ENTERED OTP', target: 'ADDED PROFILE DETAILS', value: 300 },
-      { source: 'ENTERED OTP', target: 'EXIT AT PROFILE DETAILS', value: 50 },
-      { source: 'OTP SKIPPED', target: 'PROFILE DETAILS SKIPPED', value: 400 },
-      { source: 'OTP SKIPPED', target: 'EXIT AT PROFILE DETAILS', value: 50 },
-      { source: 'ADDED PROFILE DETAILS', target: 'ADDED ADDRESS', value: 250 },
-      { source: 'ADDED PROFILE DETAILS', target: 'EXIT AT ADDRESS', value: 50 },
-      { source: 'PROFILE DETAILS SKIPPED', target: 'ADDRESS SKIPPED', value: 350 },
-      { source: 'PROFILE DETAILS SKIPPED', target: 'EXIT AT ADDRESS', value: 50 },
-      { source: 'ADDED ADDRESS', target: 'CASH', value: 20 },
-      { source: 'ADDED ADDRESS', target: 'UPI', value: 60 },
-      { source: 'ADDED ADDRESS', target: 'DEBIT CARD', value: 100 },
-      { source: 'ADDED ADDRESS', target: 'EXIT AT PAYMENT PAGE', value: 70 },
-      { source: 'ADDRESS SKIPPED', target: 'NB', value: 30 },
-      { source: 'ADDRESS SKIPPED', target: 'WALLET', value: 40 },
-      { source: 'ADDRESS SKIPPED', target: 'PAGE EXPIRED', value: 30 },
-      { source: 'ADDRESS SKIPPED', target: 'EXIT AT PAYMENT PAGE', value: 250 },
-      { source: 'CASH', target: 'SUCCESS', value: 18 },
-      { source: 'UPI', target: 'SUCCESS', value: 50 },
-      { source: 'DEBIT CARD', target: 'SUCCESS', value: 70 },
-      { source: 'DEBIT CARD', target: 'PENDING', value: 20 },
-      { source: 'NB', target: 'SUCCESS', value: 20 },
-      { source: 'WALLET', target: 'SUCCESS', value: 30 },
-      { source: 'PAGE EXPIRED', target: 'FAILED', value: 30 },
-      { source: 'EXIT AT PAYMENT PAGE', target: 'EXIT AT PREVIOUS STAGE', value: 320 }
-    ];
 
-    const { nodes: computed } = computeSankeyLayout(nodes, links, 1080 - 16, height, 16, 8, 6, 2);
+    const { nodes: computed } = computeSankeyLayout(
+      paymentFunnelNodes,
+      paymentFunnelLinks,
+      1080 - 16,
+      height,
+      16,
+      8,
+      6,
+      2
+    );
 
     const columnGroups = new Map<number, typeof computed>();
     for (const node of computed) {
@@ -143,6 +155,64 @@ describe('computeSankeyLayout', () => {
         `column ${column} bottom (${columnBottom}) exceeds height (${height})`
       ).toBeLessThanOrEqual(height);
     }
+  });
+
+  it('keeps every ribbon flush inside both of its nodes — no spill past a bar edge', () => {
+    // Regression for ribbons extending below the bottom node row: link widths
+    // were sized at the source column's px-per-value scale while target nodes
+    // were laid out at their own column's scale, so on real funnel data the
+    // incoming stacks overran target bars by 15-27px and painted past the
+    // deepest node's bottom edge.
+    const { nodes: computed, links: computedLinks } = computeSankeyLayout(
+      paymentFunnelNodes,
+      paymentFunnelLinks,
+      1080 - 16,
+      527,
+      16,
+      14,
+      6,
+      2
+    );
+
+    const nodeById = new Map(computed.map((node) => [node.id, node]));
+    const epsilon = 1e-6;
+    for (const link of computedLinks) {
+      const sourceNode = nodeById.get(link.source)!;
+      const targetNode = nodeById.get(link.target)!;
+      const label = `${link.source} -> ${link.target}`;
+      expect(link.sourceY - link.width / 2, `${label} top vs source top`).toBeGreaterThanOrEqual(
+        sourceNode.y - epsilon
+      );
+      expect(link.sourceY + link.width / 2, `${label} bottom vs source bottom`).toBeLessThanOrEqual(
+        sourceNode.y + sourceNode.height + epsilon
+      );
+      expect(link.targetY - link.width / 2, `${label} top vs target top`).toBeGreaterThanOrEqual(
+        targetNode.y - epsilon
+      );
+      expect(link.targetY + link.width / 2, `${label} bottom vs target bottom`).toBeLessThanOrEqual(
+        targetNode.y + targetNode.height + epsilon
+      );
+    }
+  });
+
+  it('renders equal values at equal heights in every column (one global scale)', () => {
+    const { nodes: computed } = computeSankeyLayout(
+      paymentFunnelNodes,
+      paymentFunnelLinks,
+      1080 - 16,
+      527,
+      16,
+      8,
+      6,
+      2
+    );
+
+    const heightOf = (id: string): number => computed.find((node) => node.id === id)!.height;
+
+    // Same value (320) in different columns must render identically tall.
+    expect(heightOf('EXIT AT PAYMENT PAGE')).toBeCloseTo(heightOf('EXIT AT PREVIOUS STAGE'), 5);
+    // Heights stay proportional to values across columns (no per-column stretch).
+    expect(heightOf('START') / heightOf('UPI')).toBeCloseTo(1050 / 60, 5);
   });
 });
 

--- a/src/lib/_chart/geometry.ts
+++ b/src/lib/_chart/geometry.ts
@@ -226,33 +226,59 @@ export function computeSankeyLayout(
   const colWidth = maxCol === 0 ? 0 : (width - nodeWidth) / maxCol;
   const columnPadding = new Map<number, number>();
 
-  // Initialize y positions
+  // Global px-per-value scale (d3-sankey's `ky`): the tightest column — least
+  // height left after node gaps — sets one scale for the whole diagram, so a
+  // given value renders the same height in every column. The previous layout
+  // stretched every column to fill the full plot height, which gave each
+  // column its own scale; link widths (sized at the source column's scale)
+  // then overflowed target nodes laid out at a smaller scale, and the ribbon
+  // stacks spilled below the bottom node row.
+  let pxPerValue = Number.POSITIVE_INFINITY;
+  for (const ids of columnGroups.values()) {
+    const totalValue = ids.reduce((s, id) => s + (nodeValues.get(id) ?? 0), 0);
+    const availableHeight = height - (ids.length - 1) * nodePadding;
+    if (totalValue > 0 && availableHeight > 0) {
+      pxPerValue = Math.min(pxPerValue, availableHeight / totalValue);
+    }
+  }
+  if (!Number.isFinite(pxPerValue)) {
+    // All-zero data: nothing carries volume, every bar collapses to the minimum.
+    pxPerValue = 0;
+  }
+
+  const linkRenderWidth = (value: number): number => Math.max(minLinkWidth, value * pxPerValue);
+
+  // Initialize y positions. A node must be at least as tall as its thicker
+  // side's rendered link stack: every ribbon is clamped to minLinkWidth, so a
+  // node fanning into many near-zero links would otherwise be shorter than the
+  // inflated stack attached to it.
   const nodeY = new Map<string, number>();
   const nodeH = new Map<string, number>();
   for (const [col, ids] of columnGroups) {
-    const totalValue = ids.reduce((s, id) => s + (nodeValues.get(id) ?? 0), 0);
     const gapCount = ids.length - 1;
-    const availableHeight = height - gapCount * nodePadding;
     const renderedHeights = ids.map((id) => {
-      const val = nodeValues.get(id) ?? 0;
-      const h =
-        totalValue > 0 ? (val / totalValue) * availableHeight : availableHeight / ids.length;
-      return Math.max(minLinkWidth, h);
+      const outStack = (outgoing.get(id) ?? []).reduce(
+        (s, link) => s + linkRenderWidth(link.value),
+        0
+      );
+      const inStack = (incoming.get(id) ?? []).reduce(
+        (s, link) => s + linkRenderWidth(link.value),
+        0
+      );
+      return Math.max(minLinkWidth, (nodeValues.get(id) ?? 0) * pxPerValue, outStack, inStack);
     });
 
     const sumRendered = renderedHeights.reduce((s, h) => s + h, 0);
     const paddingBudget = gapCount > 0 ? (height - sumRendered) / gapCount : 0;
     const effectivePadding = Math.max(0, Math.min(nodePadding, paddingBudget));
-    const scale = sumRendered > height && sumRendered > 0 ? height / sumRendered : 1;
     columnPadding.set(col, effectivePadding);
 
     let y = 0;
     for (let index = 0; index < ids.length; index++) {
       const id = ids[index];
-      const renderedH = renderedHeights[index] * scale;
       nodeY.set(id, y);
-      nodeH.set(id, renderedH);
-      y += renderedH + effectivePadding;
+      nodeH.set(id, renderedHeights[index]);
+      y += renderedHeights[index] + effectivePadding;
     }
   }
 
@@ -336,11 +362,11 @@ export function computeSankeyLayout(
   const nodeById = new Map(computedNodes.map((n) => [n.id, n]));
 
   const linkKey = (l: { source: string; target: string }): string => `${l.source} ${l.target}`;
+  // Link widths use the same global scale as node heights, so each node's link
+  // stack fills its bar exactly and never runs past its bottom edge.
   const linkWidths = new Map<string, number>();
   for (const l of links) {
-    const sVal = nodeValues.get(l.source) ?? 1;
-    const sourceH = nodeH.get(l.source) ?? 0;
-    linkWidths.set(linkKey(l), Math.max(minLinkWidth, (l.value / Math.max(sVal, 1)) * sourceH));
+    linkWidths.set(linkKey(l), linkRenderWidth(l.value));
   }
   const linkSy = new Map<string, number>();
   const linkTy = new Map<string, number>();


### PR DESCRIPTION
## Problem

`computeSankeyLayout` stretched **every column to fill the full plot height**, giving each column its own px-per-value scale (columns with more nodes lose more height to `nodePadding` gaps). Link widths, however, were sized **only at the source column's scale** — so at any target node laid out at a smaller scale, the incoming ribbon stack summed to more than the node's height. On real payment-funnel data (Lighthouse User funnel) ribbons overran target bars by **15–27px** and painted past the deepest node row — visibly "extending beyond the edges at the bottom side".

`minLinkWidth` inflation compounded it: nodes fanning into many near-zero links (e.g. CREATED with 15+ inflows clamped to 2px each) received stacks taller than their value-proportional height.

## Fix

- One **global px-per-value scale** (d3-sankey's `ky`), set by the tightest column: equal values render equally tall in every column; columns are value-true instead of stretched (matches the Breeze analytics Figma, where the Start column does not fill the plot).
- Node heights are additionally inflated to fit their `minLinkWidth`-clamped stacks (`max(value·ky, Σ clamped out-links, Σ clamped in-links)`), so no ribbon can leave its bar.
- Link widths use the same scale — each node's ribbon stack fills its bar exactly.

## Tests

- New: per-link flush containment on the real funnel dataset (every ribbon edge within both of its bars, source and target side).
- New: cross-column height equality for equal values + proportionality (no per-column stretch).
- All existing sankey regressions (zero-volume NaN guard, fan-out centring, column drift) still pass — `10/10` in `geometry.test.ts`.

## Note on CI

The Table functional specs (`tests/table-builtin-cells.test.ts`, `table-header-meta`, `table-pagination-selection` — 9 tests) **already fail on clean `origin/release`** (verified by stashing this change and re-running); they are untouched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sankey charts now use a consistent global scale across columns.
  * Nodes with equal values render at equal heights, while sizes remain proportional to their values.
  * Link widths align with the same scale for clearer visual comparisons.
  * Ribbons remain fully contained within their source and target nodes, preventing overflow past bar edges.

* **Documentation**
  * Updated Sankey chart guidance to explain the unified sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->