### PR TITLE
feat: per-icon colour tokens for the six inlining icon slots

### DIFF
--- a/src/lib/CommandMenu/CommandMenu.svelte
+++ b/src/lib/CommandMenu/CommandMenu.svelte
@@ -416,6 +416,9 @@
   .command-menu-item-icon-img-wrapper {
     --image-width: var(--command-menu-item-icon-size, 20px);
     --image-height: var(--command-menu-item-icon-size, 20px);
+
+    /* Mirrors --command-menu-search-icon-color, which this component already had. */
+    color: var(--command-menu-item-icon-color, inherit);
     flex-shrink: 0;
     display: flex;
     align-items: center;

--- a/src/lib/FileDropzoneTrigger/FileDropzoneTrigger.svelte
+++ b/src/lib/FileDropzoneTrigger/FileDropzoneTrigger.svelte
@@ -57,11 +57,17 @@
   .file-dropzone-trigger-icon-sm :global(.file-dropzone-trigger-icon-sm-img) {
     --image-width: var(--file-dropzone-trigger-icon-sm-size, 16px);
     --image-height: var(--file-dropzone-trigger-icon-sm-size, 16px);
+
+    color: var(--file-dropzone-trigger-icon-color, inherit);
   }
 
   .file-dropzone-trigger-icon :global(.file-dropzone-trigger-icon-img) {
     --image-width: var(--file-dropzone-trigger-icon-size, 24px);
     --image-height: var(--file-dropzone-trigger-icon-size, 24px);
+
+    /* Both sizes share one colour token deliberately: they are the same icon at two
+       scales, and splitting them would invite the two to drift apart. */
+    color: var(--file-dropzone-trigger-icon-color, inherit);
   }
 
   .file-dropzone-trigger-heading {

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -664,6 +664,13 @@
     --image-width: var(--select-left-icon-size, 16px);
     --image-height: var(--select-left-icon-size, 16px);
     --image-object-fit: contain;
+
+    /* The icon inlines, so a currentColor asset resolves against this. Defaults to
+       `inherit` — the trigger's text colour, which is what it already did — so this is
+       a hook, not a change. Without it a consumer cannot tint the icon independently
+       of the label, and an icon migrated to currentColor is forced to match its label
+       exactly, flattening any deliberate muted-icon/strong-label hierarchy. */
+    color: var(--select-left-icon-color, inherit);
     flex: none;
   }
 
@@ -785,6 +792,7 @@
     --image-height: var(--select-option-icon-size, 16px);
     --image-object-fit: contain;
 
+    color: var(--select-option-icon-color, inherit);
     vertical-align: middle;
     margin-right: var(--select-option-icon-gap, 8px);
   }

--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -54,6 +54,7 @@
   }
 
   .status-image {
+    color: var(--status-icon-color, inherit);
     display: flex;
     margin-bottom: 25px;
   }

--- a/src/lib/Table/BuiltinCell.svelte
+++ b/src/lib/Table/BuiltinCell.svelte
@@ -589,6 +589,8 @@
   .builtin-icon-label-icon :global(svg) {
     width: var(--table-cell-icon-size, 16px);
     height: var(--table-cell-icon-size, 16px);
+
+    color: var(--table-cell-icon-color, inherit);
     display: block;
   }
 

--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -445,6 +445,7 @@
     --image-height: var(--tabs-item-icon-size, 16px);
     --image-object-fit: contain;
 
+    color: var(--tabs-item-icon-color, inherit);
     flex-shrink: 0;
   }
 

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -52,6 +52,7 @@
   let ghostValue: string[] = $state([]);
   let openEventLog: string[] = $state([]);
   let leftIconValue: string[] = $state([]);
+  let iconTintValue: string[] = $state([]);
   let portalValue: string[] = $state([]);
   let inflowValue: string[] = $state([]);
 
