### PR TITLE
feat(ChipInput): add free-text tag/chip input component

### DIFF
--- a/docs/ChipInput.md
+++ b/docs/ChipInput.md
@@ -1,0 +1,90 @@
+# ChipInput
+
+A free-text tag/chip input composed from `Input` and `Pill`. The user types into a draft field and commits the current text into a chip by pressing Enter or by blurring the field; each committed chip renders as a dismissible `Pill` with a click-to-remove control. The bindable `values` prop is the `string[]` of committed chips -- duplicate and empty entries are silently dropped on commit. Use it for tag lists, keyword entry, blocklists, or any freeform multi-value field where the set of values is unbounded and user-authored (as opposed to `SplitInput`, which is for a fixed number of structured, fixed-position fields).
+
+## Usage
+
+```svelte
+<script>
+  import { ChipInput } from '@juspay/svelte-ui-components';
+
+  let productTags = $state(['sale', 'featured']);
+</script>
+
+<ChipInput bind:values={productTags} placeholder="Add tag…" testId="product-tags" />
+```
+
+```svelte
+<script>
+  import { ChipInput } from '@juspay/svelte-ui-components';
+
+  let blockedEmails = $state([]);
+</script>
+
+<!-- disabled, with onadd/ondismiss for side effects beyond the bound array -->
+<ChipInput
+  bind:values={blockedEmails}
+  placeholder="e.g. name@example.com"
+  disabled={blockedEmails.length >= 10}
+  onadd={(value) => console.log('added', value)}
+  ondismiss={(value) => console.log('removed', value)}
+/>
+```
+
+## Props
+
+| Prop        | Type       | Required | Default        | Description                                                                                                        |
+| ----------- | ---------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| values      | `string[]` | Yes      | `[]`            | Bindable. The committed chips, in insertion order. Replaced with a new array by add/dismiss (`values` is reassigned, not mutated in place -- do not rely on array reference identity); also settable externally.        |
+| placeholder | `string`   | No       | `'Add value…'`  | Placeholder text shown in the empty draft field.                                                                     |
+| disabled    | `boolean`  | No       | `false`         | Disables the draft field and hides each chip's dismiss control (chips remain visible, but cannot be added or removed). |
+| testId      | `string`   | No       | `-`             | Value for the `data-pw`/native `testid` attributes on the container. Chips get `` `${testId}-chip` `` and the draft field gets `` `${testId}-input` ``. |
+| classes     | `string`   | No       | `-`             | CSS class string applied to the component's top-level element.                                                      |
+
+### Duplicate values
+
+`ChipInput` is dedup-only by contract: `addChip` drops a value already present in `values`, so the component's own commit path never produces duplicate chips. `values` is bindable, so a caller can still assign an array containing duplicates directly -- if it does, dismissing a chip removes only the first matching occurrence, not every occurrence with that text.
+
+## Events
+
+| Event      | Type                          | Description                                                                                                    |
+| ---------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| onadd      | `(value: string) => void`     | Fires after a chip is committed (Enter or blur) and appended to `values`. Not fired for a duplicate or blank draft. |
+| ondismiss  | `(value: string) => void`     | Fires after a chip is removed and spliced out of `values`.                                                       |
+| onchange   | `(values: string[]) => void`  | Fires alongside `onadd`/`ondismiss`. Receives a copy of the current `values` array.                              |
+
+## CSS Variables
+
+Override these custom properties to theme the component.
+
+| Variable                         | Default                    | CSS Property   | Description                                                        |
+| --------------------------------- | --------------------------- | -------------- | -------------------------------------------------------------------- |
+| `--chip-input-gap`                | `6px`                       | gap            | Spacing between chips and the draft field.                          |
+| `--chip-input-flex-wrap`          | `wrap`                      | flex-wrap      | Whether chips wrap onto multiple lines.                             |
+| `--chip-input-align-items`        | `center`                    | align-items    | Cross-axis alignment of chips and the draft field.                  |
+| `--chip-input-justify-content`    | `flex-start`                | justify-content| Main-axis alignment of the chip/draft row.                          |
+| `--chip-input-width`              | `100%`                      | width          | Width of the overall container.                                     |
+| `--chip-input-draft-flex`         | `0 1 auto`                  | flex           | Flex sizing of the draft field's wrapper relative to the chips.     |
+| `--chip-input-draft-width`        | `90px`                      | width          | Width of the draft field.                                           |
+| `--chip-input-draft-height`       | `28px`                      | height         | Height of the draft field.                                          |
+| `--chip-input-draft-border`       | `1px solid transparent`     | border         | Border of the draft field.                                          |
+| `--chip-input-draft-radius`       | `4px`                       | border-radius  | Corner rounding of the draft field.                                 |
+| `--chip-input-draft-focus-border` | `1px solid transparent`     | border         | Border of the draft field while focused.                            |
+| `--chip-input-draft-padding`      | `0 2px`                     | padding        | Padding inside the draft field.                                     |
+| `--chip-input-draft-font-size`    | `13px`                      | font-size      | Font size of the draft field's text.                                |
+| `--chip-input-pill-gap`           | `4px`                       | gap            | Gap between a chip's label and its dismiss control.                 |
+| `--chip-input-pill-background`    | `#e0e0e0`                   | background     | Background color of each chip.                                      |
+| `--chip-input-pill-color`         | `#333333`                   | color          | Text color of each chip.                                            |
+| `--chip-input-pill-font-size`     | `13px`                      | font-size      | Font size of each chip's label.                                     |
+| `--chip-input-pill-font-weight`   | `500`                       | font-weight    | Font weight of each chip's label.                                   |
+| `--chip-input-pill-padding`       | `6px 10px`                  | padding        | Padding inside each chip.                                           |
+| `--chip-input-pill-border-radius` | `999px`                     | border-radius  | Corner rounding of each chip.                                       |
+| `--chip-input-pill-border`        | `none`                      | border         | Border of each chip.                                                |
+| `--chip-input-pill-max-width`     | (none)                      | max-width      | Maximum width of a chip before its label truncates with an ellipsis.|
+| `--chip-input-pill-dismiss-size`  | `14px`                      | width/height   | Size of the dismiss icon on each chip.                               |
+| `--chip-input-pill-dismiss-color` | `currentColor`              | color          | Color of the dismiss icon on each chip.                              |
+
+## Internal Dependencies
+
+- `Input` -- renders the draft text field that a user types a new chip's text into.
+- `Pill` -- renders each committed chip, in `dismissible` mode (except while `disabled`).

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -72,6 +72,10 @@
     "description": "A checkbox list item with an HTML-capable text label. When clicked, toggles the `checked` state and fires `onclick` with the new boolean value. Supports a custom `checkboxLabel` snippet and disabled state. The checked state is bindable."
   },
   {
+    "name": "ChipInput",
+    "description": "A free-text tag/chip input built by composing Input and Pill. Typed text commits into a chip on Enter or on blur, rendered as a dismissible Pill; the bindable `values` array holds the committed chips. Deduplicates on add, supports a disabled state, and exposes onadd/ondismiss/onchange callbacks alongside the bindable array. Use for tag lists, keyword entry, or any freeform multi-value field."
+  },
+  {
     "name": "Choicebox",
     "description": "A selectable option group with single-select (radio) or multi-select (checkbox) behavior. Each item renders a children snippet with custom content. Supports disabled items, keyboard navigation, and configurable layout via CSS grid variables."
   },

