### PR TITLE
fix(SplitInput): distribute whole-code autofill into single-char fields

### DIFF
--- a/src/lib/SplitInput/SplitInput.svelte
+++ b/src/lib/SplitInput/SplitInput.svelte
@@ -56,6 +56,32 @@
 
   // ── Input handler ───────────────────────────────────────────────
 
+  // Multi-char cleanup for the distribute paths: tel fields keep digits only
+  // (an OTP autofilled/pasted as "123-456" or "123 456" must land as 123456,
+  // never distribute a separator into a field); other dataTypes keep the old
+  // whitespace-strip behavior.
+  function sanitizeChars(config: FieldConfig, raw: string): string {
+    if ((config.dataType ?? 'text') === 'tel') {
+      return raw.replace(/\D/g, '');
+    }
+    return raw.replace(/\s/g, '');
+  }
+
+  // Single-char autoAdvance fields widen the inner Input's maxLength to the
+  // whole code length: Input's dataType='tel' sanitizer truncates an overflowing
+  // value to its LAST maxLength digits BEFORE onInput fires, so with the literal
+  // maxLength of 1 a WebOTP / Android-SMS autofill that drops the whole code
+  // into one field reached handleFieldInput as a single wrong digit and the
+  // distribute branch below could never run. One-char-per-field semantics are
+  // enforced by handleFieldInput itself, not by the inner Input.
+  function innerMaxLength(config: FieldConfig): number {
+    const configured = config.maxLength ?? 1000;
+    if (autoAdvance && configured === 1) {
+      return fieldCount;
+    }
+    return configured;
+  }
+
   function handleFieldInput(index: number, inputValue: string) {
     const config = fieldConfigs.at(index);
     if (typeof config === 'undefined') {
@@ -64,11 +90,25 @@
     const maxLen = config.maxLength ?? 1000;
 
     if (autoAdvance && maxLen === 1 && inputValue.length > 1) {
-      const chars = inputValue.replace(/\s/g, '');
-      for (let i = 0; i < fieldCount; i++) {
-        values[i] = chars.charAt(i);
+      const chars = sanitizeChars(config, inputValue);
+      if (chars.length === 0) {
+        values[index] = '';
+      } else if (index === 0 || chars.length >= fieldCount) {
+        // Autofill / OS-level insertion of a whole code: distribute from the
+        // start. Only provided characters are written — a partial string must
+        // not clear fields beyond it.
+        for (let i = 0; i < Math.min(chars.length, fieldCount); i++) {
+          values[i] = chars.charAt(i);
+        }
+        focusField(Math.min(chars.length, fieldCount) - 1);
+      } else {
+        // Overtyping an already-filled field: keep the newest character and
+        // advance, mirroring single-char entry.
+        values[index] = chars.slice(-1);
+        if (index < fieldCount - 1) {
+          focusField(index + 1);
+        }
       }
-      focusField(Math.min(chars.length, fieldCount) - 1);
     } else {
       values[index] = inputValue;
       if (autoAdvance && maxLen === 1 && inputValue.length > 0 && index < fieldCount - 1) {
@@ -111,9 +151,10 @@
     }
     e.preventDefault();
     const pasted = e.clipboardData.getData('text').trim();
+    const config = fieldConfigs.at(index);
 
-    if (autoAdvance) {
-      const chars = pasted.replace(/\s/g, '');
+    if (autoAdvance && typeof config !== 'undefined') {
+      const chars = sanitizeChars(config, pasted);
       for (let i = index; i < fieldCount; i++) {
         const charIdx = i - index;
         if (charIdx >= chars.length) {
@@ -153,7 +194,8 @@
       <Input
         value={getFieldValue(index)}
         dataType={config.dataType ?? 'text'}
-        maxLength={config.maxLength ?? 1000}
+        maxLength={innerMaxLength(config)}
+        testId={config.testId}
         min={config.min}
         max={config.max}
         placeholder={config.placeholder}

--- a/src/lib/SplitInput/properties.ts
+++ b/src/lib/SplitInput/properties.ts
@@ -12,6 +12,7 @@ export type FieldConfig = Pick<
   | 'label'
   | 'autoComplete'
   | 'inputMode'
+  | 'testId'
 >;
 
 export type SplitInputProperties = MandatorySplitInputProperties &

--- a/tests/splitinput-autofill-distribute.spec.ts
+++ b/tests/splitinput-autofill-distribute.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+
+// WebOTP / Android-SMS autofill drops the WHOLE code into the first field as a
+// single input event (no keyboard, no clipboard paste). With the default
+// single-char tel fields, the inner Input's dataType='tel' sanitizer used to
+// truncate that value to its LAST digit before SplitInput's onInput fired, so
+// the distribute branch never ran and a 4-digit code landed as one wrong digit.
+// These tests pin the fixed contract: single-char autoAdvance fields widen the
+// inner maxLength to the code length, handleFieldInput distributes the full
+// (digit-sanitized) code from field 0, and one-char-per-field semantics are
+// enforced by SplitInput itself — including overtype-replaces on filled fields.
+test.describe('SplitInput autofill/multi-char distribution', () => {
+  // Serialized into the browser by evaluate() — the injected code must arrive
+  // as the evaluate argument, never via closure.
+  const inject = (el: HTMLInputElement, code: string) => {
+    el.value = code;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+
+  test('whole code injected into field 0 distributes across all fields', async ({ page }) => {
+    await page.goto('/components/split-input');
+
+    const group = page.getByTestId('split-input-default');
+    const inputs = group.locator('input');
+
+    await inputs.nth(0).evaluate(inject, '1234');
+
+    await expect(inputs.nth(0)).toHaveValue('1');
+    await expect(inputs.nth(1)).toHaveValue('2');
+    await expect(inputs.nth(2)).toHaveValue('3');
+    await expect(inputs.nth(3)).toHaveValue('4');
+    // bind:values reached the consumer (the demo renders the joined value).
+    await expect(page.getByText('Value: 1234')).toBeVisible();
+    // Focus advanced to the last filled field so Backspace/typing continues there.
+    await expect(inputs.nth(3)).toBeFocused();
+  });
+
+  test('injected code with separators is digit-sanitized before distribution', async ({ page }) => {
+    await page.goto('/components/split-input');
+
+    const inputs = page.getByTestId('split-input-sms-otp').locator('input');
+
+    await inputs.nth(0).evaluate(inject, '56-78');
+
+    await expect(inputs.nth(0)).toHaveValue('5');
+    await expect(inputs.nth(1)).toHaveValue('6');
+    await expect(inputs.nth(2)).toHaveValue('7');
+    await expect(inputs.nth(3)).toHaveValue('8');
+  });
+
+  test('single-character typing still auto-advances field by field', async ({ page }) => {
+    await page.goto('/components/split-input');
+
+    const inputs = page.getByTestId('split-input-default').locator('input');
+
+    await inputs.nth(0).click();
+    await page.keyboard.type('9');
+    await expect(inputs.nth(0)).toHaveValue('9');
+    await expect(inputs.nth(1)).toBeFocused();
+
+    await page.keyboard.type('8');
+    await expect(inputs.nth(1)).toHaveValue('8');
+    await expect(inputs.nth(2)).toBeFocused();
+  });
+
+  test('typing into an already-filled middle field keeps the newest digit and advances', async ({
+    page
+  }) => {
+    await page.goto('/components/split-input');
+
+    const inputs = page.getByTestId('split-input-default').locator('input');
+
+    await inputs.nth(0).evaluate(inject, '1234');
+    await expect(inputs.nth(3)).toHaveValue('4');
+
+    await inputs.nth(1).click();
+    await page.keyboard.type('7');
+
+    await expect(inputs.nth(1)).toHaveValue('7');
+    await expect(inputs.nth(0)).toHaveValue('1');
+    await expect(inputs.nth(2)).toBeFocused();
+    await expect(page.getByText('Value: 1734')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Problem

WebOTP / Android SMS autofill (`autocomplete="one-time-code"`) drops the **whole code into the first field as a single input event** — no keyboard, no clipboard paste. With the default single-char fields (`{dataType:'tel', maxLength:1}`), `Input`'s tel sanitizer truncates the overflowing value to its **last** `maxLength` digits (`currentValue.substring(numberLength - maxLength)`) *before* `onInput` fires — so SplitInput's multi-char distribute branch (`inputValue.length > 1`) was unreachable, and a 6-digit code landed as one wrong digit (the last one). Clipboard paste worked only because SplitInput `preventDefault`s the paste event before Input sees it.

This is the exact scenario the downstream Lighthouse OTP migration (BZ-4233) is blocked on: adopting SplitInput today would break Android SMS autofill on the auth flow.

## Fix (SplitInput-scoped; Input untouched)

- **`innerMaxLength`**: single-char `autoAdvance` fields pass `fieldCount` as the inner Input's `maxLength`, so the sanitizer keeps the whole digit string and the distribute branch can run. One-char-per-field semantics are enforced by `handleFieldInput` itself.
- **Digit sanitization for tel** in both distribute paths (`/\D/g` instead of whitespace-only): a code arriving as `123-456` or `123 456` distributes as `123456` — a separator can never land in a field. Non-tel fields keep the old whitespace-strip.
- **Distribution semantics** aligned with the proven hand-rolled OTP implementations: whole codes distribute from field 0 with focus on the last filled field; **partial strings no longer clear fields beyond them** (the old loop wrote `''` into every remaining field — dead code until now, since the branch was unreachable for tel); **overtyping an already-filled middle field keeps the newest digit and advances** (previously: silently ignored).
- **`FieldConfig.testId`** passthrough to the inner Input (`data-pw`/`testID` per field) — downstream consumers keep their per-input test hooks (e.g. Lighthouse's `one-time-otp`).

## Evidence

`tests/splitinput-autofill-distribute.spec.ts` (4 tests) simulates OS-level autofill via value injection + input event (no keyboard/clipboard):
- **With fix: 4/4 pass.**
- **Negative control — against the base component: 3/4 fail** (both autofill-distribution tests + overtype); only the unchanged single-char typing path passes.

`pnpm run check`: 0 errors. Lint: 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-field input handling for autofill, paste, partial values, and overtyped input.
  * Telephone fields now keep digits only, while other fields remove whitespace and separators.
  * Prevented unrelated fields from being cleared during input distribution.
  * Improved auto-advance behavior and replacement of filled fields.

* **Tests**
  * Added coverage for autofill, sanitization, focus movement, and joined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->