### PR TITLE
feat(Icon): add interactive prop to stop forcing button semantics

### DIFF
--- a/docs/Icon.md
+++ b/docs/Icon.md
@@ -1,6 +1,6 @@
 # Icon
 
-A clickable icon component that displays an image or inline SVG with an optional text label. The entire container is a button for accessibility. Layout direction (row or column) is controlled via CSS variable `--icon-container-direction`. Supports two rendering modes: image URL via `icon` prop, or raw SVG markup via `svg` prop.
+An icon component that displays an image or inline SVG with an optional text label. By default the container renders as an interactive button (`role="button"`, `tabindex`, click/keydown handling) for accessibility; set `interactive={false}` for purely decorative or informational icons that shouldn't be exposed to assistive tech or the tab order. Layout direction (row or column) is controlled via CSS variable `--icon-container-direction`. Supports two rendering modes: image URL via `icon` prop, or raw SVG markup via `svg` prop.
 
 ## Usage
 
@@ -24,6 +24,7 @@ A clickable icon component that displays an image or inline SVG with an optional
 | svg     | `string`         | No       | `-`     | Raw SVG markup string to render inline via `{@html}`. When provided, takes priority over `icon`. Inherits `currentColor` for styling. **Must be trusted content** — never pass unsanitized user input (see Security note below). |
 | text    | `string \| null` | No       | `-`     | Optional text label displayed below the icon.                                                                                                                          |
 | classes | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| interactive | `boolean`    | No       | `true`  | When `true`, the container gets `role="button"`, `tabindex="0"`, and the `onclick`/`onkeydown` handlers. When `false`, none of those are rendered — use for decorative or informational icons with no click behavior. |
 
 > **Note:** At least one of `icon` or `svg` should be provided. If both are provided, `svg` takes priority.
 
@@ -33,8 +34,8 @@ A clickable icon component that displays an image or inline SVG with an optional
 
 | Event     | Type                             | Description                                                     |
 | --------- | -------------------------------- | --------------------------------------------------------------- |
-| onclick   | `(event: MouseEvent) => void`    | Fires when the icon container is clicked.                       |
-| onkeydown | `(event: KeyboardEvent) => void` | Fires when a key is pressed while the icon container has focus. |
+| onclick   | `(event: MouseEvent) => void`    | Fires when the icon container is clicked. Only wired up when `interactive` is `true` (the default). |
+| onkeydown | `(event: KeyboardEvent) => void` | Fires when a key is pressed while the icon container has focus. Only wired up when `interactive` is `true` (the default). |
 
 ## CSS Variables
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -113,7 +113,7 @@
   },
   {
     "name": "Icon",
-    "description": "A clickable icon component that displays an image with an optional text label below. The entire container is a button for accessibility."
+    "description": "An icon component that displays an image with an optional text label below. Interactive (button semantics) by default; set interactive={false} for decorative icons."
   },
   {
     "name": "IconStack",

--- a/src/lib/Icon/Icon.svelte
+++ b/src/lib/Icon/Icon.svelte
@@ -2,15 +2,25 @@
   import Img from '../Img/Img.svelte';
   import type { IconProperties } from './properties';
 
-  let { icon, svg, text, onclick, onkeydown, classes, testId }: IconProperties = $props();
+  let {
+    icon,
+    svg,
+    text,
+    onclick,
+    onkeydown,
+    classes,
+    testId,
+    interactive = true
+  }: IconProperties = $props();
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   class="icon-container {classes ?? ''}"
-  {onclick}
-  {onkeydown}
-  role="button"
-  tabindex="0"
+  onclick={interactive ? onclick : null}
+  onkeydown={interactive ? onkeydown : null}
+  role={interactive ? 'button' : null}
+  tabindex={interactive ? 0 : null}
   data-pw={typeof testId === 'string' ? testId : null}
   testID={typeof testId === 'string' ? testId : null}
 >

--- a/src/lib/Icon/properties.ts
+++ b/src/lib/Icon/properties.ts
@@ -6,6 +6,11 @@ export type OptionalIconProperties = {
   text?: string | null;
   classes?: string;
   testId?: string;
+  /** Whether the container renders as an interactive control (role="button",
+   * tabindex, and the onclick/onkeydown handlers). Defaults to `true`, matching
+   * the component's original always-interactive behavior. Set to `false` for
+   * purely decorative/informational icons that don't respond to input. */
+  interactive?: boolean;
 };
 
 export type IconEventProperties = {

--- a/src/routes/components/icon/+page.svelte
+++ b/src/routes/components/icon/+page.svelte
@@ -22,3 +22,23 @@
   <Icon svg={heartSvg} text="Heart" />
   <Icon svg={checkSvg} text="Check" />
 </div>
+
+<h3 class="demo-heading">Non-interactive (interactive={false})</h3>
+<p class="demo-caption">
+  For icons that are purely decorative or informational — no click handler, no
+  <code>role="button"</code>, no tab stop.
+</p>
+<div class="demo-row" style="align-items: center;">
+  <Icon svg={checkSvg} text="Verified" interactive={false} />
+</div>
+
+<style>
+  .demo-heading {
+    margin: 24px 0 8px;
+  }
+
+  .demo-caption {
+    margin: 0 0 12px;
+    color: #666;
+  }
+</style>

--- a/src/wc/components/Icon.wc.svelte
+++ b/src/wc/components/Icon.wc.svelte
@@ -8,7 +8,8 @@
       text: { type: 'String', reflect: true },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      onkeydown: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      interactive: { type: 'Boolean', reflect: true }
     }
   }}
 />


