### PR TITLE
fix(Img): sanitize fetched SVG before adoption; expose show-indicator on sui-choicebox

### DIFF
--- a/docs/Choicebox.md
+++ b/docs/Choicebox.md
@@ -71,6 +71,19 @@ Tag: `<sui-choicebox>`
 </sui-choicebox>
 ```
 
+### Props (HTML Attributes)
+
+| Attribute        | Maps to Prop    | Type    | Description                                                                                                                                              |
+| ---------------- | --------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selected`       | `selected`      | Boolean | Reflects the selection state.                                                                                                                            |
+| `mode`           | `mode`          | String  | `radio` or `checkbox` indicator style.                                                                                                                   |
+| `disabled`       | `disabled`      | Boolean | Disables interaction and dims the card.                                                                                                                  |
+| `show-indicator` | `showIndicator` | Boolean | Whether to render the radio dot / checkbox tick (default `true`). Boolean attributes are presence-based, so to hide the indicator set the `showIndicator` property to `false` from JS. |
+| `test-id`        | `testId`        | String  | Sets `data-pw` on the card for Playwright selectors.                                                                                                     |
+| `classes`        | `classes`       | String  | CSS classes applied to the card element.                                                                                                                 |
+
+`onclick` is a function prop — set it as a property from JS, not as an attribute.
+
 ### Indicator
 
 The indicator is decorative — the card itself carries `role` and `aria-checked`, so the mark is

--- a/docs/Img.md
+++ b/docs/Img.md
@@ -22,7 +22,7 @@ An image component with automatic fallback. If the primary `src` fails to load (
 | testId   | `string`         | No       | `-`     | Test identifier applied as `data-pw` attribute on the `<img>` element for Playwright test selectors.                                                                  |
 | classes  | `string`         | No       | `-`     | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles. |
 | inlineSvg | `boolean`       | No       | `false` | Fetch `.svg` / `data:image/svg+xml` sources and inline their markup into an `<svg>` host so page CSS (`currentColor`, fill/stroke overrides) applies. Non-SVG sources always render the plain `<img>`. If fetching or parsing fails, the component falls back to the plain `<img>` (and from there to the regular `fallback`/`onerror` chain). |
-| transformSvg | `(svg: string) => string` | No | `-` | Hook to rewrite the fetched SVG markup before it is inlined (e.g. recolour hardcoded fills). Providing a transform implies `inlineSvg`. The inlining effect re-runs when the prop identity changes, so a closure over reactive state (e.g. a theme colour) re-renders live. JS-only prop (not exposed as a web-component attribute). |
+| transformSvg | `(svg: string) => string` | No | `-` | Hook to rewrite the fetched SVG markup before it is inlined (e.g. recolour hardcoded fills). Providing a transform implies `inlineSvg`. The inlining effect re-runs when the prop identity changes, so a closure over reactive state (e.g. a theme colour) re-renders live. Root attributes the transform adds are treated as caller intent and copied to the host even when outside the fetched-attribute allowlist (see SVG inlining below). JS-only prop (not exposed as a web-component attribute). |
 
 ## SVG inlining
 
@@ -44,6 +44,8 @@ Behaviour notes:
 
 - Non-SVG sources ignore both props and always render the plain `<img>`.
 - A failed fetch/parse for a given URL falls back to the plain `<img>` for that URL (which then drives the normal `fallback`/`onerror` chain); a changed `src` gets a fresh inlining attempt.
+- The fetched document is treated as untrusted content: only an allowlist of presentational, geometry, and accessibility attributes is copied from its root onto the live `<svg>` host — `xmlns`, `xmlns:xlink`, `viewBox`, `width`, `height`, `x`, `y`, `preserveAspectRatio`, `fill`/`fill-*`, `stroke`/`stroke-*`, `clip-rule`, `color`, `opacity`, `overflow`, `role`, `focusable`, and `aria-*`. Anything else from the fetched file — event handlers (`onload`, `onclick`, …), `id`, `style`, `class`, `data-*` — never reaches the live element, so a hostile SVG cannot inject script or clobber the `data-pw` test hook. Child elements are inlined as-is.
+- Root attributes that your own `transformSvg` hook **adds** (names not present on the fetched root) are caller intent and pass through unfiltered — e.g. a transform can stamp a `data-*` marker on the host.
 - Accessibility: the `<svg>` host gets `role="img"` + `aria-label` when `alt` is non-empty, and `aria-hidden="true"` when `alt` is empty (decorative).
 - All CSS variables below apply to the inlined `<svg>` host exactly as they do to the `<img>`.
 

--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -37,6 +37,107 @@
     transform: ((svg: string) => string) | null;
   };
 
