### PR TITLE
fix: prefix demo media with the Pages base path so the static build prerenders

### DIFF
--- a/src/routes/components/chat-composer/+page.svelte
+++ b/src/routes/components/chat-composer/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import ChatComposer from '$lib/ChatComposer/ChatComposer.svelte';
 
   let value = $state('');
@@ -10,12 +11,12 @@
   // (onopenrich*) a host app would wire to its own preview surface.
   const photo = {
     id: 'img-1',
-    thumbnailData: '/demo-media/sunset-beach-thumb.jpg',
+    thumbnailData: `${base}/demo-media/sunset-beach-thumb.jpg`,
     filename: 'sunset-beach.jpg'
   };
   const clip = {
     id: 'vid-1',
-    thumbnailData: '/demo-media/promo-clip-poster.jpg',
+    thumbnailData: `${base}/demo-media/promo-clip-poster.jpg`,
     filename: 'promo-clip.mp4'
   };
 
@@ -87,10 +88,10 @@
         </button>
       </figcaption>
       {#if preview.kind === 'image'}
-        <img class="lightbox-media" src="/demo-media/sunset-beach.jpg" alt={preview.title} />
+        <img class="lightbox-media" src="{base}/demo-media/sunset-beach.jpg" alt={preview.title} />
       {:else}
         <!-- svelte-ignore a11y_media_has_caption -->
-        <video class="lightbox-media" src="/demo-media/promo-clip.mp4" controls autoplay loop
+        <video class="lightbox-media" src="{base}/demo-media/promo-clip.mp4" controls autoplay loop
         ></video>
       {/if}
     </figure>

--- a/src/routes/components/chat-header/+page.svelte
+++ b/src/routes/components/chat-header/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import ChatHeader from '$lib/ChatHeader/ChatHeader.svelte';
 </script>
 
@@ -16,7 +17,7 @@
 <div class="chat-theme chat-card header-frame">
   <ChatHeader title="Breeze Assistant" subtitle="Typically replies in seconds" onclose={() => {}}>
     {#snippet avatar()}
-      <img class="header-avatar" src="/demo-media/assistant-avatar.png" alt="" />
+      <img class="header-avatar" src="{base}/demo-media/assistant-avatar.png" alt="" />
     {/snippet}
   </ChatHeader>
 </div>

--- a/src/routes/components/thinking-indicator/+page.svelte
+++ b/src/routes/components/thinking-indicator/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import ThinkingIndicator from '$lib/ThinkingIndicator/ThinkingIndicator.svelte';
 
   let expanded = $state(false);
@@ -18,7 +19,7 @@
 <div class="demo-row">
   <ThinkingIndicator label="Working on your refund summary…">
     {#snippet avatar()}
-      <img class="assistant-avatar" src="/demo-media/assistant-avatar.png" alt="" />
+      <img class="assistant-avatar" src="{base}/demo-media/assistant-avatar.png" alt="" />
     {/snippet}
   </ThinkingIndicator>
 </div>
@@ -40,7 +41,7 @@
     expanded={false}
   >
     {#snippet avatar()}
-      <img class="assistant-avatar" src="/demo-media/assistant-avatar.png" alt="" />
+      <img class="assistant-avatar" src="{base}/demo-media/assistant-avatar.png" alt="" />
     {/snippet}
   </ThinkingIndicator>
 </div>


### PR DESCRIPTION
## What

The **Deploy to GitHub Pages** workflow has been failing on `release` since the chat-primitives merge: the demo site builds with `BASE_PATH=/svelte-ui-components`, and the chat demo pages referenced their media root-relative (`/demo-media/…`). The prerender crawl rejects that with `404 /demo-media/sunset-beach-thumb.jpg does not begin with \`base\`` — the same failure currently shows on every open PR's `build` check (e.g. #461).

Every demo-media reference (chat-composer thumbnails/lightbox/video, thinking-indicator + chat-header avatars) now resolves through `{base}` from `$app/paths`.

## Verification

- `BASE_PATH=/svelte-ui-components pnpm build` prerenders clean locally (this is exactly what the Pages workflow runs).
- `pnpm run check`: 636 files, 0 errors; lint clean.

Merging this un-breaks the `build` check on #461 and #462 (their PR builds compile the merge with release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed demo images and avatars not loading correctly when the app is hosted under a configured base path.
  * Updated chat composer, chat header, and thinking indicator demos to load media reliably in subdirectory deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->