### PR TITLE
feat(LineChart): per-series dash + single-point flat line

### DIFF
--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -141,6 +141,23 @@ Highlight a point without a callback. Set `highlightedIndex` to a zero-based poi
 <LineChart {series} showValues />
 ```
 
+### Dashed Comparison Series
+
+Set `dash` on a series to render it with a dashed stroke — the standard treatment for a comparison/previous-period line. `true` uses the default `'6 4'` pattern; pass a string for a custom SVG `stroke-dasharray`.
+
+```svelte
+<LineChart
+  series={[
+    { name: 'This week', data: current },
+    { name: 'Last week', data: previous, color: '#A4CEFF', dash: true }
+  ]}
+/>
+```
+
+### Single Data Point
+
+A series whose data resolves to a single finite point renders as a **flat horizontal line at that y across the full plot width** (design-system contract — a lone dot reads as a glitch). The point marker still renders at its true x, and hover/tooltip behave normally.
+
 ### Without Dots (Overlay Hover)
 
 ```svelte
@@ -289,6 +306,8 @@ type LineChartSeries = {
   name: string;
   data: LineChartDataPoint[];
   color?: string;
+  /** Dashed stroke: true = '6 4', string = custom stroke-dasharray. */
+  dash?: boolean | string;
 };
 
 type LineChartTooltipContext = {

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -204,11 +204,25 @@
     series.map((s, si) => {
       const color = s.color ?? getColor(si);
       const points: Point[] = s.data.map((d) => ({ x: xScale(d.x), y: yScale(d.y) }));
+      const finitePoints = points.filter(
+        (point) => Number.isFinite(point.x) && Number.isFinite(point.y)
+      );
+      // Design-system contract: a series with a single data point renders as a
+      // flat line at that y across the full plot width (a lone dot reads as a
+      // glitch), while the point marker itself still renders at its true x.
+      const isSinglePoint = finitePoints.length === 1;
+      const pathPoints: Point[] = isSinglePoint
+        ? [
+            { x: 0, y: finitePoints[0].y },
+            { x: dims.innerWidth, y: finitePoints[0].y }
+          ]
+        : points;
       return {
         color,
         points,
-        path: linePath(points, curve),
-        areaD: areaPath(points, dims.innerHeight, curve),
+        dash: s.dash === true ? '6 4' : typeof s.dash === 'string' ? s.dash : null,
+        path: linePath(pathPoints, isSinglePoint ? 'linear' : curve),
+        areaD: areaPath(pathPoints, dims.innerHeight, isSinglePoint ? 'linear' : curve),
         hidden: hiddenSeries.has(si)
       };
     })
@@ -639,6 +653,7 @@
                 d={line.path}
                 stroke={line.color}
                 stroke-width={strokeWidth}
+                stroke-dasharray={line.dash}
                 fill="none"
               />
               {#if line.points.length === 1 && !showDots && Number.isFinite(line.points[0].x) && Number.isFinite(line.points[0].y)}

--- a/src/lib/LineChart/properties.ts
+++ b/src/lib/LineChart/properties.ts
@@ -12,6 +12,12 @@ export type LineChartSeries = {
   name: string;
   data: LineChartDataPoint[];
   color?: string;
+  /**
+   * Dashed stroke for this series (e.g. a comparison/previous-period line).
+   * `true` uses the default `'6 4'` pattern; a string is passed through as a
+   * custom SVG `stroke-dasharray`. Omit for a solid line.
+   */
+  dash?: boolean | string;
 };
 
 export type LineChartTooltipContext = {


### PR DESCRIPTION
Two design-system line-chart contracts:

1. **`LineChartSeries.dash?: boolean | string`** — dashed stroke per series (comparison/previous-period treatment). `true` → default `'6 4'`; string → custom `stroke-dasharray`. Replaces consumer-side CSS tunnels keyed to stroke color (Lighthouse carries exactly that hack today, with a comment asking for this prop).
2. **Single-point flat line** — a series with one finite data point renders as a horizontal line at that y across the plot width (DS annotation: 'When only one data point is available, show graph as a flat line at that y value'); the marker still renders at its true x. Previously a lone circle.

Note: the DS 'max 6 x-ticks' contract is already enforced (xTickCount clamp with the spec comment) — no change needed.

svelte-check 0 errors; LineChart+_chart suites 67/67.