### PR TITLE
feat(Card): add titleSnippet and descriptionSnippet

### DIFF
--- a/docs/Card.md
+++ b/docs/Card.md
@@ -189,6 +189,36 @@ This pattern gives full layout control to the consumer (any number of zones, any
 </Card>
 ```
 
+### Rich-Markup Title and Description via Snippets
+
+`title` and `description` are plain strings, so they cannot carry markup or an
+attribute. When the title needs an inline icon, formatted text, or a test hook on
+the element itself, use `titleSnippet` / `descriptionSnippet` instead — each
+renders inside the same `.card-title` / `.card-description` container, so the
+card keeps its normal header typography and spacing.
+
+```svelte
+<script>
+  import { Card } from '@juspay/svelte-ui-components';
+</script>
+
+<Card>
+  {#snippet titleSnippet()}
+    <h3 data-pw="settings-card-heading">Editing window</h3>
+  {/snippet}
+  {#snippet descriptionSnippet()}
+    <p data-pw="settings-card-description">
+      Counts from when the order is created. <a href="/docs">Learn more</a>
+    </p>
+  {/snippet}
+  <p>Card body content.</p>
+</Card>
+```
+
+Providing `titleSnippet` renders the header row even when `title` is omitted, so
+there is no need to pass a placeholder `title=""`. A snippet always takes
+priority over the matching string prop — only one of the two is rendered.
+
 ### Stretch and Scrollable Card
 
 ```svelte
@@ -213,6 +243,8 @@ This pattern gives full layout control to the consumer (any number of zones, any
 | children    | `Snippet`                          | No       | `-`     | Main content body of the card. Rendered inside the `.card-content` container.                                                                                                                                                                                                                                  |
 | title       | `string`                           | No       | `-`     | Header title text. When provided, renders the `.card-header` section.                                                                                                                                                                                                                                          |
 | description | `string`                           | No       | `-`     | Header subtitle/description text displayed below the title. Only rendered if `title` is also provided.                                                                                                                                                                                                         |
+| titleSnippet | `Snippet`                         | No       | `-`     | Rich-markup override for the title. Rendered inside the same `.card-title` container and takes priority over `title`. Providing it renders the header row even when `title` is omitted.                                                                                                                        |
+| descriptionSnippet | `Snippet`                   | No       | `-`     | Rich-markup override for the description. Rendered inside the same `.card-description` container and takes priority over `description`.                                                                                                                                                                        |
 | classes     | `string`                           | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                                                                                                         |
 | testId      | `string`                           | No       | `-`     | Value for the `data-pw` attribute on the root element. Used for Playwright test selectors.                                                                                                                                                                                                                     |
 | onclick     | `(event: MouseEvent) => void`      | No       | `-`     | Click handler. When provided (and `href` is not), the card root becomes an interactive `<div>`: `role="button"`, `tabindex="0"`, and Enter/Space keydown trigger the handler. When `href` is also set, `onclick` still fires but the shim is skipped in favor of native anchor semantics. Omit both to keep a plain `<div>`.                                                                                                                                   |

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -5,6 +5,8 @@
     children,
     title,
     description,
+    titleSnippet,
+    descriptionSnippet,
     classes,
     testId,
     onclick,
@@ -64,13 +66,17 @@
   onclick={onclick ?? null}
   onkeydown={!isAnchor && isInteractive ? handleKeydown : null}
 >
-  {#if (typeof title === 'string' && title.length > 0) || typeof headerRight === 'function'}
+  {#if (typeof title === 'string' && title.length > 0) || typeof titleSnippet === 'function' || typeof headerRight === 'function'}
     <div class="card-header" class:card-header-split={typeof headerRight === 'function'}>
       <div class="card-header-main">
-        {#if typeof title === 'string' && title.length > 0}
+        {#if typeof titleSnippet === 'function'}
+          <div class="card-title">{@render titleSnippet()}</div>
+        {:else if typeof title === 'string' && title.length > 0}
           <div class="card-title">{title}</div>
         {/if}
-        {#if typeof description === 'string' && description.length > 0}
+        {#if typeof descriptionSnippet === 'function'}
+          <div class="card-description">{@render descriptionSnippet()}</div>
+        {:else if typeof description === 'string' && description.length > 0}
           <div class="card-description">{description}</div>
         {/if}
       </div>

--- a/src/lib/Card/properties.ts
+++ b/src/lib/Card/properties.ts
@@ -11,6 +11,22 @@ export type OptionalCardProperties = {
   children?: Snippet;
   title?: string;
   description?: string;
+  /**
+   * Optional snippet rendered in place of the `title` string, inside the same
+   * `.card-title` container. When provided, `title` is not rendered — the snippet
+   * takes priority — and the header row is shown even if `title` is omitted
+   * entirely. Use this when the title needs markup a string prop cannot carry:
+   * rich text, an inline icon, or a test hook such as `data-pw` /
+   * `use:testAttributes` that must sit on the title element itself.
+   */
+  titleSnippet?: Snippet;
+  /**
+   * Optional snippet rendered in place of the `description` string, inside the
+   * same `.card-description` container. When provided, `description` is not
+   * rendered. Like `titleSnippet`, this exists for descriptions that need markup
+   * or a test hook on the element itself.
+   */
+  descriptionSnippet?: Snippet;
   classes?: string;
   /** Renders as `data-pw` on the root element for Playwright test selection. */
   testId?: string;

--- a/src/routes/components/card/+page.svelte
+++ b/src/routes/components/card/+page.svelte
@@ -16,6 +16,28 @@
 </div>
 
 <div class="demo-section">
+  <h2 class="demo-section-title">Rich Title / Description (titleSnippet, descriptionSnippet)</h2>
+  <div class="demo-row" style="flex-direction: column; max-width: 420px; gap: 16px;">
+    <div class="card-theme">
+      <Card testId="card-snippet-header">
+        {#snippet titleSnippet()}
+          <h3 style="margin: 0; font: inherit;" data-pw="snippet-card-heading">Editing window</h3>
+        {/snippet}
+        {#snippet descriptionSnippet()}
+          <p style="margin: 0; font: inherit;" data-pw="snippet-card-description">
+            Counts from order creation. <a href="{base}/components/button">Learn more</a>
+          </p>
+        {/snippet}
+        <p style="margin: 0;">
+          Snippets render inside the same .card-title / .card-description containers, so the header
+          keeps its normal typography. No placeholder title="" is needed.
+        </p>
+      </Card>
+    </div>
+  </div>
+</div>
+
+<div class="demo-section">
   <h2 class="demo-section-title">Basic Cards</h2>
   <div class="demo-row" style="flex-direction: column; max-width: 420px; gap: 16px;">
     <div class="card-theme">

--- a/tests/card-title-description-snippets.test.ts
+++ b/tests/card-title-description-snippets.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+// Covers Card's `titleSnippet` / `descriptionSnippet`. The reason they exist:
+// `title` and `description` are plain strings, so a consumer whose heading
+// carries markup — or a test hook such as data-pw that a suite already selects
+// on — had no way to use the card's own header and hand-rolled one in the body
+// instead. The snippets render into the same .card-title / .card-description
+// containers, so the header keeps its normal typography.
+test.describe('Card title/description snippets', () => {
+  test('titleSnippet renders the header even when no title string is passed', async ({ page }) => {
+    await page.goto('/components/card');
+
+    const card = page.getByTestId('card-snippet-header');
+    await expect(card).toBeVisible();
+
+    // The header row exists purely because titleSnippet was supplied — this
+    // instance passes no `title` prop at all.
+    await expect(card.locator('.card-header')).toHaveCount(1);
+  });
+
+  test('snippet content renders inside the card-title / card-description containers', async ({
+    page
+  }) => {
+    await page.goto('/components/card');
+
+    const card = page.getByTestId('card-snippet-header');
+
+    // Not merely present somewhere in the card — nested in the header
+    // containers, which is what preserves the card's header typography.
+    await expect(card.locator('.card-title [data-pw="snippet-card-heading"]')).toBeVisible();
+    await expect(
+      card.locator('.card-description [data-pw="snippet-card-description"]')
+    ).toBeVisible();
+
+    // The hook the consumer put on its own element survives, which is the whole
+    // point — a string prop could not have carried it.
+    await expect(card.getByTestId('snippet-card-heading')).toHaveText('Editing window');
+  });
+
+  test('string title/description still render unchanged when no snippet is given', async ({
+    page
+  }) => {
+    await page.goto('/components/card');
+
+    // Regression guard for every existing consumer: the string path is untouched.
+    const stringCard = page.locator('.card', { hasText: 'Order Summary' }).first();
+    await expect(stringCard.locator('.card-title')).toHaveText('Order Summary');
+    await expect(stringCard.locator('.card-description')).toHaveText(
+      'Review your items before checkout.'
+    );
+  });
+});


### PR DESCRIPTION
## Why

`Card`'s `title` and `description` are plain strings. A consumer whose heading carries markup — or a test hook like `data-pw` / `use:testAttributes` that a Playwright suite already selects on — cannot use the card's own header at all. The workaround is to hand-roll a heading inside the card body, which loses the header typography and leaves the header row unrendered entirely (the whole block is gated on `title.length > 0 || headerRight`).

This came out of a migration in a consumer app: **28 `Card` call sites could not adopt the `title` prop purely because their heading carried a test hook.** Every other blocker had a workaround; this one did not.

## What

Mirrors the pattern `EmptyState` already ships. Each snippet renders **inside the same `.card-title` / `.card-description` container**, so the header keeps its normal typography and spacing, and a snippet takes priority over the matching string prop.

```svelte
<Card>
  {#snippet titleSnippet()}
    <h3 data-pw="settings-card-heading">Editing window</h3>
  {/snippet}
  {#snippet descriptionSnippet()}
    <p>Counts from order creation. <a href="/docs">Learn more</a></p>
  {/snippet}
  <p>Card body content.</p>
</Card>
```

One deliberate difference from `EmptyState`: Card's `title` is optional, so **`titleSnippet` alone renders the header row** — no placeholder `title=""` is needed. (EmptyState requires one because its `title` is mandatory.)

## Backward compatibility

The header gate only gains an `OR` on `titleSnippet`; both string branches are untouched. A consumer passing no snippet renders exactly as before — covered by a regression test.

`description` alone still does not open the header, matching today's behaviour rather than quietly changing it for existing consumers.

## Verification

- **3 new Playwright cases**: header renders from `titleSnippet` with no `title` prop; snippet content lands inside `.card-title`/`.card-description` and keeps its hook; string path unchanged.
- Full suite green — **128 unit tests**, `pnpm run lint` and `svelte-check` clean (0 errors).
- **Proven against the consumer app**: built this branch, linked it into the app, migrated one of the 28 blocked call sites, and probed the live DOM — the `data-pw` hook survives on the consumer's own `<h3>`, it renders inside `.card-title`, and a `headerRight` Toggle stays right-aligned.

Docs (`docs/Card.md`), the props table and the demo page are updated alongside.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cards now support rich custom content for titles and descriptions through snippets.
  - Custom snippets take precedence over standard text and preserve the card’s existing header layout.
  - A title header can now appear when only custom title content is provided.

- **Documentation**
  - Added API documentation and examples for custom card title and description content.
  - Updated the card demonstration page with snippet usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->