### PR TITLE
BZ-4233: fix(Tabs): add APG arrow-key navigation to the roving tabindex

### DIFF
--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from 'svelte';
   import type { TabItem, TabsProperties } from './properties';
   import Img from '../Img/Img.svelte';
   import chevronLeftSvg from '$lib/assets/chevron-left.svg?raw';
@@ -149,11 +150,49 @@
     }
   }
 
+  // After a keyboard-driven selection the active item changes (directly in
+  // string mode; via the consumer's activeKey update in object mode), and the
+  // roving tabindex re-roves with it. Move DOM focus onto the newly active tab
+  // so the user can keep arrowing — without this, focus is stranded on a
+  // tabindex="-1" item and the roving pattern breaks down.
+  function moveFocusToActiveTab(): void {
+    void tick().then(() => {
+      const activeTab = scrollContainer?.querySelector<HTMLElement>('[role="tab"][tabindex="0"]');
+      activeTab?.focus();
+    });
+  }
+
+  // WAI-ARIA APG tablist keyboard contract with activation-follows-focus:
+  // Arrow keys (orientation-aware) move selection to the adjacent tab with
+  // wrap-around, Home/End jump to the first/last tab. Without this, the roving
+  // tabindex makes every non-active tab keyboard-unreachable.
   function handleKeydown(event: KeyboardEvent, index: number): void {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       handleTabClick(index);
+      return;
     }
