### PR TITLE
fix(ChipInput): let a consuming app's Pill and Input theme reach the chips

### DIFF
--- a/src/lib/ChipInput/ChipInput.svelte
+++ b/src/lib/ChipInput/ChipInput.svelte
@@ -88,6 +88,19 @@
     justify-content: var(--chip-input-justify-content, flex-start);
     gap: var(--chip-input-gap, 6px);
     width: var(--chip-input-width, 100%);
+
+    /* Capture the surrounding cascade's Pill and Input values under distinct names, so the
+       per-token mappings below can fall back to them. This has to happen HERE, on the root, where
+       --pill-* and --input-* have not yet been re-declared: reading them in the same declaration
+       that sets them would be a custom-property cycle and would compute to invalid. Consumers that
+       theme Pill/Input app-wide get chips that match the rest of their UI, instead of the library's
+       hardcoded light-theme hexes overriding their theme. */
+    --chip-input-pill-background-default: var(--pill-background, #e0e0e0);
+    --chip-input-pill-color-default: var(--pill-color, #333333);
+    --chip-input-pill-dismiss-color-default: var(--pill-dismiss-color, currentColor);
+    --chip-input-draft-border-default: var(--input-border, 1px solid transparent);
+    --chip-input-draft-focus-border-default: var(--input-focus-border, 1px solid transparent);
+    --chip-input-draft-radius-default: var(--input-radius, 4px);
   }
 
   .chip-input-draft-wrap {
@@ -96,8 +109,8 @@
 
   .chip-input :global(.chip-input-pill) {
     --pill-gap: var(--chip-input-pill-gap, 4px);
-    --pill-background: var(--chip-input-pill-background, #e0e0e0);
-    --pill-color: var(--chip-input-pill-color, #333333);
+    --pill-background: var(--chip-input-pill-background, var(--chip-input-pill-background-default));
+    --pill-color: var(--chip-input-pill-color, var(--chip-input-pill-color-default));
     --pill-font-size: var(--chip-input-pill-font-size, 13px);
     --pill-font-weight: var(--chip-input-pill-font-weight, 500);
     --pill-padding: var(--chip-input-pill-padding, 6px 10px);
@@ -105,15 +118,21 @@
     --pill-border: var(--chip-input-pill-border, none);
     --pill-max-width: var(--chip-input-pill-max-width);
     --pill-dismiss-size: var(--chip-input-pill-dismiss-size, 14px);
-    --pill-dismiss-color: var(--chip-input-pill-dismiss-color, currentColor);
+    --pill-dismiss-color: var(
+      --chip-input-pill-dismiss-color,
+      var(--chip-input-pill-dismiss-color-default)
+    );
   }
 
   .chip-input-draft-wrap :global(.chip-input-draft) {
     --input-width: var(--chip-input-draft-width, 90px);
     --input-height: var(--chip-input-draft-height, 28px);
-    --input-border: var(--chip-input-draft-border, 1px solid transparent);
-    --input-radius: var(--chip-input-draft-radius, 4px);
-    --input-focus-border: var(--chip-input-draft-focus-border, 1px solid transparent);
+    --input-border: var(--chip-input-draft-border, var(--chip-input-draft-border-default));
+    --input-radius: var(--chip-input-draft-radius, var(--chip-input-draft-radius-default));
+    --input-focus-border: var(
+      --chip-input-draft-focus-border,
+      var(--chip-input-draft-focus-border-default)
+    );
     --input-padding: var(--chip-input-draft-padding, 0 2px);
     --input-margin: 0;
     --input-font-size: var(--chip-input-draft-font-size, 13px);

--- a/src/routes/components/chip-input/+page.svelte
+++ b/src/routes/components/chip-input/+page.svelte
@@ -4,6 +4,7 @@
   let productTags = $state(['sale', 'featured']);
   let blockedEmails = $state<string[]>([]);
   let themedTags = $state(['urgent']);
+  let inheritedTags = $state(['inherited']);
 </script>
 
 <div class="page-header">
@@ -34,7 +35,16 @@
 
 <div class="demo-row" style="max-width: 400px;">
   <h3>Themed</h3>
-  <ChipInput bind:values={themedTags} classes="chip-input-accent" />
+  <ChipInput bind:values={themedTags} classes="chip-input-accent" testId="chip-input-accent" />
+</div>
+
+<div class="demo-row app-themed" style="max-width: 400px;">
+  <h3>Inside an app that themes Pill globally</h3>
+  <p>
+    The surrounding app sets <code>--pill-background</code> / <code>--pill-color</code> the way a consumer's
+    own theme would. The chips should follow that theme rather than the library's light-mode default.
+  </p>
+  <ChipInput bind:values={inheritedTags} testId="chip-input-inherited" />
 </div>
 
 <style>
@@ -42,5 +52,13 @@
     --chip-input-pill-background: #d1ecf1;
     --chip-input-pill-color: #0c5460;
     --chip-input-draft-focus-border: 1px solid #3b82f6;
+  }
+
+  /* Mimics a consuming app that themes Pill app-wide (e.g. a dark surface). Before the token
+     passthrough fix, ChipInput re-declared --pill-background on the pill element, so this
+     inherited value was ignored and chips rendered with the library's light-mode hex. */
+  .app-themed {
+    --pill-background: #2f3542;
+    --pill-color: #f1f2f6;
   }
 </style>

--- a/tests/chipinput-token-passthrough.spec.ts
+++ b/tests/chipinput-token-passthrough.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+
+// ChipInput re-declares --pill-* on the pill element to expose its own --chip-input-pill-* API.
+// Because a declaration on the element beats an inherited one, that mapping used to swallow any
+// --pill-background/--pill-color a consuming app had set app-wide, and fall through to the
+// library's hardcoded light-mode hexes. A consumer theming Pill for a dark surface got light
+// chips. The mapping now falls back to the surrounding cascade's value, captured on the ChipInput
+// root under a distinct name (reading --pill-background in the same declaration that sets it would
+// be a custom-property cycle).
+//
+// The three precedence levels below are the whole contract: explicit component token > inherited
+// app theme > library default.
+test.describe('ChipInput token passthrough', () => {
+  test('falls back to the library default when nothing is themed', async ({ page }) => {
+    await page.goto('/components/chip-input');
+
+    const pill = page.getByTestId('chip-input-tags-chip').first();
+    await expect(pill).toBeVisible();
+
+    await expect(pill).toHaveCSS('background-color', 'rgb(224, 224, 224)');
+    await expect(pill).toHaveCSS('color', 'rgb(51, 51, 51)');
+  });
+
+  test('an explicit --chip-input-pill-* override still wins', async ({ page }) => {
+    await page.goto('/components/chip-input');
+
+    const pill = page.getByTestId('chip-input-accent-chip').first();
+    await expect(pill).toBeVisible();
+
+    // #d1ecf1 / #0c5460 from the demo's .chip-input-accent recipe.
+    await expect(pill).toHaveCSS('background-color', 'rgb(209, 236, 241)');
+    await expect(pill).toHaveCSS('color', 'rgb(12, 84, 96)');
+  });
+
+  test("inherits the app's own Pill theme when no component override is set", async ({ page }) => {
+    await page.goto('/components/chip-input');
+
+    const pill = page.getByTestId('chip-input-inherited-chip').first();
+    await expect(pill).toBeVisible();
+
+    // #2f3542 / #f1f2f6 are set as --pill-background/--pill-color on an ancestor, exactly as a
+    // consuming app's theme would. Before the fix these resolved to the library's #e0e0e0/#333333.
+    await expect(pill).toHaveCSS('background-color', 'rgb(47, 53, 66)');
+    await expect(pill).toHaveCSS('color', 'rgb(241, 242, 246)');
+  });
+});


### PR DESCRIPTION
## The bug

`ChipInput` re-declares `--pill-*` and `--input-*` **on its pill and draft-input elements** in order to expose its own `--chip-input-*` API:

```css
.chip-input :global(.chip-input-pill) {
  --pill-background: var(--chip-input-pill-background, #e0e0e0);
  --pill-color: var(--chip-input-pill-color, #333333);
}
```

A declaration on the element beats an inherited one. So for any app that themes `Pill` app-wide — the normal way to theme this library — that mapping **swallows the app's value** and falls through to the hardcoded light-mode hex, because `--chip-input-pill-background` is undefined.

The result: an app theming `Pill` for a dark surface gets light-grey chips with dark text, at wrong contrast, with no fix short of defining `--chip-input-*` overrides at **every call site**.

This is specific to `ChipInput`. A bare `<Pill>` behaves correctly — `Pill` itself does `background-color: var(--pill-background, #e0e0e0)` and simply inherits whatever the app set. `ChipInput` is the only thing breaking that chain.

## How it was found

While migrating a consumer app (Lighthouse, 11 call sites) from a local chip component onto this one. The swap moved **631,175 differing pixels against an 8px noise floor** — a ~79,000× jump. This was one of two root causes; the migration was reverted rather than papered over with per-call-site overrides.

## The fix

The mappings now fall back to the surrounding cascade's value rather than a raw hex:

```css
.chip-input {
  /* captured HERE, on the root, where --pill-*/--input-* are not yet re-declared */
  --chip-input-pill-background-default: var(--pill-background, #e0e0e0);
  --chip-input-pill-color-default: var(--pill-color, #333333);
}
.chip-input :global(.chip-input-pill) {
  --pill-background: var(--chip-input-pill-background, var(--chip-input-pill-background-default));
  --pill-color: var(--chip-input-pill-color, var(--chip-input-pill-color-default));
}
```

**Why the capture is on the root and not inline.** The obvious one-liner — `--pill-background: var(--chip-input-pill-background, var(--pill-background, #e0e0e0))` — is a custom-property **cycle**: a `var()` referencing the property it is defining. Per spec that computes to invalid, so it silently would not work. Capturing on the root, under a distinct name, where `--pill-*` has not yet been re-declared, avoids the cycle.

Applied to 6 tokens: pill background, colour, dismiss colour, and the draft input's border, focus-border and radius.

## Precedence — unchanged for existing consumers, with a new middle rung

| | Before | After |
|---|---|---|
| `--chip-input-pill-background` set | wins | wins (unchanged) |
| app sets `--pill-background` | **ignored** | **respected** |
| neither | `#e0e0e0` | `#e0e0e0` (unchanged) |

Only the middle row changes, and only from "ignored" to "respected". No existing consumer's rendering changes unless they were already setting `--pill-*` and silently not getting it.

## Tests

`tests/chipinput-token-passthrough.spec.ts` asserts all three rows, and the demo page gains a case that themes `--pill-*` on an ancestor the way a consuming app would.

**Negative control** — with the fix reverted, the inheritance test fails on exactly the intended assertion while the other two still pass:

```
Expected: "rgb(47, 53, 66)"
Received: "rgb(224, 224, 224)"
1 failed, 2 passed
```

So the test is load-bearing rather than passing incidentally, and backward compatibility is demonstrated rather than assumed.

**Full functional suite: 145 passed**, no regressions. `npm run check`: 564 files, 0 errors.

## Deliberately not included

`--chip-input-width` defaults to `100%`, which breaks a `flex-wrap` parent — in the consumer app it wrapped a five-field row onto multiple lines. That was the **second** root cause of the migration failure.

I have not changed it here: `width: 100%` is a defensible default for a form control, and flipping it to `auto` would silently reflow every existing consumer. A caller can already set `--chip-input-width: auto`. Raising it separately so a maintainer can decide, rather than bundling a behaviour change into a theming fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ChipInput theming with support for component-level customization and inheritance from surrounding application themes.
  * Added a themed ChipInput example demonstrating how shared styling tokens are applied.

* **Bug Fixes**
  * ChipInput pills and inputs now respect configured theme colors instead of relying on fixed light-theme values.

* **Tests**
  * Added coverage for default styling, component overrides, and inherited application themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->