### PR TITLE
ci(release): migrate npm publish to OIDC trusted publishing [BLOCKED: needs npm trusted-publisher setup]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [release]
 
+# Pinned so both publish jobs upgrade to the same npm, which is what supports
+# OIDC trusted publishing. Bump in one place.
+env:
+  NPM_CLI_VERSION: '11.19.0'
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -70,6 +75,7 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -82,7 +88,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -299,17 +304,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npx -y npm@${NPM_CLI_VERSION} install -g npm@${NPM_CLI_VERSION}
+
       - name: Publish to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # Create .npmrc file for authentication
-          cat > ~/.npmrc << EOF
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-          registry=https://registry.npmjs.org/
-          always-auth=true
-          EOF
+          # No token: npm >=11.15 exchanges this workflow's OIDC token for a
+          # short-lived publish credential itself, via the trusted-publisher
+          # config on npmjs.com for this repo + this workflow file.
 
           # Check if this version already exists on NPM
           PACKAGE_NAME=$(node -p "require('./package.json').name")
@@ -323,7 +325,7 @@ jobs:
 
           # Publish to NPM (with organization scope support)
           echo "Publishing $PACKAGE_NAME@$NEW_VERSION to NPM..."
-          npm publish --access public
+          npm publish --access public --provenance
           echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"
 
   publish-mcp:
@@ -341,6 +343,7 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -353,7 +356,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Configure Git
         run: |
@@ -442,19 +444,16 @@ jobs:
         working-directory: mcp
         run: npm run build
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npx -y npm@${NPM_CLI_VERSION} install -g npm@${NPM_CLI_VERSION}
+
       - name: Publish MCP to NPM
         id: npm-publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: mcp
         run: |
-          # Create .npmrc file for authentication
-          cat > ~/.npmrc << EOF
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-          registry=https://registry.npmjs.org/
-          always-auth=true
-          EOF
+          # No token: npm >=11.15 exchanges this workflow's OIDC token for a
+          # short-lived publish credential itself, via the trusted-publisher
+          # config on npmjs.com for this repo + this workflow file.
 
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
@@ -467,7 +466,7 @@ jobs:
 
           # Scoped package -> publish publicly
           echo "Publishing $PACKAGE_NAME@$NEW_VERSION to NPM..."
-          npm publish --access public
+          npm publish --access public --provenance
           echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"
 
       - name: Commit and tag MCP release


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the manual step below is done

Trusted publishing can only be configured on a package that already exists,
and configuring it requires a fresh 2FA prompt on the npm account with
`@juspay` org access — something that has to happen interactively and
can't be done from CI or by an agent. **Merging this before that step is
done will break every future release** (publish step will have no valid
auth).

Checked the registry directly before opening this: the latest published
version of both packages shows `_npmUser` as a human account, not
`GitHub Actions` with a `trustedPublisher` object, and `dist.attestations`
is empty on both — confirms OIDC is not active yet.

### Required once per package, before merging

```
npx -y npm@11.19.0 trust github @juspay/svelte-ui-components \
  --repo juspay/svelte-ui-components --file release.yml \
  --allow-publish --yes

npx -y npm@11.19.0 trust github @juspay/svelte-ui-components-mcp \
  --repo juspay/svelte-ui-components --file release.yml \
  --allow-publish --yes
```
(or the equivalent web form at `npmjs.com/package/<pkg>/access`)

## What

- `id-token: write` added to both jobs' permissions
- Pin npm to `11.19.0` before publish (OIDC needs npm ≥11.15.0; the
  runner ships older, and `npm@latest` currently resolves to npm 12,
  which raises the Node engine floor — pinned to an exact version, not
  `latest`)
- Drop the `NPM_TOKEN`-based `.npmrc` generation entirely, for both the
  root package and `mcp/`
- Add `--provenance` to both `npm publish` calls

## Why

Polymorph moved to this on 2026-08-05 (`55a1204`). Surfaced as part of a
broader capability-gap comparison against it — this closes that gap and
removes a long-lived credential from CI in the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing security to use short-lived, tokenless authentication.
  * Added build provenance information to published packages.
  * Improved release workflow authentication and publishing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->