### PR TITLE
feat(StatCard): DS trend states (— 0% / N/A) + inline comparison denominator

### DIFF
--- a/docs/StatCard.md
+++ b/docs/StatCard.md
@@ -197,7 +197,7 @@ The header renders even without a title. `onCheckboxChange` fires with the new c
 | subtitle      | `string`                      | No       | `-`     | Secondary label rendered below the value row.                                                                                                         |
 | footer        | `Snippet`                     | No       | `-`     | Snippet rendered in the card footer area, separated by a border-top line.                                                                             |
 | valueSnippet  | `Snippet`                     | No       | `-`     | Replaces the string `value` with a custom snippet for advanced value rendering.                                                                       |
-| rows          | `StatCardRow[]`               | No       | `-`     | Multiple metric rows. When set, replaces the single value/delta row with a divider-separated column. Each row supports `heading`, `change`, `invertChangeColors`, `tooltip`, `additionalContent`, `breakdownHeading`, and a `breakdown` grid. |
+| rows          | `StatCardRow[]`               | No       | `-`     | Multiple metric rows. When set, replaces the single value/delta row with a divider-separated column. Each row supports `heading`, `comparisonValue` (inline "/ ₹10L" denominator), `change` (`number` renders the delta with a "—" glyph at 0; `null` renders "N/A"; `undefined` renders nothing), `invertChangeColors`, `tooltip`, `additionalContent`, `breakdownHeading`, and a `breakdown` grid. |
 | rowsDirection | `'column' \| 'row'`           | No       | `'column'` | Layout direction for `rows`. `'column'` stacks rows vertically with horizontal dividers; `'row'` lays the sections side by side with vertical dividers, each section flexing to share the width equally. |
 | tooltip       | `StatCardTooltip`             | No       | `-`     | Tooltip shown on the card title — `{ text, position?, testId? }`.                                                                                     |
 | checkbox      | `{ text: string; checked?: boolean }` | No | `-` | Renders a checkbox next to the title. The header is shown even when `title` is omitted. Pair with `onCheckboxChange` for a controlled checkbox.       |
@@ -252,6 +252,11 @@ Override these custom properties to theme the component.
 | `--statcard-delta-line-height`    | `1.4`                    | line-height    | Line height of the delta badge.                                              |
 | `--statcard-delta-positive-color` | `#16a34a`                | color          | Colour of a positive delta (`+` prefix or `deltaPositive={true}`).           |
 | `--statcard-delta-negative-color` | `#dc2626`                | color          | Colour of a negative delta (`-` prefix or `deltaPositive={false}`).          |
+| `--statcard-delta-na-color`       | falls back to `--statcard-delta-color` | color | Colour of the "N/A" state rendered when a row's `change` is `null`.  |
+| `--statcard-comparison-font-size` | `16px`                   | font-size      | Font size of the inline `comparisonValue` denominator ("/ ₹10L").            |
+| `--statcard-comparison-font-weight` | `700`                  | font-weight    | Font weight of the inline comparison denominator.                            |
+| `--statcard-comparison-color`     | `#c7c7c7`                | color          | Colour of the inline comparison denominator.                                 |
+| `--statcard-comparison-line-height` | `1.4`                  | line-height    | Line height of the inline comparison denominator.                            |
 | `--statcard-subtitle-font-size`   | `12px`                   | font-size      | Font size of the subtitle label.                                             |
 | `--statcard-subtitle-font-weight` | `400`                    | font-weight    | Font weight of the subtitle label.                                           |
 | `--statcard-subtitle-color`       | `#9ca3af`                | color          | Colour of the subtitle label.                                                |

--- a/src/lib/DeltaIndicator/DeltaIndicator.svelte
+++ b/src/lib/DeltaIndicator/DeltaIndicator.svelte
@@ -44,6 +44,10 @@
         ><path d="M22 7L13.5 15.5L8.5 10.5L2 17" /><path d="M16 7H22V13" /></svg
       >
     </span>
+  {:else if !hideArrow}
+    <!-- Neutral/no-change glyph (design-system "— 0%" treatment): an em dash in
+         place of the trend arrow, so a flat delta still reads as a stated state. -->
+    <span class="delta-indicator-dash" aria-hidden="true">—</span>
   {/if}
   <span class="delta-indicator-text">{text}</span>
 </span>
