### PR TITLE
ci(release): publish to npm before pushing any release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,45 @@ jobs:
             echo "No changes to commit"
           fi
 
+      - name: Verify build artifacts
+        run: |
+          echo "Checking if dist directory exists..."
+          if [ -d "dist" ]; then
+            echo "✅ dist directory exists"
+            echo "Contents of dist directory:"
+            find dist -type f | head -20
+            echo "Total files in dist: $(find dist -type f | wc -l)"
+          else
+            echo "❌ dist directory does not exist"
+            echo "Current directory contents:"
+            ls -la
+            exit 1
+          fi
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npx -y npm@${NPM_CLI_VERSION} install -g npm@${NPM_CLI_VERSION}
+
+      - name: Publish to NPM
+        run: |
+          # No token: npm >=11.15 exchanges this workflow's OIDC token for a
+          # short-lived publish credential itself, via the trusted-publisher
+          # config on npmjs.com for this repo + this workflow file.
+
+          # Check if this version already exists on NPM
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
+
+          echo "Checking if $PACKAGE_NAME@$NEW_VERSION already exists..."
+          if npm view "$PACKAGE_NAME@$NEW_VERSION" version 2>/dev/null; then
+            echo "Version $NEW_VERSION already exists on NPM, skipping publish"
+            exit 0
+          fi
+
+          # Publish to NPM (with organization scope support)
+          echo "Publishing $PACKAGE_NAME@$NEW_VERSION to NPM..."
+          npm publish --access public --provenance
+          echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"
+
       - name: Push changes (without tags)
         run: |
           # Pull latest changes to avoid conflicts
@@ -261,21 +300,6 @@ jobs:
 
           echo "Successfully created and pushed tag $TAG_NAME"
 
-      - name: Verify build artifacts
-        run: |
-          echo "Checking if dist directory exists..."
-          if [ -d "dist" ]; then
-            echo "✅ dist directory exists"
-            echo "Contents of dist directory:"
-            find dist -type f | head -20
-            echo "Total files in dist: $(find dist -type f | wc -l)"
-          else
-            echo "❌ dist directory does not exist"
-            echo "Current directory contents:"
-            ls -la
-            exit 1
-          fi
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         id: create_release
@@ -303,30 +327,6 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npx -y npm@${NPM_CLI_VERSION} install -g npm@${NPM_CLI_VERSION}
-
-      - name: Publish to NPM
-        run: |
-          # No token: npm >=11.15 exchanges this workflow's OIDC token for a
-          # short-lived publish credential itself, via the trusted-publisher
-          # config on npmjs.com for this repo + this workflow file.
-
-          # Check if this version already exists on NPM
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
-
-          echo "Checking if $PACKAGE_NAME@$NEW_VERSION already exists..."
-          if npm view "$PACKAGE_NAME@$NEW_VERSION" version 2>/dev/null; then
-            echo "Version $NEW_VERSION already exists on NPM, skipping publish"
-            exit 0
-          fi
-
-          # Publish to NPM (with organization scope support)
-          echo "Publishing $PACKAGE_NAME@$NEW_VERSION to NPM..."
-          npm publish --access public --provenance
-          echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"
 
   publish-mcp:
     needs: [detect-changes, release]


### PR DESCRIPTION
## The failure this prevents already happened, five times, today

The `release` job pushed the version commit, the git tag and the GitHub Release, and only then ran `npm publish`. When publish failed, the repository advertised a version that did not exist on the registry — with no signal anywhere except a red workflow run that nobody was watching.

```
tags on origin   … 2.136.2  2.136.3  2.136.4  2.136.5  2.136.6  2.136.7
npm              … 2.136.1                                       2.136.7
```

npm went straight from 2.136.1 to 2.136.7. The five in between existed as version commits, tags and GitHub Releases and were installable by nobody. Step-level, from the 08:19Z run (`79aec19e9`):

```
14 Push changes (without tags)   success
15 Create and push git tag       success
17 Create GitHub Release         success
18 Publish to NPM                FAILURE
```

Everything irreversible succeeded; the one step that mattered failed last.

## The change

```
Stage and commit → Verify build artifacts → Upgrade npm
  → Publish to NPM → Push changes → Push tag → Create GitHub Release
```

The reasoning is asymmetry, not neatness. Git metadata can be recreated after a failed push. **An npm version cannot be unpublished after 72 hours.** So the step you cannot take back should run first, when the workspace is still disposable — and a failure then leaves the repository byte-identical to before, which makes a re-run a clean retry instead of a cleanup.

`Verify build artifacts` moves up with it, so a missing `dist/` still fails before anything is published.

**`publish-mcp` already did it this way** — publish, then commit and tag, with a rollback step. This aligns the root job with the one that was written correctly.

## Verification

Order only; no step body was edited. Proven rather than eyeballed — both versions parsed as YAML and each job's steps compared as an **unordered multiset**:

```
detect-changes   steps 2->2    content-identical=True
release          steps 18->18  content-identical=True
publish-mcp      steps 12->12  content-identical=True
```

A pure reordering is exactly the change where a diff looks alarming (39 added / 39 removed) and reviewing it line-by-line tells you very little; the multiset comparison is what actually establishes nothing was altered or dropped.

## Not in scope

The five phantom tags remain — a repository ruleset rejects tag deletion (`push declined due to repository rule violations`), so they need someone with permission to lift it. Their **GitHub Releases are already deleted**, so the misleading part of the record is gone.
