### PR TITLE
fix: emit a native testID alongside data-pw for every testId

### DIFF
--- a/src/lib/Accordion/Accordion.svelte
+++ b/src/lib/Accordion/Accordion.svelte
@@ -45,6 +45,7 @@
   class="accordion {classes ?? ''}"
   class:expanded={expand}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <div class="accordion-content">
     {@render children?.()}

--- a/src/lib/Animations/ModalAnimation.svelte
+++ b/src/lib/Animations/ModalAnimation.svelte
@@ -45,6 +45,7 @@
       in:fly|global={flyAnimationProperties}
       out:fly|global={flyAnimationProperties}
       data-pw={typeof testId === 'string' ? testId : null}
+      testID={typeof testId === 'string' ? testId : null}
     >
       {@render children?.()}
     </div>
@@ -52,6 +53,7 @@
     <div
       in:fly|global={flyAnimationProperties}
       data-pw={typeof testId === 'string' ? testId : null}
+      testID={typeof testId === 'string' ? testId : null}
     >
       {@render children?.()}
     </div>
@@ -60,6 +62,7 @@
       in:fade|global={fadeAnimationProperties}
       out:fade|global={fadeAnimationProperties}
       data-pw={typeof testId === 'string' ? testId : null}
+      testID={typeof testId === 'string' ? testId : null}
     >
       {@render children?.()}
     </div>
@@ -67,6 +70,7 @@
     <div
       in:fade|global={fadeAnimationProperties}
       data-pw={typeof testId === 'string' ? testId : null}
+      testID={typeof testId === 'string' ? testId : null}
     >
       {@render children?.()}
     </div>

--- a/src/lib/Animations/OverlayAnimation.svelte
+++ b/src/lib/Animations/OverlayAnimation.svelte
@@ -10,6 +10,10 @@
   let { children, testId }: Props = $props();
 </script>
 
-<div out:fade={{ duration: 350 }} data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  out:fade={{ duration: 350 }}
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   {@render children?.()}
 </div>

--- a/src/lib/AreaChart/AreaChart.svelte
+++ b/src/lib/AreaChart/AreaChart.svelte
@@ -350,6 +350,7 @@
   class="area-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>

--- a/src/lib/Avatar/Avatar.svelte
+++ b/src/lib/Avatar/Avatar.svelte
@@ -47,12 +47,19 @@
     type="button"
     aria-label={alt}
     data-pw={testId}
+    testID={testId}
     {onclick}
   >
     {@render content()}
   </button>
 {:else}
-  <div class="avatar avatar-{size} {classes ?? ''}" role="img" aria-label={alt} data-pw={testId}>
+  <div
+    class="avatar avatar-{size} {classes ?? ''}"
+    role="img"
+    aria-label={alt}
+    data-pw={testId}
+    testID={testId}
+  >
     {@render content()}
   </div>
 {/if}

--- a/src/lib/Badge/Badge.svelte
+++ b/src/lib/Badge/Badge.svelte
@@ -23,7 +23,11 @@
 </script>
 
 {#if showImage}
-  <div class="badge-icon {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+  <div
+    class="badge-icon {classes ?? ''}"
+    data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
+  >
     <div class="badge-wrap">
       <img class="icon-img" src={image} {alt} />
       {#if showBadge}
@@ -38,6 +42,7 @@
     role={standaloneRole}
     aria-label={standaloneAriaLabel}
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
   >
     {isDot ? '' : (value ?? '')}
   </div>

--- a/src/lib/Banner/Banner.svelte
+++ b/src/lib/Banner/Banner.svelte
@@ -53,6 +53,7 @@
     role={role !== null ? role : interactive ? 'button' : null}
     tabindex={interactive ? 0 : null}
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
     transition:slide={{ duration: 300 }}
   >
     {#if typeof icon === 'function'}

--- a/src/lib/BarChart/BarChart.svelte
+++ b/src/lib/BarChart/BarChart.svelte
@@ -796,6 +796,7 @@
   class="bar-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
@@ -951,6 +952,7 @@
                       d={stackedBarPath(bar)}
                       fill={barFillAttr(bar)}
                       data-pw={`bar-${i}`}
+                      testID={`bar-${i}`}
                       tabindex="0"
                       role="button"
                       aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
@@ -975,6 +977,7 @@
                       d={valueEndBarPath(bar)}
                       fill={barFillAttr(bar)}
                       data-pw={`bar-${i}`}
+                      testID={`bar-${i}`}
                       tabindex="0"
                       role="button"
                       aria-label="{bar.dataPoint.label}: {getDisplayValue(bar)}"
@@ -999,6 +1002,7 @@
                       text-anchor={bl.p.textAnchor}
                       dominant-baseline={bl.p.dominantBaseline}
                       data-pw={`bar-value-${i}`}
+                      testID={`bar-value-${i}`}
                       style={bl.p.placement === 'inside'
                         ? `fill: ${getContrastColor(bl.bar.color)}; stroke: ${contrastOutline(bl.bar.color)};`
                         : ''}>{bl.text}</text

--- a/src/lib/Book/Book.svelte
+++ b/src/lib/Book/Book.svelte
@@ -101,6 +101,7 @@
 <div
   class="book {classes ?? ''}"
   data-pw={testId}
+  testID={testId}
   onkeydown={handleKeyDown}
   ontouchstart={handleTouchStart}
   ontouchend={handleTouchEnd}

--- a/src/lib/BrandLoader/BrandLoader.svelte
+++ b/src/lib/BrandLoader/BrandLoader.svelte
@@ -4,7 +4,11 @@
   let { brandLogoURL, brandText, subText, classes, testId }: BrandLoaderProperties = $props();
 </script>
 
-<div class="background {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="background {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   <div class="loader">
     <img src={brandLogoURL} alt="" />
     <div class="text">{brandText}</div>

--- a/src/lib/Breadcrumb/Breadcrumb.svelte
+++ b/src/lib/Breadcrumb/Breadcrumb.svelte
@@ -8,6 +8,7 @@
   class="breadcrumb {classes ?? ''}"
   aria-label={ariaLabel}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <ol class="breadcrumb-list">
     {#each items as crumb, index (index)}

--- a/src/lib/Browser/Browser.svelte
+++ b/src/lib/Browser/Browser.svelte
@@ -17,7 +17,13 @@
   }: BrowserProperties = $props();
 </script>
 
-<div class="browser {variant} {classes ?? ''}" class:shadow class:rounded data-pw={testId}>
+<div
+  class="browser {variant} {classes ?? ''}"
+  class:shadow
+  class:rounded
+  data-pw={testId}
+  testID={testId}
+>
   <div class="chrome">
     <div class="titlebar">
       <div class="dots">

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -84,6 +84,7 @@
     {ontouchstart}
     {ontouchend}
     data-pw={testId}
+    testID={testId}
     role={role ?? null}
     aria-label={ariaLabel ?? null}
     aria-expanded={ariaExpanded ?? null}

--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -301,7 +301,13 @@
   }
 </script>
 
-<div class="calendar {classes ?? ''}" data-pw={testId} role="application" aria-label="Calendar">
+<div
+  class="calendar {classes ?? ''}"
+  data-pw={testId}
+  testID={testId}
+  role="application"
+  aria-label="Calendar"
+>
   <div class="header">
     <div class="nav-button nav-prev">
       <Button onclick={() => navigateMonth(-1)} ariaLabel="Previous month">

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -45,6 +45,7 @@
   class:card-has-scroll={scrollable}
   style={styleAttr}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
   role={isInteractive ? 'button' : null}
   tabindex={isInteractive ? 0 : null}
   onclick={isInteractive ? onclick : null}

--- a/src/lib/Carousel/Carousel.svelte
+++ b/src/lib/Carousel/Carousel.svelte
@@ -144,6 +144,7 @@
 <div
   class="carousel-container {classes ?? ''}"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if views.length > 0}
     <div class="carousel" bind:this={carouselDiv}>
@@ -164,6 +165,7 @@
     <div
       class="dots-wrapper"
       data-pw={typeof dotsWrapperTestId === 'string' ? dotsWrapperTestId : null}
+      testID={typeof dotsWrapperTestId === 'string' ? dotsWrapperTestId : null}
     >
       <!-- eslint-disable-next-line -->
       {#each views as _, index}
@@ -173,6 +175,7 @@
           {onkeydown}
           role="none"
           data-pw={typeof dotTestId === 'string' ? `${dotTestId}-${index + 1}` : null}
+          testID={typeof dotTestId === 'string' ? `${dotTestId}-${index + 1}` : null}
         ></div>
       {/each}
     </div>

--- a/src/lib/CheckListItem/CheckListItem.svelte
+++ b/src/lib/CheckListItem/CheckListItem.svelte
@@ -18,7 +18,7 @@
   }
 </script>
 
-<div class="container {classes ?? ''}" class:disabled data-pw={testId}>
+<div class="container {classes ?? ''}" class:disabled data-pw={testId} testID={testId}>
   <div class="checkbox-wrapper">
     <Checkbox
       text=""

--- a/src/lib/Checkbox/Checkbox.svelte
+++ b/src/lib/Checkbox/Checkbox.svelte
@@ -49,6 +49,7 @@
     handleClick();
   }}
   data-pw={testId}
