### PR TITLE
feat(Button): add brand variant

### DIFF
--- a/docs/Button.md
+++ b/docs/Button.md
@@ -1,6 +1,6 @@
 # Button
 
-An action button with a built-in variant and size system: four visual styles (`primary`, `secondary`, `ghost`, `destructive`), three sizes (`sm`/`md`/`lg`), plus `iconOnly` and `fullWidth` affordances. It can render as a styled link via `href`, exposes a `loading` state (spinner + `aria-busy`), and supports icon/children snippets. Every visual property remains overridable through `--button-*` CSS variables, so an explicit override or a `classes` recipe always wins over the variant default.
+An action button with a built-in variant and size system: five visual styles (`primary`, `secondary`, `ghost`, `destructive`, `brand`), three sizes (`sm`/`md`/`lg`), plus `iconOnly` and `fullWidth` affordances. It can render as a styled link via `href`, exposes a `loading` state (spinner + `aria-busy`), and supports icon/children snippets. Every visual property remains overridable through `--button-*` CSS variables, so an explicit override or a `classes` recipe always wins over the variant default.
 
 ## Usage
 
@@ -19,6 +19,28 @@ An action button with a built-in variant and size system: four visual styles (`p
 <Button text="Secondary" variant="secondary" />
 <Button text="Ghost" variant="ghost" />
 <Button text="Destructive" variant="destructive" />
+<Button text="Get Started" variant="brand" classes="btn-brand-gradient" />
+```
+
+### Brand variant (gradient CTAs)
+
+`brand` is a transparent chassis — white text, no border, no background of its own — designed to be paired with a `--button-background` gradient via `classes`. Used alone (no `--button-background` set) it renders fully transparent, so always pair it with a background recipe:
+
+```svelte
+<Button text="Get Started" variant="brand" classes="btn-brand-gradient" />
+
+<style>
+  :global(.btn-brand-gradient) {
+    --button-background: linear-gradient(135deg, #ff7a45, #8f41fc);
+    /* Also set --button-hover-color: the brand variant's internal hover default is
+       `transparent`, and it sits before --button-background in the hover fallback
+       chain — without an explicit --button-hover-color the gradient would flatten
+       to transparent on hover. */
+    --button-hover-color: linear-gradient(135deg, #ff7a45, #8f41fc);
+    --button-transition: background 0.2s ease, transform 0.15s ease;
+    --button-hover-transform: translateY(-2px);
+  }
+</style>
 ```
 
 ### Sizes
@@ -93,7 +115,7 @@ With `href` the button renders as a styled `<a>`. A disabled link is rendered in
 | Prop            | Type                              | Required | Default    | Description                                                                                                                                                                                                                |
 | --------------- | --------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | text            | `string`                          | No       | `-`        | The button label text. Rendered as plain text by default; set `allowHtml` to render as HTML.                                                                                                                               |
-| variant         | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'` | No | `'primary'` | Visual style. Maps to the `--button-*` variables; an explicit `--button-color`/`classes` override wins over the variant default.                                                          |
+| variant         | `'primary' \| 'secondary' \| 'ghost' \| 'destructive' \| 'brand'` | No | `'primary'` | Visual style. Maps to the `--button-*` variables; an explicit `--button-color`/`classes` override wins over the variant default. `brand` is a transparent chassis meant to pair with a `--button-background` gradient. |
 | size            | `'sm' \| 'md' \| 'lg'`            | No       | `'md'`     | Size preset controlling padding, height, and font size.                                                                                                                                                                    |
 | iconOnly        | `boolean`                         | No       | `false`    | Square padding for an icon-only button. Pair with `ariaLabel`.                                                                                                                                                             |
 | fullWidth       | `boolean`                         | No       | `false`    | Stretch the button to the full width of its container.                                                                                                                                                                     |
@@ -199,7 +221,7 @@ Custom types used by this component's props and events:
 ### ButtonVariant
 
 ```typescript
-type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive' | 'brand';
 ```
 
 ### ButtonSize

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -158,6 +158,21 @@
     --_btn-hover-border: none;
   }
 
