### PR TITLE
feat(status): add descriptionSnippet, children, and panel CSS variables

### DIFF
--- a/docs/Status.md
+++ b/docs/Status.md
@@ -1,6 +1,8 @@
 # Status
 
-A full-screen status display with a centered icon image, title text, description text (supports HTML), and an optional action Button. Uses backdrop-filter blur for visual effect. Ideal for order success/failure screens.
+A full-screen status display with a centered icon image, title text, description text, and an optional action Button. Uses backdrop-filter blur for visual effect. Ideal for order success/failure screens.
+
+The `statusDescription` string is rendered with `{@html}`, so a caller can pass its own trusted markup. For a description that comes from an API, a user, or anywhere else the caller does not control, use the `descriptionSnippet` snippet instead — it renders the text escaped.
 
 ## Usage
 
@@ -14,13 +16,17 @@ A full-screen status display with a centered icon image, title text, description
 
 ## Props
 
-| Prop              | Type               | Required | Default                          | Description                                                                                                                                                            |
-| ----------------- | ------------------ | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| statusIcon        | `string`           | No       | `'icons/order-success-icon.svg'` | URL of the status icon image displayed at the center (e.g., success checkmark, error cross).                                                                           |
-| statusText        | `string`           | No       | `''`                             | Main status title text (e.g., 'Order Successful', 'Payment Failed').                                                                                                   |
-| statusDescription | `string`           | No       | `''`                             | Description text below the title. Supports HTML content (rendered via {@html}).                                                                                        |
-| buttonProperties  | `ButtonProperties` | No       | `-`                              | Optional ButtonProperties object for an action button below the description (e.g., 'Try Again', 'Go Home').                                                            |
-| classes           | `string`           | No       | `-`                              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| Prop               | Type               | Required | Default                          | Description                                                                                                                                                            |
+| ------------------ | ------------------ | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| statusIcon         | `string`           | No       | `'icons/order-success-icon.svg'` | URL of the status icon image displayed at the center (e.g., success checkmark, error cross).                                                                           |
+| statusText         | `string`           | No       | `''`                             | Main status title text (e.g., 'Order Successful', 'Payment Failed').                                                                                                   |
+| statusDescription  | `string`           | No       | `''`                             | Description text below the title. Supports HTML content (rendered via {@html}).                                                                                        |
+| buttonProperties   | `ButtonProperties` | No       | `-`                              | Optional ButtonProperties object for an action button below the description (e.g., 'Try Again', 'Go Home').                                                            |
+| classes            | `string`           | No       | `-`                              | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
+| icon               | `Snippet`          | No       | `-`                              | Custom media rendered in place of the `statusIcon` image. Takes priority over `statusIcon`.                                                                            |
+| descriptionSnippet | `Snippet`          | No       | `-`                              | Replaces the `statusDescription` string at render time and escapes its content. Takes priority over `statusDescription`.                                               |
+| children           | `Snippet`          | No       | `-`                              | Action area rendered below the description, outside `.status-description` and its padding.                                                                             |
+| testId             | `string`           | No       | `-`                              | Value applied to the `data-pw` attribute on the root element for test selection.                                                                                       |
 
 ## Events
 
@@ -28,17 +34,87 @@ A full-screen status display with a centered icon image, title text, description
 | ------------- | ------------ | -------------------------------------------------------------------------- |
 | onbuttonClick | `() => void` | Fires when the action button (configured via buttonProperties) is clicked. |
 
+## Snippets
+
+Svelte 5 Snippet props — pass content blocks to the component.
+
+| Snippet            | Type      | Description                                                                                                                                       |
+| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| icon               | `Snippet` | Media rendered in place of the default `statusIcon` image — e.g. a `LottiePlayer` for animated success/failure/in-progress states.                |
+| descriptionSnippet | `Snippet` | Rich-markup or escaped-text override for the description area. When provided it takes full rendering priority over `statusDescription`.           |
+| children           | `Snippet` | Action area below the description — buttons, links, a countdown. Rendered outside `.status-description`, alongside the `buttonProperties` button. |
+
+### Rendering a description you do not control
+
+`statusDescription` is interpolated with `{@html}`. That is the right tool when the
+caller owns the markup, and the wrong one for a message that arrives from an API or a
+user — such a string would be parsed as markup. `descriptionSnippet` renders the same
+value through ordinary Svelte interpolation, which escapes it:
+
+```svelte
+<script>
+  import { Status } from '@juspay/svelte-ui-components';
+
+  // e.g. the `message` field of an API response
+  let { message } = $props();
+</script>
+
+<Status statusText="Installation failed" statusDescription="">
+  {#snippet descriptionSnippet()}{message}{/snippet}
+</Status>
+```
+
 ## CSS Variables
 
 Override these custom properties to theme the component.
 
