### PR TITLE
feat(Toast): add --toast-bottom CSS hook

### DIFF
--- a/docs/Toast.md
+++ b/docs/Toast.md
@@ -72,6 +72,7 @@ Override these custom properties to theme the component.
 | `--toast-top`                          | `10px`                                   | top              | Top position of the toast.                                              |
 | `--toast-left`                         | `0`                                      | left             | Left position of the toast.                                             |
 | `--toast-right`                        | `0`                                      | right            | Right position of the toast.                                            |
+| `--toast-bottom`                       | `auto`                                   | bottom           | Bottom position of the toast. Combine with `--toast-top: auto` to anchor to the bottom edge instead of the top. |
 | `--toast-background-color`             | `#87ceeb`                                | background-color | Default background color of the toast.                                  |
 | `--toast-opacity`                      | `1`                                      | opacity          | Opacity of the toast.                                                   |
 | `--toast-box-sizing`                   | `-`                                      | box-sizing       |                                                                         |

--- a/src/lib/Toast/Toast.svelte
+++ b/src/lib/Toast/Toast.svelte
@@ -177,6 +177,7 @@
     top: var(--toast-top, 10px);
     left: var(--toast-left, 0);
     right: var(--toast-right, 0);
+    bottom: var(--toast-bottom, auto);
     background-color: var(--toast-background-color, #87ceeb);
     opacity: var(--toast-opacity, 1);
     box-sizing: var(--toast-box-sizing);

--- a/src/routes/components/toast/+page.svelte
+++ b/src/routes/components/toast/+page.svelte
@@ -3,6 +3,7 @@
   import Toast from '$lib/Toast/Toast.svelte';
 
   let showToast = $state(false);
+  let showBottomToast = $state(false);
 </script>
 
 <div class="page-header">
@@ -20,3 +21,32 @@
     />
   {/if}
 </div>
+
+<div class="demo-row">
+  <Button text="Show Bottom-Centered Toast" onclick={() => (showBottomToast = true)} />
+  {#if showBottomToast}
+    <Toast
+      message="Anchored via --toast-bottom"
+      type="info"
+      classes="toast-bottom-center"
+      onToastHide={() => (showBottomToast = false)}
+    />
+  {/if}
+</div>
+
+<style>
+  /* Bottom-centered recipe: --toast-left/--toast-right pin the box, fit-content
+     width + auto margin centers it horizontally, and --toast-top: auto hands
+     vertical placement to --toast-bottom. There's no --toast-transform hook —
+     the fly transition writes its own inline transform during enter/leave,
+     which would fight a static transform mid-animation; this left/right +
+     auto-margin + fit-content pattern composes cleanly with it instead. */
+  :global(.toast-bottom-center) {
+    --toast-left: 0;
+    --toast-right: 0;
+    --toast-width: fit-content;
+    --toast-margin: 0 auto;
+    --toast-top: auto;
+    --toast-bottom: 24px;
+  }
+</style>


### PR DESCRIPTION
## Summary

`Toast.svelte`'s `.toast` rule exposes `--toast-top`, `--toast-left`, and `--toast-right` as CSS custom-property hooks, but has no `--toast-bottom` — so a consumer that wants to anchor a toast to the bottom edge of its container has no supported way to do it. This PR adds the missing hook.

## Design note: why this also unlocks bottom-centered toasts, and why there's no `--toast-transform` hook

With `--toast-bottom` in place, bottom-centered placement is achievable entirely through existing hooks plus this one:

```css
--toast-left: 0;
--toast-right: 0;
--toast-width: fit-content;
--toast-margin: 0 auto;
--toast-top: auto;
--toast-bottom: 24px;
```

I deliberately did **not** add a `--toast-transform` hook as an alternative centering mechanism (e.g. `left: 50%; transform: translateX(-50%)`). `Toast.svelte` applies `in:fly`/`out:fly` on the root element, and Svelte's `fly` transition writes its own inline `transform` during enter/leave. A statically-applied `--toast-transform` would fight that inline transform mid-animation and snap into place only once the transition finished. The left/right + `fit-content` width + `auto` margin recipe above has no such conflict — it composes cleanly with `fly` throughout the whole animation — so it's the recipe implemented in the new demo section rather than a transform-based one.

## Change

```css
.toast {
  ...
  top: var(--toast-top, 10px);
  left: var(--toast-left, 0);
  right: var(--toast-right, 0);
+ bottom: var(--toast-bottom, auto);
  background-color: var(--toast-background-color, #87ceeb);
  ...
}
```

Default is `auto`, identical to the property's previously-unset computed value — zero default behavior change.

`--toast-width` and `--toast-margin`, both needed for the centering recipe above, already existed on `.toast` and required no changes.

## CSS Variables contract

| Variable | Default | Property | Description |
|---|---|---|---|
| `--toast-bottom` | `auto` | `bottom` | Bottom position of the toast. Combine with `--toast-top: auto` to anchor to the bottom edge instead of the top. |

## Usage

```svelte
<!-- Bottom-centered toast -->
<Toast message="Saved" type="success" classes="toast-bottom-center" />

<style>
  :global(.toast-bottom-center) {
    --toast-left: 0;
    --toast-right: 0;
    --toast-width: fit-content;
    --toast-margin: 0 auto;
    --toast-top: auto;
    --toast-bottom: 24px;
  }
</style>
```

## Registration surfaces

- [x] `src/lib/Toast/Toast.svelte` — added the `bottom: var(--toast-bottom, auto)` declaration
- [x] `docs/Toast.md` — added the `--toast-bottom` row to the CSS Variables table
- [x] `src/routes/components/toast/+page.svelte` — added a "Show Bottom-Centered Toast" demo using the recipe above

## Gates

- `pnpm run lint` — pass
- `pnpm run check` — pass
- `pnpm run test:unit` — pass
- `pnpm run build` — pass
- `pnpm run test:integration` — 140 passed, 9 failed. The 9 failures are a pre-existing baseline unrelated to this change, all in `tests/table-builtin-cells.test.ts` (7), `tests/table-header-meta.test.ts` (1), and `tests/table-pagination-selection.test.ts` (1) — none touch Toast. **Verified by `git stash`:** re-ran the same three spec files against the unmodified tree (this change stashed out) and got the identical 9 failures by name and location, then `git stash pop`'d this change back in. Confirms the failures predate and are unrelated to this PR.

Single commit, not merging — for review only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for positioning toast notifications near the bottom edge of the screen.
  - Added a bottom-centered toast example in the component showcase.
  - Added configuration guidance for customizing toast bottom positioning.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->