### PR TITLE
fix(DateRangePicker): flip the panel above the trigger when it does not fit below

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -147,6 +147,12 @@
   let isOpen: boolean = $state(false);
   let panelRef: HTMLDivElement | null = $state(null);
   let triggerRef: HTMLDivElement | null = $state(null);
+  // The panel anchors below the trigger by default. When the trigger sits low in
+  // the viewport there is no room for it there, and because the panel is
+  // position:absolute (not portaled, not fixed) it simply extends past the fold
+  // and the lower weeks become unreachable without scrolling whatever container
+  // it happens to live in. Flipping it above the trigger keeps it on screen.
+  let opensUpward: boolean = $state(false);
   let comparePanelRef: HTMLDivElement | null = $state(null);
   let compareTriggerRef: HTMLDivElement | null = $state(null);
   // Stores the element that opened the compare panel so focus can be restored on close.
@@ -307,8 +313,42 @@
 
   function closePicker(): void {
     isOpen = false;
+    opensUpward = false;
     onopentoggle?.({ open: false });
   }
+
+  /**
+   * Decide which side of the trigger the panel should open on, by measuring
+   * rather than guessing: flip up only when the panel genuinely does not fit
+   * below AND fits better above. A panel that overflows in both directions
+   * stays below, where its first weeks are at least readable.
+   */
+  function positionPanel(): void {
+    if (panelRef === null || triggerRef === null || typeof window === 'undefined') {
+      return;
+    }
+    const trigger = triggerRef.getBoundingClientRect();
+    const panelHeight = panelRef.offsetHeight;
+    const offset = 6;
+    const roomBelow = window.innerHeight - trigger.bottom - offset;
+    const roomAbove = trigger.top - offset;
+    opensUpward = panelHeight > roomBelow && roomAbove > roomBelow;
+  }
+
+  $effect(() => {
+    if (!isOpen || panelRef === null || triggerRef === null) {
+      return;
+    }
+    positionPanel();
+    window.addEventListener('resize', positionPanel);
+    // Scrolling moves the trigger relative to the viewport, so the side that had
+    // room when the panel opened may not have it a moment later.
+    window.addEventListener('scroll', positionPanel, true);
+    return () => {
+      window.removeEventListener('resize', positionPanel);
+      window.removeEventListener('scroll', positionPanel, true);
+    };
+  });
 
   // The trigger toggles: clicking it while the panel is already open dismisses
   // the picker instead of re-opening it onto itself. The open-only handler left
@@ -856,6 +896,7 @@
     <div
       bind:this={panelRef}
       class="drp-panel"
+      class:drp-panel-above={opensUpward}
       class:drp-panel-align-left={align === 'left'}
       class:drp-panel-align-right={align === 'right'}
       role="dialog"
@@ -1259,6 +1300,12 @@
     max-width: var(--drp-panel-max-width, 760px);
     max-height: var(--drp-panel-max-height, calc(100dvh - 80px));
     overflow: hidden;
+  }
+
+  /* Set only when the panel would not fit below the trigger — see positionPanel(). */
+  .drp-panel-above {
+    top: auto;
+    bottom: calc(100% + var(--drp-panel-offset, 6px));
   }
 
   .drp-panel-align-left {


### PR DESCRIPTION
## The bug

`.drp-panel` is anchored with a hardcoded `top: calc(100% + var(--drp-panel-offset, 6px))`, so it **always opens downward**. It is `position: absolute` with no portal option (grepped: zero occurrences of `usePortal`/`use:portal` in this component), so when the trigger sits low in the viewport the panel extends past the fold and its lower weeks become unreachable — the reader has to scroll whatever container it happens to live in.

Reported downstream as *"the calendar is clipped, only the first 1–2 rows of dates are visible, and you have to scroll inside it"* (Breeze/Lighthouse BZ-4994 and BZ-4852).

Worth stating precisely, because the reported symptom is misleading: **the panel is never internally clipped**. All six week rows are in the DOM and inside the panel's own box at every viewport. They are simply below the window.

## Measurements

A date picker inside a report modal in a real consumer app. The panel is 457px tall in every case.

| viewport height | panel bottom | overflow past the fold |
|---|---|---|
| 950 | 1126 | **176px** |
| 800 | 1071 | **271px** |
| 720 | 1063 | **343px** |
| 640 | 1037 | **397px** |

I first tried fixing this consumer-side, by letting the containing modal grow instead of scroll. Measured at 720px that moved the overflow from 343px to **291px** — it changes *which* element scrolls and buys 52px. It does not fix the problem, because nothing consumer-side can move an element that is anchored downward by the component's own CSS.

## The change

On open — and on resize and scroll, since both move the trigger relative to the viewport — measure the panel against the room above and below the trigger, and anchor to `bottom` instead when it does not fit below **and** fits better above:

```ts
const roomBelow = window.innerHeight - trigger.bottom - offset;
const roomAbove = trigger.top - offset;
opensUpward = panelHeight > roomBelow && roomAbove > roomBelow;
```

A panel that overflows in *both* directions deliberately stays below, where at least its first weeks are readable — flipping it up in that case would hide the current month's opening days instead, which is worse.

The CSS is one rule:

```css
.drp-panel-above {
  top: auto;
  bottom: calc(100% + var(--drp-panel-offset, 6px));
}
```

`opensUpward` resets on close, so a picker that flipped once does not stay flipped after the page scrolls.

## After

Same consumer, same measurement:

| viewport height | overflow past the fold | panel top |
|---|---|---|
| 950 | **0** | 164 |
| 800 | **0** | 109 |
| 720 | **0** | 101 |

All 42 date cells on screen at every height, and the panel top never goes negative — it does not trade a bottom overflow for a top one.

## Checks

- `pnpm run check` — **0 errors** (4 warnings, all pre-existing: Modal, ThemeSwitcher, tsconfig)
- `pnpm run test:unit` — **128 passed / 16 files**
- `pnpm run package` — clean

## Scope note

Default behaviour is unchanged for any picker that fits below the trigger, which is the common case — `opensUpward` stays `false` and no class is applied. Only a picker that would have rendered off-screen behaves differently, and for that one the alternative is being unusable.

Happy to gate it behind a prop if you would rather it be opt-in, though it is hard to construct a case where opening off-screen is the wanted behaviour.