--- a/src/lib/ChipInput/ChipInput.svelte
+++ b/src/lib/ChipInput/ChipInput.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import Input from '$lib/Input/Input.svelte';
+  import Pill from '$lib/Pill/Pill.svelte';
+  import type { ChipInputProperties } from './properties';
+
+  let {
+    values = $bindable([]),
+    placeholder = 'Add value…',
+    disabled = false,
+    testId,
+    classes,
+    onadd,
+    ondismiss,
+    onchange
+  }: ChipInputProperties = $props();
+
+  let draft = $state('');
+
+  function addChip(): void {
+    const trimmed = draft.trim();
+    draft = '';
+    if (trimmed.length === 0 || values.includes(trimmed)) {
+      return;
+    }
+    values = [...values, trimmed];
+    onadd?.(trimmed);
+    onchange?.([...values]);
+  }
+
+  function removeChip(chip: string): void {
+    // values is dedup-only by construction (addChip rejects a value already present), so this
+    // component's own commit path never produces duplicates. If a caller assigns `values`
+    // directly through the bindable prop with a duplicate, remove only the first matching
+    // occurrence rather than every occurrence with that text.
+    const chipIndex = values.indexOf(chip);
+    if (chipIndex === -1) {
+      return;
+    }
+    values = [...values.slice(0, chipIndex), ...values.slice(chipIndex + 1)];
+    ondismiss?.(chip);
+    onchange?.([...values]);
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      addChip();
+    }
+  }
+</script>
+
+<div class="chip-input {classes ?? ''}" data-pw={testId} testID={testId}>
+  {#each values as chip (chip)}
+    <Pill
+      text={chip}
+      classes="chip-input-pill"
+      dismissible={!disabled}
+      {disabled}
+      ondismiss={() => removeChip(chip)}
+      {...typeof testId === 'string' ? { testId: `${testId}-chip` } : {}}
+    />
+  {/each}
+  <div class="chip-input-draft-wrap">
+    <Input
+      value={draft}
+      {placeholder}
+      dataType="text"
+      name=""
+      autoComplete="off"
+      actionInput={false}
+      disable={disabled}
+      classes="chip-input-draft"
+      onInput={(nextValue) => {
+        draft = nextValue;
+      }}
+      onKeyDown={handleKeyDown}
+      onBlur={addChip}
+      {...typeof testId === 'string' ? { testId: `${testId}-input` } : {}}
+    />
+  </div>
+</div>
+
+<style>
+  .chip-input {
+    display: flex;
+    flex-wrap: var(--chip-input-flex-wrap, wrap);
+    align-items: var(--chip-input-align-items, center);
+    justify-content: var(--chip-input-justify-content, flex-start);
+    gap: var(--chip-input-gap, 6px);
+    width: var(--chip-input-width, 100%);
+  }
+
+  .chip-input-draft-wrap {
+    flex: var(--chip-input-draft-flex, 0 1 auto);
+  }
+
+  .chip-input :global(.chip-input-pill) {
+    --pill-gap: var(--chip-input-pill-gap, 4px);
+    --pill-background: var(--chip-input-pill-background, #e0e0e0);
+    --pill-color: var(--chip-input-pill-color, #333333);
+    --pill-font-size: var(--chip-input-pill-font-size, 13px);
+    --pill-font-weight: var(--chip-input-pill-font-weight, 500);
+    --pill-padding: var(--chip-input-pill-padding, 6px 10px);
+    --pill-border-radius: var(--chip-input-pill-border-radius, 999px);
+    --pill-border: var(--chip-input-pill-border, none);
+    --pill-max-width: var(--chip-input-pill-max-width);
+    --pill-dismiss-size: var(--chip-input-pill-dismiss-size, 14px);
+    --pill-dismiss-color: var(--chip-input-pill-dismiss-color, currentColor);
+  }
+
+  .chip-input-draft-wrap :global(.chip-input-draft) {
+    --input-width: var(--chip-input-draft-width, 90px);
+    --input-height: var(--chip-input-draft-height, 28px);
+    --input-border: var(--chip-input-draft-border, 1px solid transparent);
+    --input-radius: var(--chip-input-draft-radius, 4px);
+    --input-focus-border: var(--chip-input-draft-focus-border, 1px solid transparent);
+    --input-padding: var(--chip-input-draft-padding, 0 2px);
+    --input-margin: 0;
+    --input-font-size: var(--chip-input-draft-font-size, 13px);
+    --input-box-shadow: none;
+  }
+</style>

--- a/src/lib/ChipInput/properties.ts
+++ b/src/lib/ChipInput/properties.ts
@@ -1,0 +1,27 @@
+export type ChipInputProperties = MandatoryChipInputProperties &
+  OptionalChipInputProperties &
+  ChipInputEventProperties;
+
+export type MandatoryChipInputProperties = {
+  /**
+   * The committed chips, in insertion order. Bindable. Dedup-only contract: the component's own
+   * commit path (`addChip`) silently drops a value already present, so ChipInput never produces
+   * duplicates itself. If a caller assigns a duplicate directly through the binding, dismiss
+   * removes only the first matching occurrence rather than every occurrence with that text.
+   */
+  values: string[];
+};
+
+export type OptionalChipInputProperties = {
+  placeholder?: string;
+  disabled?: boolean;
+  testId?: string;
+  classes?: string;
+};
+
+export type ChipInputEventProperties = {
+  onadd?: (value: string) => void;
+  ondismiss?: (value: string) => void;
+  /** Fires alongside `onadd`/`ondismiss`, after either has already updated `values`. */
+  onchange?: (values: string[]) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -75,6 +75,7 @@ export { default as DeltaIndicator } from './DeltaIndicator/DeltaIndicator.svelt
 export { default as DualAxisBarChart } from './DualAxisBarChart/DualAxisBarChart.svelte';
 export { default as FunnelChart } from './FunnelChart/FunnelChart.svelte';
 export { default as ProportionBar } from './ProportionBar/ProportionBar.svelte';
+export { default as ChipInput } from './ChipInput/ChipInput.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -147,6 +148,7 @@ export type * from './DeltaIndicator/properties';
 export type * from './DualAxisBarChart/properties';
 export type * from './FunnelChart/properties';
 export type * from './ProportionBar/properties';
+export type * from './ChipInput/properties';
 export type * from './_chart/highlight';
 
 export { validateInput } from './utils';

--- a/src/routes/components/_nav.ts
+++ b/src/routes/components/_nav.ts
@@ -46,6 +46,7 @@ export const componentNav: NavGroup[] = [
       { name: 'Choicebox', slug: 'choicebox' },
       { name: 'Color Picker', slug: 'color-picker' },
       { name: 'SplitInput', slug: 'split-input' },
+      { name: 'ChipInput', slug: 'chip-input' },
       { name: 'FileInput', slug: 'file-input' }
     ]
   },

--- a/src/routes/components/chip-input/+page.svelte
+++ b/src/routes/components/chip-input/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import ChipInput from '$lib/ChipInput/ChipInput.svelte';
+
+  let productTags = $state(['sale', 'featured']);
+  let blockedEmails = $state<string[]>([]);
+  let themedTags = $state(['urgent']);
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Form Controls</span>
+  <h1>ChipInput</h1>
+</div>
+
+<div class="demo-row" style="max-width: 400px;">
+  <h3>Product tags</h3>
+  <ChipInput bind:values={productTags} placeholder="Add tag…" testId="chip-input-tags" />
+  <p>Values: {productTags.join(', ') || '(empty)'}</p>
+</div>
+
+<div class="demo-row" style="max-width: 400px;">
+  <h3>Blocklist entry (with onadd/ondismiss)</h3>
+  <ChipInput
+    bind:values={blockedEmails}
+    placeholder="e.g. name@example.com"
+    onadd={(value) => console.log('added', value)}
+    ondismiss={(value) => console.log('removed', value)}
+  />
+</div>
+
+<div class="demo-row" style="max-width: 400px;">
+  <h3>Disabled</h3>
+  <ChipInput values={['locked', 'read-only']} disabled />
+</div>
+
+<div class="demo-row" style="max-width: 400px;">
+  <h3>Themed</h3>
+  <ChipInput bind:values={themedTags} classes="chip-input-accent" />
+</div>
+
+<style>
+  :global(.chip-input-accent) {
+    --chip-input-pill-background: #d1ecf1;
+    --chip-input-pill-color: #0c5460;
+    --chip-input-draft-focus-border: 1px solid #3b82f6;
+  }
+</style>


### PR DESCRIPTION
## Motivation

Promotes lighthouse's app-local `ChipInput` (dashboard repo, `src/lib/client/modules/order/editing/ChipInput.svelte`) into the shared library, per the [BZ-4233 component-migration campaign](https://juspay.atlassian.net/browse/BZ-4233) (R3e). The app-local component is a free-text tag/pill input built on library `Input` + `Pill` with zero domain coupling — a clean promote-to-library candidate identified by the campaign's library-gaps audit.

It has 9 call sites across 3 files in lighthouse, every one using only the same three props:

| File | Call sites | Props used |
| --- | --- | --- |
| `ItemEdits.svelte` | 4 | `bind:values`, optional `placeholder`, `dataPw` |
| `Cancellations.svelte` | 3 | `bind:values`, optional `placeholder`, `dataPw` |
| `WindowRules.svelte` | 2 | `bind:values`, `dataPw` |

That confirms the ported prop surface (below) fully covers real usage — no lighthouse call site needs anything beyond `values`/`placeholder`/`testId`.

## What's new

- `src/lib/ChipInput/ChipInput.svelte` + `properties.ts` — composes `Input` (draft field) + `Pill` (each committed chip). Enter or blur commits the trimmed draft into `values` (dedup'd, empty ignored); each chip's dismiss button removes it. Unlike the app-local original, this version is generic: no lighthouse imports, no app-specific CSS classes (`global-chip-base`/`global-pill-neutral`), and it adds a `disabled` state and `onadd`/`ondismiss`/`onchange` callbacks that the original didn't need.
- Registered in `src/lib/index.ts` (component + `properties` type export), `docs/_index.json` + `docs/ChipInput.md` (MCP docs manifest — `mcp/package.json`'s build step copies the whole `docs/` folder into the MCP package, so this is the single registration point), and `src/routes/components/_nav.ts` + a new demo route `src/routes/components/chip-input/+page.svelte` (Form Controls, next to `SplitInput`, its closest structural analog).
- Dual `data-pw`/`testID` emission on the container, each chip (`` `${testId}-chip` ``), and the draft field (`` `${testId}-input` ``), matching the library's Playwright + Appium testing convention.

## Prop / CSS-variable contract

**Props** — `values: string[]` (bindable, mandatory) · `placeholder?: string` (default `'Add value…'`) · `disabled?: boolean` · `testId?: string` · `classes?: string`

**Events** — `onadd?: (value: string) => void` · `ondismiss?: (value: string) => void` · `onchange?: (values: string[]) => void`

**CSS variables** (`--chip-input-*`, all with inline fallbacks per the library's "every visual property is a CSS custom property" philosophy) — container layout (`gap`, `flex-wrap`, `align-items`, `justify-content`, `width`), draft-field theming remapped onto the inner `Input` (`draft-width`, `draft-height`, `draft-border`, `draft-radius`, `draft-focus-border`, `draft-padding`, `draft-font-size`), and chip theming remapped onto the inner `Pill` (`pill-gap`, `pill-background`, `pill-color`, `pill-font-size`, `pill-font-weight`, `pill-padding`, `pill-border-radius`, `pill-border`, `pill-max-width`, `pill-dismiss-size`, `pill-dismiss-color`). Full table in `docs/ChipInput.md`.

## Migration note (for a future lighthouse-side slice, not part of this PR)

The app-local component hardcoded `justify-content: flex-end` on its container — that was an app-specific layout choice made at each of the 9 call sites' context, not a sensible library default, so it is **not** carried over. When lighthouse adopts the published version, callers that relied on that alignment will need `classes="…"` with `--chip-input-justify-content: flex-end` (or an equivalent app-level utility class) to preserve it. The `global-chip-base` / `global-pill-neutral` app theming classes also do not carry over — they become obsolete once this ships (the library component's own `--chip-input-pill-*` vars replace `global-pill-neutral`'s role for this specific usage).

## One correction to the audit premise

The task briefing cited an audit finding that `IframeViewer` is "missing from the MCP docs tool." I checked `docs/_index.json` on current `release` HEAD directly and `IframeViewer` is present with a full description (unrelated to this PR — no action needed there). Flagging it transparently since the premise didn't match what I found; regardless, this PR registers `ChipInub` in every one of the docs/nav/barrel surfaces so no analogous gap is introduced for the new component.

## Not in this PR

- No lighthouse-side adoption swap — app call sites keep using the local `ChipInput.svelte` until this is published and adopted in a separate follow-up slice.
- No Web Component wrapper — following the established precedent of `SplitInput` (its closest structural analog), which also opts out of WC wrapping.
- No new test file — the library's test suite isn't one-file-per-component (many existing components, including `Pill`, have none); full existing suite verified green (below).

## Gates (all green)

- `pnpm run lint` — 0 errors (3 pre-existing warnings in an unrelated `Table` test file, not touched by this PR)
- `pnpm run check` — 0 errors, 558 files, 4 pre-existing warnings unrelated to ChipInput
- `pnpm run test:unit` — 128/128 passed
- `pnpm run test:integration` — 140/149 passed; the 9 failures are all in the `Table` suite and reproduce identically on a clean, unmodified `release` checkout (verified via `git stash` + re-run) — pre-existing, unrelated to this change
- `pnpm run build` — succeeds; verified `dist/index.js` / `dist/index.d.ts` export `ChipInput` and `dist/ChipInput/` is packaged correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ChipInput component for creating, displaying, and removing chips.
  * Supports submission on Enter or blur, duplicate and empty-value filtering, disabled states, placeholders, callbacks, and customizable styling.
  * Exported the component and its public property types.
  * Added interactive examples, navigation, and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->