### PR TITLE
feat(Modal): add entryAnimation and overlayFadeIn props for centered slide-up dialogs

### DIFF
--- a/docs/Modal.md
+++ b/docs/Modal.md
@@ -22,6 +22,7 @@ A dialog overlay component that renders on top of the page with configurable siz
 | supportHardwareBackPress | `boolean`                                                                                                                   | No       | `false`         | When true, pushes a history state on mount so that pressing the device back button triggers onclose instead of navigating away. Cleans up on destroy.                                                        |
 | enableTransition         | `boolean`                                                                                                                   | No       | `true`          | When true, the modal content animates in/out using fly or fade transitions via ModalAnimation.                                                                                                               |
 | transitionType           | `ModalTransition = 'IN' \| 'ALL'`                                                                                           | No       | `'ALL'`         | Controls transition behavior. 'ALL' animates both in and out transitions. 'IN' only animates the in-transition (content disappears instantly on close).                                                      |
+| entryAnimation           | `ModalEntryAnimation = 'fade' \| 'slide-up' \| 'slide-down'`                                                                | No       | `-`             | Overrides the default per-align entry transition. 'slide-up'/'slide-down' reuse the same fly distance/duration as bottom/top alignment — e.g. pair with `align="center"` for a bottom-sheet-style slide-up dialog. Unset keeps the existing per-align default (fly for top/bottom, fade for center).            |
 | header                   | `{     leftImage?: string;     rightImage?: string;     text?: string;     testId?: string;     buttonTestId?: string;     buttonAriaLabel?: string;   }` | No       | `{}`            | Object configuring the modal header bar. leftImage: URL for left icon (e.g., back arrow); rightImage: URL for right icon (e.g., close button); text: header title text; testId/buttonTestId: test selectors; buttonAriaLabel: accessible name (rendered as `aria-label`) for the right image's `role="button"` wrapper — required for screen readers since the wrapper carries no visible text. |
 | footer                   | `{     primaryButton?: ButtonProperties;     secondaryButton?: ButtonProperties;   }`                                       | No       | `-`             | Object configuring footer action buttons. primaryButton: ButtonProperties for the main action button; secondaryButton: ButtonProperties for the alternate action button.                                     |
 | debounceTime             | `number`                                                                                                                    | No       | `700`           | Debounce delay in milliseconds for overlay click handling. Prevents rapid repeated overlay dismissals.                                                                                                       |
@@ -30,6 +31,7 @@ A dialog overlay component that renders on top of the page with configurable siz
 | testId                   | `string`                                                                                                                    | No       | `-`             | Value for data-pw on the modal overlay container.                                                                                                                                                            |
 | classes                  | `string`                                                                                                                    | No       | `-`             | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                       |
 | overlayBackdropFilter    | `string`                                                                                                                    | No       | `-`             | CSS `backdrop-filter` value applied to the overlay (e.g. `"blur(6px)"`). Sets `--modal-overlay-backdrop-filter` inline on the overlay div. Default: `none` (no blur).                                        |
+| overlayFadeIn            | `boolean`                                                                                                                   | No       | `false`         | When true, the overlay backdrop fades in on mount instead of appearing instantly. Pairs well with `entryAnimation="slide-up"` for a softer combined entrance.                                                |
 | usePortal                | `boolean`                                                                                                                   | No       | `false`         | When true, mounts the modal overlay at `document.body` so it escapes any ancestor clipping or stacking contexts. Useful inside `overflow: hidden` or `transform` containers.                                 |
 
 ## Snippets
@@ -177,6 +179,12 @@ type ModalAlign = 'top' | 'center' | 'bottom';
 
 ```typescript
 type ModalTransition = 'IN' | 'ALL';
+```
+
+### ModalEntryAnimation
+
+```typescript
+type ModalEntryAnimation = 'fade' | 'slide-up' | 'slide-down';
 ```
 
 ### ButtonProperties

--- a/docs/ModalAnimation.md
+++ b/docs/ModalAnimation.md
@@ -1,6 +1,6 @@
 # ModalAnimation
 
