### PR TITLE
fix(table): restore focus, handle Escape, and single-source the inline search value

### DIFF
--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -171,6 +171,7 @@
   let isServerSearch = $derived(typeof onSearchChange === 'function');
   let searchInputRef = $state<HTMLInputElement | null>(null);
   let inlineSearchInputRef = $state<{ focus: () => void } | null>(null);
+  let inlineSearchTriggerRef = $state<HTMLElement | null>(null);
   let isInlineSearch = $derived(searchConfig?.displayMode === 'inline');
   let isInlineSearchExpanded = $state(false);
 
@@ -191,8 +192,12 @@
   };
 
   const clearSearch = (): void => {
+    const wasInlineExpanded = isInlineSearchExpanded;
     updateSearch('');
     isInlineSearchExpanded = false;
+    if (wasInlineExpanded) {
+      focusInlineSearchTrigger();
+    }
   };
 
   const expandInlineSearch = (): void => {
@@ -200,8 +205,31 @@
     queueMicrotask(() => inlineSearchInputRef?.focus());
   };
 
+  // Mirror of expandInlineSearch: collapsing unmounts the input, so without an
+  // explicit restore the focus falls to the document and a keyboard user loses
+  // their place in the table. The trigger only exists once the collapse has
+  // rendered, hence the microtask.
+  const focusInlineSearchTrigger = (): void => {
+    queueMicrotask(() =>
+      inlineSearchTriggerRef?.querySelector<HTMLButtonElement>('button')?.focus()
+    );
+  };
+
+  // The expanded guard matters: collapsing unmounts the focused input, which can
+  // fire blur on the way out. Without it, an Escape (or close-button) collapse
+  // re-enters clearSearch and fires a second onSearchChange('') — a duplicate
+  // request on the server-search path.
   const collapseInlineSearchIfEmpty = (): void => {
-    if (searchTerm.trim() === '') {
+    if (isInlineSearchExpanded && searchTerm.trim() === '') {
+      clearSearch();
+    }
+  };
+
+  // Escape is the expected way out of an expand-in-place search; without it the
+  // only exits are the close button and blurring while already empty.
+  const handleInlineSearchKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
       clearSearch();
     }
   };
@@ -795,13 +823,14 @@
                         {#if isInlineSearchExpanded}
                           <Input
                             bind:this={inlineSearchInputRef}
-                            bind:value={searchTerm}
+                            value={searchTerm}
                             placeholder={searchConfig?.placeholder ?? 'Search…'}
                             testId={searchConfig?.testId ?? ''}
                             ariaLabel={searchConfig?.placeholder ?? 'Search'}
                             autoComplete="off"
                             onInput={(value: string) => updateSearch(value)}
                             onBlur={collapseInlineSearchIfEmpty}
+                            onKeyDown={handleInlineSearchKeyDown}
                             classes="table-inline-search-input"
                           />
                           <span class="table-inline-search-clear">
@@ -818,7 +847,10 @@
                             </Button>
                           </span>
                         {:else}
-                          <span class="table-inline-search-trigger">
+                          <span
+                            class="table-inline-search-trigger"
+                            bind:this={inlineSearchTriggerRef}
+                          >
                             <Button
                               variant="ghost"
                               iconOnly={true}


### PR DESCRIPTION
Follow-up to #456, which shipped the inline table search. Three points from the review of that PR landed after it was merged, so they are addressed here. None changes what the component does on the happy path.

## 1. `searchTerm` had two write paths

The inline `Input` was given both `bind:value={searchTerm}` and `onInput={(value) => updateSearch(value)}`. The binding writes the term directly; `updateSearch` writes it *and* performs the side effects — resetting `pageOverride`, calling `pagination.onPageChange(1)`, and firing `onSearchChange` in server mode.

So a write arriving through the binding could move the search term without any of those running. Nothing does that today, which is why this is a latent-bug guard rather than a fix for observed behaviour, but it is the kind of divergence that only shows up once someone adds a second consumer.

The prop is now one-way (`value={searchTerm}`) with `onInput` as the single entry point. That is also how the toolbar variant already works — it uses `bind:this` and reads `.value` in `handleSearchInput` — so the two variants now agree instead of each doing it differently.

## 2. Collapsing dropped focus

`expandInlineSearch` correctly moves focus into the input when the search opens:

```js
queueMicrotask(() => inlineSearchInputRef?.focus());
```

`clearSearch` had no counterpart, so collapsing unmounted the focused element and left focus on the document body — a keyboard user opening the search, changing their mind, and closing it lands back at the top of the page rather than on the control they started from.

`clearSearch` now mirrors the expand, restoring focus to the trigger button, and only when it was actually collapsing an expanded inline search — the toolbar clear button shares this function and has no trigger to return to.

## 3. No `Escape` handler

Escape is the expected way out of an expand-in-place control. Previously the only exits were clicking the close button or blurring while the field was already empty. It now closes the search, doing exactly what the close button does. The handler calls `stopPropagation` so it does not also close a surrounding modal.

## One thing the fix itself needed

Adding Escape surfaced a re-entrancy: collapsing unmounts the focused input, which can fire `blur` on the way out, re-entering `collapseInlineSearchIfEmpty` → `clearSearch` and sending a **second** `onSearchChange('')` on the server-search path — a duplicate request.

`collapseInlineSearchIfEmpty` now checks `isInlineSearchExpanded` before acting, so the second call is a no-op. This also hardens the pre-existing blur path against firing when already collapsed.

## Testing

```
pnpm run lint        prettier + eslint clean
pnpm run check       617 files, 0 errors (4 warnings, all pre-existing:
                     Modal.svelte, ThemeSwitcher.svelte, tsconfig — untouched here)
pnpm run test:unit   16 files, 128 tests passed
pnpm run build       vite build + svelte-package + publint clean
```

Single file changed, +30/−2. No API change: `TableSearchConfig` is untouched, and consumers using `displayMode: 'inline'` need no update.

## Verifying by hand

On the "Search (inline header trigger)" demo at `/components/table`:

1. Tab to the magnifier and press Enter — focus should land in the input.
2. Press Escape — the search closes and **focus returns to the magnifier**, not the document.
3. Type text, then click the close button — same, focus returns to the trigger.
4. With an `onSearchChange` handler wired, open the search, press Escape, and confirm only **one** `''` call is made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline search behavior when clearing or collapsing.
  - Pressing Escape now collapses the search field.
  - Focus returns to the search trigger after the field is closed.
  - Prevented duplicate callbacks when an empty search is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->