@@ -82,6 +86,11 @@
     display: inline-flex;
     width: var(--delta-indicator-arrow-size, 16px);
     height: var(--delta-indicator-arrow-size, 16px);
+    flex-shrink: 0;
+  }
+
+  .delta-indicator-dash {
+    color: inherit;
     flex-shrink: 0;
   }
 

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -177,12 +177,29 @@
             >
               {row.value}
             </div>
+            {#if typeof row.comparisonValue === 'string' && row.comparisonValue.length > 0}
+              <div
+                class="statcard-comparison-value"
+                data-pw={typeof testId === 'string' ? `${testId}-comparison-${rowIndex}` : null}
+              >
+                / {row.comparisonValue}
+              </div>
+            {/if}
             {#if typeof row.change === 'number'}
               <DeltaIndicator
                 value={row.change}
                 invertColors={row.invertChangeColors ?? false}
                 testId={testId ? `${testId}-delta-${rowIndex}` : null}
               />
+            {:else if row.change === null}
+              <!-- Comparison expected but not computable — a stated "N/A" beats
+                   silently rendering nothing (design-system trend states). -->
+              <div
+                class="statcard-delta statcard-delta-na"
+                data-pw={typeof testId === 'string' ? `${testId}-delta-na-${rowIndex}` : null}
+              >
+                N/A
+              </div>
             {/if}
             {#if typeof row.additionalContent === 'string' && row.additionalContent.length > 0}
               <div class="statcard-row-additional">{row.additionalContent}</div>
@@ -390,6 +407,20 @@
 
   .statcard-delta-negative {
     color: var(--statcard-delta-negative-color, #dc2626);
+  }
+
+  .statcard-delta-na {
+    color: var(--statcard-delta-na-color, var(--statcard-delta-color, #6b7280));
+  }
+
+  /* Inline comparison denominator ("₹60k / ₹10L") — a muted, slightly smaller
+     companion to the metric value, baseline-aligned by the value row. */
+  .statcard-comparison-value {
+    font-size: var(--statcard-comparison-font-size, 16px);
+    font-weight: var(--statcard-comparison-font-weight, 700);
+    color: var(--statcard-comparison-color, #c7c7c7);
+    line-height: var(--statcard-comparison-line-height, 1.4);
+    white-space: nowrap;
   }
 
   .statcard-subtitle {

--- a/src/lib/StatCard/properties.ts
+++ b/src/lib/StatCard/properties.ts
@@ -35,8 +35,17 @@ export type StatCardRow = {
   value: string;
   /** Optional row-level heading label. */
   heading?: string;
-  /** Numeric change for the delta indicator. */
-  change?: number;
+  /**
+   * Comparison-period value rendered inline after the metric as "/ <value>"
+   * (e.g. "₹60k / ₹10L") in a muted denominator style. Omit to hide.
+   */
+  comparisonValue?: string;
+  /**
+   * Numeric change for the delta indicator. A number renders the delta
+   * (0 renders the neutral "— 0%" treatment); `null` means a comparison was
+   * expected but not computable and renders "N/A"; `undefined` renders nothing.
+   */
+  change?: number | null;
   /** Invert delta colors for lower-is-better metrics on this row. */
   invertChangeColors?: boolean;
   /** Additional descriptive text rendered after the delta. */


### PR DESCRIPTION
Design-system stat-card sheet contracts (Trend = Increasing / Decreasing / No Change / Not Available, and the optional denominator):

1. **DeltaIndicator**: neutral direction now renders an em-dash glyph before the text ('— 0%') instead of hiding the arrow slot — a flat delta reads as a stated state. `hideArrow` still suppresses it.
2. **StatCardRow.change: number | null** — `null` renders a muted **N/A** ('comparison expected but not computable'); `undefined` keeps rendering nothing (no comparison). Backward compatible.
3. **StatCardRow.comparisonValue?: string** — inline '/ <value>' denominator after the metric (DS '₹60k / ₹10L' anatomy), themed via new `--statcard-comparison-*` tokens (+ `--statcard-delta-na-color`).

svelte-check 0 errors; full unit suite 120/120. Docs updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional comparison values to StatCard rows, displayed inline with the primary metric.
  - StatCard now displays “N/A” when a comparison is unavailable.
  - Neutral changes display an em dash instead of appearing blank.

- **Documentation**
  - Updated StatCard guidance for comparison values, change states, and related styling variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->