### PR TITLE
fix(ChipInput): let a consuming app's Pill size and shape reach the chips too

### DIFF
--- a/src/lib/ChipInput/ChipInput.svelte
+++ b/src/lib/ChipInput/ChipInput.svelte
@@ -94,13 +94,30 @@
        --pill-* and --input-* have not yet been re-declared: reading them in the same declaration
        that sets them would be a custom-property cycle and would compute to invalid. Consumers that
        theme Pill/Input app-wide get chips that match the rest of their UI, instead of the library's
-       hardcoded light-theme hexes overriding their theme. */
+       own values overriding their theme.
+
+       Every token that carries the chip's APPEARANCE is captured here — colour, type, spacing and
+       shape alike. An app whose Pill is a 14px, 16px-radius chip was still getting 13px and a
+       999px pill, because re-declaring a token on the element beats inheriting it no matter which
+       property it is; restoring only the colours left the same bug in a less obvious place.
+       Tokens the component owns STRUCTURALLY — the draft field's inline padding, margin and
+       shadow, and its width/height — deliberately stay fixed, since those position the field among
+       the chips rather than describe how it looks. */
     --chip-input-pill-background-default: var(--pill-background, #e0e0e0);
     --chip-input-pill-color-default: var(--pill-color, #333333);
     --chip-input-pill-dismiss-color-default: var(--pill-dismiss-color, currentColor);
+    --chip-input-pill-font-size-default: var(--pill-font-size, 13px);
+    --chip-input-pill-font-weight-default: var(--pill-font-weight, 500);
+    --chip-input-pill-padding-default: var(--pill-padding, 6px 10px);
+    --chip-input-pill-border-radius-default: var(--pill-border-radius, 999px);
+    --chip-input-pill-border-default: var(--pill-border, none);
+    --chip-input-pill-gap-default: var(--pill-gap, 4px);
+    --chip-input-pill-dismiss-size-default: var(--pill-dismiss-size, 14px);
+    --chip-input-pill-max-width-default: var(--pill-max-width);
     --chip-input-draft-border-default: var(--input-border, 1px solid transparent);
     --chip-input-draft-focus-border-default: var(--input-focus-border, 1px solid transparent);
     --chip-input-draft-radius-default: var(--input-radius, 4px);
+    --chip-input-draft-font-size-default: var(--input-font-size, 13px);
   }
 
   .chip-input-draft-wrap {
@@ -108,16 +125,25 @@
   }
 
   .chip-input :global(.chip-input-pill) {
-    --pill-gap: var(--chip-input-pill-gap, 4px);
+    --pill-gap: var(--chip-input-pill-gap, var(--chip-input-pill-gap-default));
     --pill-background: var(--chip-input-pill-background, var(--chip-input-pill-background-default));
     --pill-color: var(--chip-input-pill-color, var(--chip-input-pill-color-default));
-    --pill-font-size: var(--chip-input-pill-font-size, 13px);
-    --pill-font-weight: var(--chip-input-pill-font-weight, 500);
-    --pill-padding: var(--chip-input-pill-padding, 6px 10px);
-    --pill-border-radius: var(--chip-input-pill-border-radius, 999px);
-    --pill-border: var(--chip-input-pill-border, none);
-    --pill-max-width: var(--chip-input-pill-max-width);
-    --pill-dismiss-size: var(--chip-input-pill-dismiss-size, 14px);
+    --pill-font-size: var(--chip-input-pill-font-size, var(--chip-input-pill-font-size-default));
+    --pill-font-weight: var(
+      --chip-input-pill-font-weight,
+      var(--chip-input-pill-font-weight-default)
+    );
+    --pill-padding: var(--chip-input-pill-padding, var(--chip-input-pill-padding-default));
+    --pill-border-radius: var(
+      --chip-input-pill-border-radius,
+      var(--chip-input-pill-border-radius-default)
+    );
+    --pill-border: var(--chip-input-pill-border, var(--chip-input-pill-border-default));
+    --pill-max-width: var(--chip-input-pill-max-width, var(--chip-input-pill-max-width-default));
+    --pill-dismiss-size: var(
+      --chip-input-pill-dismiss-size,
+      var(--chip-input-pill-dismiss-size-default)
+    );
     --pill-dismiss-color: var(
       --chip-input-pill-dismiss-color,
       var(--chip-input-pill-dismiss-color-default)
@@ -133,9 +159,13 @@
       --chip-input-draft-focus-border,
       var(--chip-input-draft-focus-border-default)
     );
+    --input-font-size: var(--chip-input-draft-font-size, var(--chip-input-draft-font-size-default));
+
+    /* Structural, not thematic: the draft field sits inline among the chips, so it keeps its own
+       tight padding and no margin or shadow regardless of how the app themes Input elsewhere.
+       Override them per-instance via --chip-input-draft-* if a layout genuinely needs it. */
     --input-padding: var(--chip-input-draft-padding, 0 2px);
     --input-margin: 0;
-    --input-font-size: var(--chip-input-draft-font-size, 13px);
     --input-box-shadow: none;
   }
 </style>

--- a/src/routes/components/chip-input/+page.svelte
+++ b/src/routes/components/chip-input/+page.svelte
@@ -56,9 +56,23 @@
 
   /* Mimics a consuming app that themes Pill app-wide (e.g. a dark surface). Before the token
      passthrough fix, ChipInput re-declared --pill-background on the pill element, so this
-     inherited value was ignored and chips rendered with the library's light-mode hex. */
+     inherited value was ignored and chips rendered with the library's light-mode hex.
+
+     The size and shape tokens are here for the same reason: an app whose Pill is a larger,
+     squarer chip was still getting the library's 13px / 999px pill, because re-declaring a token
+     on the element beats inheriting it whatever the property. */
   .app-themed {
     --pill-background: #2f3542;
     --pill-color: #f1f2f6;
+    --pill-font-size: 17px;
+    --pill-padding: 3px 14px;
+    --pill-border-radius: 5px;
+
+    /* Deliberately hostile values for the draft field. These are the tokens ChipInput owns
+       structurally to keep the field inline among the chips, so they must NOT be inherited —
+       the spec asserts the component ignores them. */
+    --input-padding: 20px 30px;
+    --input-margin: 12px;
+    --input-box-shadow: 0 0 0 3px red;
   }
 </style>

--- a/tests/chipinput-token-passthrough.spec.ts
+++ b/tests/chipinput-token-passthrough.spec.ts
@@ -43,4 +43,33 @@ test.describe('ChipInput token passthrough', () => {
     await expect(pill).toHaveCSS('background-color', 'rgb(47, 53, 66)');
     await expect(pill).toHaveCSS('color', 'rgb(241, 242, 246)');
   });
+
+  // Colour was only the visible half. Size and shape were swallowed by the identical mechanism,
+  // so an app whose Pill is a larger, squarer chip still got a 13px 999px-radius one. These assert
+  // the passthrough covers appearance as a whole rather than the subset that happened to be noticed.
+  test("inherits the app's Pill size and shape, not just its colours", async ({ page }) => {
+    await page.goto('/components/chip-input');
+
+    const pill = page.getByTestId('chip-input-inherited-chip').first();
+    await expect(pill).toBeVisible();
+
+    await expect(pill).toHaveCSS('font-size', '17px');
+    await expect(pill).toHaveCSS('padding', '3px 14px');
+    await expect(pill).toHaveCSS('border-radius', '5px');
+  });
+
+  // The flip side of the contract: tokens the component owns structurally must NOT follow the app,
+  // or the draft field stops sitting inline among the chips.
+  test('keeps the draft field structural tokens regardless of the app Input theme', async ({
+    page
+  }) => {
+    await page.goto('/components/chip-input');
+
+    const draft = page.getByTestId('chip-input-inherited-input');
+    await expect(draft).toBeVisible();
+
+    await expect(draft).toHaveCSS('padding', '0px 2px');
+    await expect(draft).toHaveCSS('margin', '0px');
+    await expect(draft).toHaveCSS('box-shadow', 'none');
+  });
 });