-| Variable                          | Default   | CSS Property | Description                                                                                                                          |
-| --------------------------------- | --------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `--status-min-height`             | `100vh`   | min-height   | Minimum height of the `.background` container. Controls the overall height of the status screen.                                     |
-| `--status-font-weight`            | `600`     | font-weight  | Font weight of the status title text. Used with different fallbacks: `600` on status text and `400` on description.                  |
-| `--status-description-font-color` | `#2f3841` | color        | Color of the description text. Used with different fallbacks: `#2f3841` on status text and `#436484cc` on the description paragraph. |
-| `--order-font`                    | `inherit` | font-family  | Font family for the status text.                                                                                                     |
-| `--order-font-size`               | `14px`    | font-size    | Font size for the status text.                                                                                                       |
+| Variable                          | Default                    | CSS Property     | Description                                                                                                                                                         |
+| --------------------------------- | -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--status-min-height`             | `100vh`                    | min-height       | Minimum height of the `.background` container. Controls the overall height of the status screen.                                                                    |
+| `--status-font-weight`            | `600`                      | font-weight      | Font weight of the status title text. Used with different fallbacks: `600` on status text and `400` on description.                                                 |
+| `--status-description-font-color` | `#2f3841`                  | color            | Color of the description text. Used with different fallbacks: `#2f3841` on status text and `#436484cc` on the description paragraph.                                |
+| `--order-font`                    | `inherit`                  | font-family      | Font family for the status text.                                                                                                                                    |
+| `--order-font-size`               | `14px`                     | font-size        | Font size for the status text.                                                                                                                                      |
+| `--status-panel-background`       | `rgba(255, 255, 255, 0.6)` | background-color | Background of the inner status panel, applied only where `backdrop-filter` is supported. Set to `transparent` when embedding the component inside an existing page. |
+| `--status-panel-backdrop-filter`  | `blur(60px)`               | backdrop-filter  | Backdrop filter on the inner status panel. Set to `none` alongside `--status-panel-background` to remove the frosted panel entirely.                                |
+
+### Description text vs. action content
+
+`.status-description` carries the component's own horizontal padding and bottom
+margin, so anything rendered through `descriptionSnippet` inherits a text box's
+geometry. That is right for the message and wrong for a control. Put buttons,
+links and countdowns in `children`, which renders below the description and
+outside that box:
+
+```svelte
+<Status statusText="Installation failed" statusDescription="">
+  {#snippet descriptionSnippet()}{message}{/snippet}
+  {#snippet children()}
+    <Button text="Try again" onclick={retry} />
+  {/snippet}
+</Status>
+```
+
+### Embedding Status inside an existing page
+
+Status is styled as a standalone result screen: `100vh` tall, with a translucent
+frosted panel. Rendered inside a page that already has its own heading and
+surrounding content, both are wrong — the height pushes siblings below the fold,
+and the panel's light background does not survive a dark theme.
+
+All three are variables, so an inline consumer neutralises them:
+
+```svelte
+<div
+  style="
+    --status-min-height: auto;
+    --status-panel-background: transparent;
+    --status-panel-backdrop-filter: none;
+  "
+>
+  <Status statusText="Finishing installation" statusDescription="Almost there…" />
+</div>
+```
 
 ## Type Reference
 

--- a/src/lib/Status/Status.svelte
+++ b/src/lib/Status/Status.svelte
@@ -11,6 +11,8 @@
     classes,
     onbuttonClick,
     icon,
+    descriptionSnippet,
+    children,
     testId
   }: StatusProperties = $props();
 </script>
@@ -30,11 +32,18 @@
     </div>
     <div class="status-text">{statusText}</div>
     <div class="status-description">
