### PR TITLE
feat(Table): summaryRowIndex — DataGrid-parity summary-row highlight

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -144,6 +144,12 @@ The standalone `sortTableRows(rows, columnIndex, direction, options?)` export so
 
 `rowNumberColumn` prepends a 1-based, pagination-aware sequence column.
 
+`summaryRowIndex` marks one row (by its index in the consumer-supplied `rows`, pre-sort/pre-filter) as a summary/period-total row: it gets the `table-summary-row` class and a distinct background from `--table-summary-row-background` (falling back to the regular cell background when the token is unset). Because the row is matched by its original position, the highlight survives sorting, searching, and pagination. Pair it with `sortTableRows(..., { hasSummaryRow: true })` to also pin the row in place during client-side re-sorts.
+
+```svelte
+<Table {columns} {rows} summaryRowIndex={0} />
+```
+
 ### Controlled Selection + Bulk Toolbar
 
 `checkboxSelection.selectedIds` switches selection to controlled mode: Table renders from the consumer's set and never mutates it — `onSelectionChange` reports the would-be next set (required for cross-page-persistent selection under server pagination). Omitting it keeps the internal uncontrolled behavior exactly as before. `getRowAttributes(rowId, rowIndex)` spreads arbitrary attributes onto each row checkbox (`rowIndex` is `-1` for the header select-all) — an escape hatch for consumer-specific attributes such as native test IDs. `toolbarSlot` renders a bulk-action bar above the table while the selection is non-empty; the library owns only placement, the content is consumer-rendered:
@@ -507,6 +513,7 @@ Override these custom properties to theme the component.
 | `--table-row-alt-background`      | `-`       | background-color | Background of even-numbered rows for striped effect. Falls back to `--table-row-background`.                          |
 | `--table-row-hover-background`    | `-`       | background-color | Background color of data rows on hover.                                                                               |
 | `--table-row-selected-background` | `#eff6ff` | background-color | Background of selected rows (when `checkboxSelection` is active). Applied to both the `<tr>` and its `<td>` children. |
+| `--table-summary-row-background`  | falls back to `--table-content-background` | background-color | Background of the `summaryRowIndex` row. Applied to both the `<tr>` and its `<td>` children so it wins over a themed cell background. |
 | `--table-focus-outline-color`     | `#3b82f6` | outline          | Outline color for focused clickable rows and focused search inputs.                                                   |
 
 ### Sort Controls

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -49,6 +49,7 @@
     toolbarSlot,
     rowNumberColumn = false,
     rowNumberLabel = '#',
+    summaryRowIndex = null,
     headerTooltipIcon,
     headerTooltipPosition,
     usePortal = false
@@ -796,6 +797,8 @@
                   class="table-row"
                   class:table-row-clickable={isRowClickable}
                   class:table-row-selected={rowSelected}
+                  class:table-summary-row={summaryRowIndex !== null &&
+                    originalIndex === summaryRowIndex}
                   data-pw={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
                   onclick={isRowClickable
                     ? () => handleRowClick(rowIndex, row, originalIndex)
@@ -1251,6 +1254,17 @@
 
   .table-row-selected > .table-content {
     background-color: var(--table-row-selected-background, #eff6ff);
+  }
+
+  /* Summary/period-total row (summaryRowIndex): both the row and its cells,
+     since a themed --table-content-background would otherwise paint over a
+     row-level background. Falls back to the regular cell background. */
+  .table-summary-row {
+    background-color: var(--table-summary-row-background, var(--table-content-background));
+  }
+
+  .table-summary-row > .table-content {
+    background-color: var(--table-summary-row-background, var(--table-content-background));
   }
 
   /* ── C2-1 Checkbox column ───────────────────────────────────────────────── */

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -432,6 +432,15 @@ export type OptionalTableProperties = {
   toolbarSlot?: Snippet<[{ selectedIds: Set<string> }]>;
   /** Prepends a sequential row-number column (1-based, pagination-aware). */
   rowNumberColumn?: boolean;
+  /**
+   * Index (into the consumer-supplied `rows`, pre-sort/pre-filter) of a
+   * summary/period-total row that renders with a distinct background — the
+   * DataGrid-parity `summaryRowIndex`. The row is matched by its original
+   * position, so it keeps its highlight through sort, search, and pagination.
+   * Background comes from `--table-summary-row-background` (falls back to the
+   * regular cell background when unset). Pass `null`/omit for no summary row.
+   */
+  summaryRowIndex?: number | null;
   /** Header label for the row-number column. Defaults to `'#'`. */
   rowNumberLabel?: string;
   /**


### PR DESCRIPTION
Adds `summaryRowIndex?: number | null` to Table: the row at that original (pre-sort/pre-filter) index gets the `table-summary-row` class and a distinct background from `--table-summary-row-background` (falls back to the regular cell background when unset). Matching by `originalIndex` keeps the highlight stable through sort, search, and pagination; both the `<tr>` and its `<td>` children are painted so a themed `--table-content-background` can't cover it (same pattern as `table-row-selected`).

Restores the DataGrid-parity summary/period-total row treatment that consumers lost in the DataGrid → Table migration (Lighthouse analytics compare tables carry an explicit code comment documenting the dropped highlight; wiring lands there once this releases). Docs updated (prop + CSS var). svelte-check 0 errors; Table unit suite 31/31.