### PR TITLE
feat(toolbar): expose row-layout variables so it can serve an in-flow page header

### DIFF
--- a/docs/Toolbar.md
+++ b/docs/Toolbar.md
@@ -1,6 +1,9 @@
 # Toolbar
 
-A fixed-position header bar with a back button (left), center title text, and customizable left/center/right content areas via Snippet slots. The `additionalContent` snippet renders a second row below the main toolbar content. If `leftContent` snippet is provided, it replaces the default back button. If `centerContent` snippet is provided, it replaces the `text` prop.
+A header bar with a back button (left), center title text, and customizable left/center/right content areas via Snippet slots. It defaults to a **fixed** chrome bar, but every positioning and row-layout axis is a CSS
+variable, so the same component also serves an **in-flow page header** — see "Page-header
+shape" below. The `additionalContent` snippet renders a second row below the main toolbar
+content. If `leftContent` snippet is provided, it replaces the default back button. If `centerContent` snippet is provided, it replaces the `text` prop.
 
 ## Usage
 
@@ -115,3 +118,68 @@ The library Toolbar intentionally does not offer a `subheading` prop — string 
 | `center-content`     | `centerContent`     | Content in the center of the toolbar.          |
 | `right-content`      | `rightContent`      | Content on the right side of the toolbar.      |
 | `additional-content` | `additionalContent` | Additional content below the main toolbar row. |