+  // Root attributes that may be copied from fetched SVG markup onto the live
+  // <svg> host. The fetched document is remote, untrusted content — copying
+  // every attribute (the previous behaviour) let it plant executable `on*`
+  // handlers on an element in the host page, clobber the data-pw/testID test
+  // hooks, or override the component's CSS sizing contract with an inline
+  // style. An allowlist rather than an `on*` denylist is deliberate: a
+  // denylist misses vectors like `xlink:href="javascript:…"` and whatever
+  // attribute ships in browsers next. The names kept are what inlining
+  // actually needs — geometry/scaling, the namespace declarations exporters
+  // emit, the inheritable paint attributes that keep the icon's authored
+  // defaults while page CSS/currentColor themes it, and the accessibility
+  // metadata real icon sets ship (role, focusable, aria-*). `class` stays
+  // caller-owned via the `classes` prop, as before. Compared lowercased, so
+  // entries are lowercase (viewBox → 'viewbox') while the authored casing is
+  // preserved when the attribute is written to the host.
+  const SAFE_INLINE_ROOT_ATTRIBUTES: ReadonlySet<string> = new Set([
+    'xmlns',
+    'xmlns:xlink',
+    'viewbox',
+    'width',
+    'height',
+    'x',
+    'y',
+    'preserveaspectratio',
+    'fill',
+    'fill-opacity',
+    'fill-rule',
+    'stroke',
+    'stroke-width',
+    'stroke-opacity',
+    'stroke-linecap',
+    'stroke-linejoin',
+    'stroke-miterlimit',
+    'stroke-dasharray',
+    'stroke-dashoffset',
+    'clip-rule',
+    'color',
+    'opacity',
+    'overflow',
+    'role',
+    'focusable'
+  ]);
+
+  function isSafeInlineRootAttribute(lowerCaseName: string): boolean {
+    return SAFE_INLINE_ROOT_ATTRIBUTES.has(lowerCaseName) || lowerCaseName.startsWith('aria-');
+  }
+
+  /**
+   * Strips executable content from a fetched SVG's descendants.
+   *
+   * The root allowlist above only guards the root. Children are adopted into
+   * the live document wholesale, and an event-handler content attribute
+   * becomes a live handler the moment its element is adopted — so
+   * `<image onerror="…">` two levels down runs exactly like `onerror` on the
+   * root would. A root-only guard would look like a fix while leaving the same
+   * vector open one element deeper.
+   *
+   * A denylist rather than an allowlist here, deliberately: descendants
+   * legitimately carry the entire SVG geometry and paint vocabulary (`d`,
+   * `transform`, `gradientUnits`, …), so enumerating what is permitted would
+   * break real artwork. What is dangerous is narrow and well understood:
+   * scripting elements, `on*` handlers, and URL attributes pointing at
+   * `javascript:`.
+   */
+  function sanitizeInlinedSubtree(root: SVGSVGElement): void {
+    for (const element of Array.from(root.querySelectorAll('script, foreignObject'))) {
+      element.remove();
+    }
+    for (const element of Array.from(root.querySelectorAll('*'))) {
+      for (const attribute of Array.from(element.attributes)) {
+        const name = attribute.name.toLowerCase();
+        if (name.startsWith('on')) {
+          element.removeAttribute(attribute.name);
+          continue;
+        }
+        // `href`, `xlink:href` and `src` accept a javascript: URL, which runs
+        // on activation of an <a> wrapper or on load of a nested resource.
+        const isUrlAttribute = name === 'href' || name === 'xlink:href' || name === 'src';
+        if (isUrlAttribute && /^\s*javascript:/i.test(attribute.value)) {
+          element.removeAttribute(attribute.name);
+        }
+      }
+    }
+  }
+
+  // Root attribute names of the raw fetched markup, lowercased — or null when
+  // that markup does not parse as SVG on its own. Distinguishes what arrived
+  // over the network (untrusted, the allowlist applies) from what the caller's
+  // transformSvg hook added (caller intent, passes through).
+  function collectRootAttributeNames(markup: string): ReadonlySet<string> | null {
+    const parsed = new DOMParser().parseFromString(markup, 'image/svg+xml');
+    if (parsed.querySelector('parsererror') !== null) {
+      return null;
+    }
+    const root = parsed.querySelector('svg');
+    if (root === null) {
+      return null;
+    }
+    return new Set(Array.from(root.attributes, (attribute) => attribute.name.toLowerCase()));
+  }
+
   async function loadInlineSvg(
     host: SVGSVGElement,
     url: string,
@@ -50,7 +151,8 @@
         return;
       }
       const rawSvg = await response.text();
