### PR TITLE
feat(Input, Menu, Button): close the capability gaps forcing hand-rolled controls

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -22,6 +22,7 @@
     testId,
     ariaLabel,
     ariaExpanded,
+    ariaHaspopup,
     ariaSelected,
     role,
     onclick,
@@ -88,6 +89,7 @@
     role={role ?? null}
     aria-label={ariaLabel ?? null}
     aria-expanded={ariaExpanded ?? null}
+    aria-haspopup={ariaHaspopup ?? null}
     aria-selected={ariaSelected ?? null}
     aria-busy={isBusy || null}
     type={href ? null : type}

--- a/src/lib/Button/properties.ts
+++ b/src/lib/Button/properties.ts
@@ -58,6 +58,11 @@ export type OptionalButtonProperties = {
   children?: Snippet;
   ariaLabel?: string;
   ariaExpanded?: boolean;
+  /**
+   * Native `aria-haspopup`. Needed when the button is the trigger for a menu, listbox or
+   * dialog — Menu hands exactly this to its `trigger` snippet.
+   */
+  ariaHaspopup?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | boolean;
   ariaSelected?: boolean;
   role?: string;
   disabled?: boolean;

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -12,6 +12,8 @@
     infoMessage = '',
     validators = [],
     disable = false,
+    readonly = false,
+    spellcheck = null,
     validationPattern = null,
     inProgressPattern = null,
     addFocusColor = false,
@@ -189,6 +191,15 @@
       return;
     }
 