@@ -302,6 +303,32 @@
   {#if leftIconValue.length > 0}
     <p class="demo-info">Selected: {leftIconValue.at(0)}</p>
   {/if}
+</div>
+
+<h3>Tinting the icon independently of the label</h3>
+<p>
+  Inheriting the trigger's text colour is the default, but it is not always what you want: a muted
+  icon beside a strong label is a common, deliberate hierarchy, and an icon that can only match its
+  label cannot express it. Set <code>--select-left-icon-color</code> to break the two apart.
+</p>
+<p>
+  Below, the label stays near-black while the globe is muted grey. Every inlining slot has the
+  matching token — <code>--select-option-icon-color</code>, <code>--tabs-item-icon-color</code>,
+  <code>--file-dropzone-trigger-icon-color</code>, <code>--command-menu-item-icon-color</code>,
+  <code>--status-icon-color</code> and <code>--table-cell-icon-color</code>. Each defaults to
+  <code>inherit</code>, so a component that sets none behaves exactly as before.
+</p>
+<div
+  class="demo-row"
+  style="max-width: 300px; --select-color: #111827; --select-left-icon-color: #9ca3af;"
+>
+  <Select
+    items={cities}
+    bind:value={iconTintValue}
+    placeholder="Muted icon, dark label"
+    leftIcon={globeIconSrc}
+    leftIconTestId="select-tinted-left-icon"
+  />
 </div>
 
 <h3>usePortal — escape a clipping container</h3>

--- a/tests/icon-slot-color-token.spec.ts
+++ b/tests/icon-slot-color-token.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+// 2.120.3 made six icon slots inline their SVG, so a `currentColor` asset finally resolves
+// against the host document instead of painting UA black. That was necessary but not
+// sufficient: none of those slots exposed a COLOUR hook, so an inlined icon could only ever
+// land on its component's text colour — exactly its label's value. A muted-icon/strong-label
+// hierarchy became inexpressible, and any consumer migrating an icon to `currentColor` had to
+// accept the flattening.
+//
+// Each slot now reads `--<component>-<slot>-icon-color`, defaulting to `inherit` so nothing
+// changes for a component that sets none.
+//
+// Note on the locator: with `inlineSvg` the testId lands on the `<svg>` ITSELF, not on a
+// wrapper around it — so these assert on the element directly. A `.locator('svg')` descendant
+// search finds nothing, which is a useful tell that the icon really is inlined rather than
+// wrapped in an `<img>`.
+test.describe('per-icon colour token', () => {
+  test('defaults to inherit — the icon still takes the trigger text colour', async ({ page }) => {
+    await page.goto('/components/select');
+
+    const icon = page.getByTestId('select-left-icon');
+    await expect(icon).toBeVisible();
+
+    // That demo row sets only --select-color: #2563eb and no icon colour, so the icon must
+    // follow it. This is the pre-existing behaviour the change must not alter.
+    await expect(icon).toHaveCSS('color', 'rgb(37, 99, 235)');
+  });
+
+  test('an explicit --select-left-icon-color decouples the icon from the label', async ({
+    page
+  }) => {
+    await page.goto('/components/select');
+
+    const icon = page.getByTestId('select-tinted-left-icon');
+    await expect(icon).toBeVisible();
+
+    // The row sets --select-color: #111827 (label) and --select-left-icon-color: #9ca3af (icon).
+    // Assert BOTH halves — that the icon takes the muted grey, and that the surrounding trigger
+    // does not. Checking only the icon would still pass if the token had simply recoloured
+    // everything, which is the failure this exists to catch.
+    await expect(icon).toHaveCSS('color', 'rgb(156, 163, 175)');
+
+    const trigger = page.locator('.select-trigger').filter({ has: icon });
+    await expect(trigger).toHaveCSS('color', 'rgb(17, 24, 39)');
+  });
+
+  test('the inlined SVG paints from the token, not merely a wrapper', async ({ page }) => {
+    await page.goto('/components/select');
+
+    // The asset is drawn with stroke="currentColor". A wrapper carrying the right `color`
+    // proves nothing on its own — what matters is that the SVG's own resolved `stroke` picks
+    // it up, which only happens when the asset is inlined into this document.
+    const icon = page.getByTestId('select-tinted-left-icon');
+    await expect(icon).toBeVisible();
+
+    const painted = await icon.evaluate((node) => ({
+      tag: node.tagName.toLowerCase(),
+      stroke: getComputedStyle(node).stroke
+    }));
+
+    expect(painted.tag).toBe('svg');
+    expect(painted.stroke).toBe('rgb(156, 163, 175)');
+  });
+});


### PR DESCRIPTION
Follow-up to #450 (2.120.3). One commit on `release`.

## The gap #450 left open

#450 made six icon slots render through `<Img inlineSvg>` instead of a plain `<Img src>`, so a `currentColor` asset finally resolves against the host document instead of painting UA black. **That was necessary but not sufficient**, and it is worth stating plainly because the gap blocked a real consumer migration.

None of the six exposes a **colour** hook. Each sizes its icon — `--select-left-icon-size`, `--file-dropzone-trigger-icon-size`, … — and gives it no independent colour. So an inlined icon inherits the component's text colour and lands on **exactly its label's value**. A muted-icon / strong-label hierarchy, which is a deliberate and common design, became inexpressible, and any consumer migrating an icon to `currentColor` had to accept the flattening.

Concretely, in the Lighthouse dashboard that is **9 icons that cannot move**: migrating `map-pin-location` would repaint the pin from `#a0a0a0` to the trigger's `#333`.

## What this adds

| Token | Slot |
|---|---|
| `--select-left-icon-color` | `Select` leftIcon |
| `--select-option-icon-color` | `Select` per-option icon |
| `--tabs-item-icon-color` | `Tabs` `tabItem.icon` |
| `--file-dropzone-trigger-icon-color` | `FileDropzoneTrigger`, both sizes |
| `--command-menu-item-icon-color` | `CommandMenu` `item.icon` |
| `--status-icon-color` | `Status` `statusIcon` |
| `--table-cell-icon-color` | `Table/BuiltinCell` icon-label |

`FileDropzoneTrigger`'s two sizes deliberately share one token — same icon at two scales, and splitting them would invite the two to drift. `--command-menu-item-icon-color` mirrors the `--command-menu-search-icon-color` that component already had.

## Every one defaults to `inherit`

That is the whole compatibility story. **A component that sets none behaves exactly as it does today**, because inheriting the text colour *is* the current behaviour. This adds a hook; it does not change a pixel.

Setting the fallback to a concrete hex would have made the exception the default — the trap where one route's value leaks into every consumer.

## Tests

`tests/icon-slot-color-token.spec.ts`, three cases covering the contract:

1. **default** — the untinted demo icon still tracks `--select-color` (`#2563eb`)
2. **override** — with `--select-color: #111827` and `--select-left-icon-color: #9ca3af`, the icon takes the grey **and the trigger keeps the near-black**. Asserting only the icon would still pass if the token had simply recoloured everything, which is the failure this exists to catch.
3. **inlining** — the element's own computed `stroke` is the token colour, not merely a wrapper's `color`. A plain `<img>` would report the right wrapper colour while rendering UA black, so this is what distinguishes a real fix from a fake one.

With `inlineSvg` the testId lands on the `<svg>` **itself** rather than a wrapper, so the assertions target the element directly — noted in the spec, because a descendant `.locator('svg')` silently finds nothing and looks like a broken feature. (I hit exactly that on the first run.)

## Pre-existing failures, verified not mine

`tests/table-builtin-cells.test.ts` has 7 failures. They **reproduce identically on clean `release` with this branch stashed** — the table demo does not render, every assertion is "element(s) not found", and none concern colour. Confirmed by control run rather than assumed. Left for whoever owns that demo.

## Verification

`svelte-check` 0 errors (4 warnings, all pre-existing). `eslint` and `prettier` clean. The 3 new tests pass; the other Select/Tabs/Status specs pass unchanged.

Demo: the Select page gains a "Tinting the icon independently of the label" section showing the pairing and naming all seven tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable icon colors across command menus, file dropzones, selects, statuses, tables, and tabs.
  - Select icons can now be tinted independently from their accompanying text.
  - Updated component documentation with available icon-color customization options and defaults.

- **Tests**
  - Added coverage verifying default inherited colors, custom icon colors, and SVG color rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->