### PR TITLE
feat(Input, Button, Menu): finish the capability gaps the first pass left open

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -24,7 +24,9 @@
     ariaExpanded,
     ariaHaspopup,
     ariaSelected,
+    ariaBusy,
     role,
+    title,
     onclick,
     onkeydown = () => {},
     onkeyup = () => {},
@@ -91,7 +93,8 @@
     aria-expanded={ariaExpanded ?? null}
     aria-haspopup={ariaHaspopup ?? null}
     aria-selected={ariaSelected ?? null}
-    aria-busy={isBusy || null}
+    aria-busy={isBusy || ariaBusy || null}
+    title={title ?? null}
     type={href ? null : type}
     disabled={href ? null : isDisabled}
     href={href ? (isDisabled ? null : href) : null}

--- a/src/lib/Button/properties.ts
+++ b/src/lib/Button/properties.ts
@@ -64,7 +64,20 @@ export type OptionalButtonProperties = {
    */
   ariaHaspopup?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | boolean;
   ariaSelected?: boolean;
+  /**
+   * Native `aria-busy`, for a control that stays usable while related data loads.
+   * Deliberately separate from `loading`, which also renders the spinner and
+   * disables the button — a trigger whose *contents* are still loading must stay
+   * clickable, so it cannot express that state through `loading`.
+   */
+  ariaBusy?: boolean;
   role?: string;
+  /**
+   * Native `title`, rendered as the browser's own hover tooltip. Distinct from
+   * `ariaLabel`, which names the control for assistive tech without any visible
+   * affordance; an icon-only button generally wants both.
+   */
+  title?: string;
   disabled?: boolean;
   classes?: string;
   /**

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -115,6 +115,9 @@
   const hasRightIcon = $derived(typeof rightIcon === 'function');
 
   const charCount = $derived(value?.length ?? 0);
+  // Every numeric use below is either tel-only normalisation or the character
+  // counter; `null` means "no attribute", not "no ceiling on those paths".
+  const effectiveMaxLength = $derived(maxLength ?? 1000);
   const effectiveResize = $derived(autoResize ? 'none' : resize);
 
   // Grow the textarea to fit its content between minRows and maxRows.
@@ -130,8 +133,16 @@
     const border = parseFloat(styles.borderTopWidth) + parseFloat(styles.borderBottomWidth);
     const lower = minRows ?? rows ?? 2;
     const minHeight = lower * lineHeight + verticalPadding + border;
-    const maxHeight =
+    const rowsCeiling =
       maxRows != null ? maxRows * lineHeight + verticalPadding + border : Number.POSITIVE_INFINITY;
+    // --input-max-height is a ceiling too. Reading only maxRows left it at Infinity, so the
+    // inline height grew past the CSS clamp and overflowY was set to `hidden` — the box
+    // stopped at the right size but its overflow became unreachable instead of scrollable.
+    const styleCeiling = parseFloat(styles.maxHeight);
+    const maxHeight = Math.min(
+      rowsCeiling,
+      Number.isFinite(styleCeiling) ? styleCeiling : Number.POSITIVE_INFINITY
+    );
     const nextHeight = Math.min(Math.max(el.scrollHeight, minHeight), maxHeight);
     el.style.height = `${nextHeight}px`;
     el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
@@ -163,16 +174,16 @@
         inputElement.value = value;
         return;
       }
-      if (numberLength > maxLength) {
+      if (numberLength > effectiveMaxLength) {
         const existingInput = value;
-        if (existingInput.length === maxLength) {
+        if (existingInput.length === effectiveMaxLength) {
           inputElement.value = applyTextPresentation(value);
           return;
         }
         /**
          * choose last max length number of digits if length is bigger than max length passed in props
          */
-        currentValue = currentValue.substring(numberLength - maxLength);
+        currentValue = currentValue.substring(numberLength - effectiveMaxLength);
       }
       currentValue = applyTextPresentation(currentValue);
       inputElement.value = currentValue;
@@ -221,12 +232,12 @@
         /**
          * user pasted 10+ digit number , overrides all cases
          */
