### PR TITLE
fix(Modal): only treat header.leftImage as a control when a click handler is supplied

### DIFF
--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -158,25 +158,35 @@
           {#if (typeof header?.leftImage === 'string' && header.leftImage.length > 0) || (typeof header?.text === 'string' && header.text.length > 0) || (typeof header?.rightImage === 'string' && header.rightImage.length > 0)}
             <div class="header">
               {#if typeof header.leftImage === 'string' && header.leftImage.length > 0}
-                <div
-                  onclick={handleLeftImageClick}
-                  onkeydown={handleLeftImageKeyDown}
-                  role="button"
-                  tabindex="0"
-                  aria-label={leftImageAriaLabel ?? null}
-                  data-pw={leftImageTestId}
-                  testID={leftImageTestId}
-                >
+                {@const leftImageSrc = header.leftImage}
+                {#snippet leftImage()}
                   <!-- Inline SVGs so currentColor icons inherit the header text
                        colour; non-SVG URLs fall back to a plain <img>. -->
-                  <Img
-                    inlineSvg
-                    src={header.leftImage}
-                    alt=""
-                    fallback=""
-                    classes="header-left-img"
-                  />
-                </div>
+                  <Img inlineSvg src={leftImageSrc} alt="" fallback="" classes="header-left-img" />
+                {/snippet}
+                <!-- The left image is only a control when a click handler is actually supplied.
+                     Consumers pass a decorative brand/source logo here far more often than a back
+                     button, and announcing those as a focusable "button" that does nothing when
+                     activated is worse for assistive tech than leaving them unannounced. The two
+                     branches are written out rather than computed so the role/tabindex pairing
+                     stays statically checkable. -->
+                {#if typeof onheaderLeftImageClick === 'function'}
+                  <div
+                    onclick={handleLeftImageClick}
+                    onkeydown={handleLeftImageKeyDown}
+                    role="button"
+                    tabindex="0"
+                    aria-label={leftImageAriaLabel ?? null}
+                    data-pw={leftImageTestId}
+                    testID={leftImageTestId}
+                  >
+                    {@render leftImage()}
+                  </div>
+                {:else}
+                  <div data-pw={leftImageTestId} testID={leftImageTestId}>
+                    {@render leftImage()}
+                  </div>
+                {/if}
               {/if}
               {#if typeof header.text === 'string' && header.text.length > 0}
                 <div class="header-text" data-pw={header.testId} testID={header.testId}>

--- a/src/routes/components/modal/+page.svelte
+++ b/src/routes/components/modal/+page.svelte
@@ -5,9 +5,14 @@
   let showModal = $state(false);
   let showModalTop = $state(false);
   let showTallModal = $state(false);
+  let showDecorativeLeftImageModal = $state(false);
+  let showBackButtonModal = $state(false);
+  let backButtonClickCount = $state(0);
 
   // Inline data-URI so the demo has no external asset dependency; exercises
   // the Img component's `inlineSvg` currentColor path used by the header.
+  const backIconSrc =
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M15 18l-6-6 6-6'/%3E%3C/svg%3E";
   const closeIconSrc =
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M18 6L6 18M6 6l12 12'/%3E%3C/svg%3E";
 </script>
@@ -73,6 +78,64 @@
         {/snippet}
       </Modal>
     </div>
+  {/if}
+</div>
+
+<div class="demo-row">
+  <Button
+    text="Open modal with decorative left image"
+    onclick={() => (showDecorativeLeftImageModal = true)}
+  />
+  {#if showDecorativeLeftImageModal}
+    <Modal
+      size="medium"
+      align="center"
+      showOverlay
+      testId="decorative-left-image-modal"
+      leftImageTestId="decorative-left-image"
+      header={{ text: 'Decorative left image', leftImage: backIconSrc, rightImage: closeIconSrc }}
+      onclose={() => (showDecorativeLeftImageModal = false)}
+      onoverlayClick={() => (showDecorativeLeftImageModal = false)}
+      onheaderRightImageClick={() => (showDecorativeLeftImageModal = false)}
+    >
+      {#snippet content()}
+        <div style="padding: 16px;">
+          <p>
+            No <code>onheaderLeftImageClick</code> is supplied, so the left image is a plain decorative
+            image — it must not be focusable and must not be announced as a button.
+          </p>
+        </div>
+      {/snippet}
+    </Modal>
+  {/if}
+</div>
+
+<div class="demo-row">
+  <Button text="Open modal with back button" onclick={() => (showBackButtonModal = true)} />
+  {#if showBackButtonModal}
+    <Modal
+      size="medium"
+      align="center"
+      showOverlay
+      testId="back-button-modal"
+      leftImageTestId="back-button-left-image"
+      leftImageAriaLabel="Go back"
+      header={{ text: 'Back button', leftImage: backIconSrc, rightImage: closeIconSrc }}
+      onclose={() => (showBackButtonModal = false)}
+      onoverlayClick={() => (showBackButtonModal = false)}
+      onheaderRightImageClick={() => (showBackButtonModal = false)}
+      onheaderLeftImageClick={() => (backButtonClickCount += 1)}
+    >
+      {#snippet content()}
+        <div style="padding: 16px;">
+          <p>
+            A real back control: <code>onheaderLeftImageClick</code> is supplied, so it keeps
+            <code>role="button"</code>, its tab stop and keyboard activation.
+          </p>
+          <p data-pw="back-button-click-count">clicks: {backButtonClickCount}</p>
+        </div>
+      {/snippet}
+    </Modal>
   {/if}
 </div>
 

--- a/tests/modal-left-image-interactivity.spec.ts
+++ b/tests/modal-left-image-interactivity.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+// Modal used to wrap ANY non-empty header.leftImage in role="button" + tabindex="0" with click and
+// keydown handlers, whether or not onheaderLeftImageClick was supplied. Consumers pass a decorative
+// brand/source logo there far more often than a back button, so assistive tech announced a focusable
+// "button" that did nothing when activated — worse than leaving the image unannounced. The wrapper is
+// now interactive only when a handler is actually supplied.
+test.describe('Modal left image interactivity', () => {
+  test('a decorative left image with no click handler is not a control', async ({ page }) => {
+    await page.goto('/components/modal');
+    await page.getByText('Open modal with decorative left image').click();
+
+    const modal = page.getByTestId('decorative-left-image-modal');
+    await expect(modal).toBeVisible();
+
+    const leftImage = page.getByTestId('decorative-left-image');
+    await expect(leftImage).toBeVisible();
+
+    // Not announced as a control, and not reachable by keyboard.
+    await expect(leftImage).not.toHaveAttribute('role', 'button');
+    await expect(leftImage).not.toHaveAttribute('tabindex', /.*/);
+    await expect(leftImage).not.toHaveAttribute('aria-label', /.+/);
+
+    // The image itself still renders — this is an accessibility fix, not a visual removal.
+    await expect(leftImage.locator('img, svg')).toBeVisible();
+  });
+
+  test('a left image with a click handler stays a fully keyboard-operable button', async ({
+    page
+  }) => {
+    await page.goto('/components/modal');
+    await page.getByText('Open modal with back button').click();
+
+    const modal = page.getByTestId('back-button-modal');
+    await expect(modal).toBeVisible();
+
+    const backButton = page.getByTestId('back-button-left-image');
+    await expect(backButton).toHaveAttribute('role', 'button');
+    await expect(backButton).toHaveAttribute('tabindex', '0');
+    await expect(backButton).toHaveAttribute('aria-label', 'Go back');
+
+    const clickCount = page.getByTestId('back-button-click-count');
+    await expect(clickCount).toHaveText('clicks: 0');
+
+    await backButton.click();
+    await expect(clickCount).toHaveText('clicks: 1');
+
+    // Keyboard activation must keep working for the interactive case.
+    await backButton.focus();
+    await page.keyboard.press('Enter');
+    await expect(clickCount).toHaveText('clicks: 2');
+
+    await page.keyboard.press(' ');
+    await expect(clickCount).toHaveText('clicks: 3');
+  });
+});


### PR DESCRIPTION
Modal wrapped **any** non-empty `header.leftImage` in `role="button"` with `tabindex="0"` and click/keydown handlers, regardless of whether `onheaderLeftImageClick` was passed.

Consumers use that slot for a decorative brand or source logo far more often than for a back button. So assistive tech announced a focusable **button that does nothing when activated**, and keyboard users hit a dead tab stop on every such modal. That is worse than leaving the image unannounced — it promises an action the control does not have.

## The change

The wrapper is interactive only when `onheaderLeftImageClick` is a function.

```svelte
{#if typeof onheaderLeftImageClick === "function"}
  <div onclick={handleLeftImageClick} onkeydown={handleLeftImageKeyDown}
       role="button" tabindex="0" aria-label={leftImageAriaLabel ?? null} ...>
    {@render leftImage()}
  </div>
{:else}
  <div data-pw={leftImageTestId} testID={leftImageTestId}>
    {@render leftImage()}
  </div>
{/if}
```

Three deliberate implementation choices:

- **Two explicit branches, not computed attributes.** My first attempt used ternaries (`role={isInteractive ? "button" : undefined}`). That tripped `a11y_no_noninteractive_tabindex` — svelte-check cannot statically pair a dynamic `role` with a dynamic `tabindex` — and it violated this repo`s own `no-restricted-syntax` rule banning `undefined` (4 errors). Writing the branches out keeps the pairing statically checkable and needs no suppression.
- **Shared `{#snippet leftImage()}`** so the `Img` markup is not duplicated.
- **`{@const leftImageSrc = header.leftImage}`** because a snippet is its own scope and loses the outer `typeof header.leftImage === "string"` narrowing, which svelte-check flagged as a real type error.

`data-pw` / `testID` are preserved on both branches, so existing selectors keep working.

## Backward compatibility

The only behavioural difference is for call sites passing `leftImage` **without** a handler — where the control did nothing anyway. Sites that pass a handler are untouched.

That is asserted, not assumed: the new spec`s back-button case **passes both before and after** the change.

## Tests

New `tests/modal-left-image-interactivity.spec.ts` covers both states, driven by two new demo modals on `/components/modal` (the demo route previously had no `leftImage` case at all):

1. **decorative** (no handler) — not `role="button"`, no `tabindex`, no `aria-label`, and the image still renders.
2. **back button** (handler wired) — keeps `role="button"`, `tabindex="0"`, `aria-label`, and stays operable by click, `Enter` **and** `Space`, asserted via a visible click counter.

**Negative control performed.** With the fix reverted, the decorative test fails on the `role="button"` assertion while the back-button test still passes — so the spec genuinely detects the regression it exists to catch, and it is not accidentally green.

## Gates

- `pnpm run check` (svelte-check): **563 files, 0 errors**. The 4 remaining warnings are pre-existing and unrelated.
- `pnpm exec eslint src/lib/Modal/Modal.svelte`: clean. (3 repo-wide errors in `mcp/src/services/registry.ts` are pre-existing on `release` — confirmed by stashing this change and re-running.)
- `prettier --check`: clean.
- Playwright: 4 passed, including both pre-existing `modal-viewport-containment` specs — no regression.

## Downstream

Unblocks 7 call sites in Lighthouse (BZ-4233) that pass a decorative logo with no handler: `SettingsView`, `ai/settings/sources/data` (×2), `LoginModal`, `ai/anomaly`, and others. They need **no consumer-side change** once this lands — the wrapper simply stops being a control.

## Follow-up, not done here

`header.rightImage` has the identical unconditional wrapper and `onheaderRightImageClick` is also optional, so the same dead-control case is possible there. I did not change it: the close control is far more widely used, and a consumer census is complicated by props being spread through wrapper components, so it needs its own per-site tracing rather than a symmetric guess.