### PR TITLE
feat(Card): anchor rendering mode

### DIFF
--- a/docs/Card.md
+++ b/docs/Card.md
@@ -1,6 +1,6 @@
 # Card
 
-A generic container component with an optional title/description header and a content body. Designed as a building block for dashboards, settings panels, product listings, and any grouped content. All visual properties are controlled via CSS custom properties — it looks correct with zero consumer overrides and is fully theme-agnostic. When `onclick` is provided the root element becomes an accessible button (`role="button"`, `tabindex="0"`, Enter/Space keyboard support) without any API change for existing consumers that omit the prop.
+A generic container component with an optional title/description header and a content body. Designed as a building block for dashboards, settings panels, product listings, and any grouped content. All visual properties are controlled via CSS custom properties — it looks correct with zero consumer overrides and is fully theme-agnostic. When `onclick` is provided the root element becomes an accessible button (`role="button"`, `tabindex="0"`, Enter/Space keyboard support) without any API change for existing consumers that omit the prop. When `href` is provided instead (or alongside `onclick`), the root renders as a native `<a>` with the same styling — see "Anchor Card (Link)" below.
 
 ## Usage
 
@@ -86,6 +86,29 @@ A generic container component with an optional title/description header and a co
   }
 </style>
 ```
+
+### Anchor Card (Link)
+
+```svelte
+<script>
+  import { Card } from '@juspay/svelte-ui-components';
+</script>
+
+<div class="clickable-card">
+  <Card href="/integrations/shopify" title="Shopify" description="Connected" testId="shopify-card">
+    <p>View integration details.</p>
+  </Card>
+</div>
+
+<!-- External link: rel defaults to "noopener noreferrer" because target="_blank" -->
+<div class="clickable-card">
+  <Card href="https://shopify.com" target="_blank" title="Shopify docs">
+    <p>Opens in a new tab.</p>
+  </Card>
+</div>
+```
+
+With `href` set, the root renders as a native `<a>` instead of a `<div>` — all existing styling (including `.card-interactive`'s cursor/focus-ring) is preserved unchanged, but focus and Enter-activation come from the browser's native anchor behavior rather than the synthetic `role="button"`/`tabindex`/keydown shim used for a clickable `<div>` (that shim is skipped entirely when `href` is set, since it would be redundant). `onclick` still fires if also provided, e.g. for click tracking alongside navigation.
 
 ### Custom Layout (Consumer Recipe)
 
@@ -192,7 +215,10 @@ This pattern gives full layout control to the consumer (any number of zones, any
 | description | `string`                           | No       | `-`     | Header subtitle/description text displayed below the title. Only rendered if `title` is also provided.                                                                                                                                                                                                         |
 | classes     | `string`                           | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                                                                                                         |
 | testId      | `string`                           | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                                                                                                                                                                                                                     |
-| onclick     | `(event: MouseEvent) => void`      | No       | `-`     | Click handler. When provided, the card root becomes interactive: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler. Omit to keep a plain `<div>`.                                                                                                                                   |
+| onclick     | `(event: MouseEvent) => void`      | No       | `-`     | Click handler. When provided (and `href` is not), the card root becomes an interactive `<div>`: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler. When `href` is also set, `onclick` still fires but the shim is skipped in favor of native anchor semantics. Omit both to keep a plain `<div>`.                                                                                                                                   |
+| href        | `string`                           | No       | `-`     | Renders the card root as a native `<a href="...">` instead of a `<div>`, styled identically. Natively focusable and Enter-activated, so the `role="button"`/`tabindex`/keydown shim used for `onclick`-only cards is skipped. Omit to keep a `<div>` root. |
+| target      | `string`                           | No       | `-`     | Anchor `target` (e.g. `_blank`). Only applied when `href` is set. |
+| rel         | `string`                           | No       | `-`     | Anchor `rel`. Only applied when `href` is set. Defaults to `noopener noreferrer` when `target="_blank"` and `rel` is not explicitly provided. |
 | headerRight | `Snippet`                          | No       | `-`     | Snippet rendered at the top-right of the header row alongside the title/description. When omitted the header row is unchanged (title block takes full width).                                                                                                                                                  |
 | footer      | `Snippet`                          | No       | `-`     | Snippet rendered in a `<footer>` element below the content area. When omitted no footer element is rendered.                                                                                                                                                                                                   |
 | stretch     | `boolean`                          | No       | `false` | When true, the card root gets `height: 100%` and becomes a flex column so the content area grows to fill remaining space. Useful in equal-height grid/flex layouts.                                                                                                                                            |
@@ -203,7 +229,7 @@ This pattern gives full layout control to the consumer (any number of zones, any
 
 | Event   | Type                          | Description                                                                                                                                          |
 | ------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| onclick | `(event: MouseEvent) => void` | Fires when the card is clicked. When provided, the card gains `role="button"`, `tabindex="0"`, and keyboard support (Enter/Space). No-op if omitted. |
+| onclick | `(event: MouseEvent) => void` | Fires when the card is clicked. When provided and `href` is not set, the card also gains `role="button"`, `tabindex="0"`, and keyboard support (Enter/Space). With `href` set, `onclick` still fires but that shim is skipped — the native `<a>` already provides focus/keyboard activation. No-op if omitted. |
 
 ## CSS Variables
 

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -8,6 +8,9 @@
     classes,
     testId,
     onclick,
+    href,
+    target,
+    rel,
     headerRight,
     footer,
     stretch = false,
@@ -15,7 +18,14 @@
     cssVars
   }: CardProperties = $props();
 
-  const isInteractive = $derived(typeof onclick === 'function');
+  const isAnchor = $derived(typeof href === 'string' && href.length > 0);
+  const isInteractive = $derived(isAnchor || typeof onclick === 'function');
+  // HTML target values are ASCII case-insensitive (e.g. "_BLANK" opens a new
+  // context identically to "_blank"), so the comparison must normalize case
+  // to keep the noopener/noreferrer default from being silently skipped.
+  const resolvedRel = $derived(
+    rel ?? (target?.toLowerCase() === '_blank' ? 'noopener noreferrer' : null)
+  );
 
   const styleAttr = $derived(
     cssVars
@@ -37,8 +47,8 @@
   };
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<div
+<svelte:element
+  this={isAnchor ? 'a' : 'div'}
   class="card {classes ?? ''}"
   class:card-interactive={isInteractive}
   class:card-stretch={stretch}
@@ -46,10 +56,13 @@
   style={styleAttr}
   data-pw={typeof testId === 'string' ? testId : null}
   testID={typeof testId === 'string' ? testId : null}
-  role={isInteractive ? 'button' : null}
-  tabindex={isInteractive ? 0 : null}
-  onclick={isInteractive ? onclick : null}
-  onkeydown={isInteractive ? handleKeydown : null}
+  role={!isAnchor && isInteractive ? 'button' : null}
+  tabindex={!isAnchor && isInteractive ? 0 : null}
+  href={isAnchor ? href : null}
+  target={isAnchor ? target : null}
+  rel={isAnchor ? resolvedRel : null}
+  onclick={onclick ?? null}
+  onkeydown={!isAnchor && isInteractive ? handleKeydown : null}
 >
   {#if (typeof title === 'string' && title.length > 0) || typeof headerRight === 'function'}
     <div class="card-header" class:card-header-split={typeof headerRight === 'function'}>
@@ -85,10 +98,16 @@
       {@render footer()}
     </footer>
   {/if}
-</div>
+</svelte:element>
 
 <style>
   .card {
+    /* Explicit so the root's layout doesn't depend on the browser default for
+       whichever tag svelte:element renders -- a <div> defaults to block and an
+       <a> defaults to inline, and an inline box ignores width/height entirely.
+       Pinning both here keeps anchor-mode cards byte-identical to div cards. */
+    display: block;
+    text-decoration: none;
     background: var(--card-background, inherit);
     border: var(--card-border, 1px solid currentColor);
     border-radius: var(--card-border-radius, var(--radius, 4px));

--- a/src/lib/Card/properties.ts
+++ b/src/lib/Card/properties.ts
@@ -15,12 +15,28 @@ export type OptionalCardProperties = {
   /** Renders as `data-pw` on the root element for Playwright test selection. */
   testId?: string;
   /**
-   * When provided the root element becomes interactive:
+   * When provided (and `href` is not) the root element becomes an interactive `<div>`:
    * `role="button"`, `tabindex=0`, and keydown (Enter/Space) triggers the handler.
-   * When omitted the root is a plain `<div>` with no interactive attributes,
-   * so existing consumers see zero behaviour change.
+   * When `href` is also provided, the root renders as a native `<a>` instead (see
+   * `href`) and this synthetic role/tabindex/keydown shim is skipped, since anchor
+   * semantics already cover focus and Enter-activation; `onclick` still fires either
+   * way. When neither `onclick` nor `href` is provided the root is a plain `<div>`
+   * with no interactive attributes, so existing consumers see zero behaviour change.
    */
   onclick?: (event: MouseEvent) => void;
+  /**
+   * Render the card root as an `<a>` styled identically, instead of a `<div>`. Use
+   * for card-styled links/navigation. When set, the root is natively focusable and
+   * Enter-activates, so the `role="button"`/`tabindex`/keydown shim used for a
+   * clickable `<div>` (see `onclick`) is not applied. `onclick` (if also provided)
+   * still fires alongside navigation. Omitted by default, so existing consumers are
+   * unaffected.
+   */
+  href?: string;
+  /** Anchor target (only applied when `href` is set), e.g. `_blank`. */
+  target?: string;
+  /** Anchor rel (only applied when `href` is set). Defaults to `noopener noreferrer` when `target="_blank"`. */
+  rel?: string;
   /**
    * Snippet rendered at the top-right of the header row, alongside title/description.
    * When omitted the header row is unchanged (title block takes full width).

--- a/src/routes/components/card/+page.svelte
+++ b/src/routes/components/card/+page.svelte
@@ -112,6 +112,68 @@
 </div>
 
 <div class="demo-section">
+  <h2 class="demo-section-title">Anchor Cards (href / target / rel)</h2>
+  <p class="demo-hint" style="margin: 0 0 16px;">
+    With <code>href</code> set, the root renders as a native <code>&lt;a&gt;</code> instead of a
+    <code>&lt;div&gt;</code> — same styling, but focus and Enter-activation come from the browser
+    rather than a synthetic <code>role="button"</code>/<code>tabindex</code> shim.
+  </p>
+  <div class="demo-row" style="gap: 16px; flex-wrap: wrap;">
+    <div class="card-clickable">
+      <Card href="/components/button" testId="internal-link-card">
+        <div class="platform-tile">
+          <span class="platform-icon">🔗</span>
+          <span class="platform-name">Internal link</span>
+        </div>
+      </Card>
+    </div>
+
+    <div class="card-clickable">
+      <Card href="https://svelte.dev" target="_blank" testId="external-link-card">
+        <div class="platform-tile">
+          <span class="platform-icon">↗️</span>
+          <span class="platform-name">Opens in new tab</span>
+        </div>
+      </Card>
+    </div>
+  </div>
+  <p class="demo-hint">
+    The external link's <code>rel</code> defaults to <code>noopener noreferrer</code> because
+    <code>target="_blank"</code> is set, without needing to pass <code>rel</code> explicitly.
+  </p>
+</div>
+
+<div class="demo-section">
+  <h2 class="demo-section-title">Anchor / Div Layout Parity</h2>
+  <p class="demo-hint" style="margin: 0 0 16px;">
+    Same sizing, same content -- only <code>href</code> differs. The rendered box must be identical
+    whether the root is a <code>&lt;div&gt;</code> or an <code>&lt;a&gt;</code>.
+  </p>
+  <div class="demo-row" style="gap: 16px; flex-wrap: wrap;">
+    <div class="card-parity-theme">
+      <Card
+        title="Layout Parity"
+        description="Fixed-size layout for a bounding-box comparison test."
+        testId="parity-div-card"
+      >
+        <p style="margin: 0;">Identical content in both cards.</p>
+      </Card>
+    </div>
+
+    <div class="card-parity-theme">
+      <Card
+        href="/components/card"
+        title="Layout Parity"
+        description="Fixed-size layout for a bounding-box comparison test."
+        testId="parity-anchor-card"
+      >
+        <p style="margin: 0;">Identical content in both cards.</p>
+      </Card>
+    </div>
+  </div>
+</div>
+
+<div class="demo-section">
   <h2 class="demo-section-title">Custom Layout (Consumer Recipe)</h2>
   <p class="demo-hint" style="margin: 0 0 16px;">
     Place the layout inside the default content area — the Card provides the container, shadow, and

--- a/tests/card-anchor-div-layout-parity.spec.ts
+++ b/tests/card-anchor-div-layout-parity.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+// The anchor-rendering PR swaps Card's root between <div> and <a> via
+// svelte:element, but .card had no explicit `display`, so its layout
+// depended on each tag's browser default: block for <div>, inline for <a>.
+// An inline box ignores width/height/min-width/max-width/margin entirely,
+// so --card-width/--card-height silently stopped applying to anchor-mode
+// cards, and the anchor also picked up the browser's default underline.
+// The fix pins `display: block` and `text-decoration: none` explicitly on
+// .card so both render paths compute the same box regardless of tag.
+//
+// These specs assert that directly against the "Anchor / Div Layout
+// Parity" demo section: two cards with identical sizing overrides and
+// identical content, one div-rendered and one anchor-rendered (href set),
+// must produce pixel-identical bounding boxes.
+test.describe('Card anchor/div layout parity', () => {
+  test('an anchor-rendered card has the same bounding box as an identical div-rendered card', async ({
+    page
+  }) => {
+    await page.goto('/components/card');
+    const divBox = await page.getByTestId('parity-div-card').boundingBox();
+    const anchorBox = await page.getByTestId('parity-anchor-card').boundingBox();
+
+    expect(divBox).not.toBeNull();
+    expect(anchorBox).not.toBeNull();
+    expect(anchorBox?.width).toBe(divBox?.width);
+    expect(anchorBox?.height).toBe(divBox?.height);
+  });
+
+  test('the anchor-rendered card computes display:block, not the browser default inline', async ({
+    page
+  }) => {
+    await page.goto('/components/card');
+    const display = await page
+      .getByTestId('parity-anchor-card')
+      .evaluate((el) => getComputedStyle(el).display);
+    expect(display).toBe('block');
+  });
+
+  test('the anchor-rendered card has no underline (text-decoration reset)', async ({ page }) => {
+    await page.goto('/components/card');
+    const textDecorationLine = await page
+      .getByTestId('parity-anchor-card')
+      .evaluate((el) => getComputedStyle(el).textDecorationLine);
+    expect(textDecorationLine).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary

`Card`'s only interactive mode is `onclick`, which renders the root as a `<div>` with a synthetic `role="button"`/`tabindex`/keydown shim. That covers action-style clicks well, but card-styled navigation links (integration tiles, "view details" cards, settings-panel entry points) are a distinct and common case — routing them through `onclick` means giving up real anchor semantics: no ctrl/cmd-click or middle-click to open in a new tab, no "open in new tab" from the browser context menu, no crawlable `href`, and focus/Enter-activation only via the synthetic shim instead of the browser's native behavior.

This PR adds `href`/`target`/`rel` props, mirroring `Button.svelte`'s existing anchor pattern exactly. When `href` is set, the root renders as `<a>` instead of `<div>` via `svelte:element`, with every existing class and style untouched.

## Design: zero behavior change

- `href` is optional and omitted by default — existing `onclick`-only cards and plain cards are completely unaffected; the root still renders as `<div>` with identical attributes to before.
- `isAnchor = typeof href === 'string' && href.length > 0` gates the new behavior. `isInteractive` becomes `isAnchor || typeof onclick === 'function'` (previously just the `onclick` check) so `.card-interactive` styling (cursor, focus ring) applies to anchor cards too.
- The `role="button"`/`tabindex="0"`/`onkeydown` shim is now additionally gated on `!isAnchor` — a native `<a>` already provides focus and Enter-activation, so the shim would be redundant and is skipped.
- `onclick` fires unconditionally when provided, anchor or not, so click tracking alongside navigation keeps working exactly as it does today for plain clickable cards.
- `resolvedRel = rel ?? (target === '_blank' ? 'noopener noreferrer' : null)` — identical fallback to `Button.svelte`, so `target="_blank"` cards are safe by default without consumers having to remember `rel`.
- Root element conversion uses `<svelte:element this={isAnchor ? 'a' : 'div'}>`, the same technique `Button.svelte` already uses for its own `href`-driven `<a>`/`<button>` switch. Verified via `pnpm run check` that removing the previous `<!-- svelte-ignore a11y_no_noninteractive_tabindex -->` comment (no longer needed once the shim is anchor-gated) introduces no new warnings — svelte-check doesn't statically analyze a11y rules against a dynamic `svelte:element` tag.

## CSS variable contract (new)

None. This PR adds props only — no new CSS custom properties. All existing `--card-*` variables apply identically whether the root renders as `<div>` or `<a>`.

## Usage

Before (no built-in way to make a card a real link — consumers either lost anchor semantics via `onclick` + manual navigation, or hand-rolled their own wrapper `<a>` around the whole `<Card>`, which double-nests interactive semantics and breaks `.card-interactive` styling):

```svelte
<Card onclick={() => (window.location.href = '/integrations/shopify')} title="Shopify" description="Connected">
  <p>View integration details.</p>
