### PR TITLE
fix(Carousel): restore the properties-bag contract and announce slide changes

### DIFF
--- a/docs/Carousel.md
+++ b/docs/Carousel.md
@@ -16,17 +16,41 @@ A slideshow that renders Svelte components as slides, with opt-in autoplay (`aut
 
 ## Props
 
-| Prop             | Type             | Required | Default | Description                                                                                                                                                                                                                |
-| ---------------- | ---------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| views            | `CarouselView[]` | Yes      | `-`     | Array of CarouselView objects. Each contains a Svelte Component reference and optional properties to pass to it.                                                                                                           |
-| autoplay         | `boolean`        | No       | `false` | When true, the carousel automatically advances to the next slide at the autoplayInterval rate.                                                                                                                             |
-| autoplayInterval | `number`         | No       | `1000`  | Time in milliseconds between automatic slide transitions. Only used when autoplay is true.                                                                                                                                 |
-| showDots         | `boolean`        | No       | `false` | When true, shows dot indicators below the carousel for direct slide navigation.                                                                                                                                            |
-| isScrollableLast | `boolean`        | No       | `false` | When true, allows scrolling past the last slide (wrapping to the first) and before the first slide (wrapping to the last).                                                                                                 |
-| classes          | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides (e.g., `.btn-primary { --button-color: #0070f3; }`) and pass them to create variant styles. |
-| testId           | `string`         | No       | `-`     | `data-pw`/`testID` on the root element.                                                                                                                                                                                    |
-| dotsWrapperTestId | `string`        | No       | `-`     | `data-pw`/`testID` on the dots wrapper (only rendered when `showDots` is true).                                                                                                                                            |
-| dotTestId        | `string`         | No       | `-`     | Base `data-pw`/`testID` for each dot; each one gets `<dotTestId>-<index + 1>`.                                                                                                                                             |
+| Prop              | Type             | Required | Default | Description                                                                                                                                                                                                                |
+| ----------------- | ---------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| views             | `CarouselView[]` | Yes      | `-`     | Array of CarouselView objects. Each contains a Svelte Component reference and optional properties to pass to it.                                                                                                           |
+| autoplay          | `boolean`        | No       | `false` | When true, the carousel automatically advances to the next slide at the autoplayInterval rate.                                                                                                                             |
+| autoplayInterval  | `number`         | No       | `1000`  | Time in milliseconds between automatic slide transitions. Only used when autoplay is true.                                                                                                                                 |
+| showDots          | `boolean`        | No       | `false` | When true, shows dot indicators below the carousel for direct slide navigation.                                                                                                                                            |
+| isScrollableLast  | `boolean`        | No       | `false` | When true, allows scrolling past the last slide (wrapping to the first) and before the first slide (wrapping to the last).                                                                                                 |
+| classes           | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides (e.g., `.btn-primary { --button-color: #0070f3; }`) and pass them to create variant styles. |
+| testId            | `string`         | No       | `-`     | `data-pw`/`testID` on the root element.                                                                                                                                                                                    |
+| dotsWrapperTestId | `string`         | No       | `-`     | `data-pw`/`testID` on the dots wrapper (only rendered when `showDots` is true).                                                                                                                                            |
+| dotTestId         | `string`         | No       | `-`     | Base `data-pw`/`testID` for each dot; each one gets `<dotTestId>-<index + 1>`.                                                                                                                                             |
+
+### How a slide receives its properties
+
+`view.properties` is **spread** onto the slide component, so a slide declares named props:
+
+```svelte
+<!-- slide component -->
+<script lang="ts">
+  let { title, description } = $props();
+</script>
+```
+
+```svelte
+views={[{ component: Card, properties: { title: 'Summer Sale', description: '...' } }]}
+```
+
+Before this was fixed the whole bag was passed under a single `properties` prop, which meant
+no component taking named props — including every component in this library — ever received
+its values; slides rendered empty unless the consumer wrote a purpose-built wrapper that
+declared `properties` itself.
+
+For those wrappers, `properties` is **still passed alongside the spread**, so they keep
+working and this is not a breaking change. Reading `properties` is deprecated: prefer the
+named props, which is the only form that works with the library's own components.
 
 ## Events
 
@@ -38,20 +62,20 @@ A slideshow that renders Svelte components as slides, with opt-in autoplay (`aut
 
 Override these custom properties to theme the component.
 
-| Variable                   | Default | CSS Property  | Description                                                                      |
-| -------------------------- | ------- | ------------- | -------------------------------------------------------------------------------- |
-| `--carousel-width`         | `300px` | width         | Width of the carousel container. Read by JS at mount time for slide positioning. Note: `.carousel-container` uses this variable without a fallback; inner elements fall back to `300px`. |
-| `--carousel-height`        | `100px` | height        | Height of the carousel slides.                                                   |
-| `--carousel-shadow`        | `-`     | box-shadow    | Box shadow of the carousel container.                                            |
-| `--carousel-border-radius` | `0%`    | border-radius | Corner rounding of the carousel container.                                       |
-| `--carousel-dot-color`     | `#c4c4c4` | background  | Background color of an inactive dot indicator.                                   |
-| `--carousel-dot-active-color` | `#000000` | background | Background color of the active dot indicator.                              |
-| `--dot-gap`                | `10px`  | gap           | Gap between dot indicators.                                                      |
-| `--dot-padding-top`        | `10px`  | padding-top   | Top padding above the dot indicators.                                            |
-| `--dot-width`              | `5px`   | width         | Width of each dot indicator.                                                     |
-| `--dot-height`             | `5px`   | height        | Height of each dot indicator.                                                    |
-| `--dot-focus-outline`      | `2px solid #000000` | outline | Focus ring on a keyboard-focused dot.                                     |
-| `--dot-focus-outline-offset` | `2px` | outline-offset | Gap between a focused dot and its focus ring.                              |
+| Variable                      | Default             | CSS Property   | Description                                                                                                                                                                              |
+| ----------------------------- | ------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--carousel-width`            | `300px`             | width          | Width of the carousel container. Read by JS at mount time for slide positioning. Note: `.carousel-container` uses this variable without a fallback; inner elements fall back to `300px`. |
+| `--carousel-height`           | `100px`             | height         | Height of the carousel slides.                                                                                                                                                           |
+| `--carousel-shadow`           | `-`                 | box-shadow     | Box shadow of the carousel container.                                                                                                                                                    |
+| `--carousel-border-radius`    | `0%`                | border-radius  | Corner rounding of the carousel container.                                                                                                                                               |
+| `--carousel-dot-color`        | `#c4c4c4`           | background     | Background color of an inactive dot indicator.                                                                                                                                           |
+| `--carousel-dot-active-color` | `#000000`           | background     | Background color of the active dot indicator.                                                                                                                                            |
+| `--dot-gap`                   | `10px`              | gap            | Gap between dot indicators.                                                                                                                                                              |
+| `--dot-padding-top`           | `10px`              | padding-top    | Top padding above the dot indicators.                                                                                                                                                    |
+| `--dot-width`                 | `5px`               | width          | Width of each dot indicator.                                                                                                                                                             |
+| `--dot-height`                | `5px`               | height         | Height of each dot indicator.                                                                                                                                                            |
+| `--dot-focus-outline`         | `2px solid #000000` | outline        | Focus ring on a keyboard-focused dot.                                                                                                                                                    |
+| `--dot-focus-outline-offset`  | `2px`               | outline-offset | Gap between a focused dot and its focus ring.                                                                                                                                            |
 
 ## Accessibility
 

--- a/src/lib/Carousel/Carousel.svelte
+++ b/src/lib/Carousel/Carousel.svelte
@@ -157,7 +157,15 @@
       <div class="slidesDiv" bind:this={slidesDiv}>
         {#each views as view, index (index)}
           <div class="current-slide">
-            <view.component {...view.properties} />
+            <!-- Spread is the real fix: every component in this library takes named
+                 props, so passing the bag under a single `properties` key meant a
+                 normal slide rendered empty. `properties` is ALSO still passed so
+                 that a consumer who built a purpose-made wrapper around the old
+                 behaviour keeps working -- that wrapper was the only shape this
+                 component was usable with before, and breaking it would force a
+                 major bump for a fix that is otherwise additive. Deprecated: read
+                 the named props, not `properties`. -->
+            <view.component {...view.properties} properties={view.properties} />
           </div>
         {/each}
       </div>
@@ -190,6 +198,13 @@
       {/each}
     </div>
   {/if}
+  <!-- Slide changes are silent to assistive tech otherwise: the dots announce
+       where they GO, but nothing announces where the carousel ARRIVED, whether
+       the move came from autoplay, a swipe or a dot. polite so it never
+       interrupts, and atomic so the whole position is read as one phrase. -->
+  <div class="carousel-live-region" aria-live="polite" aria-atomic="true">
+    {#if views.length > 0}Slide {activeSlideIndex + 1} of {views.length}{/if}
+  </div>
 </div>
 
 <style>
@@ -272,4 +287,19 @@
     }
 
   } */
+
+  /* Visually hidden but readable by assistive tech -- the standard clip pattern
+     rather than display:none, which would remove it from the a11y tree. */
+  .carousel-live-region {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>

--- a/src/routes/components/carousel/+page.svelte
+++ b/src/routes/components/carousel/+page.svelte
@@ -2,6 +2,7 @@
   import Carousel from '$lib/Carousel/Carousel.svelte';
   import Card from '$lib/Card/Card.svelte';
   import type { CarouselView } from '$lib/Carousel/properties';
+  import LegacyPropertiesSlide from './LegacyPropertiesSlide.svelte';
 
   const promoViews: CarouselView[] = [
     {
@@ -15,6 +16,15 @@
     {
       component: Card,
       properties: { title: 'Free Shipping', description: 'On every order over $50.' }
+    }
+  ];
+
+  // A wrapper of the shape that was the ONLY way to use Carousel before slide
+  // properties were spread: it declares `properties` and reads the bag itself.
+  const legacyViews: CarouselView[] = [
+    {
+      component: LegacyPropertiesSlide,
+      properties: { label: 'legacy wrapper still receives its bag' }
     }
   ];
 </script>
@@ -51,6 +61,16 @@
     dotsWrapperTestId="carousel-manual-dots"
     dotTestId="carousel-manual-dot"
   />
+</div>
+
+<h2>Backward compatibility: a wrapper that reads <code>properties</code></h2>
+<p>
+  Before slide properties were spread, the only usable shape was a purpose-built wrapper that
+  declared a <code>properties</code> prop itself. Those wrappers still receive it, so the fix is not a
+  breaking change.
+</p>
+<div class="demo-row">
+  <Carousel views={legacyViews} testId="carousel-legacy-demo" />
 </div>
 
 <style>

--- a/src/routes/components/carousel/LegacyPropertiesSlide.svelte
+++ b/src/routes/components/carousel/LegacyPropertiesSlide.svelte
@@ -1,0 +1,21 @@
+<!--
+  A slide of the shape that was the ONLY usable one before `view.properties` was
+  spread: it declares `properties` and reads the bag itself. Kept as a demo so the
+  backward-compatibility guarantee in docs/Carousel.md is verifiable rather than
+  merely asserted -- if Carousel ever stops passing `properties` alongside the
+  spread, the carousel spec covering this instance fails.
+-->
+<script lang="ts">
+  let { properties }: { properties?: Record<string, unknown> } = $props();
+</script>
+
+<div class="legacy-slide" data-pw="carousel-legacy-slide">
+  {properties?.label ?? 'no properties received'}
+</div>
+
+<style>
+  .legacy-slide {
+    padding: 24px;
+    text-align: center;
+  }
+</style>

--- a/tests/carousel.test.ts
+++ b/tests/carousel.test.ts
@@ -66,3 +66,28 @@ test.describe('Carousel', () => {
       .evaluate((el) => Promise.all(el.getAnimations().map((a) => a.finished)));
   });
 });
+
+test.describe('Carousel backward compatibility and announcements', () => {
+  test('a wrapper that declares `properties` still receives the bag', async ({ page }) => {
+    await page.goto('/components/carousel');
+    const legacy = page.getByTestId('carousel-legacy-demo');
+    await expect(legacy).toBeVisible();
+    // Spreading the bag was the fix, but the pre-existing wrapper shape has to
+    // keep working or the fix is a breaking change to a published component.
+    await expect(legacy.getByTestId('carousel-legacy-slide')).toHaveText(
+      'legacy wrapper still receives its bag'
+    );
+  });
+
+  test('the active slide position is announced to assistive technology', async ({ page }) => {
+    await page.goto('/components/carousel');
+    const carousel = page.getByTestId('carousel-manual-demo');
+    const live = carousel.locator('[aria-live="polite"]');
+    await expect(live).toHaveText('Slide 1 of 3');
+
+    await page.getByTestId('carousel-manual-dot-2').click();
+    // The dots say where they GO; without this region nothing says where the
+    // carousel ARRIVED, including for autoplay and swipe.
+    await expect(live).toHaveText('Slide 2 of 3');
+  });
+});


### PR DESCRIPTION
## Why this exists

#477 merged at 09:02Z on head `d327a1e`, which is the commit **before** the fix I had pushed to that branch. My `bf8e518` was left stranded, so the CRITICAL review thread on that PR shipped unaddressed and is now in **2.136.4**.

This carries the missing half onto current `release`.

## The breaking change that shipped

`Carousel.svelte` went from

```svelte
{#if typeof view.properties === 'object'}
  <view.component properties={view.properties} />
{:else}
  <view.component />
{/if}
```

to

```svelte
<view.component {...view.properties} />
```

The spread is correct and I am not proposing reverting it. Every component in this library takes named props, so the old form meant a normal slide received nothing and rendered empty — #477's own commit message documents that Card's title and description came out blank.

But it is a runtime prop-contract change on a **published** component, which is what @Tara-ag raised three times on #477 (`Carousel.svelte:160`, `:163` x2, marked CRITICAL). The affected population is specific rather than theoretical: anyone who wrote a purpose-built wrapper declaring `properties` — the only shape Carousel was usable with before — now receives nothing under that key, silently.

## The fix

```svelte
<view.component {...view.properties} properties={view.properties} />
```

Both shapes work, so no major version bump is needed. `.github/workflows/release.yml:108` greps `^BREAKING CHANGE:` to cut a major, and forcing 3.0.0 for this seemed the wrong trade when Lighthouse has just pinned 2.136.x mid-migration — but that option is still open and is a one-line change if you would rather take the clean break.

Reading `properties` is documented as deprecated in `docs/Carousel.md`, with the named-prop form shown as the correct one.

**The guarantee is tested, not asserted.** `src/routes/components/carousel/LegacyPropertiesSlide.svelte` is a slide of exactly the old shape, and a spec pins that it still receives its bag. If Carousel ever stops passing it, that test fails rather than a consumer discovering it.

## Also: the aria-live region

Two SUGGESTION threads on #477 asked for slide announcements and merged unaddressed. Added a visually hidden `aria-live="polite"` / `aria-atomic="true"` region reading `Slide N of M`.

The dots already carry `aria-label` saying where they *go*. Nothing said where the carousel *arrived* — and autoplay and swipe never touch a dot at all, so for those two paths there was no announcement of any kind.

## Verification

- `tests/carousel.test.ts` — **5 passed**.
- **Negative control:** removing the compat prop and neutering the live region fails exactly the two new specs (2 failed / 3 passed), then restores byte-identical.
- `pnpm run lint` exit 0.

## Process note

The near-miss is worth recording: I force-pushed the fix to #477's branch and it was merged from the older head minutes later. Nothing warned either side. If a PR has open CRITICAL threads, the head moving is worth a glance before merge — and the branch still existing after merge is what let this be recovered at all.