### PR DESCRIPTION
Follow-up to #440, which fixed **half** of this bug. Same root cause, less obvious place.

## What was still broken

`ChipInput` re-declares `--pill-*` on the pill element to expose its own `--chip-input-pill-*` API. A declaration on the element beats an inherited one — **whatever the property is**. #440 restored that inheritance for `background`, `color` and `dismiss-color`, because a consumer's dark theme producing light chips was the visible symptom. The size and shape tokens were left re-declared, so they went on silently overriding the consuming app's Pill theme:

| token | library was forcing | e.g. an app whose Pill is |
|---|---|---|
| `--pill-font-size` | `13px` | `14px` |
| `--pill-padding` | `6px 10px` | `2px 12px` |
| `--pill-border-radius` | `999px` | `16px` |
| `--pill-font-weight` / `--pill-border` / `--pill-gap` / `--pill-dismiss-size` | `500` / `none` / `4px` / `14px` | whatever Pill's own theme says |

So an app with a larger, squarer chip still got a small round one. Fixing only the colours is what let this survive — the remaining half looked fine as long as nobody compared sizes.

## The line this draws

Every token carrying the chip's **appearance** now falls back to the surrounding cascade, captured on the root under distinct `--chip-input-*-default` names. That indirection is required, not stylistic: reading `--pill-font-size` in the same declaration that sets it is a custom-property cycle and computes to invalid.

Precedence is unchanged and now applies uniformly:

    explicit --chip-input-pill-*  >  the app's own --pill-* theme  >  library default

Tokens the component owns **structurally** deliberately stay fixed — the draft field's inline `padding`, `margin` and `box-shadow` position it among the chips rather than describe how it looks, so an app that themes `Input` globally must not disturb them. That distinction is now stated in the source instead of being implicit.

## Verification, including a negative control

Reverting only the component fix while keeping the demo and specs:

    Expected: "17px"
    Received: "13px"     ← the app's --pill-font-size swallowed by the library's

With the fix, **5 passed**. `svelte-check`: 565 files, **0 errors**.

The demo's `.app-themed` row now themes Pill with a larger, squarer chip, so the new appearance spec fails without this change. It also sets deliberately hostile `--input-padding`/`--input-margin`/`--input-box-shadow`, and a second spec asserts the component **ignores** them — that one passes with or without the fix by design, since it guards the structural behaviour this change preserves rather than proving the change.

One process note worth recording: an earlier run of this suite reported 4 failures that did not reproduce. Cause was `reuseExistingServer` picking up a stale preview from the previous run while heavy concurrent builds were in flight — not a code fault. The control run on unmodified `release` passing 3/3 is what isolated it.

## Why upstream rather than in the consumer

The consumer could have re-declared its own theme values as `--chip-input-pill-*` at each call site. That would mean every consumer restating central design tokens locally to undo a library default — exactly the duplication the adopting codebase is working to remove, repeated for every future call site.