### PR TITLE
feat(FileDropzoneTrigger): add shared trigger visuals for FileInput dropzones

### DIFF
--- a/docs/FileDropzoneTrigger.md
+++ b/docs/FileDropzoneTrigger.md
@@ -1,0 +1,95 @@
+# FileDropzoneTrigger
+
+The visual body for a `FileInput` trigger snippet — an icon plus heading and optional caption, built on the library's own `Img` and `Button`. It owns appearance only; it does not talk to the file system itself. Pair it with `FileInput`'s `trigger` snippet to get a ready-made dropzone or an inline compact picker without hand-rolling the icon/heading/caption markup at every call site.
+
+## Usage
+
+Non-compact, paired with `FileInput` inside its `trigger` snippet — `onclick` wires to `openFilePicker`:
+
+```svelte
+<script>
+  import { FileInput, FileDropzoneTrigger } from '@juspay/svelte-ui-components';
+  import uploadIcon from './upload-icon.svg';
+</script>
+
+<FileInput accept=".webp,.png,.jpg" onfiles={(files) => console.log(files)}>
+  {#snippet trigger({ openFilePicker })}
+    <FileDropzoneTrigger
+      icon={uploadIcon}
+      heading="Update logo"
+      caption=".webp"
+      testId="update-logo"
+      onclick={openFilePicker}
+    />
+  {/snippet}
+</FileInput>
+```
+
+Compact, for inline/dense placements (relies on `FileInput`'s own whole-area click/drop handling, so no `onclick` is wired):
+
+```svelte
+<script>
+  import { FileInput, FileDropzoneTrigger } from '@juspay/svelte-ui-components';
+  import uploadIcon from './upload-icon.svg';
+</script>
+
+<FileInput accept="image/*" onfiles={(files) => console.log(files)}>
+  {#snippet trigger()}
+    <FileDropzoneTrigger icon={uploadIcon} heading="Choose image" compact testId="jsonform-file-trigger-image" />
+  {/snippet}
+</FileInput>
+```
+
+## Props
+
+| Prop    | Type         | Required | Default | Description                                                                                                                                       |
+| ------- | ------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| icon    | `string`     | Yes      | —       | Upload icon asset, rendered through the library `Img` component.                                                                                 |
+| heading | `string`     | Yes      | —       | Primary call-to-action text (static copy, or a dynamic file name once selected).                                                                |
+| caption | `string`     | No       | —       | Secondary line below the heading (accepted file type / size limit). Non-compact only — ignored in the compact layout.                           |
+| compact | `boolean`    | No       | `false` | Renders a bare icon-sm + heading with no `Button` wrapper or caption, for inline/dense trigger placements.                                       |
+| onclick | `() => void` | No       | —       | Wire to `FileInput`'s `openFilePicker`. Non-compact only — compact relies on `FileInput`'s own whole-area click/drop handling.                   |
+| testId  | `string`     | No       | —       | Non-compact: forwarded to the inner `Button` (emits `data-pw` + `testID`). Compact: applied to the heading `<span>` (emits `data-pw` + `testID`). |
+| classes | `string`     | No       | —       | CSS class applied to the root element — the inner `Button` in non-compact, the icon+heading wrapper in compact. Use to set the CSS variables below. |
+
+## CSS Variables
+
+Override these custom properties (e.g. via the `classes` prop) to theme the trigger.
+
+| Variable                                        | Default  | CSS Property   | Description                                                                    |
+| ------------------------------------------------ | -------- | -------------- | -------------------------------------------------------------------------------- |
+| `--file-dropzone-trigger-compact-flex-direction` | `row`    | flex-direction | Layout direction of the compact icon+heading row.                                |
+| `--file-dropzone-trigger-compact-align-items`    | `center` | align-items    | Cross-axis alignment of the compact row.                                         |
+| `--file-dropzone-trigger-compact-gap`            | `8px`    | gap            | Gap between the icon and heading in the compact row.                             |
+| `--file-dropzone-trigger-icon-sm-size`           | `16px`   | width, height  | Icon size in the compact variant.                                                |
+| `--file-dropzone-trigger-icon-size`              | `24px`   | width, height  | Icon size in the non-compact variant.                                            |
+| `--file-dropzone-trigger-heading-color`          | `inherit`| color          | Heading text color, both variants.                                               |
+| `--file-dropzone-trigger-heading-font-weight`    | `600`    | font-weight    | Heading font weight, both variants.                                              |
+| `--file-dropzone-trigger-heading-margin`         | `0`      | margin         | Margin on the heading's wrapping `<p>` (non-compact only).                       |
+| `--file-dropzone-trigger-caption-margin`         | `0`      | margin         | Margin on the caption `<p>`.                                                     |
+| `--file-dropzone-trigger-caption-color`          | `#64748b`| color          | Caption text color — set this to mute/tint the caption instead of a boolean prop. |
+| `--file-dropzone-trigger-caption-font-size`      | `0.85em` | font-size      | Caption font size, relative to the heading.                                      |
+
+### Muted caption recipe
+
+There is no `mutedCaption` boolean — pure appearance concerns are exposed as CSS variables instead. To mute the caption to a tertiary tone:
+
+```svelte
+<FileDropzoneTrigger
+  icon={uploadIcon}
+  heading="Click to upload or drag and drop"
+  caption="CSV (max. 10MB)"
+  onclick={openFilePicker}
+  classes="upload-trigger-muted"
+/>
+
+<style>
+  :global(.upload-trigger-muted) {
+    --file-dropzone-trigger-caption-color: var(--text-color-tertiary, #64748b);
+  }
+</style>
+```
+
+## Web Component
+
+None. Like `SplitInput` and `ChipInput`, this is a simple presentational component consumed directly from Svelte — it is designed to compose inside `FileInput`'s `trigger` Snippet prop, which is itself not serialisable across the Web Component boundary. Use the Svelte component directly; there is no `sui-file-dropzone-trigger` custom element.

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -96,6 +96,10 @@
     "description": "A centered placeholder component for empty lists, search results, or views. Renders an optional icon snippet above a required title, an optional description (omitted entirely when absent), and an optional action area (e.g. buttons) below; all colors inherit from the parent for seamless light/dark theme support."
   },
   {
+    "name": "FileDropzoneTrigger",
+    "description": "The visual body for a FileInput trigger snippet — an icon plus heading and optional caption, built on the library's own Img and Button. Supports a compact variant (bare icon-sm + heading, no Button wrapper or caption) for inline/dense placements. Pass onclick={openFilePicker} from FileInput's trigger snippet in the non-compact variant; compact relies on FileInput's own whole-area click/drop handling. Use for upload dropzones, CSV/image pickers, or any file-picker trigger that needs the icon+heading+caption recipe instead of hand-rolled markup."
+  },
+  {
     "name": "FileInput",
     "description": "A headless file-picker region that handles drag-and-drop, click-to-open, MIME/extension filtering, and size validation. All visual chrome is supplied by the required `trigger` snippet, which receives `openFilePicker`, `dragOver`, and `disabled`."
   },

