### PR TITLE
BZ-5434: feat: add list item and pill style hooks

### DIFF
--- a/docs/ListItem.md
+++ b/docs/ListItem.md
@@ -79,6 +79,8 @@ Override these custom properties to theme the component.
 | `--list-item-transition`                         | `-`                                       | transition              | Transition animation for the list item (e.g., on hover). |
 | `--list-item-hover-background-color`             | `var(--list-item-background-color)`       | background-color        | Background color on hover.                               |
 | `--list-item-hover-border`                       | `var(--list-item-border)`                 | border                  | Border on hover.                                         |
+| `--list-item-top-section-align-items`            | `-`                                       | align-items             | Vertical alignment for the top content row.              |
+| `--list-item-top-section-gap`                    | `-`                                       | gap                     | Gap between top row content areas.                       |
 | `--list-item-left-content-display`               | `flex`                                    | display                 |                                                          |
 | `--list-item-left-image-height`                  | `24px`                                    | --image-height          | Height of the left image.                                |
 | `--list-item-left-image-width`                   | `24px`                                    | --image-width           | Width of the left image.                                 |
@@ -102,6 +104,7 @@ Override these custom properties to theme the component.
 | `--list-item-center-text-cursor`                 | `pointer`                                 | cursor                  | Cursor for the center text.                              |
 | `--list-item-center-text-font-family`            | `-`                                       | font-family             | Font family of the center text.                          |
 | `--list-item-right-content-display`              | `flex`                                    | display                 | Display mode of the right content area.                  |
+| `--list-item-right-content-flex`                 | `-`                                       | flex                    | Flex sizing for the right content area.                  |
 | `--list-item-right-content-loader-margin`        | `-`                                       | margin                  |                                                          |
 | `--list-item-right-image-height`                 | `18px`                                    | --image-height          | Height of the right image.                               |
 | `--list-item-right-image-width`                  | `18px`                                    | --image-width           | Width of the right image.                                |

--- a/docs/Pill.md
+++ b/docs/Pill.md
@@ -93,6 +93,8 @@ Override these custom properties to theme the component.
 | `--pill-gap`                 | `4px`                                     | gap              | Spacing between the text and the dismiss button.                          |
 | `--pill-cursor`              | `pointer`                                 | cursor           | Cursor style when hovering over the pill.                                 |
 | `--pill-max-width`           | `-`                                       | max-width        | Maximum width of the pill. Text is truncated with ellipsis when exceeded. |
+| `--pill-line-height`         | `1`                                       | line-height      | Line height of the pill.                                                   |
+| `--pill-flex-shrink`         | `-`                                       | flex-shrink      | Flex shrink behavior of the pill.                                          |
 | `--pill-text-overflow`       | `ellipsis`                                | text-overflow    | How overflowing text is displayed (e.g., ellipsis or clip).               |
 | `--pill-hover-background`    | `var(--pill-background, #d0d0d0)`         | background-color | Background color when hovering over the pill.                             |
 | `--pill-hover-color`         | `var(--pill-color, #333333)`              | color            | Text color when hovering over the pill.                                   |

--- a/src/lib/ListItem/ListItem.svelte
+++ b/src/lib/ListItem/ListItem.svelte
@@ -215,6 +215,8 @@
   .top-section {
     display: flex;
     flex-direction: row;
+    align-items: var(--list-item-top-section-align-items);
+    gap: var(--list-item-top-section-gap);
     margin-bottom: 0;
   }
 
@@ -263,6 +265,7 @@
 
   .right-content {
     display: var(--list-item-right-content-display, flex);
+    flex: var(--list-item-right-content-flex);
   }
 
   .right-content-loader {

--- a/src/lib/Pill/Pill.svelte
+++ b/src/lib/Pill/Pill.svelte
@@ -92,7 +92,8 @@
     border: var(--pill-border, none);
     cursor: var(--pill-cursor, pointer);
     max-width: var(--pill-max-width);
-    line-height: 1;
+    line-height: var(--pill-line-height, 1);
+    flex-shrink: var(--pill-flex-shrink);
   }
 
   .pill:hover:not(.disabled) {


### PR DESCRIPTION
- Add CSS custom variables for ListItem top-section alignment, top-section gap, and right-content flex behavior.
- Add Pill CSS variables for line-height and flex-shrink.
- Update ListItem and Pill docs with the newly supported styling hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable alignment and spacing for list item top sections.
  * Added configurable sizing for right-side list item content.
  * Added CSS variables to control pill line height and flex shrinking.

* **Documentation**
  * Documented the new list item and pill styling options, including default values and effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->