-      const markup = typeof transform === 'function' ? transform(rawSvg) : rawSvg;
+      const hasTransform = typeof transform === 'function';
+      const markup = hasTransform ? transform(rawSvg) : rawSvg;
       const parsed = new DOMParser().parseFromString(markup, 'image/svg+xml');
       if (parsed.querySelector('parsererror') !== null) {
         failedInlineSrc = url;
@@ -70,12 +172,26 @@
       while (host.firstChild !== null) {
         host.removeChild(host.firstChild);
       }
+      // With no transform the parsed root IS the fetched root, so every name
+      // is network-supplied and only the allowlist applies. With a transform,
+      // names absent from the raw payload were added by the caller's own hook
+      // and pass through; if the raw payload only parses after the transform,
+      // nothing can be attributed to the caller and the allowlist applies to
+      // everything.
+      const fetchedRootNames = hasTransform ? collectRootAttributeNames(rawSvg) : null;
       for (const attribute of Array.from(sourceSvg.attributes)) {
-        if (attribute.name === 'class') {
+        const name = attribute.name.toLowerCase();
+        if (name === 'class') {
           continue;
         }
-        host.setAttribute(attribute.name, attribute.value);
+        const addedByTransform = fetchedRootNames !== null && !fetchedRootNames.has(name);
+        if (isSafeInlineRootAttribute(name) || addedByTransform) {
+          host.setAttribute(attribute.name, attribute.value);
+        }
       }
+      // Before adoption, not after: an event-handler attribute becomes a live
+      // handler as soon as its element enters the document.
+      sanitizeInlinedSubtree(sourceSvg);
       while (sourceSvg.firstChild !== null) {
         host.appendChild(sourceSvg.firstChild);
       }

--- a/src/routes/components/img/+page.svelte
+++ b/src/routes/components/img/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import Img from '$lib/Img/Img.svelte';
+
+  const markTransformed = (svg: string): string =>
+    svg.replace('<svg', '<svg data-demo-transformed="true"');
 </script>
 
 <div class="page-header">
@@ -22,3 +25,25 @@
   />
 </div>
 <p class="state-display">testId="sample-img" → data-pw="sample-img" on the &lt;img&gt; element</p>
+
+<h3>SVG inlining</h3>
+<div class="demo-row" data-pw="img-inline-svg-row">
+  <Img
+    src="{base}/demo-media/status-success.svg"
+    alt="Success icon"
+    inlineSvg
+    testId="img-inline-svg"
+  />
+</div>
+<p class="state-display">inlineSvg → the fetched markup renders as an inline &lt;svg&gt; host</p>
+
+<h3>SVG inlining with transformSvg</h3>
+<div class="demo-row" data-pw="img-inline-svg-transform-row">
+  <Img
+    src="{base}/demo-media/placeholder-square.svg"
+    alt="Transformed placeholder"
+    transformSvg={markTransformed}
+    testId="img-inline-svg-transform"
+  />
+</div>
+<p class="state-display">transformSvg rewrites the fetched markup before it is inlined</p>

--- a/src/wc/components/Choicebox.wc.svelte
+++ b/src/wc/components/Choicebox.wc.svelte
@@ -6,6 +6,7 @@
       selected: { type: 'Boolean', reflect: true },
       mode: { type: 'String', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
+      showIndicator: { type: 'Boolean', reflect: true, attribute: 'show-indicator' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onclick: { type: 'Object' }

--- a/tests/choicebox-wc-show-indicator.spec.ts
+++ b/tests/choicebox-wc-show-indicator.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+// The Svelte component gained `showIndicator`, but the web-component wrapper
+// never declared it in customElement.props. An undeclared prop gets no
+// accessor and no observed attribute, so web-component consumers had no way
+// to turn the indicator off — the attribute sat inertly on the DOM node.
+//
+// dist-wc is a self-contained bundle rather than a route of the demo site, so
+// it is injected into a same-origin page instead of being navigated to.
+// `pnpm run build` (the webServer command) runs build:wc, so the file exists.
+const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(() => customElements.get('sui-choicebox') !== undefined, undefined, {
+    timeout: 15_000
+  });
+};
+
+test.describe('sui-choicebox — show-indicator', () => {
+  test('the show-indicator attribute is observed and toggles the indicator', async ({ page }) => {
+    await loadBundle(page);
+    await page.evaluate(() => {
+      const el = document.createElement('sui-choicebox');
+      el.id = 'attr-target';
+      el.setAttribute('show-indicator', '');
+      el.innerHTML = '<span>Option A</span>';
+      document.body.append(el);
+    });
+
+    // Boolean attributes are presence-based: present -> true (the default).
+    const indicator = page.locator('#attr-target .indicator');
+    await expect(indicator).toHaveCount(1);
+
+    // Removing an OBSERVED attribute converts null -> false and re-renders.
+    // Before the fix 'show-indicator' was not observed, so nothing happened.
+    await page.evaluate(() =>
+      document.querySelector('#attr-target')?.removeAttribute('show-indicator')
+    );
+    await expect(indicator).toHaveCount(0);
+  });
+
+  test('the showIndicator property has an accessor that reaches the component', async ({
+    page
+  }) => {
+    await loadBundle(page);
+    await page.evaluate(() => {
+      const el = document.createElement('sui-choicebox');
+      el.id = 'prop-target';
+      el.innerHTML = '<span>Option B</span>';
+      document.body.append(el);
+    });
+
+    // No attribute set: the component's own default (true) renders it.
+    const indicator = page.locator('#prop-target .indicator');
+    await expect(indicator).toHaveCount(1);
+
+    // A declared prop gets a real accessor; an undeclared one lands on the DOM
+    // node as an expando and never reaches the component.
+    await page.evaluate(() => {
+      const el = document.querySelector('#prop-target');
+      if (el !== null) {
+        (el as HTMLElement & { showIndicator?: boolean }).showIndicator = false;
+      }
+    });
+    await expect(indicator).toHaveCount(0);
+  });
+});

--- a/tests/img-inline-svg-attr-allowlist.spec.ts
+++ b/tests/img-inline-svg-attr-allowlist.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from '@playwright/test';
+
+// Img's inlineSvg path fetches remote markup and copies the fetched root's
+// attributes onto the live <svg> host — an element in the host document. The
+// fetched file is untrusted content: copying every attribute lets it plant
+// `onload`/`onclick` handlers (script injection via an image URL), clobber the
+// data-pw test hook, or override the component's sizing with an inline style.
+// Only an allowlisted presentational/geometry/a11y set may survive; attributes
+// the caller's own transformSvg ADDS are caller intent and still pass.
+//
+// Payloads are served via route interception so the tests are self-contained:
+// the demo page's real asset URLs are answered with crafted markup, no network.
+
+const INLINE_DEMO_URL = '**/demo-media/status-success.svg';
+const TRANSFORM_DEMO_URL = '**/demo-media/placeholder-square.svg';
+
+const serveSvg = async (
+  page: import('@playwright/test').Page,
+  url: string,
+  body: string
+): Promise<void> => {
+  await page.route(url, (route) =>
+    route.fulfill({ status: 200, contentType: 'image/svg+xml', body })
+  );
+};
+
+test.describe('Img — inlineSvg copies only safe root attributes from fetched markup', () => {
+  test('fetched event handlers and non-presentational attributes never reach the live host', async ({
+    page
+  }) => {
+    const hostile =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"' +
+      " onload=\"document.documentElement.setAttribute('data-svg-onload-ran', '1')\"" +
+      " onclick=\"document.documentElement.setAttribute('data-svg-onclick-ran', '1')\"" +
+      ' id="evil-root" style="outline: 6px solid red" data-pw="hijacked" tabindex="0">' +
+      '<circle cx="12" cy="12" r="8" fill="currentColor" /></svg>';
+    await serveSvg(page, INLINE_DEMO_URL, hostile);
+    await page.goto('/components/img');
+
+    // Located through the wrapper row, not data-pw on the host itself — a
+    // successful data-pw clobber must fail an assertion, not hide the element.
+    const host = page.getByTestId('img-inline-svg-row').locator('svg');
+
+    // Anchor: the intercepted payload really was inlined (the real asset on
+    // disk has viewBox "0 0 48 48", so a missed interception cannot pass).
+    await expect(host).toHaveAttribute('viewBox', '0 0 24 24');
+    await expect(host.locator('circle')).toHaveCount(1);
+
+    // A legitimate presentational attribute from the same hostile file lands.
+    await expect(host).toHaveAttribute('fill', 'none');
+
+    // The executable / non-presentational attributes do not.
+    await expect(host).not.toHaveAttribute('onload');
+    await expect(host).not.toHaveAttribute('onclick');
+    await expect(host).not.toHaveAttribute('id');
+    await expect(host).not.toHaveAttribute('style');
+    await expect(host).not.toHaveAttribute('tabindex');
+
+    // The caller's test hook survives hostile content.
+    await expect(host).toHaveAttribute('data-pw', 'img-inline-svg');
+
+    // Behavioural proof: interacting with the icon runs nothing.
+    await host.click();
+    const root = page.locator('html');
+    await expect(root).not.toHaveAttribute('data-svg-onload-ran');
+    await expect(root).not.toHaveAttribute('data-svg-onclick-ran');
+  });
+
+  test('legitimate presentational and accessibility attributes still land on the host', async ({
+    page
+  }) => {
+    const benign =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48"' +
+      ' preserveAspectRatio="xMidYMid meet" fill="none" stroke="currentColor"' +
+      ' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"' +
+      ' role="img" aria-label="Fetched success" focusable="false">' +
+      '<path d="M15 24.5l6.5 6.5L33 19.5" /></svg>';
+    await serveSvg(page, INLINE_DEMO_URL, benign);
+    await page.goto('/components/img');
+
+    const host = page.getByTestId('img-inline-svg-row').locator('svg');
+
+    await expect(host).toHaveAttribute('viewBox', '0 0 48 48');
+    await expect(host).toHaveAttribute('width', '48');
+    await expect(host).toHaveAttribute('height', '48');
+    await expect(host).toHaveAttribute('preserveAspectRatio', 'xMidYMid meet');
+    await expect(host).toHaveAttribute('fill', 'none');
+    await expect(host).toHaveAttribute('stroke', 'currentColor');
+    await expect(host).toHaveAttribute('stroke-width', '2.5');
+    await expect(host).toHaveAttribute('stroke-linecap', 'round');
+    await expect(host).toHaveAttribute('stroke-linejoin', 'round');
+    await expect(host).toHaveAttribute('role', 'img');
+    await expect(host).toHaveAttribute('aria-label', 'Fetched success');
+    await expect(host).toHaveAttribute('focusable', 'false');
+    await expect(host.locator('path')).toHaveCount(1);
+  });
+
+  test('transformSvg-added attributes pass through while fetched unsafe ones are dropped', async ({
+    page
+  }) => {
+    const hostile =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"' +
+      " onload=\"document.documentElement.setAttribute('data-svg-transform-onload-ran', '1')\">" +
+      '<rect width="64" height="64" fill="currentColor" /></svg>';
+    await serveSvg(page, TRANSFORM_DEMO_URL, hostile);
+    await page.goto('/components/img');
+
+    const host = page.getByTestId('img-inline-svg-transform-row').locator('svg');
+
+    await expect(host).toHaveAttribute('viewBox', '0 0 64 64');
+    // The demo's transform marks the root — caller intent survives the filter.
+    await expect(host).toHaveAttribute('data-demo-transformed', 'true');
+    // The fetched handler does not ride along with it.
+    await expect(host).not.toHaveAttribute('onload');
+    await expect(page.locator('html')).not.toHaveAttribute('data-svg-transform-onload-ran');
+    await expect(host.locator('rect')).toHaveCount(1);
+  });
+});
+
+// The root allowlist above guards only the root. Descendants are adopted into
+// the live document wholesale, and an event-handler content attribute becomes a
+// live handler the moment its element is adopted -- so a handler one element
+// deeper runs exactly like one on the root. Guarding only the root would look
+// like a fix while leaving the same vector open.
+test.describe('Img — inlineSvg strips executable content from fetched descendants', () => {
+  test('a child event handler does not survive adoption, and actually does not fire', async ({
+    page
+  }) => {
+    // <image> with a bad href fires onerror by itself, so this proves the
+    // handler cannot run rather than only that the attribute is absent.
+    const hostile =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+      '<image href="data:," onerror="document.documentElement.setAttribute(\'data-child-onerror-ran\', \'1\')" />' +
+      "<a href=\"javascript:document.documentElement.setAttribute('data-child-js-href', '1')\">" +
+      '<circle cx="12" cy="12" r="8" onclick="document.documentElement.setAttribute(\'data-child-onclick-ran\', \'1\')" fill="currentColor" />' +
+      '</a>' +
+      '<script>document.documentElement.setAttribute("data-child-script-ran", "1")<\/script>' +
+      '</svg>';
+    await serveSvg(page, INLINE_DEMO_URL, hostile);
+    await page.goto('/components/img');
+
+    const host = page.getByTestId('img-inline-svg-row').locator('svg');
+    // Anchor: the intercepted payload really was inlined.
+    await expect(host).toHaveAttribute('viewBox', '0 0 24 24');
+
+    const circle = host.locator('circle');
+    await expect(circle).toHaveCount(1);
+    await expect(circle).not.toHaveAttribute('onclick');
+    await expect(host.locator('script')).toHaveCount(0);
+    await expect(host.locator('image')).not.toHaveAttribute('onerror');
+
+    // Clicking must not run anything the payload planted.
+    await circle.click({ force: true });
+
+    const root = page.locator('html');
+    await expect(root).not.toHaveAttribute('data-child-onerror-ran');
+    await expect(root).not.toHaveAttribute('data-child-onclick-ran');
+    await expect(root).not.toHaveAttribute('data-child-script-ran');
+    await expect(root).not.toHaveAttribute('data-child-js-href');
+  });
+
+  test('legitimate descendant geometry and paint attributes are preserved', async ({ page }) => {
+    const legitimate =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+      '<path d="M4 12l6 6 10-14" stroke="currentColor" stroke-width="2" fill="none" transform="translate(1,1)" />' +
+      '</svg>';
+    await serveSvg(page, INLINE_DEMO_URL, legitimate);
+    await page.goto('/components/img');
+
+    const path = page.getByTestId('img-inline-svg-row').locator('svg path');
+    await expect(path).toHaveAttribute('d', 'M4 12l6 6 10-14');
+    await expect(path).toHaveAttribute('stroke-width', '2');
+    await expect(path).toHaveAttribute('transform', 'translate(1,1)');
+  });
+});


### PR DESCRIPTION
## Defect 1 — a fetched SVG could run script in the host page

`Img`'s `inlineSvg` path fetches remote markup and adopts it into the live document. Two ways that let an untrusted file execute:

**Root attributes were copied wholesale.** A payload could plant `onload`/`onclick`, clobber the `data-pw` test hook, set an `id` (DOM clobbering), or override the component's sizing contract with inline `style`.

**Descendants were adopted wholesale too** — and this is the part worth calling out. An event-handler content attribute becomes a live handler *the moment its element is adopted*, so `<image onerror="…">` inside the payload runs exactly as `onerror` on the root would. Fixing only the root would have looked like a fix while leaving the identical vector open one element deeper.

### The fix

- **Root:** allowlist — geometry, paint and a11y metadata (`viewBox`, `fill`, `stroke-*`, `role`, `focusable`, `aria-*`, …). That is what real icon pipelines emit and what this repo's own assets carry. Excluded deliberately: `on*` (executable), `id` (clobbering), `style` (defeats the `--image-width/height` contract), `tabindex`, `data-*` (could hijack `data-pw`).
- **Descendants:** denylist — scripting elements, `on*` handlers, and `javascript:` URLs are stripped *before* adoption. A denylist here on purpose: descendants legitimately carry the entire SVG geometry and paint vocabulary (`d`, `transform`, `gradientUnits`…), so enumerating what is allowed would break real artwork.

`transformSvg`'s contract is preserved. When a transform is present the raw payload is parsed separately; root attribute names absent from it were added by the caller's hook and pass through, because caller intent is trusted. Fetched names always face the allowlist, so an attacker's `onload` can never ride in on a transform. If the raw payload does not parse on its own, nothing is attributable to the caller and the allowlist applies to everything — never wide open.

### Proof

Tests fail for the right reasons **before** the fix — the live host dump shows `onload=`, `onclick=`, `id="evil-root"`, `tabindex="0"`, `data-pw="hijacked"` all landing, and the child `onerror` surviving adoption.

The child test fires the handler for real rather than only asserting an attribute is absent: `<image>` with a bad `href` triggers `onerror` by itself, and the test then clicks the planted `onclick` too. Nothing is set on `<html>` afterwards.

**17 passed** after the fix, covering the new specs plus the existing `list-item-menu-svg-role`, `select-lefticon-inline-svg`, `icon-slot-color-token` and `status-icon-slot` suites. Payloads are served via `page.route`, so no network.

`pnpm run lint` exit 0 · `pnpm run check` exit 0.

## Defect 2 — `showIndicator` never reached the web component

It shipped on `Choicebox` in #428 but was never added to `Choicebox.wc.svelte`, so `<sui-choicebox>` consumers could not reach it. Added following the pattern the file's other booleans use, with `docs/Choicebox.md` gaining the Web Component attribute table it was missing.

Caveat documented rather than hidden: Svelte's custom-element Boolean conversion is presence-based, so `show-indicator="false"` reads as `true`. Consumers hide the indicator via the property or by removing the attribute. That is platform behaviour for every Boolean-typed prop in this repo, not something the wrapper can change.

## Known remaining

When `src` changes, previously copied host attributes are not removed before the new copy — a pre-existing quirk, untouched here and worth its own fix.