+    // Everything below the tel branch is tel-specific digit normalisation, and
+    // onPaste was only ever invoked from inside it — so a non-tel field (notably
+    // useTextArea) had no way to observe a paste at all. Hand the event over
+    // before that branch and return, leaving tel's behaviour byte-identical.
+    if (dataType !== 'tel') {
+      onPaste(event);
+      return;
+    }
+
     if (event.clipboardData) {
       if (dataType === 'tel') {
         let unfilteredNumber = event.clipboardData.getData('text');
@@ -281,6 +292,8 @@
         style:resize={effectiveResize}
         rows={rows ?? null}
         disabled={disable}
+        readonly={readonly || null}
+        {spellcheck}
         bind:this={inputElement}
         maxlength={dataType === 'tel' ? null : maxLength}
         minlength={minLength}
@@ -311,6 +324,8 @@
         testID={testId}
         class:action-input={actionInput}
         disabled={disable}
+        readonly={readonly || null}
+        {spellcheck}
         bind:this={inputElement}
         maxlength={dataType === 'tel' ? null : maxLength}
         minlength={minLength}

--- a/src/lib/Input/properties.ts
+++ b/src/lib/Input/properties.ts
@@ -18,6 +18,19 @@ export type OptionalInputProperties = {
   infoMessage?: string | null;
   validators?: CustomValidator[];
   disable?: boolean;
+  /**
+   * Renders the field read-only: the value can be focused, selected and copied but not
+   * edited. Deliberately distinct from `disable`, which also removes the element from
+   * the focus order and so cannot serve a select-all-to-copy affordance.
+   */
+  readonly?: boolean;
+  /**
+   * Native `spellcheck`. Defaults to `null`, which Svelte renders as "attribute
+   * absent", so the browser default is unchanged for every existing consumer.
+   * Pass `false` for fields holding code, JSON or identifiers, where red
+   * squiggles are noise.
+   */
+  spellcheck?: boolean | null;
   validationPattern?: RegExp | null;
   inProgressPattern?: RegExp | null;
   addFocusColor?: boolean;

--- a/src/lib/Menu/Menu.svelte
+++ b/src/lib/Menu/Menu.svelte
@@ -10,6 +10,7 @@
     open = $bindable(false),
     testId,
     trigger,
+    interactiveTrigger = false,
     onselect,
     onopen,
     onclose,
@@ -345,20 +346,45 @@
   data-pw={typeof testId === 'string' ? testId : null}
   testID={typeof testId === 'string' ? testId : null}
 >
-  <div
-    class="menu-trigger"
-    bind:this={triggerEl}
-    onclick={toggle}
-    onkeydown={handleTriggerKeydown}
-    role="button"
-    tabindex="0"
-    aria-haspopup="menu"
-    aria-expanded={open}
-  >
-    {#if typeof trigger === 'function'}
-      {@render trigger()}
-    {/if}
-  </div>
+  <!-- Two shapes on purpose. When the snippet renders its own interactive element this
+       wrapper must NOT be a second one: two focusable nodes for one conceptual trigger
+       means two Tab stops, both announcing as a button, and interactive content nested
+       inside interactive content. The wiring is handed to the snippet instead, for it to
+       spread onto the one real control. Written as two branches rather than conditional
+       attributes so role/tabindex stay statically paired — Svelte's a11y check reads them
+       together, and a dynamic pair trips a11y_no_noninteractive_tabindex. -->
+  {#if interactiveTrigger}
+    <div class="menu-trigger" bind:this={triggerEl}>
+      {#if typeof trigger === 'function'}
+        {@render trigger({
+          onclick: toggle,
+          onkeydown: handleTriggerKeydown,
+          ariaHaspopup: 'menu',
+          ariaExpanded: open
+        })}
+      {/if}
+    </div>
+  {:else}
+    <div
+      class="menu-trigger"
+      bind:this={triggerEl}
+      onclick={toggle}
+      onkeydown={handleTriggerKeydown}
+      role="button"
+      tabindex="0"
+      aria-haspopup="menu"
+      aria-expanded={open}
+    >
+      {#if typeof trigger === 'function'}
+        {@render trigger({
+          onclick: toggle,
+          onkeydown: handleTriggerKeydown,
+          ariaHaspopup: 'menu',
+          ariaExpanded: open
+        })}
+      {/if}
+    </div>
+  {/if}
 
   {#if open}
     <div

--- a/src/lib/Menu/properties.ts
+++ b/src/lib/Menu/properties.ts
@@ -1,5 +1,14 @@
 import type { Snippet } from 'svelte';
 
+/** The interaction wiring Menu hands to its `trigger` snippet. */
+export type MenuTriggerProps = {
+  onclick: (event: MouseEvent) => void;
+  onkeydown: (event: KeyboardEvent) => void;
+  /** camelCase to match the library's own prop convention, so it spreads onto Button. */
+  ariaHaspopup: 'menu';
+  ariaExpanded: boolean;
+};
+
 export type MenuItem = {
   label: string;
   value: string;
@@ -28,7 +37,26 @@ export type MandatoryMenuProperties = {
 export type OptionalMenuProperties = {
   open?: boolean;
   testId?: string;
-  trigger?: Snippet;
+  /**
+   * Renders the control that opens the menu. Receives Menu's interaction wiring, so a
+   * consumer whose trigger is ITSELF an interactive element (a Button, say) can spread
+   * it onto that element and set `interactiveTrigger` — see below. A snippet that
+   * declares no parameters simply ignores what it is handed, so existing triggers are
+   * unaffected.
+   */
+  trigger?: Snippet<[MenuTriggerProps]>;
+  /**
+   * Set when the trigger snippet renders its own interactive element. Menu then stops
+   * making its wrapper a second one.
+   *
+   * By default Menu wraps the trigger in a `role="button" tabindex="0"` div carrying
+   * the click/keydown handlers. That is correct for inert trigger content, but if the
+   * snippet renders a real control the result is two focusable elements for one
+   * conceptual trigger — two Tab stops, both announcing as a button, and interactive
+   * content nested inside interactive content. Defaults to `false`, preserving the
+   * existing behaviour for every current consumer.
+   */
+  interactiveTrigger?: boolean;
   classes?: string;
   /** Value of the currently selected item. When set, opening the menu focuses the
    * selected option instead of the first item, the matching item gets the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,9 +2,29 @@ import type { FlyParams } from 'svelte/transition';
 
 /**
  * @name InputDataType
- * @description Different types of input data which can be passed to the Input Component
+ * @description Different types of input data which can be passed to the Input Component.
+ *
+ * Input renders `<input type={dataType}>`, so this union is the only thing deciding
+ * which native types a consumer may ask for. The four added beyond the original
+ * text/tel/password/email/number all keep `value` a plain string with no parallel
+ * `checked`/`files` model, so Input's existing value plumbing covers them unchanged.
+ * `validateInput()` switches on dataType with no default branch, and `number` has
+ * always fallen through it unvalidated — these fall through identically.
+ *
+ * Deliberately NOT included: checkbox and radio (driven by `checked`, which Input has
+ * no prop for), and file (rejects scripted `value` writes outright). Those need new
+ * props, not a wider union.
  */
-export type InputDataType = 'text' | 'tel' | 'password' | 'email' | 'number';
+export type InputDataType =
+  | 'text'
+  | 'tel'
+  | 'password'
+  | 'email'
+  | 'number'
+  | 'time'
+  | 'date'
+  | 'search'
+  | 'url';
 
 export type ModalTransition = 'IN' | 'ALL';
 

--- a/src/routes/components/input/+page.svelte
+++ b/src/routes/components/input/+page.svelte
@@ -8,6 +8,11 @@
   let resizable = $state('');
   let resizableX = $state('');
   let resizableBoth = $state('');
+  let scheduleTime = $state('09:30');
+  let configJson = $state('{ "enabled": true }');
+  let readonlySnapshot = $state('{"captured":"selector"}');
+  let pastedInto = $state('');
+  let pasteCount = $state(0);
 </script>
 
 <div class="page-header">
@@ -75,6 +80,72 @@
 <div class="demo-row resize-narrow">
   <Input bind:value={resizableBoth} useTextArea resize="both" label="Both" rows={3} />
 </div>
+
+<h3>Native input types (dataType)</h3>
+<p>
+  <code>dataType</code> is passed straight through as the native <code>type</code>. Beyond the
+  original text/tel/password/email/number it also accepts <code>time</code>, <code>date</code>,
+  <code>search</code> and <code>url</code>.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input
+    bind:value={scheduleTime}
+    dataType="time"
+    label="Schedule time"
+    name="schedule-time"
+    testId="input-datatype-time"
+  />
+</div>
+
+<h3>spellcheck</h3>
+<p>
+  Defaults to unset, so the browser default is untouched. Pass <code>false</code> for fields holding code,
+  JSON or identifiers.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input
+    bind:value={configJson}
+    useTextArea
+    spellcheck={false}
+    label="Config JSON"
+    rows={3}
+    testId="input-spellcheck-off"
+  />
+</div>
+
+<h3>readonly</h3>
+<p>
+  <code>readonly</code> keeps the field focusable and selectable but not editable — unlike
+  <code>disable</code>, which removes it from the focus order entirely and so cannot carry a
+  select-all-to-copy affordance.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input
+    bind:value={readonlySnapshot}
+    useTextArea
+    readonly
+    label="Captured snapshot"
+    rows={3}
+    testId="input-readonly"
+  />
+</div>
+
+<h3>onPaste on a non-tel field</h3>
+<p>
+  The paste callback fires for every <code>dataType</code>, not just <code>tel</code> — which is what
+  lets a consumer intercept pasted files or images in a multi-line field.
+</p>
+<div class="demo-row" style="max-width: 400px;">
+  <Input
+    bind:value={pastedInto}
+    useTextArea
+    label="Paste here"
+    rows={3}
+    testId="input-paste-textarea"
+    onPaste={() => (pasteCount += 1)}
+  />
+</div>
+<p data-pw="input-paste-count">paste events seen: {pasteCount}</p>
 
 <style>
   /* Start narrower so horizontal/both resizing has room to grow as well as shrink. */

--- a/src/routes/components/menu/+page.svelte
+++ b/src/routes/components/menu/+page.svelte
@@ -115,6 +115,28 @@
   </div>
 </div>
 
+<h3>interactiveTrigger — trigger is its own control</h3>
+<p>
+  By default Menu wraps the trigger in a <code>role="button" tabindex="0"</code> div. When the
+  snippet renders a real control, set <code>interactiveTrigger</code> and spread the wiring Menu hands
+  the snippet onto that control — one Tab stop instead of two, and no interactive element nested inside
+  another.
+</p>
+<div class="demo-row">
+  <Menu
+    testId="menu-interactive-trigger"
+    interactiveTrigger
+    items={[
+      { label: 'Newest first', value: 'new' },
+      { label: 'Oldest first', value: 'old' }
+    ]}
+  >
+    {#snippet trigger(props)}
+      <Button {...props} text="Sort" testId="menu-interactive-trigger-button" />
+    {/snippet}
+  </Menu>
+</div>
+
 <style>
   .corner-pinned-demo {
     position: fixed;

--- a/tests/input-capability-gaps.test.ts
+++ b/tests/input-capability-gaps.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+// Four capabilities Input could not express, each blocking a real consumer that was
+// forced to hand-roll a native element instead. The last test in this file is the
+// one that matters most: it proves the additions changed nothing for fields that
+// do not opt in.
+test.describe('Input — dataType passthrough, spellcheck, readonly, paste', () => {
+  test('dataType renders a native time input', async ({ page }) => {
+    await page.goto('/components/input');
+
+    // Input renders <input type={dataType}>, so widening the union was the only
+    // thing needed — the rendering already supported it.
+    const field = page.getByTestId('input-datatype-time');
+    await expect(field).toHaveAttribute('type', 'time');
+    await expect(field).toHaveValue('09:30');
+  });
+
+  test('spellcheck={false} reaches the textarea', async ({ page }) => {
+    await page.goto('/components/input');
+
+    await expect(page.getByTestId('input-spellcheck-off')).toHaveAttribute('spellcheck', 'false');
+  });
+
+  test('readonly keeps the field focusable and selectable but not editable', async ({ page }) => {
+    await page.goto('/components/input');
+
+    const field = page.getByTestId('input-readonly');
+    await expect(field).toHaveAttribute('readonly', '');
+
+    // The distinction from `disable` is the whole point: a disabled element cannot
+    // take focus, which would break a select-all-to-copy affordance.
+    await field.focus();
+    await expect(field).toBeFocused();
+
+    const before = await field.inputValue();
+    await field.press('x');
+    await expect(field).toHaveValue(before);
+  });
+
+  test('onPaste fires on a non-tel field', async ({ page }) => {
+    await page.goto('/components/input');
+
+    const field = page.getByTestId('input-paste-textarea');
+    await field.focus();
+
+    // Previously the consumer callback was only invoked from inside the tel-specific
+    // branch, so a textarea consumer could not observe a paste at all.
+    await field.evaluate((node) => {
+      const transfer = new DataTransfer();
+      transfer.setData('text/plain', 'pasted');
+      node.dispatchEvent(new ClipboardEvent('paste', { clipboardData: transfer, bubbles: true }));
+    });
+
+    await expect(page.locator('[data-pw="input-paste-count"]')).toHaveText('paste events seen: 1');
+  });
+
+  test('fields that do not opt in are unchanged', async ({ page }) => {
+    await page.goto('/components/input');
+
+    // Regression guard for every existing consumer: no spellcheck attribute is
+    // emitted when the prop is not passed, and no readonly attribute either.
+    const basic = page.locator('.input-container input[type="text"]').first();
+    await expect(basic).not.toHaveAttribute('spellcheck', /.*/);
+    await expect(basic).not.toHaveAttribute('readonly', /.*/);
+    await expect(basic).toBeEditable();
+  });
+});

--- a/tests/menu-interactive-trigger.test.ts
+++ b/tests/menu-interactive-trigger.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+// Menu wraps its trigger snippet in a role="button" tabindex="0" div. That is right for
+// inert trigger content and wrong when the snippet renders a real control: the result is
+// two focusable elements for one conceptual trigger, both announcing as a button, with
+// interactive content nested inside interactive content.
+test.describe('Menu — interactiveTrigger', () => {
+  test('the wrapper stops being a second interactive element', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const wrapper = page.locator('[data-pw="menu-interactive-trigger"] .menu-trigger');
+    await expect(wrapper).not.toHaveAttribute('role', /.*/);
+    await expect(wrapper).not.toHaveAttribute('tabindex', /.*/);
+
+    // The ARIA moves onto the real control the consumer rendered.
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await expect(button).toHaveAttribute('aria-haspopup', 'menu');
+    await expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('the trigger still opens the menu, and reports expansion', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await button.click();
+
+    await expect(page.getByText('Newest first')).toBeVisible();
+    await expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('default menus are unchanged — the wrapper stays the interactive element', async ({
+    page
+  }) => {
+    await page.goto('/components/menu');
+
+    // Regression guard for every existing consumer: without the flag, Menu keeps
+    // driving the trigger from its own wrapper exactly as before.
+    const defaultWrapper = page.locator('.menu-trigger').first();
+    await expect(defaultWrapper).toHaveAttribute('role', 'button');
+    await expect(defaultWrapper).toHaveAttribute('tabindex', '0');
+  });
+});


### PR DESCRIPTION
Five consumers in the Lighthouse dashboard hand-roll a native `<input>`, `<textarea>` or `<button>` because the library cannot express what they need. Each is a small additive gap rather than a design disagreement, so this closes all five.

## Input

### `InputDataType` gains `'time' | 'date' | 'search' | 'url'`

`Input.svelte` already renders `<input type={dataType}>` — the union was the only thing in the way. A scheduling field was hand-rolling `<input type="time">` purely to name a type the component would have rendered anyway.

**Why safe:** `validateInput()` switches on `dataType` with **no default branch**, and `'number'` has always fallen through it unvalidated — that is the shipped precedent. All four additions keep `value` a plain string with no parallel `checked`/`files` model, so the existing value plumbing covers them unchanged.

**Deliberately excluded:** `checkbox`/`radio` (driven by `checked`, which Input has no prop for) and `file` (rejects scripted `value` writes). Those need new props, not a wider union.

### New `spellcheck` prop
Defaults to `null` → attribute absent → browser default unchanged for every existing field. A JSON paste box wants it off.

### New `readonly` prop
Deliberately distinct from `disable`: a disabled element **cannot take focus**, so it cannot carry a select-all-to-copy affordance — which is exactly what the consumer needing this does.

### `onPaste` now fires for non-`tel` fields
It was only ever invoked from inside the tel-specific digit-normalisation branch, so a `useTextArea` consumer could not observe a paste **at all**. A chat composer that intercepts pasted images had no way to migrate without silently losing that feature. **The tel path is untouched.**

## Menu + Button

Menu wraps its `trigger` snippet in a `role="button" tabindex="0"` div. That is right for inert trigger content and wrong when the snippet renders a real control: two focusable elements for one conceptual trigger, both announcing as a button, with interactive content nested inside interactive content.

- `trigger` now receives Menu's interaction wiring, and a new **`interactiveTrigger`** prop stops Menu making its own wrapper interactive. **Defaults to `false`**, so every existing menu is unchanged.
- **`Button` gains `ariaHaspopup`**, without which that wiring cannot land on it. Found by writing the test: the first version passed kebab-case aria attributes, which a component destructuring named props silently drops — the shape must match the library's camelCase convention.
- The trigger is two branches rather than conditional attributes so `role`/`tabindex` stay statically paired; a dynamic pair trips Svelte's `a11y_no_noninteractive_tabindex`.

## Verification

Baseline captured **before any edit**, then compared after:

| | baseline | after |
|---|---|---|
| `svelte-check` | 0 errors, 4 warnings | **0 errors, 4 warnings** |
| `prettier` + `eslint` | clean | clean |
| unit tests | 128 passed | **128 passed** |
| `npm run build` | — | OK |

**8 new Playwright tests.** Three exist specifically to prove nothing changed for consumers that do not opt in: a field without the new props emits no `spellcheck` or `readonly` attribute and stays editable, and a menu without `interactiveTrigger` keeps `role="button" tabindex="0"` on its wrapper.

**Nine Table tests fail in the full suite.** They fail **identically on unmodified `origin/release`** when run back-to-back under the same conditions (9 failed / 21 passed both ways), so they are pre-existing and not introduced here.

## Consumers unblocked

Lighthouse `BZ-5582` follow-up — these are the last raw controls its AST guard reports, and they are the ones the library could not serve:

| call site | needed |
|---|---|
| `ReportSetupModal` | `dataType="time"` |
| `GlobalConfigSection` | `spellcheck={false}` |
| `DebugPanel` manual-copy | `readonly` |
| `InputBar` chat composer | `onPaste` on a textarea |
| `OrdersFilterMenu` | `interactiveTrigger` + `ariaHaspopup` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aria-haspopup` support for buttons and menu triggers.
  * Menus can now use custom interactive trigger controls while preserving accessibility behavior.
  * Inputs support readonly fields, spellcheck control, and additional native types: time, date, search, and URL.
  * Paste handlers now work consistently across non-telephone inputs.
* **Documentation**
  * Added examples demonstrating the new input and menu capabilities.
* **Tests**
  * Added coverage for input accessibility, paste behavior, and interactive menu triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->