-A wrapper that applies fly or fade Svelte transitions to its children based on the modal's `align` prop. For `top` alignment, content flies in from above; for `bottom`, from below; for `center`, a fade transition is used. The `transitionType` controls whether the out-transition is also animated ('ALL') or only the in-transition ('IN').
+A wrapper that applies fly or fade Svelte transitions to its children based on the modal's `align` prop. For `top` alignment, content flies in from above; for `bottom`, from below; for `center`, a fade transition is used. The `transitionType` controls whether the out-transition is also animated ('ALL') or only the in-transition ('IN'). The optional `entryAnimation` prop overrides the align-based default — e.g. `'slide-up'` makes a `center`-aligned modal fly in from below like a bottom sheet, reusing the same distance/duration constants as `bottom` alignment.
 
 ## Usage
 
@@ -19,6 +19,7 @@ A wrapper that applies fly or fade Svelte transitions to its children based on t
 | enable | `boolean` | No | `true` | When true, applies transition animations. When false, renders children without any transitions. |
 | align | `'top' \| 'center' \| 'bottom'` | No | `'bottom'` | Determines the transition type: 'top' and 'bottom' use fly transitions, 'center' uses fade. |
 | transitionType | `'IN' \| 'ALL'` | No | `'ALL'` | Controls whether the out-transition is animated. 'ALL' animates both in and out. 'IN' only animates the in-transition. |
+| entryAnimation | `'fade' \| 'slide-up' \| 'slide-down'` | No | `-` | Overrides the align-based transition choice above. 'slide-up' and 'slide-down' use fly with the same distance/duration as bottom/top alignment respectively. Unset keeps the existing per-align default. |
 
 ## Snippets
 

--- a/docs/OverlayAnimation.md
+++ b/docs/OverlayAnimation.md
@@ -1,6 +1,6 @@
 # OverlayAnimation
 
-A wrapper that applies a fade-out transition (350ms) to its children when they are removed from the DOM. Used internally by Modal to animate the overlay background.
+A wrapper that applies a fade-out transition (350ms) to its children when they are removed from the DOM. Used internally by Modal to animate the overlay background. The optional `fadeIn` prop additionally fades the overlay in on mount (same 350ms duration); default is `false`, which preserves the original instant-appear-on-mount behavior.
 
 ## Usage
 
@@ -10,7 +10,16 @@ A wrapper that applies a fade-out transition (350ms) to its children when they a
 </script>
 
 <OverlayAnimation />
