### PR TITLE
fix(wc): restore prettier formatting on the Combobox wrapper

### DIFF
--- a/src/wc/components/Combobox.wc.svelte
+++ b/src/wc/components/Combobox.wc.svelte
@@ -66,11 +66,4 @@
   } = $props();
 </script>
 
-<Combobox
-  {...rest}
-  bind:value
-  bind:inputValue
-  bind:open
-  bind:highlightedIndex
-  bind:selected
-/>
+<Combobox {...rest} bind:value bind:inputValue bind:open bind:highlightedIndex bind:selected />


### PR DESCRIPTION
## `release` cannot publish anything until this merges

`pnpm lint` has been failing on `release` since `ff24661d6` (#482). In the release workflow that is **step 6 of the `release` job** — before the version bump, before the tag, before the GitHub Release, before `npm publish`. The job dies there every time, so nothing downstream runs at all.

That is the current state of the registry:

```
npm dist-tag latest   2.136.1     (published 07:30Z)
git tags on origin    … 2.136.6
```

Everything merged this morning — the Carousel compatibility fix, sanitized markdown, the four exposed custom elements, the Pill hook docs — is on `release` and installable by nobody.

## The failure

```
> prettier --check src && eslint src && npm run lint:event-casing
Checking formatting...
[warn] src/wc/components/Combobox.wc.svelte
[warn] Code style issues found in the above file.
```

The `<Combobox>` element was split across seven lines; prettier wants it on one, because it fits:

```svelte
<Combobox {...rest} bind:value bind:inputValue bind:open bind:highlightedIndex bind:selected />
```

`prettier --write` on that one file. **Formatting only — no semantic change**, one line replacing eight.

## Verification

| | result |
|---|---|
| `pnpm lint` on `release` (`ce60499`, clean checkout) | **exit 1** |
| `pnpm lint` on this branch | **exit 0** |
| `tests/wc-custom-elements.spec.ts` | **5 passed** |

Both lint runs are on pristine checkouts. My first attempt to reproduce this reported a false *pass* because the worktree I used had an uncommitted edit to that very file — so the check ran against modified content rather than against `release`. Worth stating, because a formatting check on a dirty tree is exactly the kind of green that means nothing.

The spec run matters more than it looks: it is the suite the same PR added to cover these wrappers, and it exercises `Combobox` through the custom element, so a formatting change that had quietly altered the binding list would fail it rather than pass silently.