+    const nextKey = isVertical ? 'ArrowDown' : 'ArrowRight';
+    const previousKey = isVertical ? 'ArrowUp' : 'ArrowLeft';
+    let targetIndex: number | null = null;
+    if (event.key === nextKey) {
+      targetIndex = (index + 1) % items.length;
+    } else if (event.key === previousKey) {
+      targetIndex = (index - 1 + items.length) % items.length;
+    } else if (event.key === 'Home') {
+      targetIndex = 0;
+    } else if (event.key === 'End') {
+      targetIndex = items.length - 1;
+    }
+    if (targetIndex === null) {
+      return;
+    }
+    event.preventDefault();
+    if (disabled || targetIndex === index) {
+      return;
+    }
+    handleTabClick(targetIndex);
+    moveFocusToActiveTab();
   }
 
   function initOverflow(node: HTMLDivElement): () => void {
@@ -209,6 +248,7 @@
     class:fade-top={canScrollUp}
     class:fade-bottom={canScrollDown}
     role="tablist"
+    aria-orientation={isVertical ? 'vertical' : null}
     {@attach initOverflow}
     onscroll={updateOverflow}
   >

--- a/tests/tabs-keyboard-navigation.spec.ts
+++ b/tests/tabs-keyboard-navigation.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test';
+
+// The roving tabindex (active tab 0, everything else -1) used to pair with a
+// keydown handler that only covered Enter/Space — a keyboard user could Tab
+// onto the active tab and never reach any other tab. These tests pin the
+// WAI-ARIA APG tablist contract now implemented: orientation-aware arrow keys
+// move selection with activation-follows-focus and wrap-around, Home/End jump
+// to the ends, and DOM focus lands on the newly active tab so arrowing chains.
+test.describe('Tabs keyboard navigation (APG tablist contract)', () => {
+  test('ArrowRight/ArrowLeft move selection and focus with wrap-around (horizontal, string mode)', async ({
+    page
+  }) => {
+    await page.goto('/components/tabs');
+
+    const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
+    const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
+
+    await tabAt('Tab 1').focus();
+    await expect(tabAt('Tab 1')).toBeFocused();
+
+    await page.keyboard.press('ArrowRight');
+    await expect(tabAt('Tab 2')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('Tab 2')).toBeFocused();
+    await expect(tabAt('Tab 1')).toHaveAttribute('tabindex', '-1');
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(tabAt('Tab 1')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('Tab 1')).toBeFocused();
+
+    // Wrap-around: ArrowLeft from the first tab reaches the last.
+    await page.keyboard.press('ArrowLeft');
+    await expect(tabAt('Tab 20')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('Tab 20')).toBeFocused();
+  });
+
+  test('Home/End jump to the first/last tab, scrolling the offscreen target into view', async ({
+    page
+  }) => {
+    await page.goto('/components/tabs');
+
+    const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
+    const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
+
+    await tabAt('Tab 1').focus();
+    await page.keyboard.press('End');
+    await expect(tabAt('Tab 20')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('Tab 20')).toBeFocused();
+    await expect(tabAt('Tab 20')).toBeInViewport();
+
+    await page.keyboard.press('Home');
+    await expect(tabAt('Tab 1')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('Tab 1')).toBeFocused();
+    await expect(tabAt('Tab 1')).toBeInViewport();
+  });
+
+  test('vertical orientation uses ArrowDown/ArrowUp and ignores ArrowRight (object mode via activeKey)', async ({
+    page
+  }) => {
+    await page.goto('/components/tabs');
+
+    const rail = page.getByTestId('tabs-vertical-demo');
+    await expect(rail.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+
+    const tabAt = (label: string) => rail.getByRole('tab', { name: label });
+
+    await tabAt('Cart Design').focus();
+    await page.keyboard.press('ArrowDown');
+    await expect(tabAt('General')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('General')).toBeFocused();
+
+    // The cross-axis arrow is not part of a vertical tablist's contract.
+    await page.keyboard.press('ArrowRight');
+    await expect(tabAt('General')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('General')).toBeFocused();
+
+    await page.keyboard.press('ArrowUp');
+    await expect(tabAt('Cart Design')).toHaveAttribute('aria-selected', 'true');
+    await expect(tabAt('Cart Design')).toBeFocused();
+  });
+
+  test('Enter and Space still activate the focused tab', async ({ page }) => {
+    await page.goto('/components/tabs');
+
+    const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
+    const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
+
+    // Focus moves with selection (activation follows focus), so Enter/Space on
+    // the focused active tab is a no-op that must not throw or move selection.
+    await tabAt('Tab 1').focus();
+    await page.keyboard.press('Enter');
+    await expect(tabAt('Tab 1')).toHaveAttribute('aria-selected', 'true');
+    await page.keyboard.press(' ');
+    await expect(tabAt('Tab 1')).toHaveAttribute('aria-selected', 'true');
+  });
+});


### PR DESCRIPTION
## What

`Tabs` roves `tabindex` (active item `0`, every other item `-1`) but `handleKeydown` covered only Enter/Space — **no ArrowLeft/ArrowRight/Home/End**. A keyboard user who Tab-focuses the active tab can never reach any other tab: the roving pattern without its arrow-key half strands them. Found adopting `Tabs` on Lighthouse's `/ai/campaigns` (BZ-4233 wave, PR bitbucket lighthouse #6669), where it regressed per-tab native `<button>` rows that were all in the tab order; Lighthouse currently ships a consumer-side stopgap action that this fix makes deletable.

This implements the WAI-ARIA APG tablist keyboard contract in the component:

- **Arrow keys, orientation-aware**: ArrowRight/ArrowLeft when horizontal, ArrowDown/ArrowUp when vertical, moving selection to the adjacent tab with wrap-around, activation-follows-focus (consistent with the component's selection == roving-focus design).
- **Home/End** jump to the first/last tab.
- **Focus follows**: after the `tabindex` re-roves (directly in string mode; via the consumer's `activeKey` update in object mode), DOM focus moves onto the newly active tab so arrowing chains — focusing an offscreen tab also scrolls it into view natively.
- **`aria-orientation="vertical"`** now set on the tablist when vertical (APG requirement).
- Enter/Space behavior unchanged; cross-axis arrows are ignored per the contract.

## Proof — before/after, same evidence standard as the BZ-4233 waves

New spec `tests/tabs-keyboard-navigation.spec.ts` (4 tests, driving the existing `/components/tabs` demo — string-mode horizontal 20-tab overflow instance AND the object-mode vertical `activeKey`-wired rail):

| Run | Result |
|---|---|
| Spec against the **base** component (fix stashed) — negative control | **3 navigation tests FAIL** (arrows, Home/End, vertical) · Enter/Space test passes — proving the failures are the missing capability, not the harness |
| Spec against **this PR** | **4/4 pass** |
| Pre-existing `tests/tabs-fade-solid-zone.spec.ts` — no-regression control | 2/2 pass |
| `pnpm run check` | 0 errors (553 files) |
| `prettier --check` on touched files | clean |

Assertions cover: `aria-selected` + `toBeFocused()` on every move, `tabindex` re-roving, wrap-around at both ends, offscreen target `toBeInViewport()` after End/Home, ArrowRight ignored on a vertical tablist, and object-mode selection round-tripping through the consumer's `onkeychange → activeKey` update.

## Behavior notes

- No visual change — the diff is keyboard handling + one aria attribute.
- String mode updates the bindable `activeIndex` exactly as a click does; object mode fires `onkeychange` exactly as a click does — no new API surface.
- If an object-mode consumer ignores `onkeychange`, focus re-roves back to the still-active tab — same net behavior as clicking a tab the consumer refuses to switch to.

## Downstream

Lighthouse will bump to the release carrying this and delete its `tabKeyboardNav` stopgap in BZ-4233 PR #6669 (the PR's Playwright keyboard spec stays as the consumer-side guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced keyboard navigation for tabs with arrow, Home, and End keys.
  * Added focus management so the active tab receives focus after selection.
  * Added support for vertical tab orientation and appropriate ARIA semantics.
  * Improved wrap-around navigation and scrolling to offscreen tabs.

* **Tests**
  * Added coverage for keyboard navigation, focus behavior, orientation-specific controls, and activation keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->