+
+<!-- Fade in on mount too, not just fade out on unmount -->
+<OverlayAnimation fadeIn />
 ```
+
+## Props
+
+| Prop   | Type      | Required | Default | Description                                                                        |
+| ------ | --------- | -------- | ------- | ------------------------------------------------------------------------------------ |
+| fadeIn | `boolean` | No       | `false` | When true, also fades in on mount (350ms, matching the fade-out). Default preserves the original instant-appear behavior. |
 
 ## Snippets
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -161,15 +161,15 @@
   },
   {
     "name": "Modal",
-    "description": "A dialog overlay component that renders on top of the page with configurable size, alignment, header, footer, and transition animations. Locks body scroll and optionally handles hardware back-press navigation. Supports click-to-dismiss and Escape key."
+    "description": "A dialog overlay component that renders on top of the page with configurable size, alignment, header, footer, and transition animations. entryAnimation can override the per-align default, e.g. a slide-up bottom-sheet-style dialog while centered. Locks body scroll and optionally handles hardware back-press navigation. Supports click-to-dismiss and Escape key."
   },
   {
     "name": "ModalAnimation",
-    "description": "A wrapper that applies fly or fade Svelte transitions to its children based on the modal's `align` prop. For top alignment, content flies in from above; for bottom, from below; for center, a fade transition is used."
+    "description": "A wrapper that applies fly or fade Svelte transitions to its children based on the modal's `align` prop. For top alignment, content flies in from above; for bottom, from below; for center, a fade transition is used. The optional entryAnimation prop can override this per-align default."
   },
   {
     "name": "OverlayAnimation",
-    "description": "A wrapper that applies a fade-out transition (350ms) to its children when they are removed from the DOM. Used internally by Modal to animate the overlay background."
+    "description": "A wrapper that applies a fade-out transition (350ms) to its children when they are removed from the DOM, and optionally a matching fade-in on mount via the fadeIn prop. Used internally by Modal to animate the overlay background."
   },
   {
     "name": "Pagination",

--- a/src/lib/Animations/ModalAnimation.svelte
+++ b/src/lib/Animations/ModalAnimation.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { fly, fade } from 'svelte/transition';
-  import type { ModalAlign } from '$lib/Modal/properties';
+  import type { ModalAlign, ModalEntryAnimation } from '$lib/Modal/properties';
   import type { ModalTransition } from '$lib/types';
 
   type Props = {
     enable?: boolean;
     align?: ModalAlign;
     transitionType?: ModalTransition;
+    entryAnimation?: ModalEntryAnimation;
     children?: Snippet;
     testId?: string;
   };
@@ -16,12 +17,23 @@
     enable = true,
     align = 'bottom',
     transitionType = 'ALL',
+    entryAnimation,
     children,
     testId
   }: Props = $props();
 
   let flyAnimationProperties = $derived.by(() => {
     const base = { x: 0, y: 0, duration: 380 };
+
+    // entryAnimation, when set, overrides the align-based default below —
+    // e.g. a centered modal (which normally fades) can opt into the same
+    // fly distances top/bottom alignment already use.
+    if (entryAnimation === 'slide-up') {
+      return { ...base, y: 300 };
+    }
+    if (entryAnimation === 'slide-down') {
+      return { ...base, y: -30 };
+    }
 
     switch (align) {
       case 'top':
@@ -35,7 +47,9 @@
 
   let fadeAnimationProperties = { duration: 300 };
 
-  let useFlyAnimation = $derived(align === 'top' || align === 'bottom');
+  let useFlyAnimation = $derived(
+    entryAnimation != null ? entryAnimation !== 'fade' : align === 'top' || align === 'bottom'
+  );
   let useOutTransition = $derived(transitionType === 'ALL');
 </script>
 

--- a/src/lib/Animations/OverlayAnimation.svelte
+++ b/src/lib/Animations/OverlayAnimation.svelte
@@ -5,15 +5,28 @@
   type Props = {
     children?: Snippet;
     testId?: string;
+    /** When true, fades in on mount (same 350ms duration as the existing fade-out). Default false preserves the current instant-appear behavior. */
+    fadeIn?: boolean;
   };
 
-  let { children, testId }: Props = $props();
+  let { children, testId, fadeIn = false }: Props = $props();
 </script>
 
-<div
-  out:fade={{ duration: 350 }}
-  data-pw={typeof testId === 'string' ? testId : null}
-  testID={typeof testId === 'string' ? testId : null}
->
-  {@render children?.()}
-</div>
+{#if fadeIn}
+  <div
+    in:fade={{ duration: 350 }}
+    out:fade={{ duration: 350 }}
+    data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
+  >
+    {@render children?.()}
+  </div>
+{:else}
+  <div
+    out:fade={{ duration: 350 }}
+    data-pw={typeof testId === 'string' ? testId : null}
+    testID={typeof testId === 'string' ? testId : null}
+  >
+    {@render children?.()}
+  </div>
+{/if}

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -17,6 +17,7 @@
     supportHardwareBackPress = false,
     enableTransition = true,
     transitionType = 'ALL',
+    entryAnimation,
     header = {},
     footer,
     debounceTime = 700,
@@ -34,6 +35,7 @@
     onkeydown,
     classes,
     overlayBackdropFilter,
+    overlayFadeIn = false,
     usePortal = false
   }: ModalProperties = $props();
 
@@ -138,7 +140,7 @@
 <svelte:window onkeydown={handleKeyDown} />
 
 {#if typeof content === 'function'}
-  <OverlayAnimation>
+  <OverlayAnimation fadeIn={overlayFadeIn}>
     <div
       bind:this={overlayDiv}
       use:portalAction={{ usePortal }}
@@ -153,7 +155,7 @@
       data-pw={testId}
       testID={testId}
     >
-      <ModalAnimation enable={enableTransition} {align} {transitionType}>
+      <ModalAnimation enable={enableTransition} {align} {transitionType} {entryAnimation}>
         <div class="modal-content {size}">
           {#if (typeof header?.leftImage === 'string' && header.leftImage.length > 0) || (typeof header?.text === 'string' && header.text.length > 0) || (typeof header?.rightImage === 'string' && header.rightImage.length > 0)}
             <div class="header">

--- a/src/lib/Modal/properties.ts
+++ b/src/lib/Modal/properties.ts
@@ -4,6 +4,14 @@ import type { Snippet } from 'svelte';
 
 export type ModalSize = 'large' | 'medium' | 'small' | 'fit-content';
 export type ModalAlign = 'top' | 'center' | 'bottom';
+/**
+ * Overrides ModalAnimation's default per-align entry transition ('top'/'bottom'
+ * fly, 'center' fade). 'slide-up' and 'slide-down' reuse the same fly
+ * distance/duration constants as bottom/top alignment respectively, so e.g. a
+ * centered modal can slide up like a bottom sheet instead of just fading in.
+ * Leave unset to keep the existing per-align default.
+ */
+export type ModalEntryAnimation = 'fade' | 'slide-up' | 'slide-down';
 
 export type ModalProperties = OptionalModalProperties & ModalEventProperties;
 
@@ -14,6 +22,8 @@ export type OptionalModalProperties = {
   supportHardwareBackPress?: boolean;
   enableTransition?: boolean;
   transitionType?: ModalTransition;
+  /** Overrides the default per-align entry transition. See ModalEntryAnimation. Default: unset (per-align behavior). */
+  entryAnimation?: ModalEntryAnimation;
   header?: {
     leftImage?: string;
     rightImage?: string;
@@ -37,6 +47,8 @@ export type OptionalModalProperties = {
   classes?: string;
   /** CSS value applied to backdrop-filter on the overlay (e.g. "blur(6px)"). Exposed as --modal-overlay-backdrop-filter CSS var. Default: none (no blur). */
   overlayBackdropFilter?: string;
+  /** When true, the overlay backdrop fades in on mount instead of appearing instantly. Pairs well with entryAnimation="slide-up" for a softer combined entrance. Default: false (current instant-appear behavior). */
+  overlayFadeIn?: boolean;
   /** When true, mounts the overlay at document.body to escape clipping/stacking contexts. Default: false. */
   usePortal?: boolean;
 };

--- a/src/routes/components/modal/+page.svelte
+++ b/src/routes/components/modal/+page.svelte
@@ -8,6 +8,7 @@
   let showDecorativeLeftImageModal = $state(false);
   let showBackButtonModal = $state(false);
   let backButtonClickCount = $state(0);
+  let showSlideUpModal = $state(false);
 
   // Inline data-URI so the demo has no external asset dependency; exercises
   // the Img component's `inlineSvg` currentColor path used by the header.
@@ -173,6 +174,42 @@
         {/snippet}
       </Modal>
     </div>
+  {/if}
+</div>
+
+<div class="demo-row">
+  <Button text="Open centered modal (slide-up)" onclick={() => (showSlideUpModal = true)} />
+  {#if showSlideUpModal}
+    <Modal
+      size="fit-content"
+      align="center"
+      entryAnimation="slide-up"
+      overlayFadeIn
+      showOverlay
+      header={{
+        text: 'Slides Up, Stays Centered',
+        rightImage: closeIconSrc,
+        buttonTestId: 'slide-up-modal-close',
+        buttonAriaLabel: 'Close dialog'
+      }}
+      footer={{
+        primaryButton: { text: 'Got it' }
+      }}
+      onclose={() => (showSlideUpModal = false)}
+      onheaderRightImageClick={() => (showSlideUpModal = false)}
+      onoverlayClick={() => (showSlideUpModal = false)}
+      onprimaryButtonClick={() => (showSlideUpModal = false)}
+    >
+      {#snippet content()}
+        <div style="padding: 16px;">
+          <p>
+            <code>align="center"</code> paired with <code>entryAnimation="slide-up"</code> — the
+            dialog stays centered but enters like a bottom sheet instead of fading in.
+            <code>overlayFadeIn</code> softens the backdrop's appearance to match.
+          </p>
+        </div>
+      {/snippet}
+    </Modal>
   {/if}
 </div>
 

--- a/src/wc/components/Modal.wc.svelte
+++ b/src/wc/components/Modal.wc.svelte
@@ -9,6 +9,7 @@
       supportHardwareBackPress: { type: 'Boolean', attribute: 'support-hardware-back-press' },
       enableTransition: { type: 'Boolean', reflect: true, attribute: 'enable-transition' },
       transitionType: { type: 'String', reflect: true, attribute: 'transition-type' },
+      entryAnimation: { type: 'String', reflect: true, attribute: 'entry-animation' },
       header: { type: 'Object' },
       footer: { type: 'Object' },
       debounceTime: { type: 'Number', attribute: 'debounce-time' },
@@ -24,6 +25,7 @@
       onoverlayClick: { type: 'Object' },
       onkeydown: { type: 'Object' },
       overlayBackdropFilter: { type: 'String', attribute: 'overlay-backdrop-filter' },
+      overlayFadeIn: { type: 'Boolean', attribute: 'overlay-fade-in' },
       usePortal: { type: 'Boolean', attribute: 'use-portal' }
     }
   }}


### PR DESCRIPTION
## Summary

`ModalAnimation.svelte` picks its entry transition purely from the modal's `align` prop: `fly` for `top`/`bottom`, `fade` for `center`. There's no supported way to get a centered dialog that slides in like a bottom sheet — a common pattern (mobile-style centered sheets, confirmation dialogs that want a softer entrance than an instant fade) that currently requires reimplementing `ModalAnimation` from scratch to reach. This PR adds an optional `entryAnimation` override that unlocks it without touching any default behavior.

## Fix / design

Added `entryAnimation?: 'fade' | 'slide-up' | 'slide-down'` to `ModalAnimation` (and threaded through `Modal`'s public props):

```svelte
let flyAnimationProperties = $derived.by(() => {
  const base = { x: 0, y: 0, duration: 380 };

  if (entryAnimation === 'slide-up') {
    return { ...base, y: 300 };   // same distance as align="bottom"
  }
  if (entryAnimation === 'slide-down') {
    return { ...base, y: -30 };   // same distance as align="top"
  }

  switch (align) {
    case 'top': return { ...base, y: -30 };
    case 'bottom': return { ...base, y: 300 };
    default: return base;
  }
});