+  /* Transparent chassis for gradient marketing CTAs — deliberately no background
+     of its own. Pair with a --button-background gradient (and usually a matching
+     --button-hover-color, since --_btn-hover-color sits before --button-background
+     in the hover fallback chain and would otherwise flatten the gradient to
+     transparent on hover). Geometry (padding/font-size) is intentionally left to
+     the size preset, not this variant. */
+  .variant-brand {
+    --_btn-color: transparent;
+    --_btn-text-color: #ffffff;
+    --_btn-border: none;
+    --_btn-hover-color: transparent;
+    --_btn-hover-text-color: #ffffff;
+    --_btn-hover-border: none;
+  }
+
   /* ---- Size defaults (md reproduces the legacy 16px padding / 14px font) ---- */
   .size-sm {
     --_btn-padding: 8px 12px;

--- a/src/lib/Button/properties.ts
+++ b/src/lib/Button/properties.ts
@@ -3,7 +3,7 @@ import type { Snippet } from 'svelte';
 export type LoaderType = 'Circular' | 'ProgressBar';
 
 /** Visual style of the button. Maps to a built-in palette via `--button-*` variables. */
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive' | 'brand';
 
 /** Size preset controlling padding/height/font-size. */
 export type ButtonSize = 'sm' | 'md' | 'lg';
@@ -14,7 +14,8 @@ export type OptionalButtonProperties = {
   text?: string;
   /**
    * Visual style: `primary` (default, filled), `secondary` (outlined), `ghost`
-   * (transparent), `destructive` (danger). Each maps to the `--button-*` variables, so an
+   * (transparent), `destructive` (danger), `brand` (transparent chassis for gradient CTAs —
+   * pair with a `--button-background` gradient). Each maps to the `--button-*` variables, so an
    * explicit `--button-color` / `classes` override always wins over the variant default.
    */
   variant?: ButtonVariant;

--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -127,6 +127,18 @@
   <div class="demo-row">
     <Button text="Book a Demo" classes="btn-gradient" />
   </div>
+
+  <h3>Brand variant</h3>
+  <p>
+    <code>variant="brand"</code> is a transparent chassis (white text, no border, no background of
+    its own) purpose-built for gradient marketing CTAs — pair it with a
+    <code>--button-background</code> gradient via <code>classes</code>. Unlike the plain gradient
+    recipe above, the variant's internal hover default is also transparent, so set
+    <code>--button-hover-color</code> too or the gradient will flatten to transparent on hover.
+  </p>
+  <div class="demo-row">
+    <Button text="Get Started" variant="brand" classes="btn-brand-gradient" />
+  </div>
 </div>
 
 <style>
@@ -134,5 +146,12 @@
     --button-background: linear-gradient(135deg, #8f41fc, #59299c);
     --button-hover-transform: translateY(-2px);
     --button-transition: background 0.2s ease, transform 0.15s ease;
+  }
+
+  :global(.btn-brand-gradient) {
+    --button-background: linear-gradient(135deg, #ff7a45, #8f41fc);
+    --button-hover-color: linear-gradient(135deg, #ff7a45, #8f41fc);
+    --button-transition: background 0.2s ease, transform 0.15s ease;
+    --button-hover-transform: translateY(-2px);
   }
 </style>


### PR DESCRIPTION
## Summary

A cross-repo audit of Harbour's marketing site (`juspay/harbour`) matched every one of its `Button`-shaped call sites against this library's `Button` component. Eight of them converge on the exact same unstyled shape: a transparent chassis (white text, no border, no background of its own) wrapped around a `--button-background` gradient — `BuddyButton` (purple/orange), the `TalkToBuddy` call button, `EnterpriseCta`, `EnterpriseHero`, `EnterprisePricing`, `UseCases`, and a contact-us submit button. `--button-background` itself already shipped in #429 (**merged**, not "in review" — landed 2026-08-05T04:48:23Z and is already documented in `docs/Button.md`), but consumers still have to manually flatten `--button-color`/`--button-text-color`/`--button-border` to transparent at every call site to use it as a CTA chassis.

This PR adds `variant="brand"` as a sixth preset alongside `primary`/`secondary`/`ghost`/`destructive`, packaging that shape once.

## Design: zero behavior change

`variant="brand"` is additive only — a new `ButtonVariant` union member and a new `.variant-brand` class selector. It follows the exact structure of the existing variant blocks, setting only the internal `--_btn-*` layer that an explicit `--button-*` override or `classes` recipe always wins over:

```css
.variant-brand {
  --_btn-color: transparent;
  --_btn-text-color: #ffffff;
  --_btn-border: none;
  --_btn-hover-color: transparent;
  --_btn-hover-text-color: #ffffff;
  --_btn-hover-border: none;
}
```

No existing `.variant-*` block is touched, and the new class only applies when a consumer explicitly opts in with `variant="brand"` — every current consumer's rendered output is byte-for-byte unchanged.

**Documented gotcha, not a defect:** the variant's hover default is transparent (matching its rest state), which surfaces a pre-existing subtlety in `.button-el:hover`'s fallback chain — `--_btn-hover-color` sits *ahead* of `--button-background`:

```css
background: var(--button-hover-color, var(--_btn-hover-color, var(--button-background, ...)));
```

So a `brand`-variant button with only `--button-background` set (no `--button-hover-color`) will flatten to transparent on hover instead of keeping the gradient. This isn't new behavior from this PR — the same chain ordering already exists for every variant — but `brand` is the first variant where `--_btn-hover-color` is a concrete value rather than unset, so it's the first time the ordering is reachable. Docs and the demo route both show `--button-background` and `--button-hover-color` set together to steer consumers around it.

## Variant contract (new): `variant="brand"`

No new CSS custom properties are introduced — `brand` sets the same six internal properties every other variant already sets, just with different values:

| Internal property | Value | Existing public override |
|---|---|---|
| `--_btn-color` | `transparent` | `--button-color` |
| `--_btn-text-color` | `#ffffff` | `--button-text-color` |
| `--_btn-border` | `none` | `--button-border` |
| `--_btn-hover-color` | `transparent` | `--button-hover-color` |
| `--_btn-hover-text-color` | `#ffffff` | `--button-hover-text-color` |
| `--_btn-hover-border` | `none` | `--button-hover-border` |

Geometry (padding/font-size) is deliberately left untouched — `brand` composes with the existing `size` prop rather than opinionating on it.

## Usage

Before (achievable today, but every gradient CTA must manually flatten the chassis on top of `variant="primary"`):

```svelte
<Button text="Book a Demo" classes="btn-manual-brand" />

<style>
  :global(.btn-manual-brand) {
    --button-color: transparent;
    --button-text-color: #ffffff;
    --button-border: none;
    --button-background: linear-gradient(135deg, #ff7a45, #8f41fc);
    --button-hover-color: linear-gradient(135deg, #ff7a45, #8f41fc);
  }
</style>
```

After, using `variant="brand"`:

```svelte
<Button text="Book a Demo" variant="brand" classes="btn-brand-gradient" />

<style>
  :global(.btn-brand-gradient) {
    --button-background: linear-gradient(135deg, #ff7a45, #8f41fc);
    --button-hover-color: linear-gradient(135deg, #ff7a45, #8f41fc);
    --button-transition: background 0.2s ease, transform 0.15s ease;
    --button-hover-transform: translateY(-2px);
  }
</style>
```

Live in the demo route: `src/routes/components/button/+page.svelte` → "Brand variant" (directly below the existing "Gradient background" section, which now doubles as the "before" comparison).

## Registration surfaces

- [x] `src/lib/Button/Button.svelte` — `.variant-brand` CSS block (6 `--_btn-*` properties, inline comment explaining the hover-chain gotcha)
- [x] `src/lib/Button/properties.ts` — `ButtonVariant` union extended with `'brand'`; `variant` prop JSDoc updated
- [x] `docs/Button.md` — intro line (four → five visual styles), new "Brand variant (gradient CTAs)" subsection, Props table `variant` row, Type Reference `ButtonVariant` code block
- [x] `src/routes/components/button/+page.svelte` — live demo section pairing `variant="brand"` with a gradient `--button-background`/`--button-hover-color`

## Gates (re-run in full on commit `f1d3ff9`)

- `check` (svelte-check) — 0 errors, 4 pre-existing warnings in unrelated files (`Modal.svelte`, `ThemeSwitcher.svelte`, tsconfig `node`/`moduleResolution`) — identical to a clean `release` checkout
- `lint` — prettier clean, eslint 0 errors (3 pre-existing warnings in `src/lib/Table/cell-data.test.ts`, unrelated to this change)
- `test:unit` — 128/128 passed
- `test:integration` (Playwright) — 142/151 passed; 9 failures, all in `Table` (built-in cell renderers / header tooltip / pagination) — the same pre-existing list as a clean `release` checkout, reproduced via `git stash` + re-run before starting this change. Zero new failures.

Single commit, not merging — for review only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `brand` button variant with transparent styling, white text, no border, and hover behavior suited to gradient call-to-action backgrounds.
  * Preserved existing size and spacing options for the new variant.

* **Documentation**
  * Documented the `brand` variant, accessibility guidance, hover behavior, and gradient styling recipe.
  * Updated button variant references to include `brand`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->