+  testID={testId}
 >
   <input
     type="checkbox"
@@ -59,6 +60,7 @@
     aria-hidden="true"
     onclick={(e: MouseEvent) => e.stopPropagation()}
     data-pw={typeof testId === 'string' ? `${testId}-native-input` : null}
+    testID={typeof testId === 'string' ? `${testId}-native-input` : null}
   />
   <span
     class="box"
@@ -71,6 +73,7 @@
     aria-controls={ariaControls ?? null}
     onkeydown={handleKeyDown}
     data-pw={typeof testId === 'string' ? `${testId}-box` : null}
+    testID={typeof testId === 'string' ? `${testId}-box` : null}
   >
     {#if checked && !indeterminate}
       {#if typeof checkedIcon === 'function'}

--- a/src/lib/Choicebox/Choicebox.svelte
+++ b/src/lib/Choicebox/Choicebox.svelte
@@ -42,6 +42,7 @@
   onclick={handleClick}
   onkeydown={handleKeyDown}
   data-pw={testId}
+  testID={testId}
 >
   {#if typeof children === 'function'}
     {@render children()}

--- a/src/lib/ColorPicker/ColorPicker.svelte
+++ b/src/lib/ColorPicker/ColorPicker.svelte
@@ -188,6 +188,7 @@
   class="color-picker-container {classes ?? ''}"
   class:disabled
   data-pw={testId}
+  testID={testId}
   bind:this={containerEl}
 >
   {#if typeof label === 'string'}

--- a/src/lib/Combobox/Combobox.svelte
+++ b/src/lib/Combobox/Combobox.svelte
@@ -345,7 +345,13 @@
   });
 </script>
 
-<div class="combobox {classes ?? ''}" class:disabled bind:this={containerEl} data-pw={testId}>
+<div
+  class="combobox {classes ?? ''}"
+  class:disabled
+  bind:this={containerEl}
+  data-pw={testId}
+  testID={testId}
+>
   <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
   <div class="combobox-input-wrapper" class:multiple onclick={handleControlClick}>
     {#if typeof inputPrefix === 'function'}
@@ -423,6 +429,7 @@
               }
             }}
             data-pw={typeof testId === 'string' ? `${testId}-option-${item.id}` : null}
