### PR TITLE
fix(wc): reflow the Combobox wrapper so prettier passes on release

### DIFF
--- a/src/wc/components/Combobox.wc.svelte
+++ b/src/wc/components/Combobox.wc.svelte
@@ -66,11 +66,4 @@
   } = $props();
 </script>
 
-<Combobox
-  {...rest}
-  bind:value
-  bind:inputValue
-  bind:open
-  bind:highlightedIndex
-  bind:selected
-/>
+<Combobox {...rest} bind:value bind:inputValue bind:open bind:highlightedIndex bind:selected />


### PR DESCRIPTION
`release` currently fails `pnpm lint`. One line fixes it.

## The failure

`pnpm lint` runs `prettier --check src`, and `src/wc/components/Combobox.wc.svelte` does not satisfy it:

```
Checking formatting...
[warn] src/wc/components/Combobox.wc.svelte
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

Verified by checking out release's version of the file **inside the repo**. Checking it from `/tmp` is not equivalent — prettier cannot infer the Svelte parser outside the project and reports a misleading clean result, which is worth knowing before anyone tries to reproduce this. In-repo, `prettier --check` on release's version exits **1**; on this branch `pnpm run lint` exits **0**.

Because `release` is the base for every branch, anything cut from it inherits the failure until this lands.

## Where it came from

#482. That PR's final revision fixed the formatting, but the PR merged before the fix was pushed — the branch was deleted on merge, so the push was rejected and the merge commit carries the unformatted version.

Mine to own: I formatted the new spec file but not the four wrapper files I had edited by script, and pushed without running the repo's own `pnpm lint` first.

## The change

Formatting only. The `<Combobox>` call was hand-written across seven lines; prettier wants it on one.

```diff
-<Combobox
-  {...rest}
-  bind:value
-  bind:inputValue
-  bind:open
-  bind:highlightedIndex
-  bind:selected
-/>
+<Combobox {...rest} bind:value bind:inputValue bind:open bind:highlightedIndex bind:selected />
```

No attribute mapping, no binding, no behaviour change — the same five props stay bound. `tests/wc-custom-elements.spec.ts` (added in #482) passes 5/5 against this tree, which is what confirms the reflow did not disturb the bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted the combobox component markup for improved readability.
  * No user-facing functionality or behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->