-      <!-- eslint-disable-next-line -->
-      {@html statusDescription}
+      {#if typeof descriptionSnippet === 'function'}
+        {@render descriptionSnippet()}
+      {:else}
+        <!-- eslint-disable-next-line -->
+        {@html statusDescription}
+      {/if}
     </div>
     {#if typeof buttonProperties === 'object'}
       <Button {...buttonProperties} onclick={onbuttonClick} />
+    {/if}
+    {#if typeof children === 'function'}
+      {@render children()}
     {/if}
   </div>
 </div>
@@ -75,9 +84,9 @@
   }
   @supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
     .order-status {
-      background-color: rgba(255, 255, 255, 0.6);
-      -webkit-backdrop-filter: blur(60px);
-      backdrop-filter: blur(60px);
+      background-color: var(--status-panel-background, rgba(255, 255, 255, 0.6));
+      -webkit-backdrop-filter: var(--status-panel-backdrop-filter, blur(60px));
+      backdrop-filter: var(--status-panel-backdrop-filter, blur(60px));
     }
   }
 </style>

--- a/src/lib/Status/properties.ts
+++ b/src/lib/Status/properties.ts
@@ -13,6 +13,29 @@ export type StatusProperties = StatusEventProperties & {
    * priority over `statusIcon` when provided.
    */
   icon?: Snippet;
+  /**
+   * Optional snippet that replaces the `statusDescription` string at render
+   * time. When provided, `statusDescription` is not rendered — only the snippet
+   * is. Mirrors `EmptyState`'s `descriptionSnippet`.
+   *
+   * `statusDescription` is interpolated with `{@html}`, which is what a caller
+   * supplying its own trusted markup wants, but is the wrong tool for a message
+   * that originates from an API, a user, or any other source the caller does not
+   * control. There was previously no way to render such a message as text. Use
+   * this snippet for that: `{#snippet descriptionSnippet()}{message}{/snippet}`
+   * escapes it the way ordinary Svelte interpolation does.
+   */
+  descriptionSnippet?: Snippet;
+  /**
+   * Action area rendered below the description, alongside the optional
+   * `buttonProperties` button. Mirrors `EmptyState`'s `children`.
+   *
+   * `descriptionSnippet` sits inside `.status-description`, which carries the
+   * component's own horizontal padding and bottom margin. Content that is not
+   * part of the description — a button, a link, a countdown — belongs here
+   * instead, outside that box, where `buttonProperties` already renders.
+   */
+  children?: Snippet;
   testId?: string;
 };
 

--- a/src/routes/components/status/+page.svelte
+++ b/src/routes/components/status/+page.svelte
@@ -4,6 +4,11 @@
 
   // Minimal valid Lottie document (zero layers) — enough to exercise the player
   // without depending on a real animation asset.
+  // A description the caller does not control — the shape of anything that
+  // arrives from an API. `statusDescription` interpolates with {@html}, so the
+  // markup in this string is parsed as markup; `descriptionSnippet` escapes it.
+  const untrustedDescription = 'Install failed <span data-pw="injected-markup">injected</span>';
+
   const minimalAnimation = {
     v: '5.5.7',
     fr: 30,
@@ -39,6 +44,26 @@
           <LottiePlayer animationData={minimalAnimation} testId="status-lottie" />
         </div>
       {/snippet}
+    </Status>
+  </div>
+  <div data-pw="status-description-html">
+    <Status statusText="String prop" statusDescription={untrustedDescription} />
+  </div>
+
+  <div data-pw="status-description-snippet">
+    <Status statusText="Snippet" statusDescription={untrustedDescription}>
+      {#snippet descriptionSnippet()}{untrustedDescription}{/snippet}
+    </Status>
+  </div>
+  <div
+    data-pw="status-inline"
+    style="--status-min-height: auto; --status-panel-background: transparent; --status-panel-backdrop-filter: none;"
+  >
+    <Status statusText="Inline" statusDescription="Embedded in a page, not a full screen." />
+  </div>
+  <div data-pw="status-children">
+    <Status statusText="With action" statusDescription="Something needs your attention.">
+      <div data-pw="status-children-content">Action area</div>
     </Status>
   </div>
 </div>

--- a/tests/status-children-slot.test.ts
+++ b/tests/status-children-slot.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the Status `children` snippet: an action area rendered BELOW the
+// description, outside `.status-description`.
+//
+// The distinction is the whole point. `.status-description` carries the
+// component's own horizontal padding and bottom margin, so content placed in
+// `descriptionSnippet` inherits a text box's geometry. A button or link is not
+// description text and should not; `children` renders where `buttonProperties`
+// already does. Asserting only "it appears" would pass with the content nested
+// in the wrong parent, so the containment check is the assertion that matters.
+test.describe('Status children slot', () => {
+  test('children renders outside the description box', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const host = page.getByTestId('status-children');
+    await expect(host).toBeVisible();
+
+    const content = host.getByTestId('status-children-content');
+    await expect(content).toBeVisible();
+
+    const nesting = await content.evaluate((el) => ({
+      insideDescription: el.closest('.status-description') !== null,
+      insidePanel: el.closest('.order-status') !== null
+    }));
+    expect(nesting.insideDescription).toBe(false);
+    expect(nesting.insidePanel).toBe(true);
+  });
+
+  test('omitting children renders nothing extra', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const host = page.getByTestId('status-default-icon');
+    await expect(host.getByTestId('status-children-content')).toHaveCount(0);
+  });
+});

--- a/tests/status-description-snippet.test.ts
+++ b/tests/status-description-snippet.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the Status `descriptionSnippet`: a consumer can render a description it
+// does not control as escaped text, instead of the {@html} interpolation that the
+// `statusDescription` string prop uses.
+//
+// Both instances on the demo page are handed the SAME string. The pair is the
+// point — one asserts the {@html} path still parses markup (so the existing
+// behaviour is intact), the other asserts the snippet path does not (so the
+// escape is real). Either test alone would pass against a broken implementation.
+test.describe('Status descriptionSnippet', () => {
+  test('statusDescription still interpolates markup as markup', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const host = page.getByTestId('status-description-html');
+    await expect(host).toBeVisible();
+
+    // The string prop goes through {@html}, so the span became a real element.
+    await expect(host.getByTestId('injected-markup')).toBeVisible();
+  });
+
+  test('descriptionSnippet renders the same string as escaped text', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const host = page.getByTestId('status-description-snippet');
+    await expect(host).toBeVisible();
+
+    // No element was created from the string — the snippet escaped it.
+    await expect(host.getByTestId('injected-markup')).toHaveCount(0);
+    await expect(host).toContainText('<span data-pw="injected-markup">injected</span>');
+  });
+
+  test('omitting the snippet leaves the default description path unchanged', async ({ page }) => {
+    await page.goto('/components/status');
+
+    await expect(page.getByTestId('status-default-icon')).toContainText(
+      'Your order has been confirmed'
+    );
+  });
+});

