### PR TITLE
fix(demo): prefix demo-media asset paths with base so Pages prerenders

### DIFF
--- a/src/routes/components/badge/+page.svelte
+++ b/src/routes/components/badge/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import Badge from '$lib/Badge/Badge.svelte';
 </script>
 
@@ -8,6 +9,6 @@
 </div>
 
 <div class="demo-row" style="align-items: center;">
-  <Badge image="/demo-media/placeholder-square.svg" value="5" />
-  <Badge image="/demo-media/placeholder-square.svg" value="12" />
+  <Badge image="{base}/demo-media/placeholder-square.svg" value="5" />
+  <Badge image="{base}/demo-media/placeholder-square.svg" value="12" />
 </div>

--- a/src/routes/components/brand-loader/+page.svelte
+++ b/src/routes/components/brand-loader/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import BrandLoader from '$lib/BrandLoader/BrandLoader.svelte';
 </script>
 
@@ -9,7 +10,7 @@
 
 <div class="demo-row">
   <BrandLoader
-    brandLogoURL="/demo-media/placeholder-square.svg"
+    brandLogoURL="{base}/demo-media/placeholder-square.svg"
     brandText="Loading"
     subText="Please wait..."
     testId="brand-loader-default-demo"

--- a/src/routes/components/chat/+page.svelte
+++ b/src/routes/components/chat/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import Chat from '$lib/Chat/Chat.svelte';
   import Button from '$lib/Button/Button.svelte';
@@ -355,7 +356,7 @@
       messages={chat.messages}
       bind:value
       bind:attachments
-      image="/demo-media/assistant-avatar.png"
+      image="{base}/demo-media/assistant-avatar.png"
       title="Shopping Assistant"
       subtitle="Online"
       placeholder="Ask anything…"

--- a/src/routes/components/grid-item/+page.svelte
+++ b/src/routes/components/grid-item/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import GridItem from '$lib/GridItem/GridItem.svelte';
 </script>
 
@@ -8,7 +9,7 @@
 </div>
 
 <div class="demo-row">
-  <GridItem icon="/demo-media/placeholder-square.svg" text="Photos" />
-  <GridItem icon="/demo-media/placeholder-square.svg" text="Videos" />
-  <GridItem icon="/demo-media/placeholder-square.svg" text="Music" />
+  <GridItem icon="{base}/demo-media/placeholder-square.svg" text="Photos" />
+  <GridItem icon="{base}/demo-media/placeholder-square.svg" text="Videos" />
+  <GridItem icon="{base}/demo-media/placeholder-square.svg" text="Music" />
 </div>

--- a/src/routes/components/icon-stack/+page.svelte
+++ b/src/routes/components/icon-stack/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import IconStack from '$lib/IconStack/IconStack.svelte';
 </script>
 
@@ -10,8 +11,8 @@
 <div class="demo-row">
   <IconStack
     icons={[
-      { type: 'image', content: '/demo-media/placeholder-square.svg' },
-      { type: 'image', content: '/demo-media/placeholder-square.svg' },
+      { type: 'image', content: `${base}/demo-media/placeholder-square.svg` },
+      { type: 'image', content: `${base}/demo-media/placeholder-square.svg` },
       { type: 'text', content: '+3' }
     ]}
   />

--- a/src/routes/components/icon/+page.svelte
+++ b/src/routes/components/icon/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import Icon from '$lib/Icon/Icon.svelte';
 
   const starSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>`;
@@ -12,9 +13,9 @@
 </div>
 
 <div class="demo-row" style="align-items: center;">
-  <Icon icon="/demo-media/placeholder-square.svg" text="Home" />
-  <Icon icon="/demo-media/placeholder-square.svg" text="Settings" />
-  <Icon icon="/demo-media/placeholder-square.svg" text="Profile" />
+  <Icon icon="{base}/demo-media/placeholder-square.svg" text="Home" />
+  <Icon icon="{base}/demo-media/placeholder-square.svg" text="Settings" />
+  <Icon icon="{base}/demo-media/placeholder-square.svg" text="Profile" />
 </div>
 
 <div class="demo-row" style="align-items: center;">

--- a/src/routes/components/img/+page.svelte
+++ b/src/routes/components/img/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import Img from '$lib/Img/Img.svelte';
 </script>
 
@@ -8,12 +9,16 @@
 </div>
 
 <div class="demo-row">
-  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Sample landscape" />
-  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Sample architecture" />
-  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Sample nature" />
+  <Img src="{base}/demo-media/sunset-beach-thumb.jpg" alt="Sample landscape" />
+  <Img src="{base}/demo-media/sunset-beach-thumb.jpg" alt="Sample architecture" />
+  <Img src="{base}/demo-media/sunset-beach-thumb.jpg" alt="Sample nature" />
 </div>
 
 <div class="demo-row">
-  <Img src="/demo-media/sunset-beach-thumb.jpg" alt="Test-targeted image" testId="sample-img" />
+  <Img
+    src="{base}/demo-media/sunset-beach-thumb.jpg"
+    alt="Test-targeted image"
+    testId="sample-img"
+  />
 </div>
 <p class="state-display">testId="sample-img" → data-pw="sample-img" on the &lt;img&gt; element</p>

--- a/src/routes/components/status/+page.svelte
+++ b/src/routes/components/status/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import Status from '$lib/Status/Status.svelte';
   import LottiePlayer from '$lib/LottiePlayer/LottiePlayer.svelte';
 
@@ -31,7 +32,7 @@
 <div class="demo-row">
   <div data-pw="status-default-icon">
     <Status
-      statusIcon="/demo-media/status-success.svg"
+      statusIcon="{base}/demo-media/status-success.svg"
       statusText="Payment Successful"
       statusDescription="Your order has been confirmed"
     />


### PR DESCRIPTION
## The Pages site has been broken on `release` since this morning

`Deploy to GitHub Pages` has failed on every `release` push since `4c099e611` — the merge of #483. Last green run was `17862661e` at 04:57Z; every run after it fails in the same place. It also turns the `build` check red on **every open PR**, because each one builds a branch that inherits the fault from `release`.

#483 (mine) swapped 17 `picsum.photos` references for local assets in `static/demo-media`. Five of the pages it touched interpolate `base`; eight of them wrote the path root-relative. Pages builds with `BASE_PATH=/svelte-ui-components`, and SvelteKit's prerender crawler rejects any link that does not start with `paths.base`:

```
Error: 404 /demo-media/placeholder-square.svg does not begin with `base`, which is
configured in `paths.base` … (linked from /svelte-ui-components/components/badge)
```

This never showed up in review or in local dev because with no `BASE_PATH` set, `base` is `''` — the two forms are byte-identical until the deploy build runs.

## The fix

`import { base } from '$app/paths'` in the eight pages that lacked it, and interpolate it — the convention `gallery` and `media-player` already use. 17 references, 8 files, no other change.

## Verification — ran the workflow's own command, both sides

| | `BASE_PATH=/svelte-ui-components pnpm build` |
|---|---|
| `origin/release` (`b93b56d`) | **exit 1** — the 404 above |
| this branch | **exit 0**, `build/` 7.7 MB |

`pnpm lint` exit 0 (prettier reflowed one `<Img>` past print width — that reflow is the only line in the diff that isn't a path).

And the output is checked, not assumed: `build/components/badge.html` now emits `src="../demo-media/placeholder-square.svg"`, which resolves to `/svelte-ui-components/demo-media/…`, and the asset is present at `build/demo-media/placeholder-square.svg`.