+            testID={typeof testId === 'string' ? `${testId}-option-${item.id}` : null}
           >
             {#if typeof itemSnippet === 'function'}
               {@render itemSnippet(item, isHighlighted)}
@@ -446,6 +453,7 @@
           onclick={() => create()}
           onmouseenter={() => (highlightedIndex = createNavIndex)}
           data-pw={typeof testId === 'string' ? `${testId}-create` : null}
+          testID={typeof testId === 'string' ? `${testId}-create` : null}
         >
           <span class="combobox-create-icon" aria-hidden="true">
             <svg viewBox="0 0 20 20" width="14" height="14" fill="none">
@@ -474,6 +482,7 @@
           onclick={() => runAction()}
           onmouseenter={() => (highlightedIndex = actionNavIndex)}
           data-pw={typeof testId === 'string' ? `${testId}-action` : null}
+          testID={typeof testId === 'string' ? `${testId}-action` : null}
         >
           {#if typeof actionIcon === 'function'}
             <span class="combobox-action-icon" aria-hidden="true">{@render actionIcon()}</span>

--- a/src/lib/CommandMenu/CommandMenu.svelte
+++ b/src/lib/CommandMenu/CommandMenu.svelte
@@ -198,6 +198,7 @@
     aria-label="Command menu"
     tabindex="-1"
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
   >
     <div class="command-menu-dialog">
       <div class="command-menu-input-wrapper">
@@ -219,6 +220,7 @@
           autocomplete="off"
           spellcheck="false"
           data-pw={typeof testId === 'string' ? `${testId}-input` : null}
+          testID={typeof testId === 'string' ? `${testId}-input` : null}
         />
       </div>
 
@@ -253,6 +255,7 @@
                 aria-disabled={item.disabled}
                 tabindex="-1"
                 data-pw={typeof testId === 'string' ? `${testId}-item-${item.value}` : null}
+                testID={typeof testId === 'string' ? `${testId}-item-${item.value}` : null}
               >
                 {#if typeof itemIcon === 'function'}
                   <span class="command-menu-item-icon">

--- a/src/lib/ContextMenu/ContextMenu.svelte
+++ b/src/lib/ContextMenu/ContextMenu.svelte
@@ -164,6 +164,7 @@
   oncontextmenu={handleContextMenu}
   role="application"
   data-pw={testId}
+  testID={testId}
 >
   {#if typeof children === 'function'}
     {@render children()}
@@ -203,6 +204,7 @@
             }
           }}
           data-pw={testId ? `${testId}-item-${item.value}` : null}
+          testID={testId ? `${testId}-item-${item.value}` : null}
         >
           {#if item.icon}
             <img class="context-menu-item-icon" src={item.icon} alt="" />

--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -549,7 +549,7 @@
 
 <svelte:document onclick={handleDocumentClick} onkeydown={handleDocumentKeyDown} />
 
-<div class="drp-root {classes ?? ''}" data-pw={testId}>
+<div class="drp-root {classes ?? ''}" data-pw={testId} testID={testId}>
   <!-- Trigger wrapper — bind:this here so outside-click detection works -->
   <div bind:this={triggerRef} class="drp-trigger-wrapper">
     <Button
@@ -654,6 +654,7 @@
       aria-label="Date range picker"
       aria-modal="true"
       data-pw={typeof testId === 'string' ? `${testId}-panel` : null}
+      testID={typeof testId === 'string' ? `${testId}-panel` : null}
     >
       <div class="drp-panel-inner">
         <!-- Preset sidebar -->
@@ -679,6 +680,7 @@
                 aria-selected={isPresetActive(preset)}
                 onclick={() => handlePreset(preset)}
                 data-pw={typeof testId === 'string' ? `${testId}-preset-${preset.label}` : null}
+                testID={typeof testId === 'string' ? `${testId}-preset-${preset.label}` : null}
               >
                 {preset.label}
                 {#if presetCheckmark && isPresetActive(preset)}
@@ -687,6 +689,7 @@
                     class="drp-preset-check"
                     aria-hidden="true"
                     data-pw={typeof testId === 'string' ? `${testId}-preset-check` : null}
+                    testID={typeof testId === 'string' ? `${testId}-preset-check` : null}
                     >{@html checkmarkSvg}</span
                   >
                 {/if}
@@ -702,7 +705,11 @@
               <div class="drp-date-input-row">
                 {#if isInlineTime}
                   <div class="drp-date-time-group">
-                    <div class="drp-date-input" data-pw={testId ? `${testId}-start-date` : null}>
+                    <div
+                      class="drp-date-input"
+                      data-pw={testId ? `${testId}-start-date` : null}
+                      testID={testId ? `${testId}-start-date` : null}
+                    >
                       <span class="drp-date-input-value">{draftStartDateLabel || 'Start date'}</span
                       >
                     </div>
@@ -721,13 +728,18 @@
                         aria-label="Start time"
                         aria-invalid={!isStartTimeValid}
                         data-pw={testId ? `${testId}-start-time` : null}
+                        testID={testId ? `${testId}-start-time` : null}
                       />
                     </div>
                   </div>
                   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   <span class="drp-datetime-arrow" aria-hidden="true">{@html chevronRightSvg}</span>
                   <div class="drp-date-time-group">
-                    <div class="drp-date-input" data-pw={testId ? `${testId}-end-date` : null}>
+                    <div
+                      class="drp-date-input"
+                      data-pw={testId ? `${testId}-end-date` : null}
+                      testID={testId ? `${testId}-end-date` : null}
+                    >
                       <span class="drp-date-input-value">{draftEndDateLabel || 'End date'}</span>
                     </div>
                     <div
@@ -745,16 +757,25 @@
                         aria-label="End time"
                         aria-invalid={!isEndTimeValid}
                         data-pw={testId ? `${testId}-end-time` : null}
+                        testID={testId ? `${testId}-end-time` : null}
                       />
                     </div>
                   </div>
                 {:else}
-                  <div class="drp-date-input" data-pw={testId ? `${testId}-start-date` : null}>
+                  <div
+                    class="drp-date-input"
+                    data-pw={testId ? `${testId}-start-date` : null}
+                    testID={testId ? `${testId}-start-date` : null}
+                  >
                     <span class="drp-date-input-value">{draftStartDateLabel || 'Start date'}</span>
                   </div>
                   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   <span class="drp-datetime-arrow" aria-hidden="true">{@html chevronRightSvg}</span>
-                  <div class="drp-date-input" data-pw={testId ? `${testId}-end-date` : null}>
+                  <div
+                    class="drp-date-input"
+                    data-pw={testId ? `${testId}-end-date` : null}
+                    testID={testId ? `${testId}-end-date` : null}
+                  >
                     <span class="drp-date-input-value">{draftEndDateLabel || 'End date'}</span>
                   </div>
                   {#if showTimeSelection}
@@ -765,6 +786,7 @@
                       aria-label="Toggle time selection"
                       aria-pressed={showTimeRow}
                       data-pw={testId ? `${testId}-time-toggle` : null}
+                      testID={testId ? `${testId}-time-toggle` : null}
                       onclick={() => (showTimeRow = !showTimeRow)}
                     >
                       <!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -787,6 +809,7 @@
                       aria-label="Start time"
                       aria-invalid={!isStartTimeValid}
                       data-pw={testId ? `${testId}-start-time` : null}
+                      testID={testId ? `${testId}-start-time` : null}
                     />
                   </div>
                   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -803,6 +826,7 @@
                       aria-label="End time"
                       aria-invalid={!isEndTimeValid}
                       data-pw={testId ? `${testId}-end-time` : null}
+                      testID={testId ? `${testId}-end-time` : null}
                     />
                   </div>
                 </div>

--- a/src/lib/DeltaIndicator/DeltaIndicator.svelte
+++ b/src/lib/DeltaIndicator/DeltaIndicator.svelte
@@ -37,6 +37,7 @@
 <span
   class="delta-indicator delta-{tone} {classes ?? ''}"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if !hideArrow && direction !== 'neutral'}
     <span class="delta-indicator-arrow delta-arrow-{direction}" aria-hidden="true">

--- a/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
+++ b/src/lib/DualAxisBarChart/DualAxisBarChart.svelte
@@ -441,6 +441,7 @@
   class="dual-axis-bar-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if !isEmpty}
     {#if showLegend && (chartWidth === 0 || hideLegendBelow === 0 || chartWidth >= hideLegendBelow)}
@@ -568,6 +569,7 @@
               height={dims.innerHeight}
               fill="transparent"
               data-pw={`hover-target-${hr.catIdx}`}
+              testID={`hover-target-${hr.catIdx}`}
               data-category-index={hr.catIdx}
               tabindex="0"
               role="button"

--- a/src/lib/EmptyState/EmptyState.svelte
+++ b/src/lib/EmptyState/EmptyState.svelte
@@ -13,7 +13,11 @@
   }: EmptyStateProperties = $props();
 </script>
 
-<div class="empty-state {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="empty-state {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   {#if typeof icon === 'function'}
     <div class="empty-state-icon">
       {@render icon()}

--- a/src/lib/FileInput/FileInput.svelte
+++ b/src/lib/FileInput/FileInput.svelte
@@ -139,6 +139,7 @@
   class:file-input-dragover={dragOver}
   class:file-input-disabled={disabled}
   data-pw={testId}
+  testID={testId}
   role="button"
   tabindex={disabled ? -1 : 0}
   aria-disabled={disabled}
@@ -156,6 +157,7 @@
     {multiple}
     {disabled}
     data-pw={typeof testId === 'string' ? `${testId}-input` : null}
+    testID={typeof testId === 'string' ? `${testId}-input` : null}
     onchange={handleInputChange}
     tabindex="-1"
     aria-hidden="true"

--- a/src/lib/FunnelChart/FunnelChart.svelte
+++ b/src/lib/FunnelChart/FunnelChart.svelte
@@ -294,6 +294,7 @@
   class="funnel-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
@@ -333,6 +334,7 @@
               x={bx}
               y={by}
               data-pw={`funnel-bar-${index}`}
+              testID={`funnel-bar-${index}`}
               width={stageColumnWidth}
               height={bh}
               fill={color}

--- a/src/lib/Gauge/Gauge.svelte
+++ b/src/lib/Gauge/Gauge.svelte
@@ -30,6 +30,7 @@
 <div
   class="gauge {classes ?? ''}"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
   role="progressbar"
   aria-valuenow={clamped}
   aria-valuemin={0}

--- a/src/lib/GridItem/GridItem.svelte
+++ b/src/lib/GridItem/GridItem.svelte
@@ -25,6 +25,7 @@
   role="button"
   tabindex="0"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <div class="grid-header">
     <img src={headerIcon} alt="" class="grid-item-header-icon" />

--- a/src/lib/Icon/Icon.svelte
+++ b/src/lib/Icon/Icon.svelte
@@ -12,6 +12,7 @@
   role="button"
   tabindex="0"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if typeof svg === 'string' && svg.length > 0}
     <!-- eslint-disable svelte/no-at-html-tags -->

--- a/src/lib/IconStack/IconStack.svelte
+++ b/src/lib/IconStack/IconStack.svelte
@@ -4,7 +4,11 @@
   let { icons, classes, testId }: IconStackProperties = $props();
 </script>
 
-<div class="stack-container {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="stack-container {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   {#each icons as icon, i (i)}
     <div class="stack-icon" style:z-index={icons.length - i}>
       {#if icon.type === 'image'}

--- a/src/lib/IframeViewer/IframeViewer.svelte
+++ b/src/lib/IframeViewer/IframeViewer.svelte
@@ -42,7 +42,7 @@
   });
 </script>
 
-<div class="iframe-viewer {classes ?? ''}" data-pw={testId}>
+<div class="iframe-viewer {classes ?? ''}" data-pw={testId} testID={testId}>
   {#if src}
     <iframe bind:this={iframeEl} {src} {title} {allow} {sandbox} {loading} {referrerpolicy}
     ></iframe>

--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -116,9 +116,17 @@
     aria-label={alt.length > 0 ? alt : null}
     aria-hidden={alt.length === 0 ? 'true' : null}
     data-pw={testId}
+    testID={testId}
   ></svg>
 {:else}
-  <img class={classes ?? ''} src={currentSrc} {alt} onerror={handleFallback} data-pw={testId} />
+  <img
+    class={classes ?? ''}
+    src={currentSrc}
+    {alt}
+    onerror={handleFallback}
+    data-pw={testId}
+    testID={testId}
+  />
 {/if}
 
 <style>

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -275,6 +275,7 @@
         onclick={onClick}
         onkeydown={onKeyDown}
         data-pw={testId}
+        testID={testId}
         class:action-input={actionInput}
         style="--focus-border: {addFocusColor ? 1 : 0}px;"
         style:resize={effectiveResize}
@@ -307,6 +308,7 @@
         onclick={onClick}
         onkeydown={onKeyDown}
         data-pw={testId}
+        testID={testId}
         class:action-input={actionInput}
         disabled={disable}
         bind:this={inputElement}
@@ -362,6 +364,7 @@
     <div
       class="error-message"
       data-pw={typeof testId === 'string' && testId.length > 0 ? `${testId}-error-message` : null}
+      testID={typeof testId === 'string' && testId.length > 0 ? `${testId}-error-message` : null}
     >
       {onErrorMessage}
     </div>

--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -62,7 +62,11 @@
   }
 </script>
 
-<div class="container {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="container {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   {#if inputProperties.label && inputProperties.label !== ''}
     <label class="label" for={inputProperties.name}>
       {inputProperties.label}{#if mandatory}<span class="mandatory-marker" aria-label="required">

--- a/src/lib/KeyValue/KeyValue.svelte
+++ b/src/lib/KeyValue/KeyValue.svelte
@@ -29,9 +29,10 @@
   class="key-value key-value--{layout} key-value--{size} {classes}"
   style="--keyvalue-columns: {columns};"
   data-pw={testId}
+  testID={testId}
 >
   {#each visibleItems as item, index (item.label + '-' + index)}
-    <div class="key-value-item" data-pw={item.testId}>
+    <div class="key-value-item" data-pw={item.testId} testID={item.testId}>
       <dt class="key-value-label">
         {#if labelSnippet}
           {@render labelSnippet(item, index)}

--- a/src/lib/KeyboardInput/KeyboardInput.svelte
+++ b/src/lib/KeyboardInput/KeyboardInput.svelte
@@ -43,6 +43,7 @@
 <span
   class="keyboard-input {classes ?? ''}"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
   onclick={interactive ? onclick : null}
   onkeydown={interactive ? handleKeydown : null}
   role={interactive ? 'button' : null}

--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -519,6 +519,7 @@
   class="line-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>
@@ -627,6 +628,7 @@
               r={dotRadius + 6}
               fill={hp.color}
               data-pw={`dot-halo-${i}`}
+              testID={`dot-halo-${i}`}
             />
           {/each}
 
@@ -720,6 +722,7 @@
             height={dims.innerHeight}
             fill="transparent"
             data-pw="hover-overlay"
+            testID="hover-overlay"
             onpointermove={handleOverlayMove}
             onpointerleave={handleLeave}
             onclick={handleClick}

--- a/src/lib/ListItem/ListItem.svelte
+++ b/src/lib/ListItem/ListItem.svelte
@@ -73,6 +73,7 @@
       aria-selected={ariaSelected}
       {id}
       data-pw={testId}
+      testID={testId}
     >
       <div
         class="top-section"
@@ -82,6 +83,7 @@
         role="button"
         tabindex="0"
         data-pw={topSectionTestId}
+        testID={topSectionTestId}
       >
         <div class="left-content">
           {#if typeof leftImageUrl === 'string' && leftImageUrl.length > 0}
@@ -92,6 +94,7 @@
               role="button"
               tabindex="0"
               data-pw={leftImageTestId}
+              testID={leftImageTestId}
             >
               <Img src={leftImageUrl} alt="" fallback={leftImageFallbackUrl} />
             </div>
@@ -110,6 +113,7 @@
               role="button"
               tabindex="0"
               data-pw={centerTextTestId}
+              testID={centerTextTestId}
             >
               <!-- eslint-disable-next-line -->
               {@html label}
@@ -131,6 +135,7 @@
               role="button"
               tabindex="0"
               data-pw={rightImageTestId}
+              testID={rightImageTestId}
             >
               <div class="right-img-wrapper">
                 <Img src={rightImageUrl} alt="" />

--- a/src/lib/Loader/Loader.svelte
+++ b/src/lib/Loader/Loader.svelte
@@ -4,7 +4,11 @@
   let { classes, testId }: LoaderProperties = $props();
 </script>
 
-<div class="loader {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}></div>
+<div
+  class="loader {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+></div>
 
 <style>
   .loader {

--- a/src/lib/LoadingDots/LoadingDots.svelte
+++ b/src/lib/LoadingDots/LoadingDots.svelte
@@ -11,6 +11,7 @@
   role="status"
   aria-label="Loading"
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#each { length: count } as _, i (i)}
     <span
@@ -18,6 +19,7 @@
       class:pulse={animation === 'pulse'}
       style="--i: {i}"
       data-pw={typeof testId === 'string' ? `${testId}-dot-${i}` : null}
+      testID={typeof testId === 'string' ? `${testId}-dot-${i}` : null}
     ></span>
   {/each}
 </span>

--- a/src/lib/LottiePlayer/LottiePlayer.svelte
+++ b/src/lib/LottiePlayer/LottiePlayer.svelte
@@ -107,6 +107,7 @@
   aria-hidden={ariaHidden ? 'true' : null}
   role={ariaHidden ? null : 'img'}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 ></div>
 
 <style>

--- a/src/lib/Menu/Menu.svelte
+++ b/src/lib/Menu/Menu.svelte
@@ -343,6 +343,7 @@
   class="menu-container {classes ?? ''}"
   bind:this={menuContainerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <div
     class="menu-trigger"
@@ -402,6 +403,7 @@
               }
             }}
             data-pw={typeof testId === 'string' ? `${testId}-item-${item.value}` : null}
+            testID={typeof testId === 'string' ? `${testId}-item-${item.value}` : null}
           >
             {#if typeof item.icon === 'string'}
               <span class="menu-item-icon">

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -150,6 +150,7 @@
       role="button"
       tabindex="0"
       data-pw={testId}
+      testID={testId}
     >
       <ModalAnimation enable={enableTransition} {align} {transitionType}>
         <div class="modal-content {size}">
@@ -162,6 +163,7 @@
                   role="button"
                   tabindex="0"
                   data-pw={leftImageTestId}
+                  testID={leftImageTestId}
                 >
                   <!-- Inline SVGs so currentColor icons inherit the header text
                        colour; non-SVG URLs fall back to a plain <img>. -->
@@ -175,7 +177,7 @@
                 </div>
               {/if}
               {#if typeof header.text === 'string' && header.text.length > 0}
-                <div class="header-text" data-pw={header.testId}>
+                <div class="header-text" data-pw={header.testId} testID={header.testId}>
                   {header.text}
                 </div>
               {/if}
@@ -186,6 +188,7 @@
                   onclick={handleRightImageClick}
                   onkeydown={handleRightImageKeyDown}
                   data-pw={header.buttonTestId}
+                  testID={header.buttonTestId}
                 >
                   <Img
                     inlineSvg

--- a/src/lib/Pagination/Pagination.svelte
+++ b/src/lib/Pagination/Pagination.svelte
@@ -70,6 +70,7 @@
   class="pagination {classes ?? ''}"
   class:disabled
   data-pw={typeof testId === 'string' && testId.length > 0 ? testId : null}
+  testID={typeof testId === 'string' && testId.length > 0 ? testId : null}
 >
   <button
     class="page-button prev-button"
@@ -77,6 +78,7 @@
     onclick={() => goToPage(currentPage - 1)}
     aria-label="Previous page"
     data-pw={typeof prevButtonTestId === 'string' ? prevButtonTestId : null}
+    testID={typeof prevButtonTestId === 'string' ? prevButtonTestId : null}
   >
     &#8249;
   </button>
@@ -105,6 +107,7 @@
       onclick={loadMore}
       aria-label="Load more"
       data-pw={typeof nextButtonTestId === 'string' ? nextButtonTestId : null}
+      testID={typeof nextButtonTestId === 'string' ? nextButtonTestId : null}
     >
       &#8250;
     </button>
@@ -115,6 +118,7 @@
       onclick={() => goToPage(currentPage + 1)}
       aria-label="Next page"
       data-pw={typeof nextButtonTestId === 'string' ? nextButtonTestId : null}
+      testID={typeof nextButtonTestId === 'string' ? nextButtonTestId : null}
     >
       &#8250;
     </button>

--- a/src/lib/Phone/Phone.svelte
+++ b/src/lib/Phone/Phone.svelte
@@ -16,7 +16,11 @@
   let isModern = $derived(variant === 'modern');
 </script>
 
-<div class="phone-wrapper {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="phone-wrapper {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   <div class="side-buttons-left">
     <div class="side-button volume-up"></div>
     <div class="side-button volume-down"></div>

--- a/src/lib/PieChart/PieChart.svelte
+++ b/src/lib/PieChart/PieChart.svelte
@@ -292,6 +292,7 @@
   class="pie-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>

--- a/src/lib/Pill/Pill.svelte
+++ b/src/lib/Pill/Pill.svelte
@@ -52,6 +52,7 @@
   tabindex={interactive ? 0 : null}
   aria-disabled={interactive && disabled ? true : null}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if typeof leadingIcon === 'function'}
     <span class="pill-leading-icon">{@render leadingIcon()}</span>

--- a/src/lib/Progress/Progress.svelte
+++ b/src/lib/Progress/Progress.svelte
@@ -7,7 +7,11 @@
   let isIndeterminate = $derived(value < 0);
 </script>
 
-<div class="container {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="container {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   <div class="track">
     <div
       class="bar"

--- a/src/lib/ProportionBar/ProportionBar.svelte
+++ b/src/lib/ProportionBar/ProportionBar.svelte
@@ -100,6 +100,7 @@
   class="proportion-bar {classes ?? ''}"
   style={trackHeightStyle}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <div class="proportion-bar-track">
     <svg
@@ -110,6 +111,7 @@
       aria-hidden={showLegend ? 'true' : null}
       aria-label={showLegend ? null : ariaSummary}
       data-pw={typeof testId === 'string' ? `${testId}-svg` : null}
+      testID={typeof testId === 'string' ? `${testId}-svg` : null}
     >
       {#each rectSegments as rectSegment, rectIndex (rectIndex)}
         <rect
@@ -135,11 +137,13 @@
       class="proportion-bar-legend"
       aria-label="Segment breakdown"
       data-pw={typeof testId === 'string' ? `${testId}-legend` : null}
+      testID={typeof testId === 'string' ? `${testId}-legend` : null}
     >
       {#each computedSegments as computedSegment, legendIndex (legendIndex)}
         <li
           class="proportion-bar-legend-item"
           data-pw={typeof testId === 'string' ? `${testId}-legend-item-${legendIndex}` : null}
+          testID={typeof testId === 'string' ? `${testId}-legend-item-${legendIndex}` : null}
         >
           <span
             class="proportion-bar-swatch"

--- a/src/lib/Radio/Radio.svelte
+++ b/src/lib/Radio/Radio.svelte
@@ -27,6 +27,7 @@
   class="radio-container {classes ?? ''}"
   class:disabled
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <input
     type="radio"

--- a/src/lib/RelativeTime/RelativeTime.svelte
+++ b/src/lib/RelativeTime/RelativeTime.svelte
@@ -92,6 +92,7 @@
       class="relative-time {classes ?? ''}"
       datetime={isoString}
       data-pw={typeof testId === 'string' ? testId : null}
+      testID={typeof testId === 'string' ? testId : null}
     >
       {relativeText}
     </time>
@@ -101,6 +102,7 @@
     class="relative-time {classes ?? ''}"
     datetime={isoString}
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
   >
     {relativeText}
   </time>

--- a/src/lib/SankeyChart/SankeyChart.svelte
+++ b/src/lib/SankeyChart/SankeyChart.svelte
@@ -477,6 +477,7 @@
   class="sankey-chart {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if isEmpty && typeof empty === 'function'}
     <div class="chart-empty">{@render empty()}</div>

--- a/src/lib/Scroller/Scroller.svelte
+++ b/src/lib/Scroller/Scroller.svelte
@@ -159,6 +159,7 @@
   class:horizontal={direction === 'horizontal'}
   class:vertical={direction === 'vertical'}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if showArrowControls && canScrollPrev}
     <div class="arrow arrow-prev">

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -390,7 +390,7 @@
   class:disabled
   class:ghost={hierarchy === 'ghost'}
   bind:this={containerEl}
-  {...typeof testId === 'string' ? { 'data-pw': testId } : {}}
+  {...typeof testId === 'string' ? { 'data-pw': testId, testID: testId } : {}}
 >
   <div
     class="select-trigger"
@@ -428,6 +428,7 @@
             autocomplete="off"
             tabindex={disabled ? -1 : 0}
             data-pw={typeof testId === 'string' ? `${testId}-search` : null}
+            testID={typeof testId === 'string' ? `${testId}-search` : null}
           />
         {/if}
       {:else}
@@ -453,6 +454,7 @@
             autocomplete="off"
             tabindex={disabled ? -1 : 0}
             data-pw={typeof testId === 'string' ? `${testId}-search` : null}
+            testID={typeof testId === 'string' ? `${testId}-search` : null}
           />
         {:else if value.length === 0}
           <span class="select-placeholder">{placeholder}</span>
@@ -471,6 +473,7 @@
         autocomplete="off"
         tabindex={disabled ? -1 : 0}
         data-pw={typeof testId === 'string' ? `${testId}-search` : null}
+        testID={typeof testId === 'string' ? `${testId}-search` : null}
       />
     {:else}
       <span class={displayText.length > 0 ? 'select-value' : 'select-placeholder'}>
@@ -512,7 +515,9 @@
                 ? `${selectAllLabel}, ${selectedFilteredCount} of ${filteredItems.length} selected`
                 : selectAllLabel}
               tabindex="-1"
-              {...typeof testId === 'string' ? { 'data-pw': `${testId}-select-all` } : {}}
+              {...typeof testId === 'string'
+                ? { 'data-pw': `${testId}-select-all`, testID: `${testId}-select-all` }
+                : {}}
               onclick={toggleSelectAll}
               onmouseenter={() => (highlightedIndex = index)}
             >
@@ -529,6 +534,7 @@
                   aria-hidden="true"
                   data-checked={allFilteredSelected ? 'true' : 'false'}
                   data-pw={typeof testId === 'string' ? `${testId}-select-all-indicator` : null}
+                  testID={typeof testId === 'string' ? `${testId}-select-all-indicator` : null}
                 >
                   {#if allFilteredSelected}
                     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -537,6 +543,7 @@
                     <span
                       class="select-option-dash"
                       data-pw={typeof testId === 'string' ? `${testId}-select-all-dash` : null}
+                      testID={typeof testId === 'string' ? `${testId}-select-all-dash` : null}
                     ></span>
                   {/if}
                 </span>
@@ -555,11 +562,14 @@
               aria-selected={value.includes(row.item.id)}
               tabindex="-1"
               {...typeof row.item.testId === 'string'
-                ? { 'data-pw': row.item.testId }
+                ? { 'data-pw': row.item.testId, testID: row.item.testId }
                 : typeof itemTestId === 'string'
-                  ? { 'data-pw': `${itemTestId}-${row.item.id}` }
+                  ? {
+                      'data-pw': `${itemTestId}-${row.item.id}`,
+                      testID: `${itemTestId}-${row.item.id}`
+                    }
                   : typeof testId === 'string'
-                    ? { 'data-pw': `${testId}-${row.item.id}` }
+                    ? { 'data-pw': `${testId}-${row.item.id}`, testID: `${testId}-${row.item.id}` }
                     : {}}
               onclick={() => selectItem(row.item.id)}
               onmouseenter={() => (highlightedIndex = index)}
@@ -577,6 +587,9 @@
                     aria-hidden="true"
                     data-checked={value.includes(row.item.id) ? 'true' : 'false'}
                     data-pw={typeof testId === 'string'
+                      ? `${testId}-option-indicator-${row.item.id}`
+                      : null}
+                    testID={typeof testId === 'string'
                       ? `${testId}-option-indicator-${row.item.id}`
                       : null}
                   >

--- a/src/lib/Sheet/Sheet.svelte
+++ b/src/lib/Sheet/Sheet.svelte
@@ -136,6 +136,7 @@
     role="button"
     tabindex="-1"
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
     transition:fade={{ duration: 200 }}
   >
     <div
@@ -146,6 +147,7 @@
       aria-label={title ?? 'Sheet'}
       tabindex="-1"
       data-pw={typeof testId === 'string' ? `${testId}-panel` : null}
+      testID={typeof testId === 'string' ? `${testId}-panel` : null}
       transition:fly|global={flyParams}
       onintroend={handleIntroEnd}
       onoutroend={handleOutroEnd}

--- a/src/lib/Shimmer/Shimmer.svelte
+++ b/src/lib/Shimmer/Shimmer.svelte
@@ -4,7 +4,11 @@
   let { testId, classes }: ShimmerProperties = $props();
 </script>
 
-<div class="shimmer {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}></div>
+<div
+  class="shimmer {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+></div>
 
 <style>
   .shimmer {

--- a/src/lib/Slider/Slider.svelte
+++ b/src/lib/Slider/Slider.svelte
@@ -43,6 +43,7 @@
     {value}
     {disabled}
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
     oninput={handleInput}
     onchange={handleChange}
     style="--slider-fill-percent: {percentage}%"

--- a/src/lib/Snippet/Snippet.svelte
+++ b/src/lib/Snippet/Snippet.svelte
@@ -29,7 +29,11 @@
   }
 </script>
 
-<div class="snippet {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="snippet {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   <code class="snippet-code">
     <span class="snippet-prompt">{prompt}</span>
     <span class="snippet-text">{text}</span>

--- a/src/lib/SplitButton/SplitButton.svelte
+++ b/src/lib/SplitButton/SplitButton.svelte
@@ -34,6 +34,7 @@
   class="split-button {classes ?? ''}"
   class:disabled
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   <div class="split-button-primary">
     <Button {text} onclick={handlePrimaryClick} {disabled} />

--- a/src/lib/SplitInput/SplitInput.svelte
+++ b/src/lib/SplitInput/SplitInput.svelte
@@ -144,7 +144,7 @@
   }
 </script>
 
-<div class="field-group {classes ?? ''}" data-pw={testId}>
+<div class="field-group {classes ?? ''}" data-pw={testId} testID={testId}>
   {#each fieldConfigs as config, index (index)}
     {#if typeof separator === 'string' && index > 0}
       <span class="field-group-separator">{separator}</span>

--- a/src/lib/StatCard/StatCard.svelte
+++ b/src/lib/StatCard/StatCard.svelte
@@ -85,13 +85,18 @@
   class="statcard {classes ?? ''}"
   class:statcard-interactive={isInteractive}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
   role={isInteractive ? 'button' : null}
   tabindex={isInteractive ? 0 : null}
   onclick={isInteractive ? onclick : null}
   onkeydown={isInteractive ? handleKeydown : null}
 >
   {#if hasHeaderContent}
-    <div class="statcard-header" data-pw={typeof testId === 'string' ? `${testId}-header` : null}>
+    <div
+      class="statcard-header"
+      data-pw={typeof testId === 'string' ? `${testId}-header` : null}
+      testID={typeof testId === 'string' ? `${testId}-header` : null}
+    >
       <div class="statcard-header-left">
         {#if hasTitle}
           {#if tooltip}
@@ -115,6 +120,7 @@
             <div
               class="statcard-title"
               data-pw={typeof testId === 'string' ? `${testId}-title` : null}
+              testID={typeof testId === 'string' ? `${testId}-title` : null}
             >
               {title}
             </div>
@@ -146,15 +152,21 @@
       class="statcard-rows"
       class:statcard-rows-horizontal={rowsDirection === 'row'}
       data-pw={typeof testId === 'string' ? `${testId}-rows` : null}
+      testID={typeof testId === 'string' ? `${testId}-rows` : null}
     >
       {#each rows as row, rowIndex (rowIndex)}
         {#if rowIndex > 0}
           <div
             class="statcard-row-divider"
             data-pw={typeof testId === 'string' ? `${testId}-row-divider-${rowIndex}` : null}
+            testID={typeof testId === 'string' ? `${testId}-row-divider-${rowIndex}` : null}
           ></div>
         {/if}
-        <div class="statcard-row" data-pw={typeof row.testId === 'string' ? row.testId : null}>
+        <div
+          class="statcard-row"
+          data-pw={typeof row.testId === 'string' ? row.testId : null}
+          testID={typeof row.testId === 'string' ? row.testId : null}
+        >
           {#if typeof row.heading === 'string' && row.heading.length > 0}
             <div class="statcard-row-heading-wrap">
               {#if row.tooltip}
@@ -174,6 +186,7 @@
             <div
               class="statcard-value"
               data-pw={typeof testId === 'string' ? `${testId}-value-${rowIndex}` : null}
+              testID={typeof testId === 'string' ? `${testId}-value-${rowIndex}` : null}
             >
               {row.value}
             </div>
@@ -181,6 +194,7 @@
               <div
                 class="statcard-comparison-value"
                 data-pw={typeof testId === 'string' ? `${testId}-comparison-${rowIndex}` : null}
+                testID={typeof testId === 'string' ? `${testId}-comparison-${rowIndex}` : null}
               >
                 / {row.comparisonValue}
               </div>
@@ -197,6 +211,7 @@
               <div
                 class="statcard-delta statcard-delta-na"
                 data-pw={typeof testId === 'string' ? `${testId}-delta-na-${rowIndex}` : null}
+                testID={typeof testId === 'string' ? `${testId}-delta-na-${rowIndex}` : null}
               >
                 N/A
               </div>
@@ -214,6 +229,9 @@
                 <div
                   class="statcard-breakdown-item"
                   data-pw={typeof testId === 'string'
+                    ? `${testId}-breakdown-item-${rowIndex}-${breakdownIndex}`
+                    : null}
+                  testID={typeof testId === 'string'
                     ? `${testId}-breakdown-item-${rowIndex}-${breakdownIndex}`
                     : null}
                 >
@@ -237,11 +255,19 @@
   {:else}
     <div class="statcard-value-row">
       {#if typeof valueSnippet === 'function'}
-        <div class="statcard-value" data-pw={typeof testId === 'string' ? `${testId}-value` : null}>
+        <div
+          class="statcard-value"
+          data-pw={typeof testId === 'string' ? `${testId}-value` : null}
+          testID={typeof testId === 'string' ? `${testId}-value` : null}
+        >
           {@render valueSnippet()}
         </div>
       {:else if typeof value === 'string' && value.length > 0}
-        <div class="statcard-value" data-pw={typeof testId === 'string' ? `${testId}-value` : null}>
+        <div
+          class="statcard-value"
+          data-pw={typeof testId === 'string' ? `${testId}-value` : null}
+          testID={typeof testId === 'string' ? `${testId}-value` : null}
+        >
           {value}
         </div>
       {/if}
@@ -262,6 +288,7 @@
     <div
       class="statcard-subtitle"
       data-pw={typeof testId === 'string' ? `${testId}-subtitle` : null}
+      testID={typeof testId === 'string' ? `${testId}-subtitle` : null}
     >
       {subtitle}
     </div>

--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -15,7 +15,11 @@
   }: StatusProperties = $props();
 </script>
 
-<div class="background {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+<div
+  class="background {classes ?? ''}"
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+>
   <div class="order-status">
     <div class="status-image">
       {#if icon}

--- a/src/lib/Stepper/Stepper.svelte
+++ b/src/lib/Stepper/Stepper.svelte
@@ -35,7 +35,12 @@
   );
 </script>
 
-<div class={containerClass} data-pw={typeof testId === 'string' ? testId : null} role="list">
+<div
+  class={containerClass}
+  data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
+  role="list"
+>
   {#each steps as currentStep, stepIndex (stepIndex)}
     {@const effectiveStatus = resolveStatus(stepIndex, currentStep.status ?? null)}
     <div

--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -144,6 +144,7 @@
       <span
         class="builtin-icon-label-icon"
         data-pw={column.testId ? `${column.testId}-icon-${iconIndex}` : null}
+        testID={column.testId ? `${column.testId}-icon-${iconIndex}` : null}
       >
         <Img src={String(iconSrc)} alt="" fallback="" />
       </span>
@@ -154,7 +155,11 @@
   {@const data = asJsonObject(value) ?? {}}
   <div class="builtin-image-two-line {alignmentClass}">
     {#if typeof data.imageUrl === 'string' && data.imageUrl}
-      <span class="builtin-thumb" data-pw={column.testId ? `${column.testId}-thumb` : null}>
+      <span
+        class="builtin-thumb"
+        data-pw={column.testId ? `${column.testId}-thumb` : null}
+        testID={column.testId ? `${column.testId}-thumb` : null}
+      >
         <Img
           src={data.imageUrl}
           alt={typeof data.text1 === 'string' ? data.text1 : ''}
@@ -165,6 +170,7 @@
       <span
         class="builtin-thumb builtin-thumb-placeholder"
         data-pw={column.testId ? `${column.testId}-thumb-placeholder` : null}
+        testID={column.testId ? `${column.testId}-thumb-placeholder` : null}
         >{typeof data.text1 === 'string' && data.text1
           ? data.text1.charAt(0).toUpperCase()
           : ''}</span
@@ -222,6 +228,7 @@
             <span
               class="builtin-trend builtin-trend-up"
               data-pw={column.testId ? `${column.testId}-trend-up` : null}
+              testID={column.testId ? `${column.testId}-trend-up` : null}
             >
               <!-- eslint-disable svelte/no-at-html-tags -->
               <span class="builtin-trend-icon">{@html trendUpSvg}</span>
@@ -231,6 +238,7 @@
             <span
               class="builtin-trend builtin-trend-down"
               data-pw={column.testId ? `${column.testId}-trend-down` : null}
+              testID={column.testId ? `${column.testId}-trend-down` : null}
             >
               <!-- eslint-disable svelte/no-at-html-tags -->
               <span class="builtin-trend-icon">{@html trendDownSvg}</span>
@@ -256,6 +264,7 @@
     aria-checked={isChecked ? 'true' : 'false'}
     aria-label={typeof data.ariaLabel === 'string' ? data.ariaLabel : null}
     data-pw={typeof data.testId === 'string' ? data.testId : null}
+    testID={typeof data.testId === 'string' ? data.testId : null}
     onclick={stopClickPropagation}
     onkeydown={stopKeydownPropagation}
     tabindex={-1}
@@ -482,6 +491,7 @@
         rel="noopener noreferrer"
         class="builtin-link-anchor"
         data-pw={column.testId ? `${column.testId}-link-${rowIndex}` : null}
+        testID={column.testId ? `${column.testId}-link-${rowIndex}` : null}
       >
         {link.label ?? link.url}
       </a>
@@ -501,7 +511,8 @@
         {#if copied}
           <span
             class="builtin-link-copied"
-            data-pw={column.testId ? `${column.testId}-link-copied` : null}>Copied</span
+            data-pw={column.testId ? `${column.testId}-link-copied` : null}
+            testID={column.testId ? `${column.testId}-link-copied` : null}>Copied</span
           >
         {/if}
       {/if}

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -575,6 +575,7 @@
       value={searchTerm}
       oninput={handleSearchInput}
       data-pw={searchConfig?.testId ?? null}
+      testID={searchConfig?.testId ?? null}
       aria-label={searchConfig?.placeholder ?? 'Search'}
       autocomplete="off"
     />
@@ -602,6 +603,7 @@
   <div
     class="table-container {isTableScrollable ? 'scrollable-table' : ''} {classes ?? ''}"
     data-pw={testId}
+    testID={testId}
   >
     <div
       class="table-scroll-shell"
@@ -632,6 +634,7 @@
                       : headerCheckboxState === 'all'}
                     aria-label="Select all rows"
                     data-pw={typeof testId === 'string' ? `${testId}-select-all` : null}
+                    testID={typeof testId === 'string' ? `${testId}-select-all` : null}
                     {...checkboxSelection?.getRowAttributes
                       ? checkboxSelection.getRowAttributes('__header__', -1)
                       : {}}
@@ -672,6 +675,7 @@
                   class:table-header-sticky={isStickyHeader}
                   class:table-col-highlighted={headerColumn?.highlighted === true}
                   data-pw={headerColumn?.testId ?? null}
+                  testID={headerColumn?.testId ?? null}
                   style:text-align={headerColumn?.align ?? null}
                   style:max-width={headerColumn?.maxWidth ?? null}
                 >
@@ -800,6 +804,7 @@
                   class:table-summary-row={summaryRowIndex !== null &&
                     originalIndex === summaryRowIndex}
                   data-pw={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
+                  testID={typeof getRowTestId === 'function' ? getRowTestId(row, rowIndex) : null}
                   onclick={isRowClickable
                     ? () => handleRowClick(rowIndex, row, originalIndex)
                     : null}
@@ -822,6 +827,9 @@
                         aria-disabled={rowDisabled}
                         aria-label={`Select row ${rowId || 'non-selectable'}`}
                         data-pw={typeof testId === 'string'
+                          ? `${testId}-row-checkbox-${rowId}`
+                          : null}
+                        testID={typeof testId === 'string'
                           ? `${testId}-row-checkbox-${rowId}`
                           : null}
                         {...checkboxSelection?.getRowAttributes
@@ -859,6 +867,9 @@
                       data-pw={typeof getCellTestId === 'function'
                         ? getCellTestId(row, cellValue, rowIndex)
                         : null}
+                      testID={typeof getCellTestId === 'function'
+                        ? getCellTestId(row, cellValue, rowIndex)
+                        : null}
                       style:text-align={keyedColumn?.align ?? null}
                       style:max-width={keyedColumn?.maxWidth ?? null}
                       title={keyedColumn?.maxWidth && isScalarCell ? String(cellValue) : null}
@@ -867,6 +878,9 @@
                         class={isContentScrollable ? 'scrollable-content' : ''}
                         class:table-cell-clamp={keyedColumn?.maxWidth && isScalarCell}
                         data-pw={keyedColumn?.testId
+                          ? `${keyedColumn.testId}-cell-${rowIndex}`
+                          : null}
+                        testID={keyedColumn?.testId
                           ? `${keyedColumn.testId}-cell-${rowIndex}`
                           : null}
                       >
@@ -903,10 +917,19 @@
       <!-- DataGrid parity: pagination chrome only renders when the data spans
            more than one page (or the server reports more chunks); a
            single-page table shows no footer. -->
-      <div class="table-footer table-paginator" data-pw={pagination.testId ?? null}>
+      <div
+        class="table-footer table-paginator"
+        data-pw={pagination.testId ?? null}
+        testID={pagination.testId ?? null}
+      >
         <span
           class="table-paginator-range"
           data-pw={typeof testId === 'string'
+            ? `${testId}-paginator-range`
+            : pagination?.testId
+              ? `${pagination.testId}-range`
+              : null}
+          testID={typeof testId === 'string'
             ? `${testId}-paginator-range`
             : pagination?.testId
               ? `${pagination.testId}-range`

--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -187,7 +187,7 @@
   );
 </script>
 
-<div class={rootClass} class:disabled class:vertical={isVertical} data-pw={testId}>
+<div class={rootClass} class:disabled class:vertical={isVertical} data-pw={testId} testID={testId}>
   {#if showStartArrow}
     <button
       class="tabs-arrow tabs-arrow-start"
@@ -226,6 +226,7 @@
         aria-disabled={disabled ? true : null}
         tabindex={isActiveItem(index) ? 0 : -1}
         data-pw={tabItem?.testId}
+        testID={tabItem?.testId}
         onclick={() => handleTabClick(index)}
         onkeydown={(event) => handleKeydown(event, index)}
       >

--- a/src/lib/ThemeSwitcher/ThemeSwitcher.svelte
+++ b/src/lib/ThemeSwitcher/ThemeSwitcher.svelte
@@ -113,6 +113,7 @@
     onclick={handleToggle}
     aria-label="Switch theme"
     data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
   >
     {#each options as option, i (option.value)}
       <span class="icon" class:active={i === currentIndex}>
@@ -126,7 +127,11 @@
     {/each}
   </button>
 {:else}
-  <div class="segment-control {classes ?? ''}" data-pw={typeof testId === 'string' ? testId : null}>
+  <div
+    class="segment-control {classes ?? ''}"
+    data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
+  >
     <div
       class="segment-indicator"
       style="left: {indicatorLeft}px; width: {indicatorWidth}px;"

--- a/src/lib/Toast/Toast.svelte
+++ b/src/lib/Toast/Toast.svelte
@@ -117,6 +117,7 @@
     out:fly={animationConfig.out}
     onoutroend={handleAnimationEnd}
     data-pw={testId}
+    testID={testId}
   >
     {#if typeof leftIcon === 'string' && leftIcon.length > 0}
       <div class="toast-icon-wrapper">
@@ -124,10 +125,10 @@
       </div>
     {/if}
 
-    <div class="toast-message" data-pw={messageTestId}>
+    <div class="toast-message" data-pw={messageTestId} testID={messageTestId}>
       {message}
       {#if typeof subtext === 'string' && subtext.length > 0}
-        <div class="toast-subtext" data-pw={subTextTestId}>{subtext}</div>
+        <div class="toast-subtext" data-pw={subTextTestId} testID={subTextTestId}>{subtext}</div>
       {/if}
 
       {#if typeof bottomContent === 'function'}
@@ -148,6 +149,7 @@
           }
         }}
         data-pw={closeIconTestId}
+        testID={closeIconTestId}
       >
         <Img inlineSvg src={rightIcon} alt="Close" fallback="" />
       </div>

--- a/src/lib/Toggle/Toggle.svelte
+++ b/src/lib/Toggle/Toggle.svelte
@@ -18,7 +18,13 @@
   };
 </script>
 
-<div class="container {classes ?? ''}" class:disabled aria-disabled={disabled} data-pw={testId}>
+<div
+  class="container {classes ?? ''}"
+  class:disabled
+  aria-disabled={disabled}
+  data-pw={testId}
+  testID={testId}
+>
   <div class="text" hidden={text.length === 0}>{text}</div>
   <label class="switch">
     <input

--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -17,8 +17,12 @@
   }: ToolbarProperties = $props();
 </script>
 
-<div class="toolbar {classes ?? ''}" data-pw={testId}>
-  <div class="content" data-pw={typeof testId === 'string' ? `${testId}-content` : null}>
+<div class="toolbar {classes ?? ''}" data-pw={testId} testID={testId}>
+  <div
+    class="content"
+    data-pw={typeof testId === 'string' ? `${testId}-content` : null}
+    testID={typeof testId === 'string' ? `${testId}-content` : null}
+  >
     {#if typeof leftContent === 'function'}
       {@render leftContent()}
     {:else if showBackButton && typeof backIcon === 'string' && backIcon.length > 0}
@@ -31,7 +35,7 @@
         {@render centerContent()}
       </div>
     {:else if typeof text === 'string' && text.length > 0}
-      <div class="text" data-pw={headingTestId}>
+      <div class="text" data-pw={headingTestId} testID={headingTestId}>
         {text}
       </div>
     {/if}

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -234,10 +234,9 @@
     }
     const bubble = document.createElement('div');
     bubble.setAttribute('role', 'tooltip');
-    bubble.setAttribute(
-      'data-pw',
-      typeof testId === 'string' ? `${testId}-bubble` : 'tooltip-bubble'
-    );
+    const bubbleTestId = typeof testId === 'string' ? `${testId}-bubble` : 'tooltip-bubble';
+    bubble.setAttribute('data-pw', bubbleTestId);
+    bubble.setAttribute('testID', bubbleTestId);
 
     const coords = computePortalCoords(rect, pos);
     bubble.style.cssText = [
@@ -359,6 +358,7 @@
   onfocusin={showTooltip}
   onfocusout={hideTooltip}
   data-pw={testId}
+  testID={testId}
 >
   {#if typeof icon === 'function' && iconPosition === 'leading'}
     <span class="tooltip-icon" aria-hidden="true">{@render icon()}</span>
@@ -374,6 +374,7 @@
       role="tooltip"
       style:--tooltip-shift="{bubbleShift}px"
       data-pw={typeof testId === 'string' ? `${testId}-bubble` : 'tooltip-bubble'}
+      testID={typeof testId === 'string' ? `${testId}-bubble` : 'tooltip-bubble'}
     >
       <div class="tooltip-arrow"></div>
       {#if typeof content === 'function'}

--- a/src/lib/_chart/Axis.svelte
+++ b/src/lib/_chart/Axis.svelte
@@ -44,7 +44,11 @@
   const TICK_SIZE = 6;
 </script>
 
-<g class="axis axis-{orientation} {classes ?? ''}" data-pw={`axis-${orientation}`}>
+<g
+  class="axis axis-{orientation} {classes ?? ''}"
+  data-pw={`axis-${orientation}`}
+  testID={`axis-${orientation}`}
+>
   {#if isHorizontal}
     <line class="axis-line" x1={scale.range[0]} x2={scale.range[1]} y1={0} y2={0} />
     {#each tickValues as tick, i (i)}
@@ -59,6 +63,7 @@
               text-anchor="end"
               dominant-baseline="auto"
               data-pw={`tick-label-${i}`}
+              testID={`tick-label-${i}`}
             >
               {format(tick)}
             </text>
@@ -69,6 +74,7 @@
               text-anchor="middle"
               dominant-baseline={orientation === 'bottom' ? 'hanging' : 'auto'}
               data-pw={`tick-label-${i}`}
+              testID={`tick-label-${i}`}
             >
               {format(tick)}
             </text>
@@ -105,6 +111,7 @@
           text-anchor={orientation === 'left' ? 'end' : 'start'}
           dominant-baseline="middle"
           data-pw={`tick-label-${i}`}
+          testID={`tick-label-${i}`}
         >
           {format(tick)}
         </text>

--- a/src/lib/_chart/ChartContainer.svelte
+++ b/src/lib/_chart/ChartContainer.svelte
@@ -69,6 +69,7 @@
   class="chart-container {classes ?? ''}"
   bind:this={containerEl}
   data-pw={typeof testId === 'string' ? testId : null}
+  testID={typeof testId === 'string' ? testId : null}
 >
   {#if width > 0 && height > 0}
     <svg

--- a/src/lib/_chart/ChartTooltip.svelte
+++ b/src/lib/_chart/ChartTooltip.svelte
@@ -86,7 +86,7 @@
       <div class="tooltip-title">{tooltipData.title}</div>
     {/if}
     {#each tooltipData.items as item, i (i)}
-      <div class="tooltip-item" data-pw={`tooltip-item-${i}`}>
+      <div class="tooltip-item" data-pw={`tooltip-item-${i}`} testID={`tooltip-item-${i}`}>
         {#if item.color}
           <span class="tooltip-swatch" style="background: {item.color}"></span>
         {/if}
@@ -107,6 +107,7 @@
       style="left: {pos.left}px; top: {pos.top}px;"
       use:portalToBody
       data-pw="chart-tooltip"
+      testID="chart-tooltip"
     >
       {@render inner(data)}
     </div>
@@ -118,6 +119,7 @@
       class="chart-tooltip {unstyled ? 'unstyled' : ''} {classes ?? ''}"
       style="left: {pos.left}px; top: {pos.top}px;"
       data-pw="chart-tooltip"
+      testID="chart-tooltip"
     >
       {@render inner(data)}
     </div>

--- a/src/lib/_chart/Legend.svelte
+++ b/src/lib/_chart/Legend.svelte
@@ -18,6 +18,7 @@
             aria-pressed={!item.hidden}
             onclick={() => onToggle(i)}
             data-pw={`legend-toggle-${i}`}
+            testID={`legend-toggle-${i}`}
           >
             <span class="legend-swatch" style="background: {item.color}"></span>
             <span class="legend-label">{item.label}</span>

--- a/src/lib/testing-attributes.d.ts
+++ b/src/lib/testing-attributes.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Declares the native test-identifier attribute on every DOM element.
+ *
+ * Test ids have to reach two runners: Playwright reads the `data-pw` attribute,
+ * while Appium resolves an element by its native accessibility identifier and
+ * never sees `data-pw`. Components therefore emit both from the same value.
+ *
+ * `data-*` attributes are accepted by Svelte's typings automatically; a bare
+ * `testID` is not, so without this augmentation every emission fails
+ * `svelte-check` with "'testID' does not exist in type HTMLProps<...>".
+ *
+ * Spreading an attribute object would dodge the type error, but a spread makes
+ * Svelte skip its static a11y analysis for that element — silently disabling
+ * real warnings (it turns existing `svelte-ignore` comments into dead code).
+ * Declaring the attribute keeps both the type check and the a11y analysis.
+ *
+ * The declared key is lower-case because Svelte normalises DOM attribute names,
+ * as does `setAttribute` on an HTML document; authors still write `testID`.
+ *
+ * This file ships in `dist`, so consumers get the same typing for their own usage.
+ */
+/* eslint-disable unused-imports/no-unused-vars -- the type parameter name must match
+   svelte/elements' own declaration exactly, or interface merging silently fails. */
+declare module 'svelte/elements' {
+  export interface HTMLAttributes<T extends EventTarget> {
+    /** Native (Appium) test identifier. Mirrors `data-pw`, which Appium cannot read. */
+    testid?: string | null;
+  }
+
+  export interface SVGAttributes<T extends EventTarget> {
+    /** Native (Appium) test identifier. Mirrors `data-pw`, which Appium cannot read. */
+    testid?: string | null;
+  }
+}
+
+export {};

--- a/tests/native-test-id.test.ts
+++ b/tests/native-test-id.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Every component that accepts `testId` must emit the id for BOTH runners:
+ * `data-pw` for Playwright and the native accessibility id for Appium, which
+ * cannot read `data-pw`. Svelte lower-cases DOM attribute names, so the rendered
+ * attribute is `testid`.
+ */
+test.describe('testId emits both web and native test attributes', () => {
+  test('Checkbox exposes data-pw and the native testid from one testId prop', async ({ page }) => {
+    await page.goto('/components/checkbox');
+
+    const target = page.locator('[data-pw="checkbox-default"]').first();
+    await expect(target).toBeVisible();
+
+    // Same element, same value, reachable by either runner's attribute.
+    await expect(target).toHaveAttribute('testid', 'checkbox-default');
+    await expect(page.locator('[testid="checkbox-default"]').first()).toBeVisible();
+  });
+
+  test('the native attribute is omitted when no testId is supplied', async ({ page }) => {
+    await page.goto('/components/checkbox');
+
+    // A bare `testid` must never render as the literal string "undefined"/"null";
+    // absent ids emit no attribute at all.
+    const strayIds = await page
+      .locator('[testid="undefined"], [testid="null"], [testid=""]')
+      .count();
+    expect(strayIds).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Components accept a single `testId` prop but emit **only** `data-pw`. Playwright reads `data-pw`; **Appium resolves an element by its native accessibility identifier and never sees it.** So a component with a `testId` is invisible to native automation.

Consumers work around this with a hand-rolled Svelte action:

```ts
// consumer-side workaround
export function testAttributes(node: HTMLElement, id: string) {
  node.setAttribute("data-pw", id);
  node.setAttribute("testID", id);   // <- the bit the library does not do
}
```

That makes migrating a raw `<button use:testAttributes={id}>` to the library `<Button testId={id}>` a **silent loss of native-test coverage** — which is currently blocking a component-migration campaign in Lighthouse (64 such call sites across three files).

## Fix

Every `testId` emission now renders **both** attributes, from the same value:

```svelte
<button data-pw={testId} testID={testId}>
```

`119` emission sites across `66` components, plus the five hand-rolled spread objects in `Select.svelte`. `data-pw` behaviour is unchanged — this is purely additive.

A shipped module augmentation (`src/lib/testing-attributes.d.ts` → `dist/`) declares the attribute on `svelte/elements`, so it type-checks here *and* for consumers writing their own `testID`.

## Two non-obvious decisions

**1. Declared attribute, not a spread.** The obvious DRY fix is a helper spread onto each element:

```svelte
{...testAttributes(testId)}   <!-- rejected -->
```

It dodges the type error, but **a spread attribute makes Svelte skip its static a11y analysis for that element.** Implementing it that way turned six existing `svelte-ignore` comments into dead code (`svelte/no-unused-svelte-ignore` errors in `Book`, `Checkbox`, `Combobox`) — i.e. it would have silently disabled real a11y warnings across 117 elements. Explicit attributes keep both the type check and the a11y analysis.

**2. The declared key is lower-case (`testid`).** Svelte normalises DOM attribute names, as does `setAttribute` on an HTML document — the rendered attribute is `testid` either way. Authors still write `testID`. (The type parameter name in the augmentation must also match `svelte/elements` exactly: renaming `T` breaks interface merging and produced 130 phantom errors.)

## Verification

| Gate | Result |
|---|---|
| `npm run check` | **0 errors** (was 0 on base; 4 pre-existing warnings) |
| `npm run lint` | **0 errors**, 3 warnings — identical to base |
| `npm run test:unit` | **108 passed** |
| `npm run test:integration` | **127 passed** — no regressions |
| New integration test | **2 passed** |
| `npm run build` | clean; `dist/testing-attributes.d.ts` ships |

`tests/native-test-id.test.ts` is added and asserts the real rendered DOM: the same element carries `data-pw="checkbox-default"` **and** `testid="checkbox-default"`, and absent ids emit no stray `testid="undefined"`.

## Compatibility

Backwards compatible. No API change, no `data-pw` change, no visual change — one additional attribute on elements that already had `data-pw`. Consumers can delete their `testAttributes` actions and pass `testId` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native `testID` attributes across UI components, including controls, charts, navigation, overlays, inputs, and table elements.
  * Test identifiers are now available for accessibility-focused automation while preserving existing selectors.
  * Added support for test identifier typing on HTML and SVG elements.

* **Tests**
  * Added coverage confirming valid identifiers render correctly and are omitted when not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->