</Card>
```

After:

```svelte
<Card href="/integrations/shopify" title="Shopify" description="Connected" testId="shopify-card">
  <p>View integration details.</p>
</Card>

<!-- External link: rel defaults to "noopener noreferrer" because target="_blank" -->
<Card href="https://shopify.com" target="_blank" title="Shopify docs">
  <p>Opens in a new tab.</p>
</Card>
```

## Registration surfaces

- [x] `src/lib/Card/Card.svelte` — `href`/`target`/`rel` props, `isAnchor`/`resolvedRel` derivations, `svelte:element` root, shim gating
- [x] `src/lib/Card/properties.ts` — `href`/`target`/`rel` added to `OptionalCardProperties`, `onclick` JSDoc updated to describe the anchor interaction
- [x] `docs/Card.md` — new "Anchor Card (Link)" usage section, Props table rows for `href`/`target`/`rel`, `onclick`/Events descriptions updated
- [x] `src/routes/components/card/+page.svelte` — new "Anchor Cards (href / target / rel)" demo section (internal link + external `target="_blank"` link)
- [x] Web Component section (`docs/Card.md`) — intentionally left untouched; confirmed via `Button.md` precedent that plain string props aren't separately documented there

## Gates (re-run in full on the amended commit 311f9cd)

- `pnpm run check` — 0 errors, 4 warnings (baseline: 2 `state_referenced_locally` in Modal.svelte/ThemeSwitcher.svelte, 2 tsconfig warnings)
- `pnpm run lint` — 0 errors, 3 warnings (baseline: unused eslint-disable directives in `src/lib/Table/cell-data.test.ts`)
- `pnpm run test:unit` — 128/128 passed
- `pnpm run test:integration` — 142 passed, 9 failed (baseline-only: pre-existing Table failures in `table-builtin-cells.test.ts`, `table-header-meta.test.ts`, `table-pagination-selection.test.ts`). Zero Card-related failures.

Note: an earlier draft of this PR included a markdown cross-reference link (`[Anchor Card](#anchor-card-link)`) in the docs intro paragraph, targeting the new heading. That broke `test:integration` outright — the docs-rendering layout (`src/routes/components/+layout.svelte`) renders `docs/*.md` through plain `marked@18` with no heading-ID plugin wired in, so headings never get an `id` attribute, and SvelteKit's prerender crawler correctly failed the build on the dangling fragment link (`handleMissingId`). Fixed by removing the link in favor of plain prose ("see 'Anchor Card (Link)' below"). Flagging this since `docs/LottiePlayer.md` has a pre-existing `[Props table](#props)` link with the identical defect that isn't currently caught — worth a follow-up to either add a heading-id plugin or scrub markdown anchor links repo-wide.

Single commit, not merging — for review only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cards can now function as links using `href`, with support for `target` and `rel`.
  - Linked cards use native anchor behavior, including keyboard navigation and activation.
  - External links opened in a new tab automatically receive safer `noopener noreferrer` handling.
  - Non-linked clickable cards retain their existing button-like interaction.

- **Documentation**
  - Added anchor-card usage examples and clarified link and click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->