### PR TITLE
fix(demo): serve demo-page media locally instead of from picsum.photos

### DIFF
--- a/src/routes/components/badge/+page.svelte
+++ b/src/routes/components/badge/+page.svelte
@@ -8,6 +8,6 @@
 </div>
 
 <div class="demo-row" style="align-items: center;">
-  <Badge image="https://picsum.photos/24/24?random=10" value="5" />
-  <Badge image="https://picsum.photos/24/24?random=11" value="12" />
+  <Badge image="/demo-media/placeholder-square.svg" value="5" />
+  <Badge image="/demo-media/placeholder-square.svg" value="12" />
 </div>

--- a/src/routes/components/brand-loader/+page.svelte
+++ b/src/routes/components/brand-loader/+page.svelte
@@ -9,7 +9,7 @@
 
 <div class="demo-row">
   <BrandLoader
-    brandLogoURL="https://picsum.photos/64/64?random=40"
+    brandLogoURL="/demo-media/placeholder-square.svg"
     brandText="Loading"
     subText="Please wait..."
   />

--- a/src/routes/components/chat/+page.svelte
+++ b/src/routes/components/chat/+page.svelte
@@ -355,7 +355,7 @@
       messages={chat.messages}
       bind:value
       bind:attachments
-      image="https://picsum.photos/64?random=7"
+      image="/demo-media/assistant-avatar.png"
       title="Shopping Assistant"
       subtitle="Online"
       placeholder="Ask anything…"

--- a/src/routes/components/grid-item/+page.svelte
+++ b/src/routes/components/grid-item/+page.svelte
@@ -8,7 +8,7 @@
 </div>
 
 <div class="demo-row">
-  <GridItem icon="https://picsum.photos/40/40?random=1" text="Photos" />
-  <GridItem icon="https://picsum.photos/40/40?random=2" text="Videos" />
-  <GridItem icon="https://picsum.photos/40/40?random=3" text="Music" />
+  <GridItem icon="/demo-media/placeholder-square.svg" text="Photos" />
+  <GridItem icon="/demo-media/placeholder-square.svg" text="Videos" />
+  <GridItem icon="/demo-media/placeholder-square.svg" text="Music" />
 </div>

--- a/src/routes/components/icon-stack/+page.svelte
+++ b/src/routes/components/icon-stack/+page.svelte
@@ -10,8 +10,8 @@
 <div class="demo-row">
   <IconStack
     icons={[
-      { type: 'image', content: 'https://picsum.photos/32/32?random=30' },
-      { type: 'image', content: 'https://picsum.photos/32/32?random=31' },
+      { type: 'image', content: '/demo-media/placeholder-square.svg' },
+      { type: 'image', content: '/demo-media/placeholder-square.svg' },
       { type: 'text', content: '+3' }
     ]}
   />

--- a/src/routes/components/icon/+page.svelte
+++ b/src/routes/components/icon/+page.svelte
@@ -12,9 +12,9 @@
 </div>
 
 <div class="demo-row" style="align-items: center;">
-  <Icon icon="https://picsum.photos/24/24?random=50" text="Home" />
-  <Icon icon="https://picsum.photos/24/24?random=51" text="Settings" />
-  <Icon icon="https://picsum.photos/24/24?random=52" text="Profile" />
+  <Icon icon="/demo-media/placeholder-square.svg" text="Home" />
+  <Icon icon="/demo-media/placeholder-square.svg" text="Settings" />
+  <Icon icon="/demo-media/placeholder-square.svg" text="Profile" />
 </div>
 
 <div class="demo-row" style="align-items: center;">

--- a/src/routes/components/img/+page.svelte
+++ b/src/routes/components/img/+page.svelte
@@ -8,16 +8,12 @@
 </div>
 
 <div class="demo-row">
-  <Img src="https://picsum.photos/200/150?random=60" alt="Sample landscape" />
-  <Img src="https://picsum.photos/200/150?random=61" alt="Sample architecture" />
-  <Img src="https://picsum.photos/200/150?random=62" alt="Sample nature" />
+  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Sample landscape" />
+  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Sample architecture" />
+  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Sample nature" />
 </div>
 
 <div class="demo-row">
-  <Img
-    src="https://picsum.photos/200/150?random=63"
-    alt="Test-targeted image"
-    testId="sample-img"
-  />
+  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Test-targeted image" testId="sample-img" />
 </div>
 <p class="state-display">testId="sample-img" → data-pw="sample-img" on the &lt;img&gt; element</p>

