### PR TITLE
feat(ChatBubble): decouple launcher width/height tokens for pill launchers

### DIFF
--- a/docs/ChatBubble.md
+++ b/docs/ChatBubble.md
@@ -123,6 +123,36 @@ Both launcher icons are snippets; provide your own for closed (`icon`) and open 
 </ChatBubble>
 ```
 
+The launcher is not limited to icons — a snippet can render an icon plus a text label to make
+a pill launcher. Set `--chat-bubble-width: fit-content` (and a capsule `--chat-bubble-border-radius`)
+so the button's width follows its content; `--chat-bubble-size` keeps governing the height:
+
+The launcher `Button` renders with `--button-content-gap: 0`, so a snippet with several
+children needs its own gap wrapper:
+
+```svelte
+<ChatBubble bind:open label="Ask Assistant" classes="assistant-pill">
+  {#snippet icon()}
+    <span class="pill-content"><MessageIcon /> Ask Assistant</span>
+  {/snippet}
+  <Chat {messages} bind:value {onsend} onclose={() => (open = false)} />
+</ChatBubble>
+
+<style>
+  :global(.assistant-pill) {
+    --chat-bubble-width: fit-content;
+    --chat-bubble-border-radius: 999px;
+    --chat-bubble-padding: 8px 20px;
+  }
+
+  :global(.assistant-pill .pill-content) {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+</style>
+```
+
 ## Snippets
 
 | Snippet  | Description                                                                          |
@@ -184,6 +214,8 @@ Reuses `Button` (the launcher) and `Resizable` (panel resizing). Its content is 
 | `--chat-bubble-offset-x`              | `24px`                                        | left/right    | Horizontal distance from the edge.|
 | `--chat-bubble-offset-y`              | `24px`                                        | top/bottom    | Vertical distance from the edge.  |
 | `--chat-bubble-size`                  | `56px`                                        | height/width  | Launcher button size.             |
+| `--chat-bubble-width`                 | `var(--chat-bubble-size, 56px)`               | width         | Launcher width alone — set to `fit-content` for a pill launcher whose width follows its content (e.g. icon + label) while `--chat-bubble-size` keeps the height. |
+| `--chat-bubble-height`                | `var(--chat-bubble-size, 56px)`               | height        | Launcher height alone, when it must differ from the width. |
 | `--chat-bubble-padding`               | `16px`                                        | padding       | Launcher icon padding.            |
 | `--chat-bubble-border-radius`         | `50%`                                         | border-radius | Launcher corner rounding.         |
 | `--chat-bubble-background-color`      | `#18181b`                                     | background    | Launcher background.              |

--- a/src/lib/ChatBubble/ChatBubble.svelte
+++ b/src/lib/ChatBubble/ChatBubble.svelte
@@ -386,8 +386,8 @@
   }
 
   .launcher {
-    --button-width: var(--chat-bubble-size, 56px);
-    --button-height: var(--chat-bubble-size, 56px);
+    --button-width: var(--chat-bubble-width, var(--chat-bubble-size, 56px));
+    --button-height: var(--chat-bubble-height, var(--chat-bubble-size, 56px));
     --button-padding: var(--chat-bubble-padding, 16px);
     --button-border-radius: var(--chat-bubble-border-radius, 50%);
     --button-color: var(--chat-bubble-background-color, #18181b);

--- a/src/routes/components/chat-bubble/+page.svelte
+++ b/src/routes/components/chat-bubble/+page.svelte
@@ -29,6 +29,7 @@
   let value = $state('');
   let open = $state(false);
   let expanded = $state(false);
+  let pillOpen = $state(false);
 </script>
 
 <div class="page-header">
@@ -38,9 +39,13 @@
 
 <p class="demo-note">
   A launcher pinned to the corner of the viewport opens a floating chat panel. Drag the bubble — it
-  snaps to the nearest screen edge on release (the default; pass <code>dragMode="free"</code> to keep
-  it where dropped). Resize the open panel from its inner edges, or use the button below to expand the
-  panel to a larger size with an animated scale-up.
+  snaps to the nearest screen edge on release (the default; pass <code>dragMode="free"</code> to
+  keep it where dropped). Resize the open panel from its inner edges, or use the button below to
+  expand the panel to a larger size with an animated scale-up. The bottom-left corner shows a
+  <strong>pill launcher</strong>: the <code>icon</code> snippet renders a label next to the glyph
+  and
+  <code>--chat-bubble-width: fit-content</code> lets the button's width follow its content while
+  <code>--chat-bubble-size</code> keeps governing the height.
 </p>
 
 <div class="expand-control">
@@ -49,6 +54,17 @@
     disabled={!open}
     onclick={() => (expanded = !expanded)}
   />
+</div>
+
+<div class="corner-pointers">
+  <p class="corner-pointer">
+    ↘ The <strong>circular launcher</strong> floats bottom-right — click it to open the chat panel, or
+    grab and drag it.
+  </p>
+  <p class="corner-pointer">
+    ↙ The <strong>pill launcher</strong> floats bottom-left — the new
+    <code>--chat-bubble-width: fit-content</code> shape.
+  </p>
 </div>
 
 <ChatBubble bind:open bind:expanded label="Open chat" draggable resizable classes="chat-theme">
@@ -64,6 +80,25 @@
     onstop={() => chat.stop()}
     onclose={() => (open = false)}
   />
+</ChatBubble>
+
+<ChatBubble
+  bind:open={pillOpen}
+  position="bottom-left"
+  label="Ask Assistant"
+  classes="pill-launcher"
+  testId="pill-launcher-bubble"
+>
+  {#snippet icon()}<span class="pill-launcher-content">💬 Ask Assistant</span>{/snippet}
+  {#snippet openIcon()}<span class="pill-launcher-content">✕ Close</span>{/snippet}
+  <div class="pill-panel">
+    <h3>Pill launcher</h3>
+    <p>
+      The launcher stays a real <code>Button</code>; only two CSS variables changed:
+      <code>--chat-bubble-width: fit-content</code> and a capsule
+      <code>--chat-bubble-border-radius</code>.
+    </p>
+  </div>
 </ChatBubble>
 
 <style>
@@ -82,5 +117,47 @@
     --button-disabled-background-color: var(--doc-btn-bg);
     --button-disabled-text-color: var(--doc-text-faint);
     --button-disabled-border: 1px solid var(--doc-btn-border);
+  }
+
+  .corner-pointers {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 24px;
+    padding: 12px 16px;
+    border: 1px dashed var(--doc-btn-border);
+    border-radius: var(--doc-radius);
+  }
+
+  .corner-pointer {
+    margin: 0;
+    color: var(--doc-text-secondary);
+  }
+
+  :global(.pill-launcher) {
+    --chat-bubble-width: fit-content;
+    --chat-bubble-border-radius: 999px;
+    --chat-bubble-padding: 8px 20px;
+  }
+
+  .pill-launcher-content {
+    white-space: nowrap;
+    font-size: 15px;
+  }
+
+  .pill-panel {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    padding: 20px;
+    overflow: auto;
+  }
+
+  .pill-panel h3 {
+    margin: 0 0 8px;
+  }
+
+  .pill-panel p {
+    margin: 0;
   }
 </style>


### PR DESCRIPTION
## What

`--chat-bubble-width` / `--chat-bubble-height` now override each launcher axis independently, both defaulting through `--chat-bubble-size` — existing consumers are byte-identical. Setting `--chat-bubble-width: fit-content` lets an icon-plus-label `icon` snippet render as a **pill launcher** (Button's own default width is `fit-content`; the launcher was pinning both axes to one size token).

## Why

A consumer (Lighthouse's Breeze Automatic co-pilot) replaces its hand-rolled FAB + drag + floating-panel shell with ChatBubble. Its launcher is an expanding "Ask Automatic" label pill — impossible while the launcher is pinned square. With this one gap closed, the adoption is a pure win: the consumer gains Escape-close, focus management and corner flipping its bespoke shell never had, at **−123 lines**.

## Evidence

- Demo gains a bottom-left pill-launcher variant (plus corner pointers in the page body so the fixed-position launchers are discoverable); docs gain the two token rows and a pill recipe.
- Reactive-drag performance measured on the demo bubble: scripted 2s drag, 122 frames, avg 16.66ms, p95 17.8ms, zero frames >20ms — Svelte 5's fine-grained `style:` directive patches only the attribute, so the old direct-DOM-transform rationale no longer applies.
- Consumer adoption verified live: collapsed 52px circle, hover pill expansion, free-drag drop, Escape-close through the host's store bridge.

Single commit per repository policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent width and height customization for the chat launcher.
  * Added support for pill-style launchers with customizable icons, padding, and corner radius.
  * Added an example of a bottom-left pill launcher with a custom panel.

* **Documentation**
  * Documented chat launcher sizing and pill-style customization options.
  * Added guidance for positioning launchers in different corners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->