### PR TITLE
fix(LineChart): paint point markers back-to-front so the first series wins an overlap

### DIFF
--- a/src/lib/LineChart/LineChart.svelte
+++ b/src/lib/LineChart/LineChart.svelte
@@ -228,6 +228,10 @@
     })
   );
 
+  // Markers paint back-to-front so the first series ends up on top — see the
+  // comment on the marker loop in the markup.
+  let markerPaintOrder = $derived(lines.map((_line, index) => index).reverse());
+
   let legendItems = $derived<LegendItem[]>(
     series.map((s, i) => ({
       label: s.name,
@@ -658,6 +662,38 @@
                 stroke-dasharray={line.dash}
                 fill="none"
               />
+              {#if showValues && pointLabelPlacements[si]}
+                {#each line.points as _point, pi (pi)}
+                  {@const pl = pointLabelPlacements[si][pi]}
+                  {#if pl?.visible && Number.isFinite(pl.x) && Number.isFinite(pl.y)}
+                    <text
+                      class="point-value"
+                      x={pl.x}
+                      y={pl.y}
+                      text-anchor="middle"
+                      dominant-baseline={pl.dominantBaseline}
+                      >{formatNumber(series[si].data[pi].y)}</text
+                    >
+                  {/if}
+                {/each}
+              {/if}
+            {/if}
+          {/each}
+
+          <!--
+            Point markers are painted after every line, and in REVERSE series
+            order. Two series that share a value put their markers on identical
+            coordinates, and SVG has no z-index — whichever is written last wins.
+            Painting forwards meant the last series in the array hid the first,
+            so a chart passed [primary, comparison] lost the primary series'
+            marker wherever the two periods happened to agree, most visibly at
+            the first bucket. Reversing here makes the FIRST series win, which is
+            the one a reader is looking at; the legend keeps its original order
+            because it is derived from `series`, not from this loop.
+          -->
+          {#each markerPaintOrder as si (si)}
+            {@const line = lines[si]}
+            {#if !line.hidden}
               {#if line.points.length === 1 && !showDots && Number.isFinite(line.points[0].x) && Number.isFinite(line.points[0].y)}
                 <circle
                   class="single-point"
@@ -681,21 +717,6 @@
                       r={isHighlightedDot(si, pi) ? dotRadius * 1.5 : dotRadius}
                       fill={line.color}
                     />
-                  {/if}
-                {/each}
-              {/if}
-              {#if showValues && pointLabelPlacements[si]}
-                {#each line.points as _point, pi (pi)}
-                  {@const pl = pointLabelPlacements[si][pi]}
-                  {#if pl?.visible && Number.isFinite(pl.x) && Number.isFinite(pl.y)}
-                    <text
-                      class="point-value"
-                      x={pl.x}
-                      y={pl.y}
-                      text-anchor="middle"
-                      dominant-baseline={pl.dominantBaseline}
-                      >{formatNumber(series[si].data[pi].y)}</text
-                    >
                   {/if}
                 {/each}
               {/if}


### PR DESCRIPTION
Fixes #446.

## The bug

Two series that share a value put their markers on identical coordinates. SVG has no z-index, so whichever is written last is the one you see. Markers were painted inside the per-series loop in array order, so the **last** series in the array covered the first.

Charts conventionally pass `[primary, comparison]`, which means the **comparison** series hid the **primary** one — and because the first bucket is where two windows most often agree, it surfaced downstream as *"the initial data point is missing from the chart when comparison is on"*. Nothing was missing; it was underneath.

Consumers cannot work around it. Reordering the series array fixes the markers and reverses the legend, because `legendItems` is derived from the same array.

## The change

Moves the marker circles (`.dot` and `.single-point`) out of the per-series loop into their own pass that walks the series in **reverse**, after every line is drawn.

Two consequences, both intended:

1. Where markers coincide, the **first** series is now on top — the one a reader is actually looking at.
2. Markers now sit above **every** line, not just above the lines of earlier series. Previously a later series' line could cover an earlier series' points; it no longer can.

The second is a slightly wider behavioural change than the issue strictly required, and I'd rather flag it than have it found in review. Markers-above-lines is the conventional order and fixes the same class of defect, but say the word and I'll scope it to markers-only.

`legendItems` is untouched — derived from `series`, not from this loop — so legend order is unaffected.

## Verification

Built this branch, dropped the packaged component into a real consumer (Juspay's Lighthouse dashboard), and drove an actual two-series comparison chart. The fixture has **7 buckets with exactly one deliberately coinciding** (bucket 0 equal in both windows, buckets 1-6 different), so overlap is isolated rather than global.

`#1B85FF` = current period (solid), `#A4CEFF` = comparison (dashed).

**Before** — 14 dots across 7 buckets, 1 coinciding:

```
x=10     order=[#1B85FF, #A4CEFF]   topmost=#A4CEFF
x=175    order=[#1B85FF, #A4CEFF]   topmost=#A4CEFF
...all 7 buckets identical...
```

At the coinciding bucket the current-series marker is present in the DOM at `cx 9.9313725, cy 146.7673301` — the same point as the comparison marker, to seven decimal places — and invisible.

**After** — same build, same fixture, only the component swapped:

```
x=10     order=[#A4CEFF, #1B85FF]   topmost=#1B85FF
x=175    order=[#A4CEFF, #1B85FF]   topmost=#1B85FF
...all 7 buckets...
```

Legend still reads `["Today", "Yesterday"]` — unchanged.

## Checks

- `pnpm run check` — **0 errors** (4 warnings, all pre-existing: Modal, ThemeSwitcher, tsconfig)
- `pnpm run test:unit` — **128 passed / 16 files**
- `pnpm run package` — clean

## Note on the remaining overlap

Where two series genuinely hold the same value, *some* overlap is unavoidable — the points are the same point. This makes the primary series the survivor, which is the useful default. If you'd rather the chart communicate "these two are equal" explicitly, a contrasting outline on coinciding markers would do it, and I'm happy to follow up with that instead or as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line-chart marker layering so earlier series remain visible when markers overlap.
  * Updated label rendering so data-point markers appear clearly above their value labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->