--- a/src/routes/components/status/+page.svelte
+++ b/src/routes/components/status/+page.svelte
@@ -31,7 +31,7 @@
 <div class="demo-row">
   <div data-pw="status-default-icon">
     <Status
-      statusIcon="https://picsum.photos/48/48?random=20"
+      statusIcon="/demo-media/status-success.svg"
       statusText="Payment Successful"
       statusDescription="Your order has been confirmed"
     />

--- a/static/demo-media/placeholder-square.svg
+++ b/static/demo-media/placeholder-square.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dfe6ef" />
+      <stop offset="100%" stop-color="#b9c6d6" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" fill="url(#g)" />
+  <circle cx="24" cy="24" r="7" fill="#8fa2b8" />
+  <path d="M8 52l14-16 10 11 8-8 16 13z" fill="#8fa2b8" />
+</svg>

--- a/static/demo-media/status-success.svg
+++ b/static/demo-media/status-success.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Success">
+  <circle cx="24" cy="24" r="22" fill="#e6f6ec" stroke="#2e994c" stroke-width="2" />
+  <path d="M15 24.5l6.5 6.5L33 19.5" fill="none" stroke="#2e994c" stroke-width="3.5"
+        stroke-linecap="round" stroke-linejoin="round" />
+</svg>


### PR DESCRIPTION
## The suite's pass rate depended on a stranger's CDN

Eight demo routes pulled their images from `picsum.photos`. Playwright navigates with `waitUntil: 'load'`, and an image from a third-party host blocks that event — so whether a spec passed depended on how fast an unrelated public service answered.

This is not theoretical. A full suite run failed **5 specs** across `/components/status` and `/components/chat`, all at the 30s `page.goto` timeout. Instrumenting the navigation showed exactly one request still outstanding when `load` never fired:

```
attempt 1: loaded=false elapsed=30002ms readyState=interactive pending=1
  pending: https://picsum.photos/48/48?random=20
```

The same tests take ~1.3s when picsum answers quickly and ~20s when it is slow. Identical code, three different outcomes.

## The change

All **17** references across **8** routes now point at local assets in `static/demo-media/` — two new SVG placeholders plus `assistant-avatar.png` and `sunset-beach-thumb.jpg`, already vendored there.

| route | was | now |
|---|---|---|
| `status` | picsum 48×48 | `status-success.svg` (new) |
| `chat` | picsum 64 | `assistant-avatar.png` |
| `img` ×4 | picsum 200×150 | `sunset-beach-thumb.jpg` |
| `brand-loader`, `icon-stack` ×2, `grid-item` ×3, `icon` ×3, `badge` ×2 | picsum | `placeholder-square.svg` (new) |

Nothing here ships to npm — `files` publishes `dist` and `dist-wc`, and neither `static/` nor `src/routes/` is in either.

## Verification

- The **8 specs** that navigate to the two affected routes: **45/45 passed** at 3 repeats each.
- `pnpm run lint`: exit 0 — prettier clean, eslint clean, event-casing `100 known, 0 new`.
- `grep -rn picsum src/ static/` → no matches.

## Two things I could not prove, stated rather than glossed

**The negative control did not reproduce the failure.** Restoring the picsum URL and re-running gave **6/6 passing**, because picsum is responding well right now. That is the nature of a network-dependent flake — it cannot be summoned on demand. The evidence for the fix is the instrumented capture above plus the removal of the dependency, not a red-to-green control.

**This does not make the demo pages offline.** A request probe over all eight routes after the change still finds two external hosts on every page:

```
/components/status  external hosts: 2 -> fonts.googleapis.com, fonts.gstatic.com
```

`src/routes/+layout.svelte:31` loads Nunito Sans from Google Fonts, and a stylesheet blocks `load` the same way an image does. Left alone here because vendoring a variable font is a separate change with its own tradeoffs — but it is the same failure mode, and if CI keeps flaking after this, that is where to look next. The observed failures pointed at picsum, so this fixes what actually broke.

## Related

Found while rebasing #479. It is unrelated to that PR's content, and is why the library suite reported 325/5 rather than 330/0 there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated component demos to use reliable local image assets instead of external image services.
  - Improved consistency and availability of badge, loader, chat, grid, icon, image, and status examples.
  - Preserved existing image test targeting and demo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->