let useFlyAnimation = $derived(
  entryAnimation != null ? entryAnimation !== 'fade' : align === 'top' || align === 'bottom'
);
```

- `'slide-up'` and `'slide-down'` reuse the exact `y` distance (and the shared 380ms duration) that `bottom`/`top` alignment already use — no new animation constants, no visual mismatch between an aligned dialog and an animation-overridden one.
- `'fade'` explicitly forces the fade transition regardless of `align`, for symmetry (e.g. a bottom-aligned modal that should fade instead of fly).
- Left **unset** (the default), `entryAnimation` has zero effect — the original `switch(align)` logic drives the transition exactly as before. Zero default behavior change; confirmed by the existing `tests/modal-viewport-containment.spec.ts` suite (both tests still pass unmodified) plus a full integration run (see Gates).

### Why a separate `entryAnimation` axis instead of adding more `ModalAlign` values

`align` is a *position* concept (where the dialog sits) and `entryAnimation` is a *motion* concept (how it gets there). Folding "slides up but stays centered" into `align` would mean inventing values like `'center-slide-up'`, multiplying combinatorially with every future align/motion pairing and duplicating the positioning CSS for each one. Keeping the two axes orthogonal means any current or future `align` value can pair with any `entryAnimation` value for free.

### `overlayFadeIn` — opt-in overlay fade-in

Also added `overlayFadeIn` (threaded to a new `fadeIn` prop on `OverlayAnimation`, default `false`). A slide-up dialog whose backdrop still appears instantly reads as unfinished — the two are meant to be paired. `OverlayAnimation` only had an `out:fade` before; `fadeIn` adds the matching `in:fade` at the same 350ms duration:

```svelte
{#if fadeIn}
  <div in:fade={{ duration: 350 }} out:fade={{ duration: 350 }} ...>
    {@render children?.()}
  </div>
{:else}
  <div out:fade={{ duration: 350 }} ...>
    {@render children?.()}
  </div>
{/if}
```

(Duplicated-branch `{#if}/{:else}` rather than a ternary inside the transition directive — a ternary would still apply *some* `in:` transition even when "disabled." This mirrors the pattern `ModalAnimation.svelte` itself already uses for its own conditional transitions.)

I confirmed via `grep -rl "OverlayAnimation" src --include="*.svelte"` that `Modal.svelte` is `OverlayAnimation`'s only consumer in the repo, so threading `fadeIn` through as `overlayFadeIn` on `Modal`'s public props is what makes it reachable at all — left un-threaded it would be dead code. Default `false` preserves the current instant-appear overlay behavior.

## Props contract

| Prop | Component | Type | Default | Description |
|---|---|---|---|---|
| `entryAnimation` | `ModalAnimation`, `Modal` | `'fade' \| 'slide-up' \| 'slide-down'` | `-` (unset) | Overrides the `align`-based transition choice. `slide-up`/`slide-down` reuse bottom/top's fly distance and duration regardless of `align`. Unset keeps the existing per-align default. |
| `fadeIn` / `overlayFadeIn` | `OverlayAnimation` / `Modal` | `boolean` | `false` | Fades the overlay backdrop in on mount (350ms, matching the existing fade-out). Default preserves the current instant-appear behavior. |

## Usage

```svelte
<Modal
  size="fit-content"
  align="center"
  entryAnimation="slide-up"
  overlayFadeIn
  showOverlay
  header={{ text: 'Slides Up, Stays Centered' }}
  footer={{ primaryButton: { text: 'Got it' } }}
  ...
>
  {#snippet content()}
    <p>Centered position, bottom-sheet-style entrance.</p>
  {/snippet}
</Modal>
```

## Registration surfaces

- [x] `src/lib/Animations/ModalAnimation.svelte` — added `entryAnimation` prop, early-return branches in `flyAnimationProperties`, updated `useFlyAnimation` derivation
- [x] `src/lib/Animations/OverlayAnimation.svelte` — added `fadeIn` prop with the `{#if}/{:else}` duplicated-transition pattern
- [x] `src/lib/Modal/properties.ts` — added `ModalEntryAnimation` type, `entryAnimation` and `overlayFadeIn` fields on `OptionalModalProperties`
- [x] `src/lib/Modal/Modal.svelte` — threaded both props to `ModalAnimation`/`OverlayAnimation`
- [x] `src/wc/components/Modal.wc.svelte` — registered `entry-animation` (String) and `overlay-fade-in` (Boolean) custom-element attributes
- [x] `docs/Modal.md` — added both Props rows and a `ModalEntryAnimation` Type Reference entry
- [x] `docs/ModalAnimation.md` — updated description, added `entryAnimation` Props row
- [x] `docs/OverlayAnimation.md` — updated description, added a `fadeIn` usage example and a new Props section
- [x] `docs/_index.json` — updated the `Modal`, `ModalAnimation`, and `OverlayAnimation` short descriptions
- [x] `src/routes/components/modal/+page.svelte` — added an "Open centered modal (slide-up)" demo combining `align="center"`, `entryAnimation="slide-up"`, and `overlayFadeIn`

## Gates

- `pnpm run lint` — pass (3 pre-existing warnings in `src/lib/Table/cell-data.test.ts`, unrelated to this change, 0 errors)
- `pnpm run check` — pass (0 errors; 4 pre-existing warnings in `Modal.svelte`/`ThemeSwitcher.svelte`/`tsconfig.json`, unrelated — the `Modal.svelte` one is the pre-existing `debounceTime` closure warning, not something this PR touches)
- `pnpm run test:unit` — pass (128/128)
- `pnpm run build` — pass
- `pnpm run test:integration` — 140 passed, 9 failed. The 9 failures are a pre-existing baseline unrelated to this change, all in `tests/table-builtin-cells.test.ts` (7), `tests/table-header-meta.test.ts` (1), and `tests/table-pagination-selection.test.ts` (1) — none touch Modal/ModalAnimation/OverlayAnimation. Both `tests/modal-viewport-containment.spec.ts` tests pass unmodified, confirming the default (no-`entryAnimation`) path is unchanged. **Verified by `git stash`:** re-ran the same three spec files against the unmodified tree (this change stashed out) and got the identical 9 failures by name and location, then `git stash pop`'d this change back in.

Single commit, not merging — for review only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modal component now supports customizable entry animations with fade, slide-up, and slide-down options to override default behavior.
  * Modal overlay now supports animated fade-in effect on initial appearance.

* **Documentation**
  * Updated Modal component documentation with new animation customization features and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->