### PR TITLE
feat(InputButton): expose --input-button-container-width

### DIFF
--- a/docs/InputButton.md
+++ b/docs/InputButton.md
@@ -59,6 +59,7 @@ Override these custom properties to theme the component.
 
 | Variable                                | Default                                              | CSS Property                    | Description                                                                 |
 | --------------------------------------- | ---------------------------------------------------- | ------------------------------- | --------------------------------------------------------------------------- |
+| `--input-button-container-width`        | `auto`                                               | width                           | Width of the entire InputButton container. Set to `100%` to make the control fill its parent. |
 | `--input-button-container-margin`       | `-`                                                  | margin                          | Outer margin of the entire InputButton container.                           |
 | `--input-height`                        | `fit-content`                                        | height                          | Height of the input-button container. Overridden by size preset vars when `size` is set. |
 | `--input-font-size`                     | `16px`                                               | font-size                       |                                                                             |

--- a/src/lib/InputButton/InputButton.svelte
+++ b/src/lib/InputButton/InputButton.svelte
@@ -128,6 +128,7 @@
   .container {
     display: flex;
     flex-direction: column;
+    width: var(--input-button-container-width, auto);
     margin: var(--input-button-container-margin);
   }
 

--- a/src/routes/components/card/+page.svelte
+++ b/src/routes/components/card/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import Card from '$lib/Card/Card.svelte';
   import Button from '$lib/Button/Button.svelte';
 
@@ -120,7 +121,7 @@
   </p>
   <div class="demo-row" style="gap: 16px; flex-wrap: wrap;">
     <div class="card-clickable">
-      <Card href="/components/button" testId="internal-link-card">
+      <Card href="{base}/components/button" testId="internal-link-card">
         <div class="platform-tile">
           <span class="platform-icon">🔗</span>
           <span class="platform-name">Internal link</span>
@@ -162,7 +163,7 @@
 
     <div class="card-parity-theme">
       <Card
-        href="/components/card"
+        href="{base}/components/card"
         title="Layout Parity"
         description="Fixed-size layout for a bounding-box comparison test."
         testId="parity-anchor-card"


### PR DESCRIPTION
The `classes` prop lands on `.container`, which exposed only --input-button-container-margin. With no width token, a consumer that needs the control to fill its parent had no choice but to reach the element through a Svelte `:global()` escape hatch.

Defaults to `auto`, the current computed value, so no existing consumer renders differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the input button container width with a CSS variable.
  * The width defaults to `auto` and can be set to fill the parent container.

* **Documentation**
  * Documented the new width customization option and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->