### PR TITLE
ci(yama): bump the review action to v3.0.4 and migrate the config to its schema

### DIFF
--- a/.github/workflows/yama-review.yml
+++ b/.github/workflows/yama-review.yml
@@ -82,7 +82,7 @@ jobs:
         continue-on-error: true
         # External consumer → published action. For strict supply-chain
         # immutability pin the full commit SHA behind this ref.
-        uses: juspay/yama@v2.7.1
+        uses: juspay/yama@v3.0.4
         with:
           github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
           ai-provider: litellm

--- a/yama.config.yaml
+++ b/yama.config.yaml
@@ -38,18 +38,35 @@ ai:
   # codebase context. Keep enabled so the reviewer sees your repo's rules.
   explore:
     enabled: true
+    # v3 no longer defaults this to 0.1 — set it explicitly to keep the old
+    # deterministic explore behaviour.
+    temperature: 0.1
     timeout: "5m"
     cacheResults: true
 
-# GitHub MCP only. Jira/Bitbucket off so no extra credentials are needed. Yama's
-# built-in denylist already blocks repo-mutating GitHub tools; this is a
-# read + review-comment workflow.
+# GitHub MCP only (v3 schema: definitions live under mcpServers.servers.<id>
+# and are full generic definitions — nothing is hardcoded in yama any more).
+# Jira support was removed in yama v3, so no jira key exists. The token env var
+# is YAMA_GITHUB_TOKEN: the action forwards its github-token input under that
+# non-reserved name specifically for MCP config substitution (GITHUB_TOKEN can
+# be clobbered by the runner inside a composite action). This stays a
+# read + review-comment workflow: repo-mutating tools are block-listed.
 mcpServers:
-  github:
-    enabled: true
-    # transport defaults to "http" (hosted GitHub MCP at api.githubcopilot.com).
-  jira:
-    enabled: false
+  servers:
+    github:
+      enabled: true
+      transport: http
+      url: https://api.githubcopilot.com/mcp/
+      headers:
+        Authorization: "Bearer ${YAMA_GITHUB_TOKEN}"
+      roles: [review, explore]
+      modes: [pr]
+      blockedTools:
+        - push_files
+        - create_or_update_file
+        - create_branch
+        - delete_file
+        - merge_pull_request
 
 review:
   enabled: true


### PR DESCRIPTION
## What

Two things, one commit (they are inseparable — the second is why the first could never pass its own review):

1. **Pin `juspay/yama` v2.7.1 → v3.0.4** in `.github/workflows/yama-review.yml`. v2.7.1 bundles a neurolink whose `DEFAULT_TIMEOUTS.providers` has no `litellm` entry, so every litellm-backed review died at the 30s global fallback regardless of the configured 15m timeout. v3.0.4 carries the fix, with an input-compatible action interface (v4.0.0's breaking `pr`/`branch`/`config`/`vcs-token` interface is a separate migration, deliberately not taken here).

2. **Migrate `yama.config.yaml` to the v3 schema.** v3.0.4 rejects the legacy flat `mcpServers` shape at startup — `❌ Initialization failed: Legacy mcpServers config detected (key(s): github, jira)` — which is exactly how both prior runs of this PR's own review failed (no verdict + action failure → the Enforce step correctly reported an infrastructure error). Changes:
   - `mcpServers.github` → `mcpServers.servers.github` as a full server definition: `http` transport to the hosted GitHub MCP, `Authorization: Bearer ${YAMA_GITHUB_TOKEN}` (the non-reserved env name the v3 action forwards its `github-token` input under specifically for MCP config substitution), `roles`/`modes`, and a `blockedTools` denylist of repo-mutating tools.
   - `mcpServers.jira` removed — Jira support was removed end-to-end in yama v3.
   - `ai.explore.temperature: 0.1` pinned explicitly (v3 no longer defaults it; `ai.temperature: 0.2` was already explicit).

## Verification

- Config parses as valid YAML; server set is exactly `servers.github`.
- Failure diagnosis is from this PR's own run logs (attempt 2, run 32938431409): the init error above, twice reproducibly, on the merge ref that already contains the pin — i.e. the config migration is the missing half.
- This PR's next Yama run executes v3.0.4 against the migrated config end-to-end — that run is itself the live test.

## Backward compatibility

CI-only; no library code, no published surface. Reviews on other PRs (whose merge refs use `release`'s v2.7.1 + legacy config) are unaffected until this merges.