### PR TITLE
feat: add SpeechToTextController — a headless speech-to-text engine for chat composers

### DIFF
--- a/docs/SpeechToText.md
+++ b/docs/SpeechToText.md
@@ -1,0 +1,78 @@
+# SpeechToText
+
+Headless speech-to-text controller over the browser's non-standard `SpeechRecognition` API. It owns the whole lifecycle a mic button needs — support detection, a one-shot host permission hook, start-with-retry, interim/final transcript assembly, and a self-hiding error toast — and exposes reactive fields plus callbacks. It renders nothing: pair it with `ChatComposer`'s voice control (`recording`, `onvoice`), or any UI of your own.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { ChatComposer, SpeechToTextController } from '@juspay/svelte-ui-components';
+
+  let committed = $state('');
+  const stt = new SpeechToTextController({
+    seedTranscript: () => committed,
+    onTranscript: (transcript) => {
+      committed = transcript;
+    }
+  });
+  let value = $derived(stt.listening ? stt.interimText : committed);
+</script>
+
+<ChatComposer
+  bind:value
+  recording={stt.listening}
+  oninput={(typed) => {
+    committed = typed;
+  }}
+  onvoice={() => stt.toggle()}
+/>
+{#if stt.errorVisible}
+  <p role="alert">{stt.errorMessage}</p>
+{/if}
+```
+
+Call `initialize()` eagerly (e.g. in `onMount`) when you want support detection before the first tap; otherwise `start()`/`toggle()` initialize lazily. Call `destroy()` on teardown.
+
+## Reactive fields
+
+| Field          | Type      | Description                                                                    |
+| -------------- | --------- | ------------------------------------------------------------------------------ |
+| `listening`    | `boolean` | True between the notified start and end of a listening session.                |
+| `interimText`  | `string`  | Committed transcript plus the current interim guess — what a composer shows while listening. |
+| `errorMessage` | `string`  | The current user-facing error.                                                 |
+| `errorVisible` | `boolean` | Toast visibility; auto-clears after `errorTimeoutMs` (default 4000ms).         |
+| `supported`    | `boolean` | Whether a recognition constructor was found (set by `initialize`).             |
+
+## Methods
+
+| Method         | Description                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| `initialize()` | Detects the API and builds a wired instance. Safe to call again to rebuild after a failure.       |
+| `start()`      | Starts listening; retries once through a re-init if the underlying `start()` throws.              |
+| `stop()`       | Stops listening and notifies.                                                                     |
+| `toggle()`     | The mic-button handler: stops when listening, otherwise runs the permission gate and starts.      |
+| `destroy()`    | Clears the toast timer and aborts/tears down the recognition instance.                            |
+
+## Options
+
+| Option                      | Type                                                     | Default            | Description                                                                                             |
+| --------------------------- | -------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------- |
+| `lang`                      | `string`                                                 | `'en-US'`          | Recognition language.                                                                                    |
+| `continuous`                | `boolean`                                                | `false`            | Keep listening across pauses.                                                                            |
+| `interimResults`            | `boolean`                                                | `true`             | Emit interim guesses.                                                                                    |
+| `errorTimeoutMs`            | `number`                                                 | `4000`             | Toast auto-hide delay.                                                                                   |
+| `errorMessages`             | `Record<string, string>`                                 | built-in map       | Per-recognition-error-code copy, merged over the defaults (`not-allowed`, `no-speech`, `network`, …).    |
+| `messages`                  | `Partial<SpeechToTextMessages>`                          | built-in copy      | Overrides for the non-code messages (unsupported, init failure, permission denial, …).                   |
+| `getRecognitionConstructor` | `() => SpeechRecognitionConstructor \| null`             | reads `window`     | Injectable constructor source — the seam for tests, demos, and non-browser hosts.                        |
+| `requestPermission`         | `() => Promise<SpeechPermissionResult> \| null`          | `-`                | Host permission hook (e.g. a native shell's mic bridge). Return `null` to mean "no bridge here". Asked at most once; a denial is remembered. |
+| `seedTranscript`            | `() => string`                                           | `-`                | Text the transcript starts from when listening begins (e.g. the composer's current value).               |
+| `onTranscript`              | `(transcript: string) => void`                           | `-`                | Fires with the accumulated transcript each time a final result lands.                                    |
+| `onListeningChange`         | `(listening: boolean) => void`                           | `-`                | Fires on notified start/stop.                                                                            |
+| `onError`                   | `(message: string, code: string \| null) => void`        | `-`                | Fires whenever the toast is shown; `code` is the recognition error code when there is one.               |
+| `onDiagnostic`              | `(event: string, detail: Record<string, string \| number \| boolean \| null>) => void` | `-` | Non-fatal internals worth logging; wire to your telemetry.                                               |
+
+## Notes
+
+- The controller is UI-free by design: hosts keep their own toast markup, recording ring, and composer wiring.
+- `SpeechRecognitionLike` (exported) is the reduced API surface the controller drives — implement it to fake the engine in tests.
+- The permission hook models a native-shell bridge: availability is re-checked per attempt (return `null` when absent), the request itself happens at most once, and a resolved denial short-circuits later attempts with `permissionPreviouslyDenied`.

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -320,6 +320,10 @@
     "description": "An auto-growing message input with a send button (the Button component). Enter submits, Shift+Enter inserts a newline (IME-safe); clears on submit. Opt-in controls light up when you wire a callback: `onattach` adds a file picker with removable attachment chips (bindable `attachments`), `onvoice` adds a mic button (with `recording` state), and `streaming` + `onstop` morph send into a stop button. Every icon is snippet-overridable."
   },
   {
+    "name": "SpeechToText",
+    "description": "Headless speech-to-text controller over the browser SpeechRecognition API: support detection, one-shot host permission hook, start-with-retry, interim/final transcript assembly, and a self-hiding error toast. Renders nothing; pair with ChatComposer's voice control."
+  },
+  {
     "name": "ChatSuggestions",
     "description": "A row of tappable prompt chips (the Pill component), typically shown on an empty conversation. Each item is a string or `{ label, value }`; selecting a chip fires `onselect` with the value and index."
   },

--- a/src/lib/SpeechToText/controller.svelte.ts
+++ b/src/lib/SpeechToText/controller.svelte.ts
@@ -1,0 +1,349 @@
+import type {
+  SpeechRecognitionConstructor,
+  SpeechRecognitionErrorEvent,
+  SpeechRecognitionLike,
+  SpeechRecognitionResultEvent,
+  SpeechToTextMessages,
+  SpeechToTextOptions
+} from './types';
+
+const DEFAULT_ERROR_MESSAGES: Record<string, string> = {
+  'not-allowed':
+    'Microphone access is blocked. Allow microphone access in your browser settings to use voice input.',
+  'service-not-allowed':
+    'Microphone access is blocked. Allow microphone access in your browser settings to use voice input.',
+  'no-speech': 'No speech detected. Please speak closer to your microphone and try again.',
+  'audio-capture': 'No microphone found. Please connect a microphone and try again.',
+  network: 'A network error interrupted voice input. Please check your connection and try again.'
+};
+
+const DEFAULT_MESSAGES: SpeechToTextMessages = {
+  unsupported: 'Speech recognition not supported in this browser.',
+  initFailed: 'Failed to initialize speech recognition service.',
+  startFailed: 'Recognition service could not be initialized for starting.',
+  startRetryFailedPrefix: 'Failed to start speech recognition even after retry: ',
+  fallback: 'Could not start voice input. Please try again.',
+  permissionDenied: 'Microphone permission denied.',
+  permissionPreviouslyDenied: 'Microphone permission was previously denied.',
+  permissionRequestFailed: 'Failed to request microphone permission.'
+};
+
+const DEFAULT_ERROR_TIMEOUT_MS = 4000;
+
+type SpeechCapableWindow = Window & {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+};
+
+function defaultRecognitionConstructor(): SpeechRecognitionConstructor | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const speechWindow: SpeechCapableWindow = window;
+  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition ?? null;
+}
+
+function errorName(raw: unknown): string {
+  return raw instanceof Error ? raw.name : 'UnknownError';
+}
+
+function errorDetail(raw: unknown): string {
+  return raw instanceof Error ? raw.message : String(raw);
+}
+
+function permissionRejectionDetail(raw: unknown): string | null {
+  if (
+    typeof raw === 'object' &&
+    raw !== null &&
+    'error' in raw &&
+    typeof raw.error === 'string' &&
+    raw.error.length > 0
+  ) {
+    return raw.error;
+  }
+  if (raw instanceof Error && raw.message.length > 0) {
+    return raw.message;
+  }
+  return null;
+}
+
+/**
+ * Headless speech-to-text over the browser's SpeechRecognition API. Owns the whole
+ * lifecycle a mic button needs — support detection, a one-shot host permission hook,
+ * start-with-retry, interim/final transcript assembly, and a self-hiding error toast —
+ * and exposes it as reactive fields plus callbacks. Rendering stays entirely with the
+ * host; pair it with ChatComposer's voice control (`recording`, `onvoice`).
+ */
+export class SpeechToTextController {
+  /** True between the notified start and end of a listening session. */
+  listening = $state(false);
+  /** Committed transcript plus the current interim guess; what a composer shows while listening. */
+  interimText = $state('');
+  errorMessage = $state('');
+  errorVisible = $state(false);
+  supported = $state(false);
+
+  private readonly options: SpeechToTextOptions;
+  private readonly messages: SpeechToTextMessages;
+  private readonly errorMessages: Record<string, string>;
+  private recognition: SpeechRecognitionLike | null = null;
+  // Bumped per initialize(); handlers captured by a discarded instance compare
+  // against it so a late onend/onerror from the old engine cannot end the new
+  // session (start() rebuilds the instance on its retry path).
+  private instanceGeneration = 0;
+  private transcript = '';
+  private internalListening = false;
+  private everInitialized = false;
+  private errorTimer: ReturnType<typeof setTimeout> | null = null;
+  private permissionRequested = false;
+  private permissionGranted: boolean | null = null;
+
+  constructor(options: SpeechToTextOptions = {}) {
+    this.options = options;
+    this.messages = { ...DEFAULT_MESSAGES, ...options.messages };
+    this.errorMessages = { ...DEFAULT_ERROR_MESSAGES, ...options.errorMessages };
+  }
+
+  /**
+   * Detects the API and builds a wired recognition instance. Safe to call again
+   * to rebuild after a failure; `start` calls it lazily if the host never did.
+   */
+  initialize(): boolean {
+    this.everInitialized = true;
+    const getConstructor = this.options.getRecognitionConstructor ?? defaultRecognitionConstructor;
+    const RecognitionApi = getConstructor();
+    this.supported = RecognitionApi !== null;
+    if (RecognitionApi === null) {
+      this.recognition = null;
+      return false;
+    }
+    try {
+      const instance = new RecognitionApi();
+      this.instanceGeneration += 1;
+      const generation = this.instanceGeneration;
+      const isCurrent = (): boolean => generation === this.instanceGeneration;
+      instance.continuous = this.options.continuous ?? false;
+      instance.interimResults = this.options.interimResults ?? true;
+      instance.lang = this.options.lang ?? 'en-US';
+      instance.onstart = () => {
+        if (isCurrent()) {
+          this.handleStart();
+        }
+      };
+      instance.onresult = (event) => {
+        if (isCurrent()) {
+          this.handleResult(event);
+        }
+      };
+      instance.onerror = (event) => {
+        if (isCurrent()) {
+          this.handleRecognitionError(event);
+        }
+      };
+      instance.onend = () => {
+        if (isCurrent()) {
+          this.handleEnd();
+        }
+      };
+      this.recognition = instance;
+      return true;
+    } catch (error) {
+      this.supported = false;
+      this.recognition = null;
+      this.diagnose('initializeFailed', { error: errorDetail(error) });
+      this.showError(this.messages.initFailed);
+      return false;
+    }
+  }
+
+  start(): void {
+    if (!this.everInitialized) {
+      this.initialize();
+    }
+    if (!this.supported) {
+      this.showError(this.messages.unsupported);
+      return;
+    }
+    if (this.recognition === null && !this.initialize()) {
+      return;
+    }
+    this.attemptStart(false);
+  }
+
+  stop(): void {
+    if (this.internalListening) {
+      this.internalListening = false;
+      this.setListening(false);
+    }
+    if (this.recognition !== null) {
+      this.recognition.stop();
+    }
+  }
+
+  /**
+   * The mic-button handler: stops when listening, otherwise runs the permission
+   * gate (at most one proactive host request, denial remembered) and starts.
+   */
+  async toggle(): Promise<void> {
+    if (this.internalListening) {
+      this.stop();
+      return;
+    }
+    const requestPermission = this.options.requestPermission ?? null;
+    if (requestPermission === null) {
+      this.start();
+      return;
+    }
+    if (this.permissionRequested) {
+      if (this.permissionGranted === false) {
+        this.showError(this.messages.permissionPreviouslyDenied);
+      } else {
+        this.start();
+      }
+      return;
+    }
+    const pending = requestPermission();
+    if (pending === null) {
+      this.start();
+      return;
+    }
+    this.permissionRequested = true;
+    try {
+      const result = await pending;
+      this.permissionGranted = result.granted;
+      if (result.granted) {
+        this.start();
+      } else {
+        const denialMessage =
+          typeof result.error === 'string' && result.error.length > 0
+            ? result.error
+            : this.messages.permissionDenied;
+        this.showError(denialMessage);
+      }
+    } catch (error) {
+      this.permissionGranted = false;
+      this.showError(permissionRejectionDetail(error) ?? this.messages.permissionRequestFailed);
+    }
+  }
+
+  /** Clears the toast timer and tears the recognition instance down. */
+  destroy(): void {
+    if (this.errorTimer !== null) {
+      clearTimeout(this.errorTimer);
+      this.errorTimer = null;
+    }
+    if (this.recognition !== null) {
+      try {
+        this.recognition.abort();
+      } catch (abortError) {
+        this.diagnose('recognitionAbortErrorOnDestroy', { error: errorDetail(abortError) });
+      }
+      this.recognition = null;
+    }
+    this.internalListening = false;
+    // abort() is not guaranteed to fire onend, so clear the public state too —
+    // a consumer's recording indicator must not survive teardown.
+    if (this.listening) {
+      this.setListening(false);
+    }
+  }
+
+  private attemptStart(isRetry: boolean): void {
+    if (this.recognition === null) {
+      this.showError(this.messages.startFailed);
+      this.internalListening = false;
+      this.setListening(false);
+      return;
+    }
+    try {
+      this.internalListening = true;
+      this.errorMessage = '';
+      this.errorVisible = false;
+      this.recognition.start();
+    } catch (error) {
+      if (!isRetry) {
+        try {
+          this.recognition.abort();
+        } catch (abortError) {
+          this.diagnose('recognitionAbortErrorOnRetry', {
+            error: errorDetail(abortError),
+            rawError: String(abortError)
+          });
+        }
+        if (this.initialize()) {
+          this.attemptStart(true);
+        } else {
+          this.internalListening = false;
+          this.setListening(false);
+        }
+      } else {
+        this.showError(
+          `${this.messages.startRetryFailedPrefix}${errorName(error)} - ${errorDetail(error)}`
+        );
+        this.internalListening = false;
+        this.setListening(false);
+      }
+    }
+  }
+
+  private handleStart(): void {
+    this.transcript = this.options.seedTranscript ? this.options.seedTranscript() : '';
+    this.interimText = this.transcript;
+    this.internalListening = true;
+    this.setListening(true);
+  }
+
+  private handleResult(event: SpeechRecognitionResultEvent): void {
+    let finalTranscript = '';
+    let currentInterimTranscript = '';
+
+    for (let index = event.resultIndex; index < event.results.length; index += 1) {
+      const result = event.results[index];
+      if (result.isFinal) {
+        finalTranscript += result[0].transcript;
+      } else {
+        currentInterimTranscript += result[0].transcript;
+      }
+    }
+
+    this.interimText =
+      this.transcript + (currentInterimTranscript ? ' ' + currentInterimTranscript : '');
+    if (finalTranscript) {
+      this.transcript = this.transcript ? `${this.transcript.trimEnd()} ` : '';
+      this.transcript += finalTranscript;
+      this.options.onTranscript?.(this.transcript);
+    }
+  }
+
+  private handleRecognitionError(event: SpeechRecognitionErrorEvent): void {
+    this.internalListening = false;
+    this.setListening(false);
+    this.showError(this.errorMessages[event.error] ?? this.messages.fallback, event.error);
+  }
+
+  private handleEnd(): void {
+    this.internalListening = false;
+    this.setListening(false);
+  }
+
+  private setListening(listening: boolean): void {
+    this.listening = listening;
+    this.options.onListeningChange?.(listening);
+  }
+
+  private showError(message: string, code: string | null = null): void {
+    this.errorMessage = message;
+    this.errorVisible = true;
+    if (this.errorTimer !== null) {
+      clearTimeout(this.errorTimer);
+    }
+    this.errorTimer = setTimeout(() => {
+      this.errorVisible = false;
+    }, this.options.errorTimeoutMs ?? DEFAULT_ERROR_TIMEOUT_MS);
+    this.options.onError?.(message, code);
+  }
+
+  private diagnose(event: string, detail: Record<string, string | number | boolean | null>): void {
+    this.options.onDiagnostic?.(event, detail);
+  }
+}

--- a/src/lib/SpeechToText/types.ts
+++ b/src/lib/SpeechToText/types.ts
@@ -1,0 +1,83 @@
+export type SpeechRecognitionAlternative = {
+  transcript: string;
+};
+
+export type SpeechRecognitionResultItem = {
+  0: SpeechRecognitionAlternative;
+  isFinal: boolean;
+};
+
+export type SpeechRecognitionResultEvent = {
+  resultIndex: number;
+  results: SpeechRecognitionResultItem[];
+};
+
+export type SpeechRecognitionErrorEvent = {
+  error: string;
+};
+
+/**
+ * The browser's non-standard SpeechRecognition surface, reduced to the members the
+ * controller drives. lib.dom does not declare the API, so the shape lives here and
+ * a fake implementing it can be injected for tests and demos.
+ */
+export type SpeechRecognitionLike = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+  onstart: () => void;
+  onresult: (event: SpeechRecognitionResultEvent) => void;
+  onerror: (event: SpeechRecognitionErrorEvent) => void;
+  onend: () => void;
+};
+
+export type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
+
+export type SpeechPermissionResult = {
+  granted: boolean;
+  error?: string;
+};
+
+/** User-facing copy the controller emits outside the per-error-code map. */
+export type SpeechToTextMessages = {
+  unsupported: string;
+  initFailed: string;
+  startFailed: string;
+  startRetryFailedPrefix: string;
+  fallback: string;
+  permissionDenied: string;
+  permissionPreviouslyDenied: string;
+  permissionRequestFailed: string;
+};
+
+export type SpeechToTextOptions = {
+  lang?: string;
+  continuous?: boolean;
+  interimResults?: boolean;
+  /** How long an error toast stays visible. */
+  errorTimeoutMs?: number;
+  /** Per-recognition-error-code messages, merged over the built-in map. */
+  errorMessages?: Record<string, string>;
+  /** Copy overrides, merged over the built-in defaults. */
+  messages?: Partial<SpeechToTextMessages>;
+  /** Resolves the recognition constructor; defaults to the browser's. Injectable for tests. */
+  getRecognitionConstructor?: () => SpeechRecognitionConstructor | null;
+  /**
+   * Host permission hook (e.g. a native shell's microphone bridge). Called on a start
+   * attempt; return null to mean "no bridge here", which falls through to the standard
+   * browser flow without consuming the single proactive request. A resolved denial is
+   * remembered and short-circuits later attempts.
+   */
+  requestPermission?: () => Promise<SpeechPermissionResult> | null;
+  /** Text the transcript starts from when listening begins (e.g. the composer's current value). */
+  seedTranscript?: () => string;
+  /** Fires with the accumulated transcript each time a final result lands. */
+  onTranscript?: (transcript: string) => void;
+  onListeningChange?: (listening: boolean) => void;
+  onError?: (message: string, code: string | null) => void;
+  /** Non-fatal internals worth logging; hosts wire this to their telemetry. */
+  onDiagnostic?: (event: string, detail: Record<string, string | number | boolean | null>) => void;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -89,6 +89,7 @@ export { default as ChatBubble } from './ChatBubble/ChatBubble.svelte';
 export { default as Resizable } from './Resizable/Resizable.svelte';
 export { ChatController } from './Chat/controller.svelte';
 export { partyOf } from './Chat/roles';
+export { SpeechToTextController } from './SpeechToText/controller.svelte';
 
 export type * from './Button/properties';
 export type * from './Modal/properties';
@@ -167,6 +168,7 @@ export type * from './_chart/highlight';
 
 export type * from './Chat/properties';
 export type * from './Chat/types';
+export type * from './SpeechToText/types';
 export type * from './ChatHeader/properties';
 export type * from './ChatMessage/properties';
 export type * from './ChatMessageList/properties';

--- a/src/routes/components/_nav.ts
+++ b/src/routes/components/_nav.ts
@@ -132,6 +132,7 @@ export const componentNav: NavGroup[] = [
       { name: 'ChatMessage', slug: 'chat-message' },
       { name: 'ChatMessageList', slug: 'chat-message-list' },
       { name: 'ChatComposer', slug: 'chat-composer' },
+      { name: 'SpeechToText', slug: 'speech-to-text' },
       { name: 'ChatHeader', slug: 'chat-header' },
       { name: 'ChatToolStatus', slug: 'chat-tool-status' },
       { name: 'ChatSuggestions', slug: 'chat-suggestions' },

--- a/src/routes/components/speech-to-text/+page.svelte
+++ b/src/routes/components/speech-to-text/+page.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import ChatComposer from '$lib/ChatComposer/ChatComposer.svelte';
+  import { SpeechToTextController } from '$lib/SpeechToText/controller.svelte';
+  import type {
+    SpeechRecognitionErrorEvent,
+    SpeechRecognitionResultEvent
+  } from '$lib/SpeechToText/types';
+
+  // A deterministic stand-in for the browser API so the demo (and any headless
+  // environment) exercises the full lifecycle without a microphone or network.
+  class SimulatedRecognition {
+    continuous = false;
+    interimResults = true;
+    lang = 'en-US';
+    onstart: () => void = () => {};
+    onresult: (event: SpeechRecognitionResultEvent) => void = () => {};
+    onerror: (event: SpeechRecognitionErrorEvent) => void = () => {};
+    onend: () => void = () => {};
+    private timers: ReturnType<typeof setTimeout>[] = [];
+
+    start(): void {
+      const emit = (delay: number, transcript: string, isFinal: boolean): void => {
+        this.timers.push(
+          setTimeout(() => {
+            this.onresult({ resultIndex: 0, results: [{ 0: { transcript }, isFinal }] });
+          }, delay)
+        );
+      };
+      this.timers.push(setTimeout(() => this.onstart(), 100));
+      emit(500, 'show me', false);
+      emit(1000, 'show me refund', false);
+      emit(1600, 'show me refund trends for last month', true);
+      this.timers.push(
+        setTimeout(() => {
+          this.onend();
+        }, 2100)
+      );
+    }
+
+    stop(): void {
+      this.clearTimers();
+      this.onend();
+    }
+
+    abort(): void {
+      this.clearTimers();
+    }
+
+    private clearTimers(): void {
+      for (const timer of this.timers) {
+        clearTimeout(timer);
+      }
+      this.timers = [];
+    }
+  }
+
+  let committed = $state('');
+  const simulated = new SpeechToTextController({
+    getRecognitionConstructor: () => SimulatedRecognition,
+    seedTranscript: () => committed,
+    onTranscript: (transcript) => {
+      committed = transcript;
+    },
+    onListeningChange: (listening) => {
+      if (!listening && simulated.interimText.length > committed.length) {
+        committed = simulated.interimText;
+      }
+    }
+  });
+  let simulatedValue = $derived(simulated.listening ? simulated.interimText : committed);
+
+  let browserCommitted = $state('');
+  const browserEngine = new SpeechToTextController({
+    seedTranscript: () => browserCommitted,
+    onTranscript: (transcript) => {
+      browserCommitted = transcript;
+    }
+  });
+  let browserValue = $derived(
+    browserEngine.listening ? browserEngine.interimText : browserCommitted
+  );
+
+  // A host permission bridge that always denies: the first tap consumes the single
+  // proactive request, the second shows the remembered-denial message.
+  const denied = new SpeechToTextController({
+    getRecognitionConstructor: () => SimulatedRecognition,
+    requestPermission: () =>
+      Promise.resolve({ granted: false, error: 'Microphone permission denied by the host shell.' })
+  });
+
+  onDestroy(() => {
+    simulated.destroy();
+    browserEngine.destroy();
+    denied.destroy();
+  });
+</script>
+
+<div class="page-header">
+  <span class="category-badge">Chat</span>
+  <h1>SpeechToText</h1>
+</div>
+
+<p>
+  Headless controller for the browser's SpeechRecognition API: support detection, a one-shot host
+  permission hook, start-with-retry, interim/final transcript assembly, and a self-hiding error
+  toast. It renders nothing — pair it with ChatComposer's voice control.
+</p>
+
+<h2>Simulated engine — works everywhere</h2>
+<div class="demo-row">
+  <div class="composer-host">
+    <ChatComposer
+      bind:value={simulatedValue}
+      placeholder="Tap the mic — a scripted transcript streams in"
+      recording={simulated.listening}
+      oninput={(value) => {
+        committed = value;
+      }}
+      onvoice={() => simulated.toggle()}
+      onsubmit={() => {
+        committed = '';
+      }}
+    />
+    <p class="state-line">
+      listening: <code>{simulated.listening}</code> · interim:
+      <code>{simulated.interimText || '—'}</code>
+    </p>
+  </div>
+</div>
+
+<h2>Browser engine</h2>
+<div class="demo-row">
+  <div class="composer-host">
+    <ChatComposer
+      bind:value={browserValue}
+      placeholder="Uses the real microphone where the browser supports it"
+      recording={browserEngine.listening}
+      oninput={(value) => {
+        browserCommitted = value;
+      }}
+      onvoice={() => browserEngine.toggle()}
+      onsubmit={() => {
+        browserCommitted = '';
+      }}
+    />
+    {#if browserEngine.errorVisible}
+      <p class="state-line error" role="alert">{browserEngine.errorMessage}</p>
+    {/if}
+  </div>
+</div>
+
+<h2>Host permission bridge — denial is remembered</h2>
+<div class="demo-row">
+  <div class="composer-host">
+    <ChatComposer
+      value=""
+      placeholder="First tap asks the host once; the second reports the remembered denial"
+      recording={denied.listening}
+      onvoice={() => denied.toggle()}
+    />
+    {#if denied.errorVisible}
+      <p class="state-line error" role="alert">{denied.errorMessage}</p>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .composer-host {
+    width: min(36rem, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .state-line {
+    margin: 0;
+    font-size: 0.875rem;
+    opacity: 0.75;
+  }
+
+  .state-line.error {
+    color: #dc2626;
+    opacity: 1;
+  }
+</style>


### PR DESCRIPTION
## What

A headless, runes-reactive controller for the browser's non-standard `SpeechRecognition` API — the speech engine every chat composer needs and every app hand-rolls:

- Support detection with lazy/eager `initialize()`, and start-with-retry through a re-init when the underlying `start()` throws.
- One-shot host permission hook (`requestPermission`) modelling native-shell mic bridges: availability re-checked per attempt, the request made at most once, denial remembered.
- Interim/final transcript assembly seeded from the composer's current value (`seedTranscript`, `onTranscript`).
- Self-hiding error toast state with a per-error-code message map; every user-facing string overridable.
- `getRecognitionConstructor` injection seam — tests, demos, and headless CI run the full lifecycle without a microphone (the demo route ships a deterministic fake).
- Renders nothing: pairs with ChatComposer's voice control (`recording`, `onvoice`), reactive fields (`listening`, `interimText`, `errorMessage`, `errorVisible`, `supported`) drive the host UI.

## Why

Ports the engine folded inside Lighthouse's InputBar (originally a SpeechToText component) into the library, completing the composer's voice story: mic button (ChatComposer) + engine (this controller).

## Verification

- Adopted in Lighthouse: InputBar now wires this controller; a dedicated mocked E2E spec injects a fake recognition constructor and proves the real mic button streams interim text into the composer and commits the final transcript (part of a 32/32 sweep).
- Demo route exercises simulated engine, real browser engine, and the remembered-denial permission flow.
- `pnpm run lint` and `pnpm run check` green (0 errors); follows the ChatController runes-class precedent; rebased onto 2.126.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based speech-to-text voice input with microphone permission handling, transcript assembly, retry behavior, and error notifications.
  * Added configurable speech recognition options and lifecycle callbacks.
  * Added a speech-to-text component demo with simulated and browser microphone modes.
* **Documentation**
  * Added usage guidance, configuration details, and API reference for speech-to-text functionality.
  * Added the feature to the component documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->