### PR DESCRIPTION
## Summary

`Icon.svelte`'s root container unconditionally renders `role="button"`, `tabindex="0"`, and wires up `onclick`/`onkeydown` — regardless of whether the consumer actually supplied a click handler. Every purely decorative or informational `Icon` usage (a glyph next to a stat, a status icon, a label icon) is pulled into the tab order and announced as a button to assistive tech despite doing nothing on activation. That's a WCAG 4.1.2 (Name, Role, Value) mismatch between the exposed role and the actual behavior. This PR makes the interactive semantics opt-out instead of forced.

## Fix

Add an `interactive` prop, default `true`, gating `role`, `tabindex`, `onclick`, and `onkeydown` together:

```svelte
<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
<div
  class="icon-container {classes ?? ''}"
  onclick={interactive ? onclick : null}
  onkeydown={interactive ? onkeydown : null}
  role={interactive ? 'button' : null}
  tabindex={interactive ? 0 : null}
  ...
>
```

Default `true` reproduces the current render output byte-for-byte — zero default behavior change for existing consumers. Setting `interactive={false}` renders a plain, non-focusable, non-announced container for decorative icons.

## Why not derive it from `onclick` like the sibling components?

`Pill`, `Card`, `StatCard`, `KeyboardInput`, and `Banner` already implement this same conditional-interactivity idea, but derive it from `typeof onclick === 'function'` instead of an explicit prop:

```svelte
let interactive = $derived(typeof onclick === 'function');
```

`Icon` intentionally does **not** adopt that pattern in this PR. Doing so would silently flip `interactive` to `false` for every existing `Icon` consumer that doesn't currently pass `onclick` — even ones that might rely on the tabindex/role for some other reason (e.g. a click handled via delegation higher up the tree). An explicit prop defaulting to `true` guarantees no existing consumer changes behavior.

`interactive = !!onclick` would be a reasonable default for a future major version, once consumers can be audited for the behavior change — noting it here for that purpose, but keeping the safe default in this PR.

## Props contract

| Prop | Type | Default | Description |
|---|---|---|---|
| `interactive` | `boolean` | `true` | When `true`, the container gets `role="button"`, `tabindex="0"`, and the `onclick`/`onkeydown` handlers. When `false`, none of those are rendered. |

## Usage

```svelte
<!-- Decorative icon: no click behavior, not in the tab order, not announced as a button -->
<Icon svg={checkSvg} text="Verified" interactive={false} />
```

## Registration surfaces

- [x] `src/lib/Icon/Icon.svelte` — added the `interactive` prop, gated `role`/`tabindex`/`onclick`/`onkeydown`, added the required `<!-- svelte-ignore a11y_no_noninteractive_tabindex -->` (same pattern as Pill/Card/StatCard/KeyboardInput/Banner)
- [x] `src/lib/Icon/properties.ts` — added `interactive?: boolean` to `OptionalIconProperties`
- [x] `src/wc/components/Icon.wc.svelte` — registered `interactive: { type: 'Boolean', reflect: true }`
- [x] `docs/Icon.md` — updated the top description, added the `interactive` row to the Props table, noted the gating on the `onclick`/`onkeydown` Events rows
- [x] `docs/_index.json` — updated the Icon short description
- [x] `src/routes/components/icon/+page.svelte` — added a "Non-interactive" demo section with a caption explaining the a11y rationale

## Gates

- `pnpm run lint` — pass (3 pre-existing warnings in `src/lib/Table/cell-data.test.ts`, unrelated to this change, 0 errors)
- `pnpm run check` — pass (0 errors; 4 pre-existing warnings in `Modal.svelte`/`ThemeSwitcher.svelte`/`tsconfig.json`, unrelated)
- `pnpm run test:unit` — pass (128/128)
- `pnpm run build` — pass
- `pnpm run test:integration` — 140 passed, 9 failed. The 9 failures are a pre-existing baseline unrelated to this change, all in `tests/table-builtin-cells.test.ts` (7), `tests/table-header-meta.test.ts` (1), and `tests/table-pagination-selection.test.ts` (1) — none touch Icon. **Verified by `git stash`:** re-ran the same three spec files against the unmodified tree (this change stashed out) and got the identical 9 failures by name and location, then `git stash pop`'d this change back in.

Single commit, not merging — for review only.
