### PR TITLE
feat(IframeViewer): add credentialless prop and postMessage accessor

### DIFF
--- a/docs/IframeViewer.md
+++ b/docs/IframeViewer.md
@@ -26,6 +26,7 @@ A security-conscious iframe embed. It renders an `<iframe>` for the given `src` 
 | allowedOrigins | `string[]`          | No       | `[]`                 | Origins allowed to send `postMessage` events to `onMessage`. An empty array (the default) processes nothing — secure by default. |
 | allow          | `string`            | No       | `'fullscreen'`       | Permissions policy applied to the iframe `allow` attribute.                                                                      |
 | sandbox        | `string`            | No       | `-`                  | Value for the iframe `sandbox` attribute. Omitted when not set.                                                                  |
+| credentialless | `boolean`           | No       | `-`                  | Sets the iframe's `credentialless` attribute. Applied in the same render statement as `src`, so it is present before the iframe's first load — no dependency on effect-scheduling order. |
 | loading        | `'eager' \| 'lazy'` | No       | `-`                  | Loading strategy for the iframe. Omitted when not set.                                                                           |
 | referrerpolicy | `ReferrerPolicy`    | No       | `-`                  | Referrer policy for the iframe. Omitted when not set.                                                                            |
 | testId         | `string`            | No       | `-`                  | Test selector applied as `data-pw` on the container.                                                                             |
@@ -38,6 +39,29 @@ Event handler props with callback signatures.
 | Event     | Type                            | Description                                                                                                                                 |
 | --------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | onMessage | `(event: MessageEvent) => void` | Called with the `MessageEvent` for `postMessage` events whose origin is in `allowedOrigins` and whose source is the embedded iframe window. |