+
+## Page-header shape
+
+The defaults describe a fixed chrome bar. The same component renders an in-flow page header
+with **no additional props** — only CSS variables and the snippets it already has:
+
+```svelte
+<Toolbar showBackButton onbackClick={goBack}>
+  {#snippet centerContent()}
+    <div class="heading-block">
+      <h2>Shipping profiles</h2>
+      <p>Set delivery rates and zones for this store</p>
+    </div>
+  {/snippet}
+  {#snippet rightContent()}
+    <div class="actions">…</div>
+  {/snippet}
+</Toolbar>
+```
+
+```css
+.page-header {
+  --toolbar-position: relative;
+  --toolbar-width: 100%;
+  --toolbar-background: transparent;
+  --toolbar-box-shadow: none;
+
+  /* Top-align the row so the back control sits on the title's first line rather than
+     centred against the whole two-line block. */
+  --toolbar-content-align-items: flex-start;
+  --toolbar-content-column-gap: 16px;
+
+  /* The title side yields and ellipsizes; the actions stay whole. */
+  --toolbar-center-flex: 1 1 auto;
+  --toolbar-center-min-width: 0;
+  --toolbar-right-flex-shrink: 0;
+}
+```
+
+Note what is **not** here. There is no `subheading`, `headingLevel` or `headingClasses` prop:
+the title block is the consumer's own markup in `centerContent`, so it keeps its semantic tags
+and its design system's type classes without the library restating them. That follows the same
+reasoning as "Subheading (consumer recipe)" above — presentational structure belongs in a
+Snippet, and how a title *looks* is reachable with ordinary CSS on the consumer's own elements.
+
+Responsive behaviour is the consumer's too. The component ships **no media queries** — it
+exposes the mechanism and the app picks the breakpoints, because "wrap the actions below 1024px"
+and "hide the subheading on a phone" are design decisions the library cannot make for everyone.
+
+### Additional CSS variables
+
+| Variable                                    | Default | Description                                                                                           |
+| ------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `--toolbar-content-align-items`             | `center` | Cross-axis alignment of the main row. `flex-start` top-aligns a title that has a subline under it.   |
+| `--toolbar-content-min-height`              | `auto`  | Floor for the main row's height — a fixed-height bar sets it here, not on the outer column.           |
+| `--toolbar-content-flex-wrap`               | `nowrap` | Lets the action side drop to its own line on a narrow viewport.                                      |
+| `--toolbar-content-row-gap` / `-column-gap` | `0`     | Gaps between the row's regions, and between wrapped lines.                                            |
+| `--toolbar-center-flex`                     | `1`     | `1 1 auto` lets the centre region grow from its CONTENT width, so a deficit is shared with the actions rather than collapsing the title. |
+| `--toolbar-center-min-width`                | `auto`  | Set `0` so a long title can shrink and ellipsize.                                                      |
+| `--toolbar-right-flex-shrink`               | `1`     | Set `0` so actions never get crushed by a long title.                                                  |
+| `--toolbar-right-min-width` / `-max-width` / `-width` | `auto` / `none` / `auto` | Action-region sizing as a flex item. Its INNER layout stays the snippet's own markup. |
+| `--toolbar-right-display`                   | `block` | Set `flex` only if you want the region itself to be the flex container.                                |
+
+Every default above resolves to the value the component already rendered, so adding them
+changes nothing for an existing consumer.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,17 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
+// Dedicated port: 4173 is vite's shared default and a preview server from an unrelated project
+// on it silently satisfies reuseExistingServer. 43199 avoids that collision, but it is still a
+// FIXED port, so two checkouts of THIS repo collide with each other — the second run reuses the
+// first's server and asserts against the wrong build, reporting failures that belong to another
+// worktree's code (or, worse, passes that were never earned). Set PW_PORT to a private value
+// when running alongside another checkout.
+const port = Number(process.env.PW_PORT ?? 43199);
+
 const config: PlaywrightTestConfig = {
   webServer: {
-    // Dedicated port: 4173 is vite's shared default and a preview server from
-    // an unrelated project on it silently satisfies reuseExistingServer.
-    command: 'pnpm run build && pnpm run preview --port 43199 --strictPort',
-    port: 43199,
+    command: `pnpm run build && pnpm run preview --port ${port} --strictPort`,
+    port,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000
   },
@@ -13,7 +19,7 @@ const config: PlaywrightTestConfig = {
   testMatch: /(.+\.)?(test|spec)\.[jt]s/,
   timeout: 30_000,
   use: {
-    baseURL: 'http://localhost:43199',
+    baseURL: `http://localhost:${port}`,
     // This repo's demo pages expose data-pw hooks; getByTestId must target them.
     testIdAttribute: 'data-pw'
   },

--- a/src/lib/Toolbar/Toolbar.svelte
+++ b/src/lib/Toolbar/Toolbar.svelte
@@ -72,7 +72,7 @@
   .content {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: var(--toolbar-content-align-items, center);
     padding: var(--toolbar-content-padding, 0px);
     justify-content: var(--toolbar-justify-content, normal);
     visibility: var(--toolbar-content-visibility, visible);
@@ -83,8 +83,15 @@
        defaults reproduce the previous rendering exactly. */
     width: var(--toolbar-content-width, auto);
     height: var(--toolbar-content-height, auto);
+    min-height: var(--toolbar-content-min-height, auto);
     max-width: var(--toolbar-content-max-width, none);
     margin: var(--toolbar-content-margin, 0);
+
+    /* Row wrapping and gaps. An in-flow page header lets its action side drop to its own
+       line on a narrow viewport; the fixed bar never wraps, which is the default. */
+    flex-wrap: var(--toolbar-content-flex-wrap, nowrap);
+    row-gap: var(--toolbar-content-row-gap, 0);
+    column-gap: var(--toolbar-content-column-gap, 0);
   }
 
   .additional-content {
@@ -118,7 +125,22 @@
 
   .center-content {
     display: flex;
-    flex: 1;
+    /* `1 1 auto` rather than the default `1` (`1 1 0%`) lets a title region grow from its
+       CONTENT width, so a row deficit is shared with the action side instead of collapsing
+       the title to nothing. `min-width: 0` is what actually permits the shrink. */
+    flex: var(--toolbar-center-flex, 1);
+    min-width: var(--toolbar-center-min-width, auto);
+  }
+
+  /* The action region as a flex ITEM of the row. Its inner layout stays the consumer's —
+     the snippet's own markup — so there is no gap/justify/align token here. Every default
+     below is the property's initial value, i.e. what a bare div already rendered. */
+  .right-content {
+    display: var(--toolbar-right-display, block);
+    flex-shrink: var(--toolbar-right-flex-shrink, 1);
+    min-width: var(--toolbar-right-min-width, auto);
+    max-width: var(--toolbar-right-max-width, none);
+    width: var(--toolbar-right-width, auto);
   }
 
   .text {

--- a/src/routes/components/toolbar/+page.svelte
+++ b/src/routes/components/toolbar/+page.svelte
@@ -34,4 +34,89 @@
       onbackClick={() => alert('Back clicked')}
     />
   </div>
+
+  <!-- In-flow page-header shape: same component, no extra props. Positioning and row
+       behaviour come from CSS variables; the title block is the consumer's own markup,
+       passed through centerContent. -->
+  <div class="page-header-demo">
+    <Toolbar testId="toolbar-page-header" showBackButton onbackClick={() => alert('Back clicked')}>
+      {#snippet centerContent()}
+        <div class="heading-block">
+          <h2 class="demo-title" data-pw="toolbar-page-header-heading">Shipping profiles</h2>
+          <p class="demo-subheading" data-pw="toolbar-page-header-subheading">
+            Set delivery rates and zones for this store
+          </p>
+        </div>
+      {/snippet}
+      {#snippet rightContent()}
+        <div class="demo-actions">
+          <button type="button">Discard</button>
+          <button type="button">Save</button>
+        </div>
+      {/snippet}
+    </Toolbar>
+  </div>
+
+  <!-- backIcon={null} keeps its historical meaning: render no icon at all. -->
+  <div
+    style="position: relative; width: 100%;
+           --toolbar-position: relative;
+           --toolbar-width: 100%;
+           --toolbar-background: transparent;
+           --toolbar-box-shadow: none;"
+  >
+    <Toolbar text="No back icon" testId="toolbar-no-back-icon" showBackButton backIcon={null} />
+  </div>
 </div>
+
+<style>
+  .page-header-demo {
+    position: relative;
+    width: 100%;
+
+    --toolbar-position: relative;
+    --toolbar-width: 100%;
+    --toolbar-background: transparent;
+    --toolbar-box-shadow: none;
+
+    /* Top-align the row so the back control sits on the title's first line rather than
+       centred against the whole two-line block. */
+    --toolbar-content-align-items: flex-start;
+    --toolbar-content-column-gap: 16px;
+
+    /* The title side yields and ellipsizes; the actions stay whole. */
+    --toolbar-center-flex: 1 1 auto;
+    --toolbar-center-min-width: 0;
+    --toolbar-right-flex-shrink: 0;
+  }
+
+  /* The title block is this page's markup, so it is styled with ordinary scoped CSS —
+     no class-name props and no typography tokens on the component. */
+  .heading-block {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .demo-title {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .demo-subheading {
+    margin: 0;
+    font-size: 13px;
+    color: #59616e;
+  }
+
+  .demo-actions {
+    display: flex;
+    gap: 8px;
+  }
+</style>

--- a/tests/toolbar-page-header.test.ts
+++ b/tests/toolbar-page-header.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+// Toolbar gained no props for the page-header shape — only CSS variables. The component's
+// documented position is that presentational structure belongs in a Snippet, so a title with
+// a subheading is the consumer's own markup passed through centerContent. These tests pin
+// both halves of that contract: the defaults are untouched, and the tokens do the work.
+test.describe('Toolbar page-header shape', () => {
+  test('an unconfigured toolbar is untouched by any of this', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    const root = page.getByTestId('toolbar-root');
+    await expect(root).toBeVisible();
+
+    // The title is still a div carrying the library's own type, and the back control is still
+    // the image it has always been, from the same URL.
+    const heading = page.getByTestId('toolbar-heading');
+    expect(await heading.evaluate((element) => element.tagName.toLowerCase())).toBe('div');
+    await expect(heading).toHaveCSS('font-size', '18px');
+    await expect(heading).toHaveCSS('font-weight', '400');
+
+    const backImage = root.locator('.back img');
+    await expect(backImage).toHaveCount(1);
+    await expect(backImage).toHaveAttribute('src', 'https://sdk.breeze.in/gallery/icons/back.svg');
+
+    // Every new declaration resolves to the value the row already rendered.
+    const content = root.locator('.content');
+    await expect(content).toHaveCSS('align-items', 'center');
+    await expect(content).toHaveCSS('flex-wrap', 'nowrap');
+    await expect(content).toHaveCSS('row-gap', '0px');
+    await expect(content).toHaveCSS('column-gap', '0px');
+    await expect(content).toHaveCSS('min-height', 'auto');
+  });
+
+  test('backIcon={null} still renders no icon', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    const root = page.getByTestId('toolbar-no-back-icon');
+    await expect(root).toBeVisible();
+    await expect(root.locator('.back')).toHaveCount(0);
+  });
+
+  test('tokens turn the fixed bar into an in-flow page header', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    const header = page.getByTestId('toolbar-page-header');
+    await expect(header).toBeVisible();
+    await expect(header).toHaveCSS('position', 'relative');
+    await expect(header).toHaveCSS('box-shadow', 'none');
+
+    // Top-aligned row, so the back control lands on the title's first line.
+    await expect(header.locator('.content')).toHaveCSS('align-items', 'flex-start');
+
+    const [backBox, titleBox] = await Promise.all([
+      header.locator('.back').boundingBox(),
+      page.getByTestId('toolbar-page-header-heading').boundingBox()
+    ]);
+    expect(backBox).not.toBeNull();
+    expect(titleBox).not.toBeNull();
+    // The back control's centre sits within the title's own line box, not below it.
+    const backCentre = backBox!.y + backBox!.height / 2;
+    expect(backCentre).toBeGreaterThan(titleBox!.y - 4);
+    expect(backCentre).toBeLessThan(titleBox!.y + titleBox!.height + 4);
+  });
+
+  test('the title block keeps the consumer tags, classes and type scale', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    // Semantic tags the library never sees, because the markup is the consumer's.
+    const heading = page.getByTestId('toolbar-page-header-heading');
+    const subheading = page.getByTestId('toolbar-page-header-subheading');
+    expect(await heading.evaluate((element) => element.tagName.toLowerCase())).toBe('h2');
+    expect(await subheading.evaluate((element) => element.tagName.toLowerCase())).toBe('p');
+
+    // Styled by the page's own scoped CSS — no headingClasses prop, no typography variable.
+    await expect(heading).toHaveCSS('font-size', '22px');
+    await expect(subheading).toHaveCSS('font-size', '13px');
+
+    // Stacked, not side by side.
+    const [titleBox, subBox] = await Promise.all([heading.boundingBox(), subheading.boundingBox()]);
+    expect(subBox!.y).toBeGreaterThan(titleBox!.y);
+  });
+
+  test('the action region absorbs no shrink while the title ellipsizes', async ({ page }) => {
+    await page.goto('/components/toolbar');
+
+    const right = page.getByTestId('toolbar-page-header').locator('.right-content');
+    await expect(right).toHaveCSS('flex-shrink', '0');
+
+    // The title is the side that yields: it is allowed below its content width.
+    const centre = page.getByTestId('toolbar-page-header').locator('.center-content');
+    await expect(centre).toHaveCSS('min-width', '0px');
+  });
+});


### PR DESCRIPTION
## What this is

Lighthouse hand-rolls an in-flow page header (76 call sites) that is structurally this
component: left / centre / right regions over an optional second row. Toolbar defaults to a
**fixed chrome bar**. This makes the second shape reachable.

## It adds no props

The markup, the props and the TypeScript are **byte-identical to `release`**. The whole change
is 26 lines of CSS — variables on the three region elements, each defaulting to the value the
component already rendered:

```
--toolbar-content-align-items / -min-height / -flex-wrap / -row-gap / -column-gap
--toolbar-center-flex / -min-width
--toolbar-right-display / -flex-shrink / -min-width / -max-width / -width
```

The action region's **inner** layout is deliberately not tokenised — that is the consumer's own
snippet markup, which it can style directly.

## What an earlier revision of this PR got wrong

It added `subheading`, `headingLevel`, `subheadingLevel`, `headingClasses` and
`subheadingClasses`, and swapped the default back icon. All reverted:

- **`docs/Toolbar.md` already rejected it.** "String props that carry presentational structure
  are rejected in favour of Snippets." A title with a subline is `centerContent`, and always
  was. The consuming app now keeps its own markup, semantic tags and type-scale classes.
- **A class-name prop is inert in the web-component build.** `sui-toolbar` is `shadow: 'open'`,
  so a class passed as `heading-classes` lands inside the shadow root where the consumer's
  stylesheet cannot reach it — and nothing reports the failure.
- **The back-icon swap changed every existing consumer.** `backIcon` already defaulted to
  `https://sdk.breeze.in/gallery/icons/back.svg` (a long arrow, `fill="#020202"`); replacing it
  with an inline `currentColor` chevron altered both shape and colour for consumers who never
  asked. `backIcon` and its `<img>` are back exactly as they were.

If a future consumer genuinely needs the library to render its title text, the fix is
`:where(.text) { … }` — measured, Svelte compiles that to `:where(.text.svelte-hash)`, which
stays **(0,0,0)**, so even a bare tag selector on the consumer's side wins. A plain `.text`
compiles to `.text.svelte-hash` at (0,2,0) and beats a consumer's utility class, which is the
trap the class props were reaching for.

## Harness fix

`playwright.config.ts` pinned port 43199 with `reuseExistingServer`. Two checkouts of this repo
therefore collide: a run here bound to a **sibling worktree's** preview server and asserted
against the wrong build — failing on properties that are correct in this checkout, then
flooding `ERR_CONNECTION_REFUSED`. A shorter suite would simply have reported green against
code that was never built. Port is now `PW_PORT`-overridable, default unchanged.

## Tests

5 new cases. The important one asserts an **unconfigured** Toolbar is untouched: title still a
`div` at 18px/400, back control still the same `<img>` from the same URL, and every new
declaration resolving to its previous computed value (`align-items: center`, `flex-wrap:
nowrap`, `row-gap: 0px`, `column-gap: 0px`, `min-height: auto`). The rest cover the tokens
producing the page-header shape and the consumer's markup keeping its tags and type scale.

Full suite: **201 passed**. 15 failures are pre-existing Status/Table cases failing on
`order-success-icon.svg`, which is not in the repo (`git ls-files` finds no such asset) and is
untouched by this branch.

## Consumer

juspay/lighthouse PR 7298 renders `PageHeader` through this. Verified against `beta` with a
30-cell matrix (5 routes x 3 viewports x light/dark): **30/30 at 0.000%** pixel difference, with
a same-build control at 0.000% and a negative control that moves exactly the 6 `/ai` cells.
