### PR TITLE
BZ-5472: fix: resolve DateRangePicker lint failure

### DIFF
--- a/src/lib/DateRangePicker/DateRangePicker.svelte
+++ b/src/lib/DateRangePicker/DateRangePicker.svelte
@@ -323,32 +323,33 @@
    * below AND fits better above. A panel that overflows in both directions
    * stays below, where its first weeks are at least readable.
    */
-  function positionPanel(): void {
-    if (panelRef === null || triggerRef === null || typeof window === 'undefined') {
+  function positionPanel(panelNode: HTMLDivElement | null = panelRef): void {
+    if (panelNode === null || triggerRef === null || typeof window === 'undefined') {
       return;
     }
     const trigger = triggerRef.getBoundingClientRect();
-    const panelHeight = panelRef.offsetHeight;
+    const panelHeight = panelNode.offsetHeight;
     const offset = 6;
     const roomBelow = window.innerHeight - trigger.bottom - offset;
     const roomAbove = trigger.top - offset;
     opensUpward = panelHeight > roomBelow && roomAbove > roomBelow;
   }
 
-  $effect(() => {
-    if (!isOpen || panelRef === null || triggerRef === null) {
-      return;
-    }
-    positionPanel();
-    window.addEventListener('resize', positionPanel);
+  function positionPanelWhileMounted(panelNode: HTMLDivElement): { destroy: () => void } {
+    const updatePanelPosition = () => positionPanel(panelNode);
+    updatePanelPosition();
+    tick().then(updatePanelPosition);
+    window.addEventListener('resize', updatePanelPosition);
     // Scrolling moves the trigger relative to the viewport, so the side that had
     // room when the panel opened may not have it a moment later.
-    window.addEventListener('scroll', positionPanel, true);
-    return () => {
-      window.removeEventListener('resize', positionPanel);
-      window.removeEventListener('scroll', positionPanel, true);
+    window.addEventListener('scroll', updatePanelPosition, true);
+    return {
+      destroy: () => {
+        window.removeEventListener('resize', updatePanelPosition);
+        window.removeEventListener('scroll', updatePanelPosition, true);
+      }
     };
-  });
+  }
 
   // The trigger toggles: clicking it while the panel is already open dismisses
   // the picker instead of re-opening it onto itself. The open-only handler left
@@ -894,6 +895,7 @@
   <!-- Dropdown panel -->
   {#if isOpen}
     <div
+      use:positionPanelWhileMounted
       bind:this={panelRef}
       class="drp-panel"
       class:drp-panel-above={opensUpward}

--- a/src/lib/Table/cell-data.test.ts
+++ b/src/lib/Table/cell-data.test.ts
@@ -96,20 +96,17 @@ describe('cell narrowing', () => {
       iconUrl: '/assets/edit.svg',
       ariaLabel: 'Edit'
     });
-    // eslint-disable-next-line no-script-url -- asserting the guard rejects it
     expect(asButtonCellData({ iconUrl: 'javascript:alert(1)', ariaLabel: 'Edit' })).toBeNull();
     expect(
       asButtonCellData({ iconUrl: 'data:text/html,<script>1</script>', ariaLabel: 'Edit' })
     ).toBeNull();
     // A text button keeps rendering when its icon URL is rejected.
-    // eslint-disable-next-line no-script-url -- asserting the guard rejects it
     expect(asButtonCellData({ text: 'Renew', iconUrl: 'javascript:alert(1)' })).toEqual({
       text: 'Renew'
     });
     expect(asInputCellData({ iconUrl: 'data:image/svg+xml;utf8,x' })).toEqual({
       iconUrl: 'data:image/svg+xml;utf8,x'
     });
-    // eslint-disable-next-line no-script-url -- asserting the guard rejects it
     expect(asInputCellData({ iconUrl: 'javascript:alert(1)' })).toEqual({});
   });
 


### PR DESCRIPTION
- Replace restricted DateRangePicker `$effect` usage with a panel-scoped Svelte action.
- Remove unused eslint-disable comments from Table cell data tests.
- DateRangePicker integration tests passed: 17 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-range dropdown positioning after mounting and during window resizing or page scrolling.
  * Ensured positioning updates are properly cleaned up when the dropdown closes.

* **Tests**
  * Maintained coverage for rejecting unsafe icon URLs while preserving valid icons and text buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->