+
+## Instance Methods
+
+`postMessage` is exported from the component instance — bind it to send messages into the embedded iframe (outbound), mirroring `onMessage` for the inbound direction:
+
+```svelte
+<script>
+  import { IframeViewer } from '@juspay/svelte-ui-components';
+
+  let viewerRef;
+</script>
+
+<IframeViewer bind:this={viewerRef} src="https://example.com" />
+<button onclick={() => viewerRef.postMessage({ type: 'ping' }, 'https://example.com')}>
+  Send message
+</button>
+```
+
+| Method                                                | Description                                                                                        |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `postMessage(message: unknown, targetOrigin: string)` | Posts `message` to the embedded iframe's `contentWindow` at `targetOrigin`. No-op before the iframe mounts (`src` unset) or once it unmounts. |
+
+This is a Svelte-only accessor via `bind:this` (same pattern as `FileInput`'s `openFilePicker`) — it is not bridged onto the `<sui-iframe-viewer>` custom element; see Web Component section below.
 
 ## CSS Variables
 
@@ -60,6 +84,7 @@ Tag: `<sui-iframe-viewer>`
   title="Example"
   allow="fullscreen"
   sandbox="allow-scripts allow-same-origin"
+  credentialless
   loading="lazy"
   referrer-policy="no-referrer"
   test-id="commerce-frame"
@@ -73,3 +98,5 @@ const frame = document.querySelector('sui-iframe-viewer');
 frame.allowedOrigins = ['https://example.com'];
 frame.onMessage = (event) => console.log(event.data);
 ```
+
+`postMessage` is **not** exposed on `<sui-iframe-viewer>` — it is a Svelte-only instance accessor (see Instance Methods above). Web Component consumers already have a standard way to reach the same outcome: query the rendered `<iframe>` inside the element's shadow root and call its `contentWindow.postMessage` directly.

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -113,7 +113,7 @@
   },
   {
     "name": "IframeViewer",
-    "description": "A security-conscious iframe embed. Renders an `<iframe>` for the given `src` and forwards `postMessage` events to `onMessage` only when the message origin is in `allowedOrigins` and the source is the embedded iframe window \u2014 an empty list (the default) processes nothing, so it is secure by default. Themeable size/border via CSS variables; ships a `sui-iframe-viewer` web component."
+    "description": "A security-conscious iframe embed. Renders an `<iframe>` for the given `src` and forwards `postMessage` events to `onMessage` only when the message origin is in `allowedOrigins` and the source is the embedded iframe window \u2014 an empty list (the default) processes nothing, so it is secure by default. Supports an optional `credentialless` attribute (applied in the same render statement as `src`, no effect-timing dependency) and an exported `postMessage(message, targetOrigin)` instance method for sending messages into the embedded frame. Themeable size/border via CSS variables; ships a `sui-iframe-viewer` web component."
   },
   {
     "name": "Img",

--- a/src/lib/IframeViewer/IframeViewer.svelte
+++ b/src/lib/IframeViewer/IframeViewer.svelte
@@ -10,12 +10,17 @@
     sandbox,
     loading,
     referrerpolicy,
+    credentialless,
     testId,
     classes,
     onMessage = () => {}
   }: IframeViewerProperties = $props();
 
   let iframeEl: HTMLIFrameElement | null = $state(null);
+
+  export const postMessage = (message: unknown, targetOrigin: string): void => {
+    iframeEl?.contentWindow?.postMessage(message, targetOrigin);
+  };
 
   const messageHandler = (event: MessageEvent): void => {
     // Secure by default: forward a message only when its origin is allow-listed AND it
@@ -44,7 +49,15 @@
 
 <div class="iframe-viewer {classes ?? ''}" data-pw={testId} testID={testId}>
   {#if src}
-    <iframe bind:this={iframeEl} {src} {title} {allow} {sandbox} {loading} {referrerpolicy}
+    <iframe
+      bind:this={iframeEl}
+      {src}
+      {title}
+      {allow}
+      {sandbox}
+      {loading}
+      {referrerpolicy}
+      {...credentialless ? { credentialless: '' } : {}}
     ></iframe>
   {/if}
 </div>

--- a/src/lib/IframeViewer/properties.ts
+++ b/src/lib/IframeViewer/properties.ts
@@ -19,6 +19,13 @@ export type OptionalIframeViewerProperties = {
   allow?: string;
   /** Value for the iframe `sandbox` attribute. Omitted when not set. */
   sandbox?: string;
+  /**
+   * Sets the iframe's `credentialless` attribute, isolating it from the embedding
+   * document's credentials/storage. Applied in the same render statement as `src` (not
+   * via a post-mount effect), so it is guaranteed to be present before the iframe's
+   * first load — no timing dependency on effect scheduling.
+   */
+  credentialless?: boolean;
   /** Loading strategy for the iframe. Omitted when not set. */
   loading?: 'eager' | 'lazy';
   /** Referrer policy for the iframe. Omitted when not set. */

--- a/src/routes/components/iframe-viewer/+page.svelte
+++ b/src/routes/components/iframe-viewer/+page.svelte
@@ -7,6 +7,24 @@
       '<p>This document is rendered inside an IframeViewer.</p>' +
       '</div>'
   )}`;
+
+  const messagingDoc = `data:text/html,${encodeURIComponent(
+    '<div style="font-family: sans-serif; padding: 24px; color: #1a1a1a;">' +
+      '<h2>credentialless + postMessage</h2>' +
+      '<p id="log">Waiting for a message…</p>' +
+      '<script>' +
+      'window.addEventListener("message", (event) => {' +
+      'document.getElementById("log").textContent = "Received: " + JSON.stringify(event.data);' +
+      '});' +
+      '<\\/script>' +
+      '</div>'
+  )}`;
+
+  let messagingFrame: IframeViewer | null = $state(null);
+
+  const sendPing = (): void => {
+    messagingFrame?.postMessage({ type: 'ping', at: Date.now() }, '*');
+  };
 </script>
 
 <div class="page-header">
@@ -24,6 +42,27 @@
 <div class="demo-row">
   <div class="frame-box">
     <IframeViewer src={demoDoc} title="Demo document" allow="fullscreen" />
+  </div>
+</div>
+
+<h3>credentialless + outbound postMessage</h3>
+<div class="demo-row" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+  <button
+    class="toggle-btn"
+    onclick={sendPing}
+    data-pw="iframe-viewer-send-message"
+    testID="iframe-viewer-send-message"
+  >
+    Send message to iframe
+  </button>
+  <div class="frame-box">
+    <IframeViewer
+      bind:this={messagingFrame}
+      src={messagingDoc}
+      title="Messaging demo"
+      credentialless
+      testId="iframe-viewer-messaging"
+    />
   </div>
 </div>
 

--- a/src/wc/components/IframeViewer.wc.svelte
+++ b/src/wc/components/IframeViewer.wc.svelte
@@ -8,6 +8,7 @@
       allowedOrigins: { type: 'Object', attribute: 'allowed-origins' },
       allow: { type: 'String', reflect: true },
       sandbox: { type: 'String', reflect: true },
+      credentialless: { type: 'Boolean', reflect: true, attribute: 'credentialless' },
       loading: { type: 'String', reflect: true },
       referrerpolicy: { type: 'String', attribute: 'referrer-policy' },
       testId: { type: 'String', attribute: 'test-id' },


### PR DESCRIPTION
## Summary

Closes the API gap documented against lighthouse PR #6699 (`refactor/bz4233-r3a-iframeviewer-livepreview`, adopting `IframeViewer` on `LivePreview.svelte`). Yama's `CHANGES_REQUESTED` review on that PR flagged a MAJOR finding: `IframeViewer` exposed no ref to its internal `<iframe>`, so the consumer had to fall back to a parent `$effect` + DOM query (`getRenderedIframe`) to (a) set `credentialless` and (b) send outbound `postMessage`. For (a) specifically, Yama's finding was that this DOM query ran *after* `IframeViewer` already created the `<iframe>` (its `src` is only truthy once the effect runs), relying on implicit Svelte 5 effect-batching order for a security-relevant isolation attribute — fragile, not a single-statement guarantee.

This PR fixes both gaps upstream, generically, minimal and structural (not cosmetic):

- **`credentialless` boolean prop**, spread onto the `<iframe>` in the exact same `{#if src}` render statement that sets `src`. This eliminates the effect-scheduling dependency entirely — the attribute is guaranteed present at iframe creation, not applied after the fact.
- **`postMessage(message, targetOrigin)`** exported from the component instance, reached via `bind:this` — the outbound counterpart to the existing `onMessage` inbound callback.

**Note:** lighthouse #6699's `getRenderedIframe` DOM-query escape hatch gets deleted in a follow-up once this releases.

## Design notes

- **`postMessage` follows `FileInput`'s exact precedent**: `export const openFilePicker` (`FileInput.svelte`) is the house pattern for exposing imperative element access — an exported const method reached via `bind:this`. `IframeViewer` has no snippet-prop channel (unlike `FileInput`'s `trigger` snippet, which also forwards `openFilePicker` as a snippet param), so the `bind:this` route is the only transferable piece of that precedent, and it's applied as-is.
- **Not bridged to the Web Component.** Verified via `FileInput.wc.svelte`: it consumes `openFilePicker` internally (through the snippet param) for its default slot button, but never re-exposes it as a method on `<sui-file-input>`. `postMessage` follows the same rule — Svelte-only. WC consumers already have a standard workaround (query the shadow-DOM `<iframe>` and call `contentWindow.postMessage` directly), documented in `docs/IframeViewer.md`.
- `credentialless` uses a conditional attribute spread (`{...credentialless ? { credentialless: '' } : {}}`) rather than relying on Svelte's boolean-attribute attribute-list heuristic, since `credentialless` is a newer, non-standard iframe attribute that may not be in the compiler's internal known-boolean-attributes list — this guarantees correct presence/absence semantics regardless.

