### PR TITLE
feat: add showIndicator prop and enhance indicator styling

### DIFF
--- a/docs/Choicebox.md
+++ b/docs/Choicebox.md
@@ -21,6 +21,7 @@ A large-target selection card used for prominent single or multi-choice selectio
 | selected | `boolean`               | No       | `false`     | The current selection state of the choicebox. Bindable.                                                                                                                |
 | mode     | `'radio' \| 'checkbox'` | No       | `'radio'`   | Controls the indicator style. `radio` shows a filled circle when selected, `checkbox` shows a checkmark box.                                                           |
 | disabled | `boolean`               | No       | `false`     | When true, the choicebox is non-interactive and visually dimmed.                                                                                                       |
+| showIndicator | `boolean`          | No       | `true`      | Whether to render the radio dot / checkbox tick. Set false when the card supplies its own selected affordance.                                                          |
 | testId   | `string`                | No       | `undefined` | Value for the `data-pw` attribute used in Playwright test selectors.                                                                                                   |
 | classes  | `string`                | No       | `-`         | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
 
@@ -69,3 +70,23 @@ Tag: `<sui-choicebox>`
   <span>Option A</span>
 </sui-choicebox>
 ```
+
+### Indicator
+
+The indicator is decorative — the card itself carries `role` and `aria-checked`, so the mark is
+`aria-hidden`. It is placed last and pushed to the trailing edge; reorder it with
+`--choicebox-indicator-order`.
+
+| Variable                                    | Default             | Description                                        |
+| ------------------------------------------- | ------------------- | -------------------------------------------------- |
+| `--choicebox-indicator-size`                 | `20px`              | Width and height of the indicator.                 |
+| `--choicebox-indicator-border`               | `2px solid #757575` | Border when unselected.                            |
+| `--choicebox-indicator-background`           | `transparent`       | Fill when unselected.                              |
+| `--choicebox-indicator-selected-border`      | `2px solid #2196f3` | Border when selected.                              |
+| `--choicebox-indicator-selected-background`  | `#2196f3`           | Fill when selected.                                |
+| `--choicebox-indicator-border-radius`        | `var(--radius, 4px)`| Corner rounding in `checkbox` mode.                |
+| `--choicebox-indicator-dot-inset`            | `4px`               | Ring thickness that forms the dot in `radio` mode. |
+| `--choicebox-indicator-icon-size`            | `14px`              | Size of the checkmark in `checkbox` mode.          |
+| `--choicebox-indicator-icon-color`           | `#ffffff`           | Colour of the checkmark.                           |
+| `--choicebox-indicator-order`                | `1`                 | Flex order of the indicator within the card.       |
+| `--choicebox-indicator-margin-inline-start`  | `auto`              | Leading margin; `auto` pins it to the trailing edge. |

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -208,7 +208,8 @@
     opacity: var(--opacity, 1);
     border: var(--button-border, var(--_btn-border, none));
     box-sizing: border-box;
-    text-decoration: none;
+    text-decoration: var(--button-text-decoration, none);
+    line-height: var(--button-line-height, normal);
     display: flex;
     justify-content: var(--button-justify-content, center);
     align-items: center;
@@ -230,6 +231,7 @@
     color: var(--disabled-text-color, var(--button-text-color, var(--_btn-text-color, white)));
     font-size: var(--disabled-font-size);
     font-weight: var(--disabled-font-weight);
+    text-decoration: var(--button-disabled-text-decoration, var(--button-text-decoration, none));
     /* Preserve the variant border when disabled so secondary (bordered) stays distinct from ghost. */
     border: var(--disabled-border, var(--button-border, var(--_btn-border, none)));
     background: var(--disabled-background-color, var(--button-color, var(--_btn-color, #3a4550)));

--- a/src/lib/Choicebox/Choicebox.svelte
+++ b/src/lib/Choicebox/Choicebox.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import type { ChoiceboxProperties } from './properties';
+  import checkmarkSvg from '$lib/assets/checkmark.svg?raw';
 
   let {
     children,
     selected = $bindable(false),
     mode = 'radio',
     disabled = false,
+    showIndicator = true,
     testId,
     onclick,
     classes
@@ -47,6 +49,14 @@
   {#if typeof children === 'function'}
     {@render children()}
   {/if}
+  {#if showIndicator}
+    <span class="indicator {mode}" class:selected aria-hidden="true">
+      {#if mode === 'checkbox' && selected}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        <span class="indicator-icon">{@html checkmarkSvg}</span>
+      {/if}
+    </span>
+  {/if}
 </div>
 
 <style>
@@ -86,5 +96,50 @@
   .choicebox.disabled {
     opacity: var(--choicebox-disabled-opacity, 0.4);
     cursor: var(--choicebox-disabled-cursor, not-allowed);
+  }
+
+  .indicator {
+    flex: 0 0 auto;
+    order: var(--choicebox-indicator-order, 1);
+    margin-inline-start: var(--choicebox-indicator-margin-inline-start, auto);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    width: var(--choicebox-indicator-size, 20px);
+    height: var(--choicebox-indicator-size, 20px);
+    border: var(--choicebox-indicator-border, 2px solid #757575);
+    background: var(--choicebox-indicator-background, transparent);
+    transition: var(--choicebox-indicator-transition, background 0.2s, border-color 0.2s);
+  }
+
+  .indicator.radio {
+    border-radius: 50%;
+  }
+
+  .indicator.checkbox {
+    border-radius: var(--choicebox-indicator-border-radius, var(--radius, 4px));
+  }
+
+  .indicator.selected {
+    border: var(--choicebox-indicator-selected-border, 2px solid #2196f3);
+    background: var(--choicebox-indicator-selected-background, #2196f3);
+  }
+
+  .indicator.radio.selected {
+    box-shadow: inset 0 0 0 var(--choicebox-indicator-dot-inset, 4px)
+      var(--choicebox-background, #ffffff);
+  }
+
+  .indicator-icon {
+    display: flex;
+    width: var(--choicebox-indicator-icon-size, 14px);
+    height: var(--choicebox-indicator-icon-size, 14px);
+    color: var(--choicebox-indicator-icon-color, #ffffff);
+  }
+
+  .indicator-icon :global(svg) {
+    width: 100%;
+    height: 100%;
   }
 </style>

--- a/src/lib/Choicebox/properties.ts
+++ b/src/lib/Choicebox/properties.ts
@@ -9,6 +9,7 @@ export type OptionalChoiceboxProperties = {
   selected?: boolean;
   mode?: ChoiceboxMode;
   disabled?: boolean;
+  showIndicator?: boolean;
   testId?: string;
   classes?: string;
 };


### PR DESCRIPTION
  - add showIndicator prop and enhance indicator styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choiceboxes now display customizable radio or checkbox selection indicators by default, with an option to hide them.
  * Added styling support for indicator size, shape, selected states, and checkmark presentation.
  * Button text decoration and line height can now be customized, including separate disabled-state decoration.

* **Documentation**
  * Documented the Choicebox indicator option, accessibility behavior, and styling variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->