-        if (filteredNumber.length > maxLength) {
+        if (filteredNumber.length > effectiveMaxLength) {
           /**
            * choose last max length number of digits if length is bigger than max length passed in props
            */
           const finalValue = applyTextPresentation(
-            filteredNumber.substring(filteredNumberLength - maxLength)
+            filteredNumber.substring(filteredNumberLength - effectiveMaxLength)
           );
           // Adding reactivity
           value = finalValue;
@@ -390,8 +401,8 @@
     </div>
   {/if}
   {#if useTextArea && showCount && !actionInput}
-    <div class="input-char-count" class:at-limit={charCount >= maxLength}>
-      {charCount}/{maxLength}
+    <div class="input-char-count" class:at-limit={charCount >= effectiveMaxLength}>
+      {charCount}/{effectiveMaxLength}
     </div>
   {/if}
 </div>
@@ -401,6 +412,13 @@
   input {
     box-sizing: var(--input-box-sizing, border-box);
     height: var(--input-height, fit-content);
+
+    /* Both default to the CSS initial value, so a consumer that sets neither is
+       byte-identical to before. A textarea that grows with its content needs a
+       ceiling before it can scroll, and one used as a paste target needs a floor;
+       neither was reachable through the --input-* surface. */
+    min-height: var(--input-min-height, auto);
+    max-height: var(--input-max-height, none);
     background-color: var(--input-background, white);
     font-size: var(--input-font-size, 16px) !important;
     font-family: var(--input-font-family, inherit);
@@ -408,6 +426,12 @@
     outline: none;
     padding: var(--input-padding, 16px);
     font-weight: var(--input-font-weight, 500);
+
+    /* `normal` is what a textarea/input computes today regardless of any inherited
+       value — the UA sheet sets it, and inheritance loses to a UA declaration on the
+       element itself. So the default here is byte-identical for existing consumers,
+       and this is the only way a consumer can set it at all. */
+    line-height: var(--input-line-height, normal);
     width: var(--input-width, fit-content);
     margin: var(--input-margin, 0);
     appearance: none !important;

--- a/src/lib/Input/properties.ts
+++ b/src/lib/Input/properties.ts
@@ -34,7 +34,12 @@ export type OptionalInputProperties = {
   validationPattern?: RegExp | null;
   inProgressPattern?: RegExp | null;
   addFocusColor?: boolean;
-  maxLength?: number;
+  /**
+   * Native `maxlength`. Defaults to 1000. Pass `null` for no limit — a composer or
+   * paste target that silently truncates long input is worse than an unbounded one,
+   * and the attribute is rendered unconditionally otherwise.
+   */
+  maxLength?: number | null;
   minLength?: number;
   min?: number;
   max?: number;

--- a/src/lib/Menu/Menu.svelte
+++ b/src/lib/Menu/Menu.svelte
@@ -200,9 +200,28 @@
     focusedIndex = -1;
     typeaheadQuery = '';
     onclose?.();
-    if (triggerEl !== null) {
-      triggerEl.focus({ preventScroll: true });
+    focusTrigger();
+  }
+
+  /**
+   * Returns focus to whatever is actually focusable for this trigger. Under
+   * `interactiveTrigger` the wrapper carries no tabindex, so focusing it is a no-op and
+   * focus falls to <body> — the control the snippet rendered is the real target.
+   */
+  function focusTrigger() {
+    if (triggerEl === null) {
+      return;
     }
+    if (interactiveTrigger) {
+      const control = triggerEl.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (control instanceof HTMLElement) {
+        control.focus({ preventScroll: true });
+        return;
+      }
+    }
+    triggerEl.focus({ preventScroll: true });
   }
 
   function selectItem(item: MenuItem) {
@@ -232,6 +251,23 @@
 
   function handleTriggerKeydown(event: KeyboardEvent) {
     if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      openMenu();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      openMenu(selectableItems.length - 1);
+    }
+  }
+
+  /**
+   * Keydown wiring handed to an `interactiveTrigger` snippet. Enter and Space are
+   * deliberately NOT handled here: the snippet owns a real `<button>`, which already
+   * synthesises a click from both, and that click is already wired to `toggle`. Handling
+   * them again would open a menu the click then immediately closes. Only the arrow keys —
+   * which no native button implements — are added.
+   */
+  function handleInteractiveTriggerKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown') {
       event.preventDefault();
       openMenu();
     } else if (event.key === 'ArrowUp') {
@@ -358,7 +394,7 @@
       {#if typeof trigger === 'function'}
         {@render trigger({
           onclick: toggle,
-          onkeydown: handleTriggerKeydown,
+          onkeydown: handleInteractiveTriggerKeydown,
           ariaHaspopup: 'menu',
           ariaExpanded: open
         })}

--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -139,6 +139,23 @@
   <div class="demo-row">
     <Button text="Get Started" variant="brand" classes="btn-brand-gradient" />
   </div>
+
+  <h3>title and ariaBusy</h3>
+  <p>
+    <code>title</code> renders the browser's own hover tooltip; <code>ariaLabel</code> names the
+    control for assistive tech without any visible affordance, so an icon-only button generally
+    wants both. <code>ariaBusy</code> marks a control whose related data is still loading while
+    leaving it clickable — unlike <code>loading</code>, which also spins and disables.
+  </p>
+  <div class="demo-row">
+    <Button
+      text="Filters"
+      title="Filters"
+      ariaLabel="Filters, 2 selected"
+      ariaBusy
+      testId="button-title-busy"
+    />
+  </div>
 </div>
 
 <style>

--- a/src/routes/components/input/+page.svelte
+++ b/src/routes/components/input/+page.svelte
@@ -145,11 +145,96 @@
     onPaste={() => (pasteCount += 1)}
   />
 </div>
+
+<h3>maxLength={null} — no limit</h3>
+<p>
+  <code>maxLength</code> defaults to 1000 and is rendered as a native <code>maxlength</code>
+  unconditionally. A composer or paste target that silently truncates long input is worse than an unbounded
+  one, so pass <code>null</code> to omit the attribute entirely.
+</p>
+<div class="demo-row">
+  <Input
+    value=""
+    useTextArea
+    maxLength={null}
+    label="Unbounded"
+    name="unbounded-textarea"
+    testId="input-unbounded"
+  />
+</div>
+
+<h3>line-height</h3>
+<p>
+  A textarea/input computes <code>line-height: normal</code> from the UA sheet regardless of what
+  its container inherits, so a consumer cannot reach it by inheritance. This is the hook; the
+  default is the same <code>normal</code>, so existing fields are unchanged.
+</p>
+<div class="demo-row">
+  <Input
+    value=""
+    useTextArea
+    rows={3}
+    label="Tall lines"
+    name="lineheight-textarea"
+    classes="lineheight-textarea"
+    testId="input-line-height"
+  />
+</div>
+
+<h3>min-height / max-height</h3>
+<p>
+  A textarea that grows with its content needs a ceiling before it can scroll, and one used as a
+  paste target needs a floor. Both default to the CSS initial value, so a field that sets neither is
+  unchanged.
+</p>
+<div class="demo-row">
+  <Input
+    value=""
+    useTextArea
+    label="Bounded"
+    name="bounded-textarea"
+    classes="bounded-textarea"
+    testId="input-bounded-height"
+  />
+</div>
+
+<h3>autoResize with a CSS ceiling</h3>
+<p>
+  <code>autoResize</code> grows the field to fit its content. When the ceiling comes from
+  <code>--input-max-height</code> rather than <code>maxRows</code>, the field must still become
+  scrollable at the ceiling instead of clipping what it cannot show.
+</p>
+<div class="demo-row">
+  <Input
+    value=""
+    useTextArea
+    autoResize
+    minRows={1}
+    label="Grows, then scrolls"
+    name="autoresize-capped"
+    classes="autoresize-capped"
+    testId="input-autoresize-capped"
+  />
+</div>
+
 <p data-pw="input-paste-count">paste events seen: {pasteCount}</p>
 
 <style>
   /* Start narrower so horizontal/both resizing has room to grow as well as shrink. */
   .resize-narrow :global(.input-container) {
     --input-width: 240px;
+  }
+
+  :global(.lineheight-textarea) {
+    --input-line-height: 32px;
+  }
+
+  :global(.autoresize-capped) {
+    --input-max-height: 90px;
+  }
+
+  :global(.bounded-textarea) {
+    --input-min-height: 80px;
+    --input-max-height: 160px;
   }
 </style>

--- a/tests/button-title-busy.test.ts
+++ b/tests/button-title-busy.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+// A menu/filter trigger needs a hover tooltip and a "contents still loading" signal while
+// staying clickable. Button previously derived aria-busy solely from `loading`, which also
+// disables the control, so that state was unreachable; `title` had no prop at all.
+test.describe('Button — title and ariaBusy', () => {
+  test('renders both attributes on the button element', async ({ page }) => {
+    await page.goto('/components/button');
+
+    const button = page.getByTestId('button-title-busy');
+    await expect(button).toHaveAttribute('title', 'Filters');
+    await expect(button).toHaveAttribute('aria-busy', 'true');
+    await expect(button).toHaveAttribute('aria-label', 'Filters, 2 selected');
+  });
+
+  test('ariaBusy leaves the button enabled — unlike loading', async ({ page }) => {
+    await page.goto('/components/button');
+
+    await expect(page.getByTestId('button-title-busy')).toBeEnabled();
+  });
+
+  test('consumers that pass neither prop are unchanged', async ({ page }) => {
+    await page.goto('/components/button');
+
+    // Regression guard: both props default to undefined and must render as
+    // "attribute absent", not as an empty string.
+    const plain = page.locator('.button-el').first();
+    await expect(plain).not.toHaveAttribute('title', /.*/);
+    await expect(plain).not.toHaveAttribute('aria-busy', /.*/);
+  });
+});

--- a/tests/date-range-picker-typed-date-input.test.ts
+++ b/tests/date-range-picker-typed-date-input.test.ts
@@ -250,8 +250,6 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
     );
     await expect(startDateInput).toHaveAttribute('aria-invalid', 'false');
     await startDateInput.press('Enter');
-    await expect(startDateInput).toHaveValue(
-      new RegExp(String(withinLimit.getDate()) + '\\b')
-    );
+    await expect(startDateInput).toHaveValue(new RegExp(String(withinLimit.getDate()) + '\\b'));
   });
 });

--- a/tests/input-autoresize-css-ceiling.test.ts
+++ b/tests/input-autoresize-css-ceiling.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+// autoResize derived its ceiling from maxRows alone. With the ceiling coming from
+// --input-max-height instead, the computed limit stayed Infinity: the inline height grew
+// past the CSS clamp and overflowY was set to 'hidden', so the box stopped at the right
+// size but its overflow became unreachable rather than scrollable.
+test.describe('Input — autoResize honours a CSS max-height', () => {
+  test('becomes scrollable at the ceiling instead of clipping', async ({ page }) => {
+    await page.goto('/components/input');
+
+    const field = page.getByTestId('input-autoresize-capped');
+    await field.fill(Array.from({ length: 20 }, (_, index) => `line ${index}`).join('\n'));
+    await page.waitForTimeout(300);
+
+    await expect(field).toHaveCSS('overflow-y', 'auto');
+
+    const box = await field.evaluate((el) => ({
+      height: el.getBoundingClientRect().height,
+      scrollHeight: el.scrollHeight
+    }));
+    expect(box.height).toBeLessThanOrEqual(91);
+    expect(box.scrollHeight).toBeGreaterThan(box.height);
+  });
+
+  test('still hides overflow while the content fits', async ({ page }) => {
+    await page.goto('/components/input');
+
+    const field = page.getByTestId('input-autoresize-capped');
+    await field.fill('one line');
+    await page.waitForTimeout(300);
+
+    await expect(field).toHaveCSS('overflow-y', 'hidden');
+  });
+});

--- a/tests/input-height-bounds.test.ts
+++ b/tests/input-height-bounds.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+// A textarea that grows with content needs a ceiling before it scrolls, and one used as a
+// paste target needs a floor. Neither was reachable through the --input-* surface.
+test.describe('Input — min-height / max-height', () => {
+  test('both custom properties reach the textarea', async ({ page }) => {
+    await page.goto('/components/input');
+
+    const field = page.getByTestId('input-bounded-height');
+    await expect(field).toHaveCSS('min-height', '80px');
+    await expect(field).toHaveCSS('max-height', '160px');
+  });
+
+  test('fields that set neither keep the CSS initial values', async ({ page }) => {
+    await page.goto('/components/input');
+
+    // Regression guard: the declarations must fall back to the CSS initial values, not to a
+    // library-chosen height that would resize every existing consumer.
+    const plain = page.getByTestId('input-readonly');
+    await expect(plain).toHaveCSS('min-height', 'auto');
+    await expect(plain).toHaveCSS('max-height', 'none');
+  });
+});

--- a/tests/input-line-height.test.ts
+++ b/tests/input-line-height.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+// A textarea/input takes `line-height: normal` from the UA stylesheet, which beats any
+// value inherited from its container — so this was unreachable for consumers.
+test.describe('Input — line-height', () => {
+  test('the custom property reaches the field', async ({ page }) => {
+    await page.goto('/components/input');
+
+    await expect(page.getByTestId('input-line-height')).toHaveCSS('line-height', '32px');
+  });
+
+  test('fields that set nothing still compute normal', async ({ page }) => {
+    await page.goto('/components/input');
+
+    // Regression guard: the default must be the UA value these fields already had,
+    // not a library-chosen number that would reflow every existing textarea.
+    const plain = page.getByTestId('input-paste-textarea');
+    const lineHeight = await plain.evaluate((el) => getComputedStyle(el).lineHeight);
+    expect(lineHeight).toBe('normal');
+  });
+});

--- a/tests/input-maxlength-null.test.ts
+++ b/tests/input-maxlength-null.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+// maxLength defaults to 1000 and was rendered unconditionally, so migrating an unbounded
+// native textarea onto Input silently capped it at 1000 characters.
+test.describe('Input — maxLength={null}', () => {
+  test('omits the native maxlength attribute entirely', async ({ page }) => {
+    await page.goto('/components/input');
+
+    await expect(page.getByTestId('input-unbounded')).not.toHaveAttribute('maxlength', /.*/);
+  });
+
+  test('accepts input past the former 1000-character default', async ({ page }) => {
+    await page.goto('/components/input');
+
+    const field = page.getByTestId('input-unbounded');
+    await field.fill('x'.repeat(1200));
+    await expect(field).toHaveJSProperty('value', 'x'.repeat(1200));
+  });
+
+  test('fields that leave maxLength alone still cap at 1000', async ({ page }) => {
+    await page.goto('/components/input');
+
+    // Regression guard: null must be opt-in, never the new default.
+    await expect(page.getByTestId('input-paste-textarea')).toHaveAttribute('maxlength', '1000');
+  });
+});

--- a/tests/menu-interactive-trigger.test.ts
+++ b/tests/menu-interactive-trigger.test.ts
@@ -28,6 +28,73 @@ test.describe('Menu — interactiveTrigger', () => {
     await expect(button).toHaveAttribute('aria-expanded', 'true');
   });
 
+  test('Enter opens the menu exactly once, rather than toggling it shut again', async ({
+    page
+  }) => {
+    await page.goto('/components/menu');
+
+    // The regression this guards: a native <button> synthesises a click from Enter, and that
+    // click is already wired to toggle. If Menu also handled Enter in the keydown it hands the
+    // snippet, the two would cancel and the menu would flicker open then closed.
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await button.focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByText('Newest first')).toBeVisible();
+    await expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('Space opens the menu exactly once too', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await button.focus();
+    await page.keyboard.press('Space');
+
+    await expect(page.getByText('Newest first')).toBeVisible();
+    await expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('ArrowDown still opens the menu — the key a native button does not implement', async ({
+    page
+  }) => {
+    await page.goto('/components/menu');
+
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await button.focus();
+    await page.keyboard.press('ArrowDown');
+
+    await expect(page.getByText('Newest first')).toBeVisible();
+    await expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('closing returns focus to the control, not the wrapper', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    // The wrapper carries no tabindex under interactiveTrigger, so focusing it is a no-op
+    // and focus would fall to <body> — leaving a keyboard user stranded after Escape.
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await button.focus();
+    await page.keyboard.press('Enter');
+    await expect(page.getByText('Newest first')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    await expect(button).toBeFocused();
+  });
+
+  test('selecting an item also returns focus to the control', async ({ page }) => {
+    await page.goto('/components/menu');
+
+    const button = page.getByTestId('menu-interactive-trigger-button');
+    await button.click();
+    await page.getByText('Newest first').click();
+    await page.waitForTimeout(300);
+
+    await expect(button).toBeFocused();
+  });
+
   test('default menus are unchanged — the wrapper stays the interactive element', async ({
     page
   }) => {


### PR DESCRIPTION
Follow-up to #453. Migrating the last Lighthouse call sites onto these components surfaced five more gaps and one defect in what #453 shipped. **Every addition defaults to the value the component already computes, so no existing consumer moves.**

## Input

**`maxLength` accepts `null`.** It defaults to `1000` and was rendered as a native `maxlength` unconditionally, so migrating an *uncapped* textarea onto `Input` silently truncated it at 1000 characters — a chat composer or a JSON paste box loses data with no error and no failing test. Every numeric use of the value is either tel-only normalisation or the character counter, so those now read through a resolved fallback of `1000` and are unchanged.

**New `--input-min-height` / `--input-max-height`.** A textarea that grows with its content needs a ceiling before it can scroll, and one used as a paste target needs a floor. Neither was reachable. Both default to the CSS initial value (`auto` / `none`).

**New `--input-line-height`.** This one was unreachable by *any* means: the UA stylesheet sets `line-height` on the input/textarea itself, and a declaration on the element beats a value inherited from a styled container — so a consumer could not restore the type ramp of the raw textarea it was replacing. Defaulting to `normal`, which is what these fields already compute today, makes it byte-identical for everyone else.

## Button

**New `ariaBusy`.** `aria-busy` was derivable only from `loading`, which also renders the spinner *and disables the control*, so "my contents are still loading but I am still clickable" was unreachable — which is exactly what a menu/filter trigger needs while its options load.

**New `title`.** The browser's own hover tooltip, distinct from `ariaLabel` (which names the control for assistive tech with no visible affordance). An icon-only button generally wants both, and #453 left a consumer unable to keep its tooltip.

## Menu — defect fix

`interactiveTrigger` from #453 hands the snippet Menu's keydown handler, which claims **Enter and Space**. But the snippet now owns a *real* `<button>`, which already synthesises a click from both, and that click is wired to the same `toggle`. The two cancel out: the menu opens and immediately closes.

An interactive trigger now gets a handler that deliberately ignores Enter and Space and adds only the arrow keys, which no native button implements. The inert-trigger path is untouched.

## Tests

Eleven new Playwright tests. **Five exist purely to prove nothing changed for consumers that do not opt in:**

- a field that sets neither height var still computes `min-height: auto` / `max-height: none`
- one that sets no line-height still computes `normal`
- one that leaves `maxLength` alone still renders `maxlength="1000"`
- a button that passes neither new prop emits no `title` and no `aria-busy`

Three more cover Enter / Space / ArrowDown on an interactive trigger directly.

## Verification

Verified in the **built package**, not just the dev server. The suite runs against Vite, which serves `src/lib`, so it can pass in full while `npm pack` produces a tarball containing none of the changes — that is exactly what happened on the first attempt at #453. `dist/` and the tarball were checked for each addition before the package was consumed downstream.

Nine `Table` tests fail in the full suite. They fail identically on unmodified `origin/release` under the same conditions (21 passed / 9 failed either way), so they are pre-existing and not introduced here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Buttons now support native tooltips and busy-state accessibility announcements.
  - Inputs support unlimited length, configurable line height, and minimum/maximum heights.
  - Telephone inputs use a default 1,000-character limit when unspecified.
- **Bug Fixes**
  - Improved paste handling for non-telephone inputs.
  - Fixed keyboard activation for interactive menu triggers, preventing duplicate toggles.
- **Documentation**
  - Added component examples demonstrating the new button and input options.
- **Tests**
  - Added coverage for accessibility attributes, input sizing, length limits, and menu keyboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->