--- a/src/lib/FileDropzoneTrigger/FileDropzoneTrigger.svelte
+++ b/src/lib/FileDropzoneTrigger/FileDropzoneTrigger.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import Button from '../Button/Button.svelte';
+  import Img from '../Img/Img.svelte';
+  import type { FileDropzoneTriggerProperties } from './properties';
+
+  let {
+    icon,
+    heading,
+    caption,
+    compact = false,
+    onclick,
+    testId,
+    classes
+  }: FileDropzoneTriggerProperties = $props();
+</script>
+
+{#if compact}
+  <div class="file-dropzone-trigger-compact {classes ?? ''}">
+    <div class="file-dropzone-trigger-icon-sm" aria-hidden="true">
+      <Img src={icon} alt="" fallback="" classes="file-dropzone-trigger-icon-sm-img" />
+    </div>
+    <span class="file-dropzone-trigger-heading" data-pw={testId} testID={testId}>{heading}</span>
+  </div>
+{:else}
+  <Button
+    classes={`file-dropzone-trigger-button ${classes ?? ''}`}
+    {onclick}
+    {...typeof testId === 'string' ? { testId } : {}}
+  >
+    <div class="file-dropzone-trigger-icon" aria-hidden="true">
+      <Img src={icon} alt="" fallback="" classes="file-dropzone-trigger-icon-img" />
+    </div>
+    <p class="file-dropzone-trigger-heading-wrap">
+      <span class="file-dropzone-trigger-heading">{heading}</span>
+    </p>
+    {#if caption}
+      <p class="file-dropzone-trigger-caption">{caption}</p>
+    {/if}
+  </Button>
+{/if}
+
+<style>
+  .file-dropzone-trigger-compact {
+    display: flex;
+    flex-direction: var(--file-dropzone-trigger-compact-flex-direction, row);
+    align-items: var(--file-dropzone-trigger-compact-align-items, center);
+    gap: var(--file-dropzone-trigger-compact-gap, 8px);
+  }
+
+  .file-dropzone-trigger-icon-sm,
+  .file-dropzone-trigger-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .file-dropzone-trigger-icon-sm :global(.file-dropzone-trigger-icon-sm-img) {
+    --image-width: var(--file-dropzone-trigger-icon-sm-size, 16px);
+    --image-height: var(--file-dropzone-trigger-icon-sm-size, 16px);
+  }
+
+  .file-dropzone-trigger-icon :global(.file-dropzone-trigger-icon-img) {
+    --image-width: var(--file-dropzone-trigger-icon-size, 24px);
+    --image-height: var(--file-dropzone-trigger-icon-size, 24px);
+  }
+
+  .file-dropzone-trigger-heading {
+    color: var(--file-dropzone-trigger-heading-color, inherit);
+    font-weight: var(--file-dropzone-trigger-heading-font-weight, 600);
+  }
+
+  .file-dropzone-trigger-heading-wrap {
+    margin: var(--file-dropzone-trigger-heading-margin, 0);
+  }
+
+  .file-dropzone-trigger-caption {
+    margin: var(--file-dropzone-trigger-caption-margin, 0);
+    color: var(--file-dropzone-trigger-caption-color, #64748b);
+    font-size: var(--file-dropzone-trigger-caption-font-size, 0.85em);
+  }
+</style>

--- a/src/lib/FileDropzoneTrigger/properties.ts
+++ b/src/lib/FileDropzoneTrigger/properties.ts
@@ -1,0 +1,29 @@
+export type FileDropzoneTriggerProperties = MandatoryFileDropzoneTriggerProperties &
+  OptionalFileDropzoneTriggerProperties &
+  FileDropzoneTriggerEventProperties;
+
+export type MandatoryFileDropzoneTriggerProperties = {
+  /** Upload icon asset, rendered through the library `Img` component. */
+  icon: string;
+  /** Primary call-to-action text (static copy, or a dynamic file name once selected). */
+  heading: string;
+};
+
+export type OptionalFileDropzoneTriggerProperties = {
+  /** Secondary line below the heading (accepted file type / size limit). Non-compact only. */
+  caption?: string;
+  /** Bare icon + heading with no Button wrapper or caption, for inline/compact trigger placements. */
+  compact?: boolean;
+  /**
+   * Non-compact: forwarded to the inner `Button`. Compact: applied to the heading `<span>`.
+   * Emits both `data-pw` and `testID` on that element.
+   */
+  testId?: string;
+  /** CSS class applied to the root element — the inner `Button` in non-compact, the icon+heading wrapper in compact. */
+  classes?: string;
+};
+
+export type FileDropzoneTriggerEventProperties = {
+  /** Wire to `FileInput`'s `openFilePicker`. Non-compact only — compact relies on `FileInput`'s own whole-area click/drop handling. */
+  onclick?: () => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -76,6 +76,7 @@ export { default as DualAxisBarChart } from './DualAxisBarChart/DualAxisBarChart
 export { default as FunnelChart } from './FunnelChart/FunnelChart.svelte';
 export { default as ProportionBar } from './ProportionBar/ProportionBar.svelte';
 export { default as ChipInput } from './ChipInput/ChipInput.svelte';
+export { default as FileDropzoneTrigger } from './FileDropzoneTrigger/FileDropzoneTrigger.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -149,6 +150,7 @@ export type * from './DualAxisBarChart/properties';
 export type * from './FunnelChart/properties';
 export type * from './ProportionBar/properties';
 export type * from './ChipInput/properties';
+export type * from './FileDropzoneTrigger/properties';
 export type * from './_chart/highlight';
 
 export { validateInput } from './utils';

--- a/src/routes/components/_nav.ts
+++ b/src/routes/components/_nav.ts
@@ -47,6 +47,7 @@ export const componentNav: NavGroup[] = [
       { name: 'Color Picker', slug: 'color-picker' },
       { name: 'SplitInput', slug: 'split-input' },
       { name: 'ChipInput', slug: 'chip-input' },
+      { name: 'FileDropzoneTrigger', slug: 'file-dropzone-trigger' },
       { name: 'FileInput', slug: 'file-input' }
     ]
   },

--- a/src/routes/components/file-dropzone-trigger/+page.svelte
+++ b/src/routes/components/file-dropzone-trigger/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import FileInput from '$lib/FileInput/FileInput.svelte';
+  import FileDropzoneTrigger from '$lib/FileDropzoneTrigger/FileDropzoneTrigger.svelte';
+
+  const uploadIcon =
+    'data:image/svg+xml;utf8,' +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%233b82f6" stroke-width="2"><path d="M12 16V4M12 4l-5 5M12 4l5 5" stroke-linecap="round" stroke-linejoin="round"/><path d="M4 16v3a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-3" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+    );
+
+  let acceptedFiles: File[] = $state([]);
+  let compactFiles: File[] = $state([]);
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Form Controls</span>
+  <h1>FileDropzoneTrigger</h1>
+</div>
+
+<h3>Non-compact, with caption (paired with FileInput)</h3>
+<div class="demo-row" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+  <FileInput accept=".webp,.png,.jpg" onfiles={(files) => (acceptedFiles = files)}>
+    {#snippet trigger({ openFilePicker })}
+      <FileDropzoneTrigger
+        icon={uploadIcon}
+        heading="Update logo"
+        caption=".webp"
+        testId="update-logo"
+        onclick={openFilePicker}
+      />
+    {/snippet}
+  </FileInput>
+  {#if acceptedFiles.length > 0}
+    <p class="state-display">Accepted: {acceptedFiles.map((file) => file.name).join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Compact (inline/dense placement)</h3>
+<div class="demo-row" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+  <FileInput accept="image/*" onfiles={(files) => (compactFiles = files)}>
+    {#snippet trigger()}
+      <FileDropzoneTrigger
+        icon={uploadIcon}
+        heading="Choose image"
+        compact
+        testId="jsonform-file-trigger-image"
+      />
+    {/snippet}
+  </FileInput>
+  {#if compactFiles.length > 0}
+    <p class="state-display">Accepted: {compactFiles.map((file) => file.name).join(', ')}</p>
+  {/if}
+</div>
+
+<h3>Muted caption (CSS variable recipe, no mutedCaption boolean)</h3>
+<div class="demo-row" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+  <FileInput accept=".csv" onfiles={() => {}}>
+    {#snippet trigger({ openFilePicker })}
+      <FileDropzoneTrigger
+        icon={uploadIcon}
+        heading="Click to upload or drag and drop"
+        caption="CSV (max. 10MB)"
+        onclick={openFilePicker}
+        classes="upload-trigger-muted"
+      />
+    {/snippet}
+  </FileInput>
+</div>
+
+<style>
+  :global(.upload-trigger-muted) {
+    --file-dropzone-trigger-caption-color: #94a3b8;
+  }
+</style>


### PR DESCRIPTION
## Summary

New standing rule: any new shared component is born in this library and imported from lighthouse, never authored app-side. This promotes lighthouse PR #6700's app-side `FileDropzoneTrigger` (the copy-pasted dropzone-trigger body, 9 files / 14 call sites) into a generic library component.

`FileDropzoneTrigger` is the visual body for a `FileInput` trigger snippet — icon + heading + optional caption, built on the library's own `Img` and `Button`. It composes directly with `FileInput`'s existing `trigger` snippet pattern (`onclick={openFilePicker}`).

**Note:** lighthouse's app-side twin (PR #6700, `src/lib/components/FileDropzoneTrigger/FileDropzoneTrigger.svelte`) is on hold pending this component's release, then will be deleted in favor of importing this one.

## Adoption evidence (from lighthouse #6700 — 9 files / 14 occurrences)

| File | Occurrences | Variant |
|---|---|---|
| `shop/config/product/+page.svelte` | 5 | non-compact |
| `JSONForm.svelte` | 2 | compact |
| `AddCustomerModal.svelte` | 1 | non-compact, muted caption |
| `JsonUpload.svelte` | 1 | compact |
| `settings/+page.svelte` | 1 | non-compact |
| `payment/link/+page.svelte` | 1 | non-compact |
| `FileUpload.svelte` | 1 | non-compact |
| `CustomerApplicabilityField.svelte` | 1 | non-compact |
| `PincodeUploadModal.svelte` | 1 | non-compact |

## Design notes

- **No `mutedCaption` boolean.** Pure-appearance concerns are CSS variables, not props — `--file-dropzone-trigger-caption-color` (default `#64748b`) replaces it. `AddCustomerModal`'s tertiary caption color becomes a consumer-side `classes` override in the lighthouse follow-up (recipe documented in `docs/FileDropzoneTrigger.md`).
- **No Web Component wrapper**, matching `SplitInput`/`ChipInput` precedent for simple presentational components. It's designed to live inside `FileInput`'s `trigger` Snippet prop, which isn't serialisable across the WC boundary anyway.
- `testId` forwarding to the inner `Button` uses the conditional-spread pattern (`{...typeof testId === 'string' ? { testId } : {}}`) to satisfy `no-restricted-syntax` (no bare `undefined`), matching `Pill`'s existing pattern.

## Prop contract

| Prop | Type | Required | Default | Description |
|---|---|---|---|---|
| `icon` | `string` | Yes | — | Upload icon asset, rendered through `Img`. |
| `heading` | `string` | Yes | — | Primary CTA text. |
| `caption` | `string` | No | — | Secondary line below heading. Non-compact only. |
| `compact` | `boolean` | No | `false` | Bare icon-sm + heading, no `Button`/caption. |
| `onclick` | `() => void` | No | — | Wire to `FileInput`'s `openFilePicker`. Non-compact only. |
| `testId` | `string` | No | — | Emits `data-pw` + `testID`. |
| `classes` | `string` | No | — | Root CSS class — set the vars below. |

## CSS variable contract

| Variable | Default |
|---|---|
| `--file-dropzone-trigger-compact-flex-direction` | `row` |
| `--file-dropzone-trigger-compact-align-items` | `center` |
| `--file-dropzone-trigger-compact-gap` | `8px` |
| `--file-dropzone-trigger-icon-sm-size` | `16px` |
| `--file-dropzone-trigger-icon-size` | `24px` |
| `--file-dropzone-trigger-heading-color` | `inherit` |
| `--file-dropzone-trigger-heading-font-weight` | `600` |
| `--file-dropzone-trigger-heading-margin` | `0` |
| `--file-dropzone-trigger-caption-margin` | `0` |
| `--file-dropzone-trigger-caption-color` | `#64748b` |
| `--file-dropzone-trigger-caption-font-size` | `0.85em` |

## Registration surfaces (all 4)

- [x] `src/lib/index.ts` — component + type export
- [x] `docs/_index.json` — manifest entry (alphabetical, between `EmptyState` and `FileInput`)
- [x] `docs/FileDropzoneTrigger.md` — usage paired with `FileInput`, props table, CSS variables table, muted-caption recipe, WC note
- [x] `src/routes/components/_nav.ts` + `src/routes/components/file-dropzone-trigger/+page.svelte` — demo route (Form Controls category, after `SplitInput`, before `FileInput`)

## Gates

- `lint` — 0 errors (3 pre-existing warnings in an unrelated test file)
- `check` (svelte-check) — 558 files, 0 errors, 4 pre-existing warnings in unrelated files
- `build` — passes, component packages correctly into `dist/FileDropzoneTrigger/`
- `test:unit` — 128/128 passed
- `test:integration` (Playwright) — 9 pre-existing failures, all in `Table` component tests (cell renderers / header tooltip / pagination), unrelated to this change. **Verified**: reproduced the identical 9 failures on a clean `origin/release` checkout with none of this PR's changes applied — confirmed pre-existing baseline flakiness, not a regression from this PR.

Single commit, not merging — for review only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `FileDropzoneTrigger` component with full and compact layouts.
  * Supports configurable icons, headings, captions, styling, test IDs, and click handling.
  * Integrated the component with file-selection workflows and added live examples.
  * Exported the component and its property types for use in applications.

* **Documentation**
  * Added comprehensive usage documentation, configuration details, styling options, and navigation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->