## Prop/method contract

| Name | Kind | Type | Description |
|---|---|---|---|
| `credentialless` | prop | `boolean` | Sets the iframe's `credentialless` attribute, same render statement as `src`. |
| `postMessage` | exported instance method (`bind:this`) | `(message: unknown, targetOrigin: string) => void` | Posts `message` to the embedded iframe's `contentWindow`. No-op before `src` mounts the iframe or after unmount. |

## Registration surfaces

- [x] `src/lib/IframeViewer/properties.ts` — `credentialless` added to `OptionalIframeViewerProperties`
- [x] `src/lib/IframeViewer/IframeViewer.svelte` — prop spread + exported `postMessage`
- [x] `src/wc/components/IframeViewer.wc.svelte` — `credentialless: { type: 'Boolean', reflect: true, attribute: 'credentialless' }` added to the WC props map (`postMessage` deliberately not bridged)
- [x] `docs/IframeViewer.md` — Props table row, new "Instance Methods" section, WC section updated with the `credentialless` attribute + an explicit note on why `postMessage` isn't exposed there
- [x] `docs/_index.json` — description updated to mention both additions
- [x] `src/routes/components/iframe-viewer/+page.svelte` — new demo: `credentialless` iframe + a button that calls `postMessage` and the embedded document echoes the received message back

## Gates

- `lint` — 0 errors (3 pre-existing warnings in an unrelated test file)
- `check` (svelte-check) — 554 files, 0 errors, 4 pre-existing warnings in unrelated files
- `build` — passes
- `test:unit` — 128/128 passed
- `test:integration` (Playwright) — 140 passed, 9 pre-existing failures, all in `Table` component tests (cell renderers / header tooltip / pagination), unrelated to this change — same failures reproduced on a clean `origin/release` checkout with no changes applied (confirmed baseline, not a regression).

Single commit, not merging — for review only.