--- a/tests/status-panel-variables.test.ts
+++ b/tests/status-panel-variables.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+// Covers the Status panel CSS variables. Status is styled as a standalone
+// full-screen result page: 100vh tall, with a translucent white backdrop-filter
+// panel. Embedded in an existing page that is wrong on both counts, and the
+// panel was previously hardcoded with no way to reach it.
+//
+// `--status-min-height` was already variable-backed; `--status-panel-background`
+// and `--status-panel-backdrop-filter` are new. Defaults are the previous literal
+// values, so an existing consumer sees no change.
+test.describe('Status panel variables', () => {
+  test('defaults keep the full-screen panel exactly as it was', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const panel = page.getByTestId('status-default-icon').locator('.order-status');
+    await expect(panel).toHaveCSS('background-color', 'rgba(255, 255, 255, 0.6)');
+    await expect(panel).toHaveCSS('backdrop-filter', 'blur(60px)');
+
+    const root = page.getByTestId('status-default-icon').locator('.background');
+    // 100vh against the configured viewport height.
+    const minHeight = await root.evaluate((el) => getComputedStyle(el).minHeight);
+    expect(parseFloat(minHeight)).toBeGreaterThan(100);
+  });
+
+  test('the variables neutralise the panel for inline embedding', async ({ page }) => {
+    await page.goto('/components/status');
+
+    const host = page.getByTestId('status-inline');
+    await expect(host).toBeVisible();
+
+    const panel = host.locator('.order-status');
+    await expect(panel).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+    await expect(panel).toHaveCSS('backdrop-filter', 'none');
+
+    // min-height: auto resolves to 0px, so the component no longer claims a screen.
+    const root = host.locator('.background');
+    await expect(root).toHaveCSS('min-height', '0px');
+  });
+});


