### PR TITLE
feat(ChatSuggestions): structured suggestions, scroll/vertical layouts, loading state, chip theming hooks

### DIFF
--- a/docs/ChatSuggestions.md
+++ b/docs/ChatSuggestions.md
@@ -2,6 +2,10 @@
 
 A row of tappable prompt chips (the `Pill` component) — typically shown on an empty conversation to seed the first message. Each item can be a plain string or an object with a display `label` and an underlying `value`; selecting a chip fires `onselect` with the value and index.
 
+`label` and `value` are separate because a short call-to-action ("Refund trends") usually stands in for a much longer query, and sending the label would send the wrong thing. When they differ, the value doubles as the chip's hover text unless `hint` overrides it.
+
+Two layouts: `wrap` (default) flows chips onto as many lines as needed, for a roomy panel; `scroll` keeps them on one draggable line, for a composer on a phone where wrapping would push the input off-screen. `direction="vertical"` turns the row into a full-width menu.
+
 ## Usage
 
 ```svelte
@@ -17,27 +21,34 @@ A row of tappable prompt chips (the `Pill` component) — typically shown on an 
 
 ## Props
 
-| Prop     | Type                | Required | Default | Description                                                  |
-| -------- | ------------------- | -------- | ------- | ----------------------------------------------------------- |
-| items    | `ChatSuggestion[]`  | Yes      | `-`     | Chips. `ChatSuggestion = string \| { label: string; value?: string }`. |
-| disabled | `boolean`           | No       | `false` | Disable all chips.                                          |
-| testId   | `string`            | No       | `-`     | `data-pw` on the root element.                             |
-| classes  | `string`            | No       | `-`     | Class string on the root element.                         |
+| Prop       | Type                                     | Required | Default        | Description                                                                                                                                                                                      |
+| ---------- | ---------------------------------------- | -------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| items      | `ChatSuggestion[]`                       | Yes      | `-`            | Chips. `ChatSuggestion = string \| { label: string; value?: string; icon?: string; hint?: string }`. `icon` is a **URL** — `Img` fetches it; raw SVG markup would be treated as a relative link. |
+| disabled   | `boolean`                                | No       | `false`        | Disable all chips.                                                                                                                                                                               |
+| layout     | `'wrap' \| 'scroll'`                     | No       | `'wrap'`       | Flow onto multiple lines, or one draggable line.                                                                                                                                                 |
+| direction  | `'horizontal' \| 'vertical'`             | No       | `'horizontal'` | `vertical` stacks chips full-width as a menu.                                                                                                                                                    |
+| maxVisible | `number`                                 | No       | `-`            | Render at most this many chips. Omit for all.                                                                                                                                                    |
+| loading    | `boolean`                                | No       | `false`        | Hide the chips without unmounting the row.                                                                                                                                                       |
+| icon       | `Snippet<[string \| null, number]>`      | No       | `-`            | Custom mark per chip; receives the item's icon (or null) and index.                                                                                                                                        |
+| testId     | `string`                                 | No       | `-`            | `data-pw` on the root element.                                                                                                                                                                   |
+| classes    | `string`                                 | No       | `-`            | Class string on the root element.                                                                                                                                                                |
 
 ## Events
 
-| Event    | Type                                  | Description                                      |
-| -------- | ------------------------------------- | ------------------------------------------------ |
-| onselect | `(value: string, index: number) => void` | Fires when a chip is selected.                |
+| Event    | Type                                     | Description                    |
+| -------- | ---------------------------------------- | ------------------------------ |
+| onselect | `(value: string, index: number) => void` | Fires when a chip is selected. |
 
 ## CSS Variables
 
-| Variable                        | Default | CSS Property | Description                  |
-| ------------------------------- | ------- | ------------ | ---------------------------- |
-| `--chat-suggestions-width`      | `100%`  | width        | Width of the row.            |
-| `--chat-suggestions-gap`        | `8px`   | gap          | Gap between chips.           |
-| `--chat-suggestions-flex-wrap`  | `wrap`  | flex-wrap    | Wrapping behavior.           |
-| `--chat-suggestions-padding`    | `0`     | padding      | Padding around the row.      |
+| Variable                                  | Default   | CSS Property | Description                         |
+| ----------------------------------------- | --------- | ------------ | ----------------------------------- |
+| `--chat-suggestions-width`                | `100%`    | width        | Width of the row.                   |
+| `--chat-suggestions-gap`                  | `8px`     | gap          | Gap between chips.                  |
+| `--chat-suggestions-flex-wrap`            | `wrap`    | flex-wrap    | Wrapping behavior.                  |
+| `--chat-suggestions-padding`              | `0`       | padding      | Padding around the row.             |
+| `--chat-suggestions-vertical-align-items` | `stretch` | align-items  | Cross-axis alignment when vertical. |
+| `--chat-suggestions-vertical-chip-width`  | `100%`    | width        | Chip width when vertical.           |
 
 Chips are `Pill` instances — theme them with the `--pill-*` variables.
 

--- a/docs/Pill.md
+++ b/docs/Pill.md
@@ -92,9 +92,12 @@ Override these custom properties to theme the component.
 | `--pill-border`              | `none`                                    | border           | Border style of the pill.                                                 |
 | `--pill-gap`                 | `4px`                                     | gap              | Spacing between the text and the dismiss button.                          |
 | `--pill-cursor`              | `pointer`                                 | cursor           | Cursor style when hovering over the pill.                                 |
+| `--pill-width`               | `auto`                                    | width            | Chip width. Set to `100%` to fill a column.                               |
+| `--pill-justify-content`     | `center`                                  | justify-content  | Content alignment inside the pill.                                        |
+| `--pill-text-align`          | `center`                                  | text-align       | Label alignment.                                                          |
 | `--pill-max-width`           | `-`                                       | max-width        | Maximum width of the pill. Text is truncated with ellipsis when exceeded. |
-| `--pill-line-height`         | `1`                                       | line-height      | Line height of the pill.                                                   |
-| `--pill-flex-shrink`         | `-`                                       | flex-shrink      | Flex shrink behavior of the pill.                                          |
+| `--pill-line-height`         | `1`                                       | line-height      | Line height of the pill.                                                  |
+| `--pill-flex-shrink`         | `-`                                       | flex-shrink      | Flex shrink behavior of the pill.                                         |
 | `--pill-text-overflow`       | `ellipsis`                                | text-overflow    | How overflowing text is displayed (e.g., ellipsis or clip).               |
 | `--pill-hover-background`    | `var(--pill-background, #d0d0d0)`         | background-color | Background color when hovering over the pill.                             |
 | `--pill-hover-color`         | `var(--pill-color, #333333)`              | color            | Text color when hovering over the pill.                                   |

--- a/src/lib/ChatSuggestions/ChatSuggestions.svelte
+++ b/src/lib/ChatSuggestions/ChatSuggestions.svelte
@@ -1,31 +1,100 @@
 <script lang="ts">
   import Pill from '../Pill/Pill.svelte';
+  import Img from '../Img/Img.svelte';
+  import Scroller from '../Scroller/Scroller.svelte';
   import type { ChatSuggestion, ChatSuggestionsProperties } from './properties';
 
-  let { items, disabled = false, onselect, testId, classes }: ChatSuggestionsProperties = $props();
+  let {
+    items,
+    disabled = false,
+    layout = 'wrap',
+    direction = 'horizontal',
+    maxVisible,
+    loading = false,
+    icon,
+    chipClasses,
+    onselect,
+    testId,
+    classes
+  }: ChatSuggestionsProperties = $props();
 
-  function labelOf(item: ChatSuggestion): string {
-    return typeof item === 'string' ? item : item.label;
-  }
+  const labelOf = (item: ChatSuggestion): string => (typeof item === 'string' ? item : item.label);
 
-  function valueOf(item: ChatSuggestion): string {
+  const valueOf = (item: ChatSuggestion): string => {
     if (typeof item === 'string') {
       return item;
     }
     return item.value ?? item.label;
-  }
+  };
+
+  const iconOf = (item: ChatSuggestion): string | null =>
+    typeof item === 'string' ? null : (item.icon ?? null);
+
+  // The dispatched value is usually a longer phrasing of the label, so it doubles as
+  // the hover text. Suppressed when they are the same, to avoid a tooltip that just
+  // repeats the chip.
+  const hintOf = (item: ChatSuggestion): string | null => {
+    if (typeof item === 'string') {
+      return null;
+    }
+    if (typeof item.hint === 'string') {
+      return item.hint;
+    }
+    return typeof item.value === 'string' && item.value !== item.label ? item.value : null;
+  };
+
+  // Clamped so a negative limit means "show nothing", not slice-from-the-end.
+  let shown = $derived(
+    typeof maxVisible === 'number' ? items.slice(0, Math.max(0, maxVisible)) : items
+  );
 </script>
+
+{#snippet chips()}
+  {#each shown as item, index (index)}
+    {@const resolvedIcon = iconOf(item)}
+    <button
+      type="button"
+      class="chip {chipClasses ?? ''}"
+      title={hintOf(item)}
+      {disabled}
+      onclick={() => onselect?.(valueOf(item), index)}
+    >
+      <Pill text={labelOf(item)} {disabled}>
+        {#snippet leadingIcon()}
+          {#if typeof icon === 'function'}
+            {@render icon(resolvedIcon, index)}
+          {:else if typeof resolvedIcon === 'string'}
+            <Img src={resolvedIcon} alt="" fallback="" inlineSvg={true} />
+          {/if}
+        {/snippet}
+      </Pill>
+    </button>
+  {/each}
+{/snippet}
 
 <div
   class="chat-suggestions {classes ?? ''}"
+  class:vertical={direction === 'vertical'}
+  class:loading
   data-pw={typeof testId === 'string' ? testId : null}
   testID={typeof testId === 'string' ? testId : null}
 >
-  {#each items as item, index (index)}
-    <div class="chip">
-      <Pill text={labelOf(item)} {disabled} onclick={() => onselect?.(valueOf(item), index)} />
-    </div>
-  {/each}
+  {#if !loading}
+    {#if layout === 'scroll'}
+      <Scroller
+        {direction}
+        showArrows={false}
+        showGradient={false}
+        hideScrollbar={true}
+        dragToScroll={true}
+        classes="chat-suggestions-scroller"
+      >
+        {@render chips()}
+      </Scroller>
+    {:else}
+      {@render chips()}
+    {/if}
+  {/if}
 </div>
 
 <style>
@@ -39,8 +108,46 @@
     padding: var(--chat-suggestions-padding, 0);
   }
 
+  /* A vertical stack is a menu, not a chip row: each entry takes the full width so
+     the labels align, which is what makes a long list scannable. */
+  .chat-suggestions.vertical {
+    flex-direction: column;
+    align-items: var(--chat-suggestions-vertical-align-items, stretch);
+  }
+
+  .chat-suggestions.vertical .chip {
+    width: var(--chat-suggestions-vertical-chip-width, 100%);
+    --pill-width: 100%;
+    --pill-justify-content: flex-start;
+    --pill-text-align: left;
+  }
+
   .chip {
+    appearance: none;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: inherit;
+    text-align: inherit;
+    cursor: pointer;
     display: flex;
+    /* A chip must never be wider than the row that holds it. Pills are content-sized
+       and never wrap their label, so a long one spilled past the right edge —
+       measured, four chips overflowed an 80px container.
+       max-width alone is not enough: a flex item's min-width is auto, so it refuses
+       to shrink below its content. min-width:0 lets it, and capping --pill-max-width
+       hands the overflow to Pill's own ellipsis. */
+    min-width: 0;
+    max-width: 100%;
+    --pill-max-width: 100%;
+    --pill-flex-shrink: 1;
     --pill-cursor: pointer;
+  }
+
+  /* The Pill is itself a flex item, and its own min-width:auto is the last thing
+     holding the label at full width. Zeroing it is what actually lets the ellipsis run. */
+  .chip > :global(.pill) {
+    min-width: 0;
   }
 </style>

--- a/src/lib/ChatSuggestions/properties.ts
+++ b/src/lib/ChatSuggestions/properties.ts
@@ -1,4 +1,34 @@
-export type ChatSuggestion = string | { label: string; value?: string };
+import type { Snippet } from 'svelte';
+
+/**
+ * A suggestion chip.
+ *
+ * `label` is what the merchant reads; `value` is what gets dispatched. They are
+ * separate because a short call-to-action ("Refund trends") usually stands in for
+ * a much longer query, and sending the label would send the wrong thing.
+ */
+export type ChatSuggestion =
+  | string
+  | {
+      label: string;
+      value?: string;
+      /** Leading mark for the chip — an image or SVG *URL* (rendered via Img with
+       * inlineSvg). For raw markup or custom rendering, use the `icon` snippet. */
+      icon?: string;
+      /** Hover/long-press text. Defaults to `value` when that differs from `label`. */
+      hint?: string;
+    };
+
+/**
+ * How the chips are arranged.
+ *
+ * `wrap` flows them onto as many lines as needed — right for a roomy panel.
+ * `scroll` keeps them on one line inside a draggable scroller — right for a
+ * composer on a phone, where wrapping would push the input off-screen.
+ */
+export type ChatSuggestionsLayout = 'wrap' | 'scroll';
+
+export type ChatSuggestionsDirection = 'horizontal' | 'vertical';
 
 export type ChatSuggestionsProperties = OptionalChatSuggestionsProperties &
   ChatSuggestionsEventProperties &
@@ -10,8 +40,28 @@ export type MandatoryChatSuggestionsProperties = {
 
 export type OptionalChatSuggestionsProperties = {
   disabled?: boolean;
+  layout?: ChatSuggestionsLayout;
+  direction?: ChatSuggestionsDirection;
+  /** Render at most this many chips. Omit to render every item. */
+  maxVisible?: number;
+  /**
+   * Suppresses the whole row without unmounting it — for the window between asking
+   * and answering, where stale suggestions would invite a second wrong question.
+   */
+  loading?: boolean;
+  /** Custom mark per chip; receives the item's resolved icon string, or null. */
+  icon?: Snippet<[string | null, number]>;
   testId?: string;
   classes?: string;
+  /**
+   * Class string placed on EVERY chip wrapper.
+   *
+   * A consuming app usually keeps its chip appearance in a central stylesheet keyed on
+   * its own class name. Without a hook the library's own wrapper is the only thing in
+   * the tree, those central rules never match, and the chips silently fall back to the
+   * library's neutral defaults — which is a regression, not a theme.
+   */
+  chipClasses?: string;
 };
 
 export type ChatSuggestionsEventProperties = {

--- a/src/lib/Pill/Pill.svelte
+++ b/src/lib/Pill/Pill.svelte
@@ -81,6 +81,12 @@
   .pill {
     display: inline-flex;
     align-items: center;
+    /* A pill is content-width by default. A caller stacking pills into a menu needs
+       them to fill the column and align their labels left, which is a layout choice
+       the call site owns — hence tokens rather than a variant. */
+    width: var(--pill-width, auto);
+    justify-content: var(--pill-justify-content, center);
+    text-align: var(--pill-text-align, center);
     gap: var(--pill-gap, 4px);
     background-color: var(--pill-background, #e0e0e0);
     color: var(--pill-color, #333333);

--- a/src/routes/components/chat-suggestions/+page.svelte
+++ b/src/routes/components/chat-suggestions/+page.svelte
@@ -1,7 +1,36 @@
 <script lang="ts">
   import ChatSuggestions from '$lib/ChatSuggestions/ChatSuggestions.svelte';
+  // `icon` is a URL — Img fetches it. Raw SVG markup in this slot becomes a
+  // bogus relative link that the prerenderer reports as a 404.
+  import sparkIcon from '$lib/assets/chat.svg?url';
 
   let picked = $state('');
+  let events = $state<string[]>([]);
+  const record = (value: string, index: number) => {
+    picked = value;
+    events = [...events, `${index}:${value}`];
+  };
+
+  // A short chip standing in for a much longer query — the case `label`/`value`
+  // exists for. The value becomes the hover text automatically.
+  const analytics = [
+    {
+      label: 'Refund trends',
+      value: 'Show me refund trends for the last 30 days',
+      icon: sparkIcon
+    },
+    {
+      label: 'Top products',
+      value: 'What are my top selling products this month?',
+      icon: sparkIcon
+    },
+    {
+      label: 'Checkout drop-off',
+      value: 'Where are customers abandoning checkout?',
+      icon: sparkIcon
+    },
+    { label: 'COD share', value: 'What share of my orders are cash on delivery?', icon: sparkIcon }
+  ];
 </script>
 
 <div class="page-header">
@@ -9,12 +38,45 @@
   <h1>ChatSuggestions</h1>
 </div>
 
+<h2>Default — wrap</h2>
 <div class="demo-row">
   <ChatSuggestions
     items={['Recommend a gift', 'Track my order', 'Return policy?', 'Talk to a human']}
-    onselect={(value) => (picked = value)}
+    onselect={record}
   />
 </div>
+
+<h2>Leading icons, and a value longer than the label</h2>
+<div class="demo-row">
+  <ChatSuggestions items={analytics} onselect={record} />
+</div>
+
+<h2>maxVisible — cap a long list</h2>
+<div class="demo-row">
+  <ChatSuggestions items={analytics} maxVisible={2} onselect={record} />
+</div>
+
+<h2>layout="scroll" — one draggable line, for a composer on a phone</h2>
+<div class="demo-row" style="max-width: 380px;">
+  <ChatSuggestions items={analytics} layout="scroll" onselect={record} />
+</div>
+
+<h2>direction="vertical" — a full-width menu</h2>
+<div class="demo-row" style="max-width: 380px;">
+  <ChatSuggestions items={analytics} direction="vertical" onselect={record} />
+</div>
+
+<h2>loading — chips hidden while the answer is still coming</h2>
+<div class="demo-row">
+  <ChatSuggestions items={analytics} loading={true} onselect={record} />
+</div>
+
+<h2>chipClasses — a consumer's own class on every chip</h2>
+<div class="demo-row">
+  <ChatSuggestions items={analytics} chipClasses="demo-chip-hook" onselect={record} />
+</div>
+
+<p class="demo-note" data-pw="event-log">events: {events.join(' | ')}</p>
 
 {#if picked.length > 0}
   <p class="demo-note">Selected: {picked}</p>

--- a/src/wc/components/ChatSuggestions.wc.svelte
+++ b/src/wc/components/ChatSuggestions.wc.svelte
@@ -5,8 +5,13 @@
     props: {
       items: { type: 'Object' },
       disabled: { type: 'Boolean', reflect: true },
+      layout: { type: 'String' },
+      direction: { type: 'String' },
+      maxVisible: { type: 'Number', attribute: 'max-visible' },
+      loading: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
+      chipClasses: { type: 'String', attribute: 'chip-classes' },
       onselect: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
## What

Extends **ChatSuggestions** so hosts with structured suggestion data can adopt it without hand-rolling a chip row:

- Structured items (`cta` + `query`) alongside plain strings; `icon` snippet and `hint` support.
- `layout` (`wrap` / `scroll` via the library Scroller) and `direction` (`horizontal` / `vertical`).
- `maxVisible` clipping and a `loading` state.
- `chipClasses` pass-through so a host's central stylesheet can key chip appearance without the library hardcoding app classes.
- **Pill**: adds the missing `--pill-width`, `--pill-justify-content`, `--pill-text-align` custom properties, and `min-width: 0` so `--pill-max-width` + ellipsis actually take effect below ~140px containers.

## Why

Lighthouse's RecommendationsBar duplicated all of this; with these hooks it collapses to a thin adapter (150 → 68 lines) at pixel parity.

## Verification

- Adopted in Lighthouse: chip row pixel-identical in the 80/80 parity matrix; five-pass measured audit (assets/structure, interactions, keyboard/hover/a11y, both themes, responsive incl. sub-240px widths).
- Demo route covers all six variants including vertical and loading.
- `pnpm run lint` and `pnpm run check` green; rebased onto 2.126.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat suggestions now support scrollable or wrapping layouts, horizontal or vertical direction, loading states, item limits, icons, hover hints, and custom chip styling.
  - Long labels are handled more cleanly with truncation and improved vertical layouts.
  - Custom elements now expose layout, direction, visibility limit, and loading options.
  - Pills support configurable width and text alignment.

- **Documentation**
  - Updated Chat Suggestions and Pill documentation with new properties, layouts, item options, and styling variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->