### PR TITLE
fix(SplitInput): resolve overtyped digit independently of caret position

### DIFF
--- a/src/lib/SplitInput/SplitInput.svelte
+++ b/src/lib/SplitInput/SplitInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from 'svelte';
   import Input from '$lib/Input/Input.svelte';
   import type { FieldConfig, SplitInputProperties } from './properties';
 
@@ -35,6 +36,31 @@
 
   function getFieldValue(index: number): string {
     return values.at(index) ?? '';
+  }
+
+  /**
+   * Writes the resolved state back onto the DOM element.
+   *
+   * Needed because the element can hold a value the state never had. Typing
+   * into a filled field produces a two-character string in the DOM, and when
+   * the character we resolve out of it happens to equal what was already
+   * stored -- overtyping 2 with another 2 -- the assignment is a no-op, Svelte
+   * sees no change, and nothing re-renders. The field is then left displaying
+   * "22" indefinitely while the state says "2".
+   */
+  async function syncFieldElement(index: number) {
+    // After the pending render, not before it: writing during the input handler
+    // is undone when Svelte flushes, and when the resolved value is unchanged
+    // there is no flush to piggyback on -- so the correction has to come last.
+    await tick();
+    const element = inputRefs.at(index)?.getInputRef();
+    if (element === null || typeof element === 'undefined') {
+      return;
+    }
+    const resolved = getFieldValue(index);
+    if (element.value !== resolved) {
+      element.value = resolved;
+    }
   }
 
   function commitValues() {
@@ -104,7 +130,19 @@
       } else {
         // Overtyping an already-filled field: keep the newest character and
         // advance, mirroring single-char entry.
-        values[index] = chars.slice(-1);
+        //
+        // Which character is "newest" cannot be assumed to be the last one.
+        // The browser inserts at the caret, and where the caret sits after a
+        // click on a filled single-character field is platform-dependent:
+        // Chromium on macOS puts it after the character, Chromium on Linux
+        // before it. So typing 7 into a field holding 2 yields "27" on one and
+        // "72" on the other, and slice(-1) silently picks the *old* digit on
+        // Linux. Removing one occurrence of the previous value identifies the
+        // newly typed character wherever it landed.
+        const previous = getFieldValue(index);
+        const remainder = previous.length === 1 ? chars.replace(previous, '') : '';
+        values[index] = remainder.length > 0 ? remainder.slice(-1) : chars.slice(-1);
+        void syncFieldElement(index);
         if (index < fieldCount - 1) {
           focusField(index + 1);
         }

--- a/tests/splitinput-overtype-caret.spec.ts
+++ b/tests/splitinput-overtype-caret.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+// The existing overtype test passed on macOS and failed on Linux CI, because it
+// relied on where Chromium happens to put the caret when you click a filled
+// single-character field: after the character on macOS, before it on Linux.
+// These tests pin the caret explicitly instead of inheriting the platform's
+// choice, so the behaviour is asserted rather than the environment.
+
+const inject = (element: HTMLInputElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(element, value);
+  element.dispatchEvent(new Event('input', { bubbles: true }));
+};
+
+/** Types a character with the caret forced to a known offset. */
+async function typeAtCaret(
+  page: import('@playwright/test').Page,
+  locator: import('@playwright/test').Locator,
+  caret: number,
+  character: string
+) {
+  await locator.evaluate((element, offset) => {
+    const field = element as HTMLInputElement;
+    field.focus();
+    field.setSelectionRange(offset, offset);
+  }, caret);
+  await page.keyboard.type(character);
+}
+
+test.describe('SplitInput — overtyping is independent of caret position', () => {
+  for (const caret of [0, 1]) {
+    test(`the newly typed digit wins when the caret sits at offset ${caret}`, async ({ page }) => {
+      await page.goto('/components/split-input');
+
+      const inputs = page.getByTestId('split-input-default').locator('input');
+      await inputs.nth(0).evaluate(inject, '1234');
+      await expect(inputs.nth(3)).toHaveValue('4');
+
+      // Field 1 holds "2". Typing 7 must leave "7" whether the browser inserts
+      // before the existing digit (offset 0 -> "72") or after it (offset 1 ->
+      // "27"). Taking the last character of the raw string picks the old digit
+      // in the first case.
+      await typeAtCaret(page, inputs.nth(1), caret, '7');
+
+      await expect(inputs.nth(1)).toHaveValue('7');
+      await expect(inputs.nth(0)).toHaveValue('1');
+      await expect(inputs.nth(2)).toBeFocused();
+      await expect(page.getByText('Value: 1734')).toBeVisible();
+    });
+  }
+
+  test('overtyping a digit with the same digit still clears the extra character', async ({
+    page
+  }) => {
+    await page.goto('/components/split-input');
+
+    const inputs = page.getByTestId('split-input-default').locator('input');
+    await inputs.nth(0).evaluate(inject, '1234');
+
+    // The resolved value equals what was already stored, so the assignment is a
+    // no-op and Svelte re-renders nothing -- leaving the element showing "22"
+    // unless the DOM is explicitly resynced.
+    await typeAtCaret(page, inputs.nth(1), 0, '2');
+
+    await expect(inputs.nth(1)).toHaveValue('2');
+    await expect(page.getByText('Value: 1234')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## The bug the CI gate found

`tests/splitinput-autofill-distribute.spec.ts` **fails on CI and passes on macOS.** It is not a flake — it failed all three attempts on CI, and reproduces deterministically in the Linux Playwright container. `continue-on-error` on the integration step is exactly what kept it invisible.

Two stacked defects in `SplitInput`:

**1. The caret-position assumption.** Overtyping a filled single-character field took `chars.slice(-1)` — "keep the newest character". But the browser inserts at the caret, and where the caret lands after clicking a filled field is platform-dependent: Chromium on macOS puts it *after* the character, on Linux *before* it.

| Platform | Typing `7` into a field holding `2` | `slice(-1)` gives |
|---|---|---|
| macOS | `"27"` | `7` ✅ |
| Linux | `"72"` | `2` ❌ — the old digit |

**2. DOM/state desync.** When the resolved character equals what was already stored — overtyping `2` with another `2` — the assignment is a no-op, Svelte re-renders nothing, and the element is left displaying `"22"` indefinitely while state says `"2"`.

## The fix

Removing one occurrence of the previous value identifies the newly typed character wherever the browser inserted it — no caret introspection, no platform assumption.

For the desync, the element is resynced after `tick()`. Writing during the input handler does not work: the pending flush undoes it, and when state does not change there is no flush to piggyback on. My first attempt did exactly that and still produced `"22"`, which is how the ordering requirement surfaced.

## Proof

Tests pin the caret explicitly rather than inheriting the platform's choice, so the behaviour is asserted instead of the environment.

**Before the fix** (component stashed, tests unchanged) — fails for the right reasons:
```
unexpected value "72"     <- caret at offset 0, the Linux path
unexpected value "22"     <- same-digit overtype, the desync
2 failed, 1 passed        <- the macOS path (offset 1) always worked
```

**After the fix:**
```
macOS:            7 passed
Linux container:  7 passed
```

Both runs cover the new spec **and** the previously-failing `splitinput-autofill-distribute.spec.ts`.

`pnpm run lint` exit 0 · `pnpm run check` exit 0.

## Note on the full Linux run

A full suite run in my local Playwright container shows 354 passed / 3 failed, the 3 being `media-player.test.ts` video-playback assertions. Those are an artifact of codec support in that container — GitHub's runner passed all of them (its only failure was this SplitInput test, 353 passed / 1 failed). Flagging it rather than quietly omitting it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SplitInput behavior when typing over existing characters at different caret positions.
  * Ensured the newly entered digit is retained and the input display stays synchronized.
  * Corrected handling when replacing a character with the same digit.

* **Tests**
  * Added deterministic coverage for caret positioning and overtyping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->