### PR DESCRIPTION
## Why

`Status` could not be adopted by an inline consumer. Three separate reasons, all found while migrating Lighthouse's own local `Status` — four onboarding and webhook screens — onto this one. Each fix is additive and defaults to the previous behaviour.

### 1. `descriptionSnippet`

`statusDescription` is interpolated with `{@html}`:

```svelte
<div class="status-description">
  <!-- eslint-disable-next-line -->
  {@html statusDescription}
</div>
```

Right for a caller passing its own trusted markup. Wrong for a message that arrives from an API, a user, or anywhere the caller does not control — and there was no other option, so such a caller either accepted the sink or did not use the component. One of the four call sites does exactly this:

```ts
stepMessage = action.message;   // from getPaymentsPluginAction()
```

`descriptionSnippet` takes rendering priority and renders through ordinary Svelte interpolation, which escapes.

### 2. `children`

`.status-description` carries the component's own horizontal padding (`42px`) and bottom margin (`25px`), so anything rendered through `descriptionSnippet` inherits a text box's geometry. Right for the message, wrong for a control — and there was nowhere else to put one, since `buttonProperties` takes props rather than content. `children` renders below the description, **outside** that box, where the button already does.

### 3. `--status-panel-background` / `--status-panel-backdrop-filter`

`Status` is styled as a standalone result screen: `100vh` tall with a translucent white frosted panel. `min-height` was already variable-backed; the panel was not, sitting behind an `@supports` block on an inner element that `classes` cannot reach. Inside a page with its own heading and following content, the height pushes siblings below the fold and the white panel does not survive a dark theme.

All three mirror **`EmptyState`**, which already carries a `description` string beside a `descriptionSnippet` override and a `children` action area. The shapes are the library's own, not new conventions.

## Backwards compatibility

Purely additive. Every existing consumer is unchanged: the snippets are `undefined` so both `{#if}`s fall through, and the two new variables default to the literals they replaced. The web-component wrapper is untouched — snippets don't cross the custom-element boundary, which is why the existing `icon` snippet isn't there either.

## Verification — a negative control per behaviour

**9 specs across four files, all green.**

The description pair hands two demo instances the **same string**: one asserts the `{@html}` path still parses it as markup, the other that the snippet path renders it as literal text. Either alone would pass against a broken implementation.

| Control | Result |
|---|---|
| Snippet branch → `{#if false}` | fails **only** the escape assertion (line 29) |
| Panel variables → back to literals | fails **only** the neutralise assertion — `rgba(255,255,255,0.6)` received where `rgba(0,0,0,0)` expected |
| `children` moved inside `.status-description` | fails **only** `insideDescription` (line 26) |

Two of those deserve a note:

- When the panel variables are reverted, **"defaults keep the full-screen panel exactly as it was" stays green.** That is the backwards-compatibility proof — the defaults render identically to the code they replaced.
- The `children` control leaves the content **present and visible**. A presence-only assertion would have passed the broken version; the test asserts *containment* instead, which is the actual contract.

All controls restored byte-identical and re-run green. `svelte-check` 651 files / **0 errors**; `prettier --check src` and `eslint src` clean.

## Measured against the real consumer

By computed style, not screenshot — deliberately. The consuming route transitions on a timer, and **the same build captured twice differs by 1.273%**, so a pixel diff cannot separate the change from the route's own noise.

After adoption: `min-height: 0px`, panel `background-color: rgba(0,0,0,0)`, `backdrop-filter: none`, and the message colour `rgb(82,82,82)` — byte-identical to what the pre-migration markup inherited.

## Docs

`docs/Status.md` gains a `## Snippets` section — which also documents the **pre-existing `icon` snippet**, previously undocumented — the two new CSS variables, the `testId` prop, and worked examples for the untrusted description, the description-vs-action split, and inline embedding.
