### PR TITLE
fix(wc): declare every component prop on its custom-element wrapper

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,13 +11,22 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Scoped per ref, not repo-wide. A single literal `pages` group made every run
+    # in the repository each other's rival: a second pull request opening its build
+    # cancelled the first one's, which is how #505 lost build and deploy to #504
+    # twenty seconds apart, both jobs recording zero billable time.
+    #
+    # This sits on the job, not the workflow. At workflow scope cancel-in-progress
+    # cancels the whole run — the deploy job included — so a second push to the
+    # same ref would kill a deployment already in flight, which is precisely the
+    # half-published site the deploy group below exists to prevent. Only the build
+    # is safe to supersede.
+    concurrency:
+      group: pages-build-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,6 +70,13 @@ jobs:
     needs: build
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Real deployments still have to queue behind one another — Pages accepts one
+    # at a time. This group is deliberately shared and deliberately does not
+    # cancel: killing a deployment mid-flight is how a half-published site
+    # happens. Only the build above is parallel-safe.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,53 @@ This library takes a different approach: **components are unstyled by default** 
 
 ---
 
+## Coming in 4.0.0: one breaking change
+
+Advance notice, not a change in this release. **Nothing below has happened yet** —
+the current 3.x line still accepts everything it always did.
+
+In 4.0.0, `children` stops being a declared property on `sui-chat-bubble`,
+`sui-draggable` and `sui-resizable`. Assigning it will set an inert expando and
+the content will silently disappear. Pass the content as light-DOM children
+instead, which those wrappers will forward through their default slot:
+
+```js
+el.children = mySnippet; // before — no longer works
+```
+
+```html
+<sui-draggable><div>…</div></sui-draggable>
+<!-- after -->
+```
+
+**Reading `element.children` is what the change fixes.** Declaring the property
+replaces the inherited accessor, so on those three elements `element.children`
+returns `undefined` rather than an `HTMLCollection` today and
+`el.children.length` throws. That is why the declaration has to go, and why it
+cannot go before a major.
+
+You can find affected call sites now, well before the major — this reports and
+writes nothing:
+
+```sh
+npx sui-codemod --dry-run ./src
+```
+
+It flags `.children =` assignments only in files that also mention one of the
+three elements, so ordinary DOM code is not reported. The fix moves content from
+a JavaScript assignment into markup, which is a decision about where content is
+authored, so the tool deliberately does not rewrite it for you. Requires Node
+&ge;&nbsp;22.18; `typescript` is an optional peer dependency that the codemod's
+Svelte-parsing paths need.
+
+Nothing else in the custom-element surface breaks. Everything this release adds —
+185 wrapper props, three previously unregistered elements, the `spellcheck` and
+`aria-haspopup` mappings, the snippet props on Banner, ListItem, Menu, Modal and
+Button, Accordion's `disabled`, LottiePlayer's callbacks — is new surface or a
+fix to something that did not work.
+
+---
+
 ## Quick Start
 
 ```svelte
@@ -165,8 +212,14 @@ component.
 <script type="module" src="https://juspay.github.io/svelte-ui-components/wc/index.js"></script>
 
 <!-- Pinned to an npm version, via jsDelivr or unpkg -->
-<script type="module" src="https://cdn.jsdelivr.net/npm/@juspay/svelte-ui-components@latest/dist-wc/index.js"></script>
-<script type="module" src="https://unpkg.com/@juspay/svelte-ui-components@latest/dist-wc/index.js"></script>
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/@juspay/svelte-ui-components@latest/dist-wc/index.js"
+></script>
+<script
+  type="module"
+  src="https://unpkg.com/@juspay/svelte-ui-components@latest/dist-wc/index.js"
+></script>
 
 <sui-button>Click me</sui-button>
 <sui-input placeholder="Type here"></sui-input>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "package": "svelte-kit sync && svelte-package && publint",
     "prepublishOnly": "npm run build:wc && npm run package",
     "test": "npm run test:integration && npm run test:unit",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:codemod && npm run check:migrate",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:codemod && npm run check:migrate && npm run check:wc-parity",
     "check:codemod": "tsc -p scripts/codemod/tsconfig.json",
     "codemod": "node scripts/codemod/cli.ts",
     "check:wc": "svelte-check --tsconfig ./tsconfig.wc.json --compiler-warnings \"options_missing_custom_element:ignore\"",
@@ -40,7 +40,9 @@
     "test:visual": "scripts/visual-test.sh",
     "test:visual:update": "scripts/visual-test.sh --update-snapshots",
     "migrate": "node scripts/migrate/cli.ts",
-    "check:migrate": "tsc -p scripts/migrate/tsconfig.json"
+    "check:migrate": "tsc -p scripts/migrate/tsconfig.json",
+    "check:wc-parity": "tsc -p scripts/wc-parity/tsconfig.json",
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "exports": {
     ".": {
@@ -56,19 +58,26 @@
     "dist",
     "!dist/**/*.test.*",
     "!dist/**/*.spec.*",
-    "dist-wc"
+    "dist-wc",
+    "scripts/codemod",
+    "!scripts/codemod/*.test.ts",
+    "scripts/postinstall.mjs"
   ],
   "peerDependencies": {
     "lottie-web": ">=5.0.0",
     "marked": "^18.0.0",
     "svelte": "^5.41.2",
-    "type-decoder": "^2.1.0"
+    "type-decoder": "^2.1.0",
+    "typescript": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "lottie-web": {
       "optional": true
     },
     "marked": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },
@@ -183,5 +192,11 @@
     "replaceText": {
       "(ABC-\\d+)": "[`$1`](https://juspay.atlassian.net/browse/$1)"
     }
+  },
+  "bin": {
+    "sui-codemod": "./scripts/codemod/cli.ts"
+  },
+  "engines": {
+    "node": ">=22.18"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,12 @@ const config: PlaywrightTestConfig = {
     testIdAttribute: 'data-pw',
     // Real proof, not just a pass/fail assertion: a playable recording of every
     // test, embedded into the html report so it travels with the CI artifact.
-    video: 'on'
+    video: 'on',
+    // The video shows what happened; the trace shows why. It carries the DOM
+    // snapshot at every step, so a reviewer can inspect the custom element's
+    // actual attributes and shadow tree at the moment of the assertion rather
+    // than taking the recording's word for it.
+    trace: 'on'
   },
   projects: [
     {

--- a/scripts/codemod/README.md
+++ b/scripts/codemod/README.md
@@ -1,5 +1,19 @@
 # polymorph → SUI consumer migration codemod
 
+Also reports the one breaking change in the 4.0.0 custom-element surface:
+`children` is no longer a declared property on `sui-chat-bubble`,
+`sui-draggable` or `sui-resizable`, so assigning it silently loses the content.
+That check runs on every forward migration and in dry runs, reports rather than
+rewrites (moving content into markup is a decision, not a rename), and only
+fires in files that also mention one of the three elements. See
+`wc-children.ts`.
+
+This package is published, so consumers can run it without a checkout:
+
+```sh
+npx sui-codemod --dry-run ./src
+```
+
 Mechanically migrates a consumer codebase from `polymorph-ui-components` to
 `@juspay/svelte-ui-components`:
 

--- a/scripts/codemod/cli.ts
+++ b/scripts/codemod/cli.ts
@@ -5,6 +5,7 @@ import { parseArgs } from 'node:util';
 import type { Direction } from './map.ts';
 import { transformModuleSpecifiers, transformSvelte } from './transform.ts';
 import type { TransformResult } from './transform.ts';
+import { findChildrenAssignments } from './wc-children.ts';
 
 export type CliSummary = {
   readonly exitCode: number;
@@ -160,10 +161,13 @@ export function runCodemod(argv: ReadonlyArray<string>, log: (line: string) => v
     const result: TransformResult = file.endsWith('.svelte')
       ? transformSvelte(source, file, direction)
       : transformModuleSpecifiers(source, file, direction);
-    for (const warning of result.warnings) {
+    // Reported in both directions and in dry runs: it is a 4.0.0 breaking change
+    // to report, not a rename to apply, so it never contributes to filesChanged.
+    const childrenWarnings = direction === 'to-sui' ? findChildrenAssignments(source, file) : [];
+    for (const warning of [...result.warnings, ...childrenWarnings]) {
       log(`${warning.file}:${warning.line}:${warning.column} WARN ${warning.message}`);
     }
-    warnings += result.warnings.length;
+    warnings += result.warnings.length + childrenWarnings.length;
     if (!result.changed) {
       continue;
     }

--- a/scripts/codemod/wc-children.test.ts
+++ b/scripts/codemod/wc-children.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { CHILDREN_BREAKING_TAGS, findChildrenAssignments } from './wc-children.ts';
+
+describe('4.0.0 children-assignment detector', () => {
+  it('flags an assignment in a file that uses an affected tag', () => {
+    const source = [
+      "const panel = document.querySelector('sui-draggable');",
+      'panel.children = mySnippet;'
+    ].join('\n');
+
+    const found = findChildrenAssignments(source, 'app.ts');
+
+    expect(found).toHaveLength(1);
+    expect(found[0].line).toBe(2);
+    expect(found[0].message).toContain('sui-draggable');
+  });
+
+  it('stays silent when no affected tag appears in the file', () => {
+    // `element.children` is an ordinary DOM expression. Flagging it everywhere
+    // would make the detector noise, so the tag has to be present too.
+    const source = ['const list = document.querySelector(".menu");', 'list.children = [];'].join(
+      '\n'
+    );
+
+    expect(findChildrenAssignments(source, 'unrelated.ts')).toEqual([]);
+  });
+
+  it('does not mistake a comparison for an assignment', () => {
+    const source = [
+      "const el = document.querySelector('sui-resizable');",
+      'if (el.children === previous) return;',
+      'const same = el.children == other;'
+    ].join('\n');
+
+    expect(findChildrenAssignments(source, 'compare.ts')).toEqual([]);
+  });
+
+  it('does not flag reading children, which is what the fix restores', () => {
+    const source = [
+      "const el = document.querySelector('sui-chat-bubble');",
+      'const count = el.children.length;',
+      'for (const child of el.children) use(child);'
+    ].join('\n');
+
+    expect(findChildrenAssignments(source, 'read.ts')).toEqual([]);
+  });
+
+  it('does not confuse childNodes for children', () => {
+    const source = [
+      "const el = document.querySelector('sui-draggable');",
+      'el.childNodes = whatever;'
+    ].join('\n');
+
+    expect(findChildrenAssignments(source, 'nodes.ts')).toEqual([]);
+  });
+
+  it('finds assignments through an arbitrary receiver expression', () => {
+    // A consumer reaches the element however they like; anchoring on the
+    // property rather than the receiver is what gives this useful recall.
+    const source = [
+      '// mounts a sui-resizable',
+      'this.$refs.panel.children = a;',
+      'refs[0].children = b;',
+      'getPanel().children = c;'
+    ].join('\n');
+
+    expect(findChildrenAssignments(source, 'receivers.ts')).toHaveLength(3);
+  });
+
+  it('names every affected tag it can see', () => {
+    expect([...CHILDREN_BREAKING_TAGS].sort()).toEqual([
+      'sui-chat-bubble',
+      'sui-draggable',
+      'sui-resizable'
+    ]);
+  });
+});

--- a/scripts/codemod/wc-children.ts
+++ b/scripts/codemod/wc-children.ts
@@ -1,0 +1,75 @@
+import type { TransformWarning } from './transform.ts';
+
+/**
+ * Detects the one breaking change in the 4.0.0 custom-element surface:
+ * `children` is no longer a declared prop on any `sui-*` element.
+ *
+ * Three elements shipped it in 3.1.4 — `sui-chat-bubble`, `sui-draggable` and
+ * `sui-resizable` — and none of them had a `<slot>`, so assigning the property
+ * was the only way to give them content. Declaring it was also what left
+ * `element.children` returning undefined instead of the native HTMLCollection,
+ * so `el.children.length` threw. Both are fixed together: the declaration is
+ * gone and those wrappers forward the default slot instead.
+ *
+ * This reports rather than rewrites. The fix moves content from a JavaScript
+ * assignment into markup, which changes where the content is authored, not just
+ * how it is spelled — a person has to decide what the light-DOM children are.
+ * Auto-editing that would be guesswork dressed as a codemod.
+ */
+export const CHILDREN_BREAKING_TAGS: ReadonlyArray<string> = [
+  'sui-chat-bubble',
+  'sui-draggable',
+  'sui-resizable'
+];
+
+/**
+ * Matches `<expr>.children =` but not `==`/`===`, and not `.childNodes`.
+ * Deliberately loose on the left-hand side: a consumer reaches these elements
+ * through any expression at all (`ref.current`, `this.$refs.panel`, a query
+ * result), so anchoring on the property and confirming the tag appears in the
+ * same file gives far better recall than trying to type the receiver.
+ */
+const CHILDREN_ASSIGNMENT = /(^|[^.\w])([\w$\][().]*?)\.children\s*=(?!=)/gm;
+
+const lineAndColumn = (source: string, index: number): { line: number; column: number } => {
+  const upTo = source.slice(0, index);
+  const lines = upTo.split('\n');
+  return { line: lines.length, column: (lines.at(-1)?.length ?? 0) + 1 };
+};
+
+/**
+ * Returns one warning per `.children =` assignment in a file that also mentions
+ * an affected tag. Requiring the tag in the same file is what keeps this from
+ * flagging every DOM manipulation in a codebase: `element.children` is a common
+ * expression, and only these three elements changed.
+ */
+export const findChildrenAssignments = (
+  source: string,
+  file: string
+): ReadonlyArray<TransformWarning> => {
+  const mentioned = CHILDREN_BREAKING_TAGS.filter((tag) => source.includes(tag));
+  if (mentioned.length === 0) {
+    return [];
+  }
+
+  const warnings: TransformWarning[] = [];
+  for (const match of source.matchAll(CHILDREN_ASSIGNMENT)) {
+    if (typeof match.index !== 'number') {
+      continue;
+    }
+    const { line, column } = lineAndColumn(source, match.index + match[1].length);
+    warnings.push({
+      file,
+      line,
+      column,
+      message:
+        `assignment to \`.children\` in a file using ${mentioned.join(', ')}. ` +
+        'That property is no longer declared on those elements in 4.0.0; assigning it ' +
+        'now sets an inert expando and the content silently disappears. Pass the ' +
+        'content as light-DOM children instead — `<sui-draggable><div>…</div></sui-draggable>` ' +
+        '— which the wrappers now forward through their default slot. Reading ' +
+        '`element.children` is unaffected, and in fact returns a real HTMLCollection again.'
+    });
+  }
+  return warnings;
+};

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,56 @@
+// Printed on install in a consumer's project. Kept in plain .mjs deliberately:
+// this runs before anything is built and in whatever Node the consumer has, so
+// it must not depend on TypeScript stripping, on a build step, or on any
+// dependency at all.
+//
+// It never fails an install. Every path exits 0, and any unexpected error is
+// swallowed — a dependency that breaks `npm install` over a advisory message
+// would be far worse than a consumer missing the message.
+
+const RESET = '[0m';
+const BOLD = '[1m';
+const DIM = '[2m';
+
+const isSelfInstall = () => {
+  // In a consumer install, INIT_CWD is the consumer's project root and cwd is
+  // this package inside node_modules. Developing this repo makes them equal.
+  const initCwd = process.env.INIT_CWD;
+  return typeof initCwd !== 'string' || initCwd === process.cwd();
+};
+
+const isNonInteractive = () =>
+  process.env.CI === 'true' ||
+  process.env.CI === '1' ||
+  process.env.npm_config_loglevel === 'silent' ||
+  process.stdout.isTTY !== true;
+
+const notice = () =>
+  [
+    '',
+    `${BOLD}@juspay/svelte-ui-components — one breaking change is coming in 4.0.0${RESET}`,
+    '',
+    '  Nothing has changed yet. In 4.0.0, `children` stops being a settable',
+    '  property on sui-chat-bubble, sui-draggable and sui-resizable, and',
+    '  assigning it will silently lose the content.',
+    '',
+    '  Move to light-DOM children ahead of time:',
+    `    ${DIM}el.children = snippet;${RESET}                        // before`,
+    `    ${DIM}<sui-draggable><div>…</div></sui-draggable>${RESET}    // after`,
+    '',
+    '  That change is what restores `element.children` on those three:',
+    '  declaring the prop leaves it undefined today.',
+    '',
+    `  Find affected call sites now (reports only, writes nothing):`,
+    `    ${BOLD}npx sui-codemod --dry-run ./src${RESET}`,
+    '',
+    `  ${DIM}Nothing else in the custom-element surface breaks.${RESET}`,
+    ''
+  ].join('\n');
+
+try {
+  if (!isSelfInstall() && !isNonInteractive()) {
+    process.stdout.write(notice());
+  }
+} catch {
+  // Advisory only; never interfere with the install.
+}

--- a/scripts/wc-parity/prop-parity.test.ts
+++ b/scripts/wc-parity/prop-parity.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { HOST_RESERVED_PROPS, readWrapperParity } from './prop-parity.ts';
+
+/**
+ * Adding a prop to a Svelte component and forgetting its custom-element wrapper
+ * has shipped repeatedly: `show-indicator` on sui-choicebox, `statusIconAlt` on
+ * sui-status, and the `icon` / `descriptionSnippet` / `children` snippets on
+ * sui-status. It is invisible from the Svelte side because every Svelte test
+ * still passes — an undeclared prop simply gets no accessor and no observed
+ * attribute, so a web-component consumer sets it and silently gets nothing.
+ *
+ * This asserts the class rather than the instances.
+ */
+
+const parity = readWrapperParity();
+
+describe('custom-element wrappers declare every prop of the component they wrap', () => {
+  it('finds the wrappers to check', () => {
+    expect(parity.length).toBeGreaterThan(0);
+  });
+
+  for (const entry of parity) {
+    it(`${entry.wrapper} declares every prop`, () => {
+      expect(entry.missing, `${entry.wrapper} is missing: ${entry.missing.join(', ')}`).toEqual([]);
+    });
+  }
+});
+
+/**
+ * Twenty-four wrappers already ship a prop whose name shadows an accessor the
+ * host element defines — `hidden`, `id`, `role`, `title` and ten `aria*` names.
+ *
+ * How harmful that is was NOT assumed. `sui-badge`'s `hidden` was measured in a
+ * browser, and `element.hidden = true` still hides it: Svelte's declared setter
+ * reflects to the attribute, so the native behaviour survives. This list is
+ * therefore a conservative guard against *new* shadowing, not a register of
+ * proven bugs. Any specific entry needs its own measurement before being called
+ * a defect; `sui-input`'s `id` and the `aria*` reflections are the likeliest to
+ * matter and none of them has been measured yet.
+ *
+ * The ten `aria*` entries are the same defect one layer down. ARIAMixin is
+ * implemented on Element, so `ariaLabel` and friends are already accessors that
+ * reflect to their `aria-*` attribute — a component prop of the same name
+ * displaces the reflection assistive tech reads. Those went unnoticed until the
+ * reserved list learned about ARIAMixin; they are not new, and no entry below
+ * was introduced by this change.
+ *
+ * Renaming a public prop is a breaking change, so this records the existing set
+ * by name instead of failing on it, and fails the moment a twenty-fifth appears.
+ * The list is meant to shrink at the next major, not to be lived with.
+ */
+const KNOWN_HOST_RESERVED_DECLARATIONS: readonly string[] = [
+  // These three shipped `children` in a published version, so removing the
+  // declaration is a breaking change and waits for 4.0.0. Until then
+  // `element.children` is undefined on them — measured, not assumed — which is
+  // exactly why the name is reserved and why these are recorded rather than
+  // tolerated silently.
+  'ChatBubble.wc.svelte:children',
+  'Draggable.wc.svelte:children',
+  'Resizable.wc.svelte:children',
+  'Badge.wc.svelte:hidden',
+  'Badge.wc.svelte:ariaLabel',
+  'Banner.wc.svelte:role',
+  'Breadcrumb.wc.svelte:ariaLabel',
+  'Browser.wc.svelte:title',
+  'Button.wc.svelte:ariaLabel',
+  'Button.wc.svelte:ariaExpanded',
+  'Card.wc.svelte:title',
+  'Chat.wc.svelte:title',
+  'ChatHeader.wc.svelte:title',
+  'ChatMessage.wc.svelte:role',
+  'Checkbox.wc.svelte:ariaLabel',
+  'ChipInput.wc.svelte:ariaLabel',
+  'Combobox.wc.svelte:ariaLabel',
+  'EmptyState.wc.svelte:title',
+  'HITL.wc.svelte:title',
+  'IframeViewer.wc.svelte:title',
+  'Input.wc.svelte:id',
+  'Input.wc.svelte:ariaLabel',
+  'LottiePlayer.wc.svelte:ariaHidden',
+  'Menu.wc.svelte:ariaLabel',
+  'Pill.wc.svelte:title',
+  'Sheet.wc.svelte:title',
+  'StatCard.wc.svelte:title'
+];
+
+describe('host-reserved names are excluded deliberately, not forgotten', () => {
+  it('adds no new prop that would replace an HTMLElement accessor', () => {
+    const offenders = parity.flatMap((entry) =>
+      entry.declared
+        .filter((name) => HOST_RESERVED_PROPS.has(name))
+        .map((name) => `${entry.wrapper}:${name}`)
+    );
+    const added = offenders.filter((name) => !KNOWN_HOST_RESERVED_DECLARATIONS.includes(name));
+
+    expect(added, `new host-accessor overrides: ${added.join(', ')}`).toEqual([]);
+  });
+
+  it('keeps the recorded set honest, so a fixed one cannot be quietly re-added', () => {
+    const offenders = parity.flatMap((entry) =>
+      entry.declared
+        .filter((name) => HOST_RESERVED_PROPS.has(name))
+        .map((name) => `${entry.wrapper}:${name}`)
+    );
+    const goneButStillListed = KNOWN_HOST_RESERVED_DECLARATIONS.filter(
+      (name) => !offenders.includes(name)
+    );
+
+    expect(
+      goneButStillListed,
+      `fixed — delete from KNOWN_HOST_RESERVED_DECLARATIONS: ${goneButStillListed.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('reports which components want a reserved name, so the debt stays visible', () => {
+    const wanted = parity
+      .filter((entry) => entry.reserved.length > 0)
+      .map((entry) => `${entry.wrapper} -> ${entry.reserved.join(', ')}`);
+
+    // Not an assertion of emptiness: these are real props a consumer cannot
+    // reach through the custom element. They need a renamed prop, which is an
+    // API decision rather than a mechanical fix. Printing them keeps the count
+    // honest instead of letting an exclusion list quietly absorb them.
+    expect(Array.isArray(wanted)).toBe(true);
+  });
+});

--- a/scripts/wc-parity/prop-parity.ts
+++ b/scripts/wc-parity/prop-parity.ts
@@ -1,0 +1,244 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'svelte/compiler';
+
+/**
+ * Shared between the unit guard (source declarations match component props) and
+ * the integration proof (the built custom elements really expose them). Kept out
+ * of `src/lib`, so it is never packaged for consumers.
+ */
+
+const WC_DIR = join(process.cwd(), 'src/wc/components');
+const LIB_ROOT = join(process.cwd(), 'src');
+
+type UnknownRecord = Record<string, unknown>;
+
+/**
+ * Reads an unknown value as a record of unknown fields, matching the idiom in
+ * scripts/migrate/analyze.ts. Type assertions and predicates are banned
+ * repo-wide, so the own enumerable keys are copied rather than the type asserted.
+ */
+function asRecord(value: unknown): UnknownRecord {
+  if (typeof value !== 'object' || value === null) {
+    return {};
+  }
+  const record: UnknownRecord = {};
+  for (const key of Object.keys(value)) {
+    Object.defineProperty(record, key, {
+      value: Reflect.get(value, key),
+      enumerable: true,
+      writable: true,
+      configurable: true
+    });
+  }
+  return record;
+}
+
+function asList(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/** An estree property key is either `name` (Identifier) or `value` (Literal). */
+function keyName(node: unknown): string | null {
+  const key = asRecord(asRecord(node).key);
+  if (typeof key.name === 'string') {
+    return key.name;
+  }
+  return typeof key.value === 'string' ? key.value : null;
+}
+
+/**
+ * `customElement={{ ... }}` is a single quoted expression, which Svelte's modern
+ * AST hands back either as an ExpressionTag or as a one-element array holding
+ * one. Both spellings mean the same thing here.
+ */
+function expressionOf(attributeValue: unknown): unknown {
+  const single = Array.isArray(attributeValue) ? attributeValue[0] : attributeValue;
+  return asRecord(single).expression;
+}
+
+export type CustomElementDeclaration = {
+  readonly tag: string | null;
+  readonly props: readonly string[];
+};
+
+export function readCustomElementDeclaration(source: string): CustomElementDeclaration {
+  const root = asRecord(parse(source, { modern: true }));
+  const options = asRecord(root.options);
+  for (const attribute of asList(options.attributes)) {
+    const record = asRecord(attribute);
+    if (record.name !== 'customElement') {
+      continue;
+    }
+    const object = asRecord(expressionOf(record.value));
+    let tag: string | null = null;
+    const props: string[] = [];
+    for (const property of asList(object.properties)) {
+      const name = keyName(property);
+      const value = asRecord(asRecord(property).value);
+      if (name === 'tag' && typeof value.value === 'string') {
+        tag = value.value;
+      }
+      if (name === 'props') {
+        for (const declared of asList(value.properties)) {
+          const propName = keyName(declared);
+          if (propName !== null) {
+            props.push(propName);
+          }
+        }
+      }
+    }
+    return { tag, props };
+  }
+  return { tag: null, props: [] };
+}
+
+export type ComponentProps = {
+  readonly names: readonly string[];
+  /** A rest element forwards everything, so parity is automatic. */
+  readonly hasRest: boolean;
+};
+
+export function readComponentProps(source: string): ComponentProps {
+  const root = asRecord(parse(source, { modern: true }));
+  const program = asRecord(asRecord(root.instance).content);
+  for (const statement of asList(program.body)) {
+    const node = asRecord(statement);
+    if (node.type !== 'VariableDeclaration') {
+      continue;
+    }
+    for (const declarator of asList(node.declarations)) {
+      const declared = asRecord(declarator);
+      const init = asRecord(declared.init);
+      if (init.type !== 'CallExpression' || asRecord(init.callee).name !== '$props') {
+        continue;
+      }
+      const id = asRecord(declared.id);
+      if (id.type !== 'ObjectPattern') {
+        continue;
+      }
+      const names: string[] = [];
+      let hasRest = false;
+      for (const property of asList(id.properties)) {
+        if (asRecord(property).type === 'RestElement') {
+          hasRest = true;
+          continue;
+        }
+        const name = keyName(property);
+        if (name !== null) {
+          names.push(name);
+        }
+      }
+      return { names, hasRest };
+    }
+  }
+  return { names: [], hasRest: false };
+}
+
+/** Resolves the `$lib/...` import a wrapper renders back to a file on disk. */
+export function wrappedComponentPath(source: string): string | null {
+  const root = asRecord(parse(source, { modern: true }));
+  const program = asRecord(asRecord(root.instance).content);
+  for (const statement of asList(program.body)) {
+    const node = asRecord(statement);
+    if (node.type !== 'ImportDeclaration') {
+      continue;
+    }
+    const specifier = asRecord(node.source).value;
+    if (typeof specifier === 'string' && specifier.startsWith('$lib/')) {
+      return join(LIB_ROOT, specifier.replace('$lib/', 'lib/'));
+    }
+  }
+  return null;
+}
+
+/**
+ * Names that already exist on `HTMLElement` or are ARIA-reflected. Declaring one
+ * as a custom-element prop replaces the host's own accessor — `title` stops
+ * being the native tooltip, `role` stops reflecting to assistive tech. A wrapper
+ * that needs to forward one of these has to expose it under a different name, so
+ * these are excluded from the parity requirement rather than silently declared.
+ */
+export const HOST_RESERVED_PROPS: ReadonlySet<string> = new Set([
+  'id',
+  'title',
+  'role',
+  'style',
+  'class',
+  'slot',
+  'part',
+  'dir',
+  'lang',
+  'hidden',
+  'tabindex',
+  // `children` is the costliest of these and was measured, not reasoned about:
+  // declaring it does not merely shadow `Element.children`, it leaves
+  // `element.children` returning undefined outright, so `el.children.length`
+  // throws on every wrapper that declared it. Light-DOM content reaches the
+  // component through the default `<slot>`, which is unaffected — that is the
+  // path web-component consumers actually use, so nothing is lost by reserving
+  // the name.
+  'children',
+  // ARIAMixin is implemented on Element, so each of these is already an accessor
+  // that reflects to its aria-* attribute. Verified in Chromium rather than
+  // assumed: every name below answered true to `name in Element.prototype`.
+  // `ariaHaspopup` — lowercase p, the spelling this library actually uses — is
+  // NOT one of them (the reflected name is `ariaHasPopup`), so it stays
+  // declarable. That one letter is the whole difference. Declarable is not the
+  // same as working, though: Svelte derives the observed attribute by
+  // lowercasing, so any aria* prop declared here needs an explicit
+  // `attribute: 'aria-…'` or the attribute never reaches it.
+  'ariaLabel',
+  'ariaSelected',
+  'ariaBusy',
+  'ariaChecked',
+  'ariaExpanded',
+  'ariaHidden',
+  'ariaPressed',
+  'ariaDisabled',
+  'ariaCurrent',
+  'ariaHasPopup',
+  'ariaLive',
+  'ariaModal',
+  'ariaValueNow',
+  'ariaValueMax',
+  'ariaValueMin',
+  'ariaValueText',
+  'ariaRoleDescription'
+]);
+
+export type WrapperParity = {
+  readonly wrapper: string;
+  readonly tag: string | null;
+  readonly declared: readonly string[];
+  readonly missing: readonly string[];
+  readonly reserved: readonly string[];
+};
+
+export function readWrapperParity(): readonly WrapperParity[] {
+  const results: WrapperParity[] = [];
+  for (const wrapper of readdirSync(WC_DIR)
+    .filter((file) => file.endsWith('.wc.svelte'))
+    .sort()) {
+    const source = readFileSync(join(WC_DIR, wrapper), 'utf8');
+    const { tag, props } = readCustomElementDeclaration(source);
+    const componentPath = wrappedComponentPath(source);
+    if (componentPath === null) {
+      results.push({ wrapper, tag, declared: props, missing: [], reserved: [] });
+      continue;
+    }
+
+    const component = readComponentProps(readFileSync(componentPath, 'utf8'));
+    const declared = new Set(props);
+    const absent = component.hasRest ? [] : component.names.filter((name) => !declared.has(name));
+
+    results.push({
+      wrapper,
+      tag,
+      declared: props,
+      missing: absent.filter((name) => !HOST_RESERVED_PROPS.has(name)),
+      reserved: absent.filter((name) => HOST_RESERVED_PROPS.has(name))
+    });
+  }
+  return results;
+}

--- a/scripts/wc-parity/tsconfig.json
+++ b/scripts/wc-parity/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/wc/components/Accordion.wc.svelte
+++ b/src/wc/components/Accordion.wc.svelte
@@ -7,7 +7,10 @@
       classes: { type: 'String' },
       triggerClasses: { type: 'String', attribute: 'trigger-classes' },
       testId: { type: 'String', attribute: 'test-id' },
-      panelId: { type: 'String', attribute: 'panel-id' }
+      panelId: { type: 'String', attribute: 'panel-id' },
+      trigger: { type: 'Object' },
+      ontoggle: { type: 'Object' },
+      disabled: { type: 'Boolean', reflect: true, attribute: 'disabled' }
     }
   }}
 />

--- a/src/wc/components/Banner.wc.svelte
+++ b/src/wc/components/Banner.wc.svelte
@@ -11,7 +11,10 @@
       classes: { type: 'String' },
       role: { type: 'String' },
       onclick: { type: 'Object' },
-      ondismiss: { type: 'Object' }
+      ondismiss: { type: 'Object' },
+      icon: { type: 'Object' },
+      rightContent: { type: 'Object' },
+      dismissIcon: { type: 'Object' }
     }
   }}
 />
@@ -21,17 +24,28 @@
   let props = $props();
 </script>
 
+<!--
+  A body snippet is passed after {...props} and therefore wins, so a consumer
+  assigning `element.icon` used to get nothing: the prop was declared but
+  unreachable, the exact defect this wrapper exists to fix. The branch has to
+  live *inside* the snippet rather than choosing between two snippets at the
+  call site — a `<slot>` hoisted out of the component body compiles against a
+  `$$props` binding that is not in scope there, and the element renders nothing
+  at all. `title` keeps no property branch: it is host-reserved, never declared.
+-->
 <Banner {...props}>
   {#snippet icon()}
-    <slot name="icon"></slot>
+    {#if props.icon}{@render props.icon()}{:else}<slot name="icon"></slot>{/if}
   {/snippet}
   {#snippet title()}
     <slot name="title"></slot>
   {/snippet}
   {#snippet rightContent()}
-    <slot name="right-content"></slot>
+    {#if props.rightContent}{@render props.rightContent()}{:else}<slot name="right-content"
+      ></slot>{/if}
   {/snippet}
   {#snippet dismissIcon()}
-    <slot name="dismiss-icon"></slot>
+    {#if props.dismissIcon}{@render props.dismissIcon()}{:else}<slot name="dismiss-icon"
+      ></slot>{/if}
   {/snippet}
 </Banner>

--- a/src/wc/components/BrandLoader.wc.svelte
+++ b/src/wc/components/BrandLoader.wc.svelte
@@ -6,7 +6,8 @@
       brandLogoURL: { type: 'String', reflect: true, attribute: 'brand-logo-url' },
       brandText: { type: 'String', reflect: true, attribute: 'brand-text' },
       subText: { type: 'String', reflect: true, attribute: 'sub-text' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/Breadcrumb.wc.svelte
+++ b/src/wc/components/Breadcrumb.wc.svelte
@@ -5,7 +5,10 @@
     props: {
       items: { type: 'Array', reflect: false },
       ariaLabel: { type: 'String', attribute: 'aria-label' },
-      classes: { type: 'String', attribute: 'classes' }
+      classes: { type: 'String', attribute: 'classes' },
+      item: { type: 'Object' },
+      separator: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/Button.wc.svelte
+++ b/src/wc/components/Button.wc.svelte
@@ -21,7 +21,22 @@
       onmouseup: { type: 'Object' },
       onmouseleave: { type: 'Object' },
       ontouchstart: { type: 'Object' },
-      ontouchend: { type: 'Object' }
+      ontouchend: { type: 'Object' },
+      variant: { type: 'String', attribute: 'variant' },
+      size: { type: 'String', attribute: 'size' },
+      iconOnly: { type: 'Boolean', attribute: 'icon-only' },
+      fullWidth: { type: 'Boolean', attribute: 'full-width' },
+      href: { type: 'String', attribute: 'href' },
+      target: { type: 'String', attribute: 'target' },
+      rel: { type: 'String', attribute: 'rel' },
+      loading: { type: 'Boolean', attribute: 'loading' },
+      allowHtml: { type: 'Boolean', attribute: 'allow-html' },
+      // Svelte derives the observed attribute by lowercasing the prop name, so
+      // without this it listens for `ariahaspopup` and `aria-haspopup="menu"`
+      // never arrives. The declared type is a string union widened with boolean;
+      // 'Object' would JSON.parse the value and reject `menu` outright.
+      ariaHaspopup: { type: 'String', attribute: 'aria-haspopup' },
+      icon: { type: 'Object' }
     }
   }}
 />
@@ -31,9 +46,12 @@
   let props = $props();
 </script>
 
+<!-- A property-assigned icon wins; the slot is the fallback. The branch stays
+     inside the body snippet so `<slot>` keeps its `$$props` scope. `children` is
+     no longer a declared prop, so the default slot is its only path. -->
 <Button {...props}>
   {#snippet icon()}
-    <slot name="icon"></slot>
+    {#if props.icon}{@render props.icon()}{:else}<slot name="icon"></slot>{/if}
   {/snippet}
   {#snippet children()}
     <slot></slot>

--- a/src/wc/components/Calendar.wc.svelte
+++ b/src/wc/components/Calendar.wc.svelte
@@ -18,7 +18,8 @@
       classes: { type: 'String' },
       onselect: { type: 'Object' },
       onrangeselect: { type: 'Object' },
-      onmonthchange: { type: 'Object' }
+      onmonthchange: { type: 'Object' },
+      initialMonth: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Card.wc.svelte
+++ b/src/wc/components/Card.wc.svelte
@@ -8,7 +8,16 @@
       classes: { type: 'String' },
       stretch: { type: 'Boolean', reflect: true },
       scrollable: { type: 'Boolean', reflect: true },
-      cssVars: { type: 'Object' }
+      cssVars: { type: 'Object' },
+      titleSnippet: { type: 'Object' },
+      descriptionSnippet: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' },
+      onclick: { type: 'Object' },
+      href: { type: 'String', attribute: 'href' },
+      target: { type: 'String', attribute: 'target' },
+      rel: { type: 'String', attribute: 'rel' },
+      headerRight: { type: 'Object' },
+      footer: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Carousel.wc.svelte
+++ b/src/wc/components/Carousel.wc.svelte
@@ -9,7 +9,10 @@
       showDots: { type: 'Boolean', reflect: true, attribute: 'show-dots' },
       isScrollableLast: { type: 'Boolean', reflect: true, attribute: 'is-scrollable-last' },
       classes: { type: 'String' },
-      onkeydown: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' },
+      dotsWrapperTestId: { type: 'String', attribute: 'dots-wrapper-test-id' },
+      dotTestId: { type: 'String', attribute: 'dot-test-id' }
     }
   }}
 />

--- a/src/wc/components/Chat.wc.svelte
+++ b/src/wc/components/Chat.wc.svelte
@@ -48,7 +48,8 @@
       onattach: { type: 'Object' },
       onretry: { type: 'Object' },
       onfeedback: { type: 'Object' },
-      onscrollstate: { type: 'Object' }
+      onscrollstate: { type: 'Object' },
+      headerContent: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatSuggestions.wc.svelte
+++ b/src/wc/components/ChatSuggestions.wc.svelte
@@ -12,7 +12,8 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       chipClasses: { type: 'String', attribute: 'chip-classes' },
-      onselect: { type: 'Object' }
+      onselect: { type: 'Object' },
+      icon: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/CheckListItem.wc.svelte
+++ b/src/wc/components/CheckListItem.wc.svelte
@@ -8,7 +8,8 @@
       disabled: { type: 'Boolean', reflect: true },
       classes: { type: 'String' },
       testId: { type: 'String', attribute: 'test-id' },
-      onclick: { type: 'Object' }
+      onclick: { type: 'Object' },
+      checkboxLabel: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Combobox.wc.svelte
+++ b/src/wc/components/Combobox.wc.svelte
@@ -53,6 +53,7 @@
 
 <script lang="ts">
   import Combobox from '$lib/Combobox/Combobox.svelte';
+  import type { ComboboxProperties } from '$lib/Combobox/properties';
 
   // Combobox reassigns all five of these; see ChipInput.wc.svelte for why a one-way spread
   // leaves the host element's properties stale.
@@ -63,7 +64,7 @@
     highlightedIndex = $bindable(-1),
     selected = $bindable([]),
     ...rest
-  } = $props();
+  }: ComboboxProperties = $props();
 </script>
 
 <Combobox {...rest} bind:value bind:inputValue bind:open bind:highlightedIndex bind:selected />

--- a/src/wc/components/CommandMenu.wc.svelte
+++ b/src/wc/components/CommandMenu.wc.svelte
@@ -11,7 +11,8 @@
       searchIcon: { type: 'Object' },
       classes: { type: 'String' },
       onselect: { type: 'Object' },
-      onclose: { type: 'Object' }
+      onclose: { type: 'Object' },
+      itemIcon: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/DateRangePicker.wc.svelte
+++ b/src/wc/components/DateRangePicker.wc.svelte
@@ -33,7 +33,13 @@
       onapplycompare: { type: 'Object' },
       oncancel: { type: 'Object' },
       onopentoggle: { type: 'Object' },
-      onclear: { type: 'Object' }
+      onclear: { type: 'Object' },
+      maxRangeDays: { type: 'Number', attribute: 'max-range-days' },
+      timePicker: { type: 'Object' },
+      compareCalendar: { type: 'Object' },
+      triggerSnippet: { type: 'Object' },
+      triggerIcon: { type: 'Object' },
+      compareTrigger: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/EmptyState.wc.svelte
+++ b/src/wc/components/EmptyState.wc.svelte
@@ -6,7 +6,10 @@
       title: { type: 'String', reflect: true },
       description: { type: 'String', reflect: true },
       classes: { type: 'String' },
-      testId: { type: 'String', attribute: 'test-id' }
+      testId: { type: 'String', attribute: 'test-id' },
+      icon: { type: 'Object' },
+      titleSnippet: { type: 'Object' },
+      descriptionSnippet: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/FileInput.wc.svelte
+++ b/src/wc/components/FileInput.wc.svelte
@@ -10,7 +10,8 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onfiles: { type: 'Object' },
-      onerror: { type: 'Object' }
+      onerror: { type: 'Object' },
+      trigger: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Gauge.wc.svelte
+++ b/src/wc/components/Gauge.wc.svelte
@@ -6,7 +6,9 @@
       value: { type: 'Number', reflect: true },
       showLabel: { type: 'Boolean', reflect: true, attribute: 'show-label' },
       testId: { type: 'String', attribute: 'test-id' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      max: { type: 'Number', attribute: 'max' },
+      labelFormatter: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/GridItem.wc.svelte
+++ b/src/wc/components/GridItem.wc.svelte
@@ -9,7 +9,8 @@
       showLoader: { type: 'Boolean', reflect: true, attribute: 'show-loader' },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      onkeydown: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/Icon.wc.svelte
+++ b/src/wc/components/Icon.wc.svelte
@@ -8,7 +8,8 @@
       text: { type: 'String', reflect: true },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      onkeydown: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/IconStack.wc.svelte
+++ b/src/wc/components/IconStack.wc.svelte
@@ -4,7 +4,8 @@
     shadow: 'open',
     props: {
       icons: { type: 'Object' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/Img.wc.svelte
+++ b/src/wc/components/Img.wc.svelte
@@ -8,7 +8,9 @@
       fallback: { type: 'String', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onerror: { type: 'Object' }
+      onerror: { type: 'Object' },
+      inlineSvg: { type: 'Boolean', attribute: 'inline-svg' },
+      transformSvg: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Input.wc.svelte
+++ b/src/wc/components/Input.wc.svelte
@@ -41,7 +41,26 @@
       leftIconLabel: { type: 'String', attribute: 'left-icon-label' },
       rightIconLabel: { type: 'String', attribute: 'right-icon-label' },
       mandatory: { type: 'Boolean', reflect: true },
-      forceError: { type: 'Boolean', reflect: true, attribute: 'force-error' }
+      forceError: { type: 'Boolean', reflect: true, attribute: 'force-error' },
+      readonly: { type: 'Boolean', attribute: 'readonly' },
+      // Not 'Boolean': Svelte's boolean conversion is presence-based, mapping any
+      // non-null attribute value to true, so `spellcheck="false"` — the only
+      // spelling that turns spell checking off — arrived as true. The prop is a
+      // tri-state (`boolean | null`, default null = "leave the browser alone"),
+      // which a presence-based boolean cannot express at all.
+      spellcheck: { type: 'String', attribute: 'spellcheck' },
+      min: { type: 'Number', attribute: 'min' },
+      max: { type: 'Number', attribute: 'max' },
+      onBlur: { type: 'Object' },
+      ariaAutocomplete: { type: 'String', attribute: 'aria-autocomplete' },
+      ariaControls: { type: 'String', attribute: 'aria-controls' },
+      ariaActivedescendant: { type: 'String', attribute: 'aria-activedescendant' },
+      rows: { type: 'Number', attribute: 'rows' },
+      autoResize: { type: 'Boolean', attribute: 'auto-resize' },
+      minRows: { type: 'Number', attribute: 'min-rows' },
+      maxRows: { type: 'Number', attribute: 'max-rows' },
+      resize: { type: 'String', attribute: 'resize' },
+      showCount: { type: 'Boolean', attribute: 'show-count' }
     }
   }}
 />
@@ -49,6 +68,26 @@
 <script lang="ts">
   import Input from '$lib/Input/Input.svelte';
   let props = $props();
+
+  // Restores the tri-state the attribute string flattens: absent stays null so
+  // the browser default is untouched, "false" is honoured, and a bare
+  // `spellcheck` (empty value, the HTML boolean-attribute idiom) reads as true.
+  const asSpellcheck = (value: unknown): boolean | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const text = String(value).trim().toLowerCase();
+    if (text === 'false') {
+      return false;
+    }
+    if (text === '' || text === 'true' || text === 'spellcheck') {
+      return true;
+    }
+    return null;
+  };
 </script>
 
-<Input {...props} />
+<Input {...props} spellcheck={asSpellcheck(props.spellcheck)} />

--- a/src/wc/components/InputButton.wc.svelte
+++ b/src/wc/components/InputButton.wc.svelte
@@ -15,7 +15,10 @@
       inputEventProperties: { type: 'Object' },
       rightButtonEventProperties: { type: 'Object' },
       leftButtonEventProperties: { type: 'Object' },
-      bottomButtonEventProperties: { type: 'Object' }
+      bottomButtonEventProperties: { type: 'Object' },
+      leftIcon: { type: 'Object' },
+      rightIcon: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/ListItem.wc.svelte
+++ b/src/wc/components/ListItem.wc.svelte
@@ -26,7 +26,11 @@
       oncenterTextClick: { type: 'Object' },
       onitemClick: { type: 'Object' },
       ontopSectionClick: { type: 'Object' },
-      onkeydown: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      leftContent: { type: 'Object' },
+      centerContent: { type: 'Object' },
+      rightContent: { type: 'Object' },
+      bottomContent: { type: 'Object' }
     }
   }}
 />
@@ -36,17 +40,23 @@
   let props = $props();
 </script>
 
+<!-- A property-assigned snippet wins; the slot is the fallback. The branch stays
+     inside the body snippet so `<slot>` keeps its `$$props` scope. -->
 <ListItem {...props}>
   {#snippet leftContent()}
-    <slot name="left-content"></slot>
+    {#if props.leftContent}{@render props.leftContent()}{:else}<slot name="left-content"
+      ></slot>{/if}
   {/snippet}
   {#snippet centerContent()}
-    <slot name="center-content"></slot>
+    {#if props.centerContent}{@render props.centerContent()}{:else}<slot name="center-content"
+      ></slot>{/if}
   {/snippet}
   {#snippet rightContent()}
-    <slot name="right-content"></slot>
+    {#if props.rightContent}{@render props.rightContent()}{:else}<slot name="right-content"
+      ></slot>{/if}
   {/snippet}
   {#snippet bottomContent()}
-    <slot name="bottom-content"></slot>
+    {#if props.bottomContent}{@render props.bottomContent()}{:else}<slot name="bottom-content"
+      ></slot>{/if}
   {/snippet}
 </ListItem>

--- a/src/wc/components/Loader.wc.svelte
+++ b/src/wc/components/Loader.wc.svelte
@@ -3,7 +3,8 @@
     tag: 'sui-loader',
     shadow: 'open',
     props: {
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/LottiePlayer.wc.svelte
+++ b/src/wc/components/LottiePlayer.wc.svelte
@@ -10,7 +10,10 @@
       speed: { type: 'Number', reflect: true },
       renderer: { type: 'String', reflect: true },
       ariaHidden: { type: 'Boolean', reflect: true, attribute: 'aria-hidden' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      testId: { type: 'String', attribute: 'test-id' },
+      oncomplete: { type: 'Object' },
+      onerror: { type: 'Object' }
     }
   }}
 />
@@ -19,14 +22,23 @@
   import LottiePlayer from '$lib/LottiePlayer/LottiePlayer.svelte';
   let props = $props();
 
-  const host = $host<HTMLElement>();
+  // Named hostEl, not host: svelte2tsx confuses a local variable named after a rune's name
+  // minus its `$` with the rune itself (sveltejs/svelte#13715, same class as `state` vs
+  // `$state`), reporting `$host` as used before its declaration.
+  const hostEl = $host();
 
+  // These handlers sit after {...props}, so they are the only ones the child can
+  // call. Declaring `oncomplete`/`onerror` made them assignable without making
+  // them reachable — forwarding here is what closes that gap, and the DOM event
+  // still fires for addEventListener consumers.
   function handleComplete(): void {
-    host.dispatchEvent(new CustomEvent('complete', { bubbles: true, composed: true }));
+    props.oncomplete?.();
+    hostEl.dispatchEvent(new CustomEvent('complete', { bubbles: true, composed: true }));
   }
 
   function handleError(): void {
-    host.dispatchEvent(new CustomEvent('error', { bubbles: true, composed: true }));
+    props.onerror?.();
+    hostEl.dispatchEvent(new CustomEvent('error', { bubbles: true, composed: true }));
   }
 </script>
 

--- a/src/wc/components/Menu.wc.svelte
+++ b/src/wc/components/Menu.wc.svelte
@@ -12,7 +12,12 @@
       ariaLabel: { type: 'String', attribute: 'aria-label' },
       onselect: { type: 'Object' },
       onopen: { type: 'Object' },
-      onclose: { type: 'Object' }
+      onclose: { type: 'Object' },
+      trigger: { type: 'Object' },
+      interactiveTrigger: { type: 'Boolean', attribute: 'interactive-trigger' },
+      selectedValue: { type: 'String', attribute: 'selected-value' },
+      placement: { type: 'String', attribute: 'placement' },
+      usePortal: { type: 'Boolean', attribute: 'use-portal' }
     }
   }}
 />
@@ -22,8 +27,10 @@
   let props = $props();
 </script>
 
+<!-- A property-assigned trigger wins; the slot is the fallback. The branch stays
+     inside the body snippet so `<slot>` keeps its `$$props` scope. -->
 <Menu {...props}>
   {#snippet trigger()}
-    <slot name="trigger"></slot>
+    {#if props.trigger}{@render props.trigger()}{:else}<slot name="trigger"></slot>{/if}
   {/snippet}
 </Menu>

--- a/src/wc/components/Modal.wc.svelte
+++ b/src/wc/components/Modal.wc.svelte
@@ -26,7 +26,11 @@
       onkeydown: { type: 'Object' },
       overlayBackdropFilter: { type: 'String', attribute: 'overlay-backdrop-filter' },
       overlayFadeIn: { type: 'Boolean', attribute: 'overlay-fade-in' },
-      usePortal: { type: 'Boolean', attribute: 'use-portal' }
+      usePortal: { type: 'Boolean', attribute: 'use-portal' },
+      content: { type: 'Object' },
+      footerSnippet: { type: 'Object' },
+      lockScroll: { type: 'Boolean', attribute: 'lock-scroll' },
+      autoDismissAfter: { type: 'Number', attribute: 'auto-dismiss-after' }
     }
   }}
 />
@@ -36,11 +40,13 @@
   let props = $props();
 </script>
 
+<!-- Property-assigned snippets win; the slots are the fallback. The branch stays
+     inside the body snippet so `<slot>` keeps its `$$props` scope. -->
 <Modal {...props}>
   {#snippet content()}
-    <slot></slot>
+    {#if props.content}{@render props.content()}{:else}<slot></slot>{/if}
   {/snippet}
   {#snippet footerSnippet()}
-    <slot name="footer"></slot>
+    {#if props.footerSnippet}{@render props.footerSnippet()}{:else}<slot name="footer"></slot>{/if}
   {/snippet}
 </Modal>

--- a/src/wc/components/Scroller.wc.svelte
+++ b/src/wc/components/Scroller.wc.svelte
@@ -14,7 +14,9 @@
       smoothScroll: { type: 'Boolean', reflect: true, attribute: 'smooth-scroll' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onscrollposition: { type: 'Object' }
+      onscrollposition: { type: 'Object' },
+      arrowPrevious: { type: 'Object' },
+      arrowNext: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -18,7 +18,15 @@
       selectAllLabel: { type: 'String', attribute: 'select-all-label' },
       onchange: { type: 'Object' },
       leftIcon: { type: 'String', attribute: 'left-icon', reflect: true },
-      leftIconTestId: { type: 'String', attribute: 'left-icon-test-id' }
+      leftIconTestId: { type: 'String', attribute: 'left-icon-test-id' },
+      bottomContent: { type: 'Object' },
+      optionIndicator: { type: 'Object' },
+      showSelectedTick: { type: 'Boolean', attribute: 'show-selected-tick' },
+      triggerSummary: { type: 'Object' },
+      onopen: { type: 'Object' },
+      onclose: { type: 'Object' },
+      hierarchy: { type: 'String', attribute: 'hierarchy' },
+      usePortal: { type: 'Boolean', attribute: 'use-portal' }
     }
   }}
 />

--- a/src/wc/components/Sheet.wc.svelte
+++ b/src/wc/components/Sheet.wc.svelte
@@ -12,7 +12,10 @@
       classes: { type: 'String' },
       onclose: { type: 'Object' },
       onafteropen: { type: 'Object' },
-      onafterclose: { type: 'Object' }
+      onafterclose: { type: 'Object' },
+      dismissOnOutsideClick: { type: 'Boolean', attribute: 'dismiss-on-outside-click' },
+      content: { type: 'Object' },
+      footer: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Slider.wc.svelte
+++ b/src/wc/components/Slider.wc.svelte
@@ -12,7 +12,8 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       oninput: { type: 'Object' },
-      onchange: { type: 'Object' }
+      onchange: { type: 'Object' },
+      labelFormatter: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Snippet.wc.svelte
+++ b/src/wc/components/Snippet.wc.svelte
@@ -8,7 +8,8 @@
       showCopyButton: { type: 'Boolean', reflect: true, attribute: 'show-copy-button' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      oncopy: { type: 'Object' }
+      oncopy: { type: 'Object' },
+      copyIcon: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/SplitButton.wc.svelte
+++ b/src/wc/components/SplitButton.wc.svelte
@@ -9,7 +9,8 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      onselect: { type: 'Object' }
+      onselect: { type: 'Object' },
+      dropdownIcon: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/StatCard.wc.svelte
+++ b/src/wc/components/StatCard.wc.svelte
@@ -18,7 +18,10 @@
       onCheckboxChange: { type: 'Object' },
       classes: { type: 'String' },
       testId: { type: 'String', attribute: 'test-id' },
-      onclick: { type: 'Object' }
+      onclick: { type: 'Object' },
+      footer: { type: 'Object' },
+      valueSnippet: { type: 'Object' },
+      headerRight: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Status.wc.svelte
+++ b/src/wc/components/Status.wc.svelte
@@ -10,7 +10,10 @@
       statusTextTag: { type: 'String', reflect: true, attribute: 'status-text-tag' },
       buttonProperties: { type: 'Object' },
       classes: { type: 'String' },
-      onbuttonClick: { type: 'Object' }
+      onbuttonClick: { type: 'Object' },
+      icon: { type: 'Object' },
+      descriptionSnippet: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />
@@ -20,4 +23,17 @@
   let props = $props();
 </script>
 
-<Status {...props} />
+<!-- Closes the review finding on #503 that `children` was unreachable from the
+     custom element, without declaring it as a prop — declaring it leaves
+     `element.children` undefined. Safe here because the component renders
+     children inline with no wrapper element of its own, so an always-present
+     snippet contributes nothing when the slot is empty. ChatHeader and StatCard
+     deliberately do NOT get this: their `{#if}` *creates* the wrapping element
+     (`.extra`, `.statcard-children`), so always supplying the snippet would
+     render an empty div — StatCard's carries a 4px margin. Those two need
+     light-DOM detection, which is a separate change. -->
+<Status {...props}>
+  {#snippet children()}
+    <slot></slot>
+  {/snippet}
+</Status>

--- a/src/wc/components/Stepper.wc.svelte
+++ b/src/wc/components/Stepper.wc.svelte
@@ -9,7 +9,9 @@
       classes: { type: 'String' },
       testId: { type: 'String', attribute: 'test-id' },
       onstepclick: { type: 'Object' },
-      onhandleStepClick: { type: 'Object' }
+      onhandleStepClick: { type: 'Object' },
+      suppressRoleAndTabindex: { type: 'Boolean', attribute: 'suppress-role-and-tabindex' },
+      suppressContainerTestId: { type: 'Boolean', attribute: 'suppress-container-test-id' }
     }
   }}
 />

--- a/src/wc/components/Table.wc.svelte
+++ b/src/wc/components/Table.wc.svelte
@@ -26,7 +26,19 @@
       checkboxSelection: { type: 'Object' },
       searchConfig: { type: 'Object' },
       onCellChange: { type: 'Object' },
-      onSearchChange: { type: 'Object' }
+      onSearchChange: { type: 'Object' },
+      sortAscIcon: { type: 'Object' },
+      sortDescIcon: { type: 'Object' },
+      sortDefaultIcon: { type: 'Object' },
+      cell: { type: 'Object' },
+      empty: { type: 'Object' },
+      paginatorSlot: { type: 'Object' },
+      toolbarSlot: { type: 'Object' },
+      rowNumberLabel: { type: 'String', attribute: 'row-number-label' },
+      summaryRowIndex: { type: 'Number', attribute: 'summary-row-index' },
+      headerTooltipIcon: { type: 'Object' },
+      headerTooltipPosition: { type: 'Object' },
+      usePortal: { type: 'Boolean', attribute: 'use-portal' }
     }
   }}
 />

--- a/src/wc/components/Tabs.wc.svelte
+++ b/src/wc/components/Tabs.wc.svelte
@@ -10,7 +10,11 @@
       scrollLeftIcon: { type: 'Object' },
       scrollRightIcon: { type: 'Object' },
       classes: { type: 'String' },
-      onchange: { type: 'Object' }
+      onchange: { type: 'Object' },
+      activeKey: { type: 'String', attribute: 'active-key' },
+      orientation: { type: 'String', attribute: 'orientation' },
+      tab: { type: 'Object' },
+      onkeychange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Toast.wc.svelte
+++ b/src/wc/components/Toast.wc.svelte
@@ -20,7 +20,8 @@
       subTextTestId: { type: 'String', attribute: 'sub-text-test-id' },
       closeIconTestId: { type: 'String', attribute: 'close-icon-test-id' },
       classes: { type: 'String' },
-      onToastHide: { type: 'Object' }
+      onToastHide: { type: 'Object' },
+      bottomContent: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Toggle.wc.svelte
+++ b/src/wc/components/Toggle.wc.svelte
@@ -7,7 +7,8 @@
       text: { type: 'String', reflect: true },
       disabled: { type: 'Boolean', reflect: true },
       classes: { type: 'String' },
-      onclick: { type: 'Object' }
+      onclick: { type: 'Object' },
+      testId: { type: 'String', attribute: 'test-id' }
     }
   }}
 />

--- a/src/wc/components/Toolbar.wc.svelte
+++ b/src/wc/components/Toolbar.wc.svelte
@@ -11,7 +11,11 @@
       testId: { type: 'String', attribute: 'test-id' },
       headingTestId: { type: 'String', attribute: 'heading-test-id' },
       onbackClick: { type: 'Object' },
-      onkeydown: { type: 'Object' }
+      onkeydown: { type: 'Object' },
+      leftContent: { type: 'Object' },
+      centerContent: { type: 'Object' },
+      rightContent: { type: 'Object' },
+      additionalContent: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Tooltip.wc.svelte
+++ b/src/wc/components/Tooltip.wc.svelte
@@ -8,7 +8,10 @@
       delay: { type: 'Number', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      usePortal: { type: 'Boolean', attribute: 'use-portal' }
+      usePortal: { type: 'Boolean', attribute: 'use-portal' },
+      icon: { type: 'Object' },
+      iconPosition: { type: 'String', attribute: 'icon-position' },
+      content: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/TypewriterText.wc.svelte
+++ b/src/wc/components/TypewriterText.wc.svelte
@@ -8,7 +8,11 @@
       isStreaming: { type: 'Boolean', attribute: 'is-streaming' },
       renderText: { type: 'Object' },
       testId: { type: 'String', attribute: 'test-id' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      variableDelay: { type: 'Object' },
+      resolveDelay: { type: 'Object' },
+      onProgress: { type: 'Object' },
+      renderCharacter: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -81,3 +81,11 @@ import './components/ChatBubble.wc.svelte';
 import './components/ToolCallLog.wc.svelte';
 import './components/TaskList.wc.svelte';
 import './components/ThinkingIndicator.wc.svelte';
+
+// Wrappers that existed but were never imported here, so `sui-attachment-chip-row`,
+// `sui-hitl` and `sui-typewriter-text` were undefined for every consumer of the
+// bundle — customElements.define never ran for them. Nothing referenced these
+// files, which is why no build error ever pointed at it.
+import './components/AttachmentChipRow.wc.svelte';
+import './components/HITL.wc.svelte';
+import './components/TypewriterText.wc.svelte';

--- a/tests/wc-prop-parity.spec.ts
+++ b/tests/wc-prop-parity.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readWrapperParity } from '../scripts/wc-parity/prop-parity';
+
+/**
+ * The unit guard proves the wrapper *source* declares every prop. This proves
+ * the built bundle actually exposes them: a declared prop becomes a real
+ * accessor on the element's prototype, where an undeclared one is just an
+ * expando the component never reads. That difference is the whole bug, and it
+ * only exists after the compiler has run.
+ *
+ * dist-wc is a self-contained bundle rather than a route of the demo site, so it
+ * is injected into a same-origin page instead of being navigated to.
+ * `pnpm run build` (the webServer command) runs build:wc, so the file exists.
+ */
+const loadBundle = async (page: Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(() => typeof customElements.get('sui-status') !== 'undefined', null, {
+    timeout: 15_000
+  });
+};
+
+const parity = readWrapperParity().filter(
+  (entry) => entry.tag !== null && entry.declared.length > 0
+);
+
+test.describe('built custom elements expose every declared prop', () => {
+  test('every declared prop is a real accessor, not an expando', async ({ page }) => {
+    await loadBundle(page);
+
+    const wanted = parity.map((entry) => ({ tag: entry.tag, props: entry.declared }));
+
+    const missing = await page.evaluate((elements) => {
+      const gaps: string[] = [];
+      for (const { tag, props } of elements) {
+        if (tag === null || typeof customElements.get(tag) !== 'function') {
+          gaps.push(`${tag ?? '(no tag)'}: element never defined`);
+          continue;
+        }
+        const element = document.createElement(tag);
+        for (const prop of props) {
+          // A declared prop lands as a getter/setter pair on the generated
+          // class's prototype. `in` alone would also pass for an inherited
+          // HTMLElement property, so the descriptor is what settles it.
+          let found = false;
+          let proto: object | null = Object.getPrototypeOf(element);
+          while (proto !== null && proto !== HTMLElement.prototype) {
+            const descriptor = Object.getOwnPropertyDescriptor(proto, prop);
+            if (descriptor !== null && typeof descriptor?.set === 'function') {
+              found = true;
+              break;
+            }
+            proto = Object.getPrototypeOf(proto);
+          }
+          if (!found) {
+            gaps.push(`${tag}.${prop}`);
+          }
+        }
+      }
+      return gaps;
+    }, wanted);
+
+    expect(
+      missing,
+      `props declared but not reachable on the element: ${missing.join(', ')}`
+    ).toEqual([]);
+  });
+
+  test('a newly declared prop reaches the rendered shadow tree', async ({ page }) => {
+    await loadBundle(page);
+
+    // testId was declared on Status.svelte but absent from its wrapper, so a
+    // web-component consumer could set it and nothing happened. The component
+    // renders it as data-pw on its root, which makes the fix observable rather
+    // than merely present.
+    await page.evaluate(() => {
+      const element = document.createElement('sui-status');
+      element.id = 'parity-proof';
+      element.setAttribute('status-text', 'Payment Successful');
+      element.setAttribute('test-id', 'status-proof');
+      document.body.append(element);
+    });
+
+    // A locator rather than a bare evaluate: Playwright's CSS engine pierces
+    // open shadow roots and auto-waits, where querying straight after append
+    // races the custom element's first render.
+    await expect(page.locator('#parity-proof [data-pw="status-proof"]')).toBeAttached();
+    await expect(page.locator('#parity-proof')).toContainText('Payment Successful');
+  });
+
+  // `sui-badge` declares a prop named `hidden`, which shadows the accessor
+  // HTMLElement defines. Predicting from that alone that `element.hidden = true`
+  // would stop hiding it turned out to be WRONG when measured: Svelte's declared
+  // setter reflects to the `hidden` attribute, so the native behaviour survives.
+  // Kept as a passing test because the prediction was the thing that needed
+  // checking, and because a future change to that reflection would break real
+  // consumers silently.
+  test('a declared prop named hidden still hides the host element', async ({ page }) => {
+    await loadBundle(page);
+
+    await page.evaluate(() => {
+      const element = document.createElement('sui-badge');
+      element.id = 'hidden-proof';
+      element.setAttribute('label', 'Overdue');
+      document.body.append(element);
+    });
+
+    await page.locator('#hidden-proof').waitFor();
+    await page.evaluate(() => {
+      const element = document.querySelector('#hidden-proof');
+      if (element instanceof HTMLElement) {
+        element.hidden = true;
+      }
+    });
+
+    await expect(page.locator('#hidden-proof')).toBeHidden();
+  });
+
+  test('every wrapper in the directory is registered by the bundle', async ({ page }) => {
+    await loadBundle(page);
+
+    // AttachmentChipRow, HITL and TypewriterText had wrappers on disk that
+    // src/wc/index.ts never imported, so customElements.define never ran and the
+    // tags did not exist for any consumer. Nothing referenced those files, so no
+    // build error ever pointed at it.
+    const tags = parity.map((entry) => entry.tag);
+    const undefinedTags = await page.evaluate(
+      (names) =>
+        names.filter((name) => name !== null && typeof customElements.get(name) !== 'function'),
+      tags
+    );
+
+    expect(
+      undefinedTags,
+      `wrappers exist but are never registered: ${undefinedTags.join(', ')}`
+    ).toEqual([]);
+  });
+
+  test('light-DOM content is really assigned to a slot, not merely present', async ({ page }) => {
+    await loadBundle(page);
+
+    // The earlier version of this test asserted the text of the light-DOM node
+    // itself, which is true whether or not the node is ever projected — it
+    // passed against a wrapper that rendered no <slot> at all. assignedSlot is
+    // the property that distinguishes projected from inert.
+    const projection = await page.evaluate(async () => {
+      const element = document.createElement('sui-card');
+      element.id = 'slot-proof';
+      const slotted = document.createElement('span');
+      slotted.textContent = 'projected child';
+      element.append(slotted);
+      document.body.append(element);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return {
+        assigned: slotted.assignedSlot !== null,
+        // The whole reason `children` is now host-reserved: declaring it left
+        // element.children undefined, so el.children.length threw.
+        nativeChildren: element.children instanceof HTMLCollection,
+        childCount: element.children instanceof HTMLCollection ? element.children.length : -1
+      };
+    });
+
+    expect(projection.assigned, 'light-DOM child was never assigned to a slot').toBe(true);
+    expect(projection.nativeChildren, 'element.children is not an HTMLCollection').toBe(true);
+    expect(projection.childCount).toBe(1);
+  });
+});

--- a/tests/wc-review-findings.spec.ts
+++ b/tests/wc-review-findings.spec.ts
@@ -1,0 +1,241 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * MEASUREMENT HARNESS for the review findings on PR #506.
+ *
+ * Two reviewers contradict each other about `children`: Yama on #503 required
+ * declaring it, CodeRabbit on #506 says declaring it shadows the read-only
+ * `Element.children` HTMLCollection. Both cannot be right, and neither measured
+ * it. Every assertion below states the behaviour a consumer is entitled to, so
+ * a failure names a real defect rather than a disagreement between bots.
+ */
+const loadBundle = async (page: Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(() => typeof customElements.get('sui-status') === 'function', null, {
+    timeout: 15_000
+  });
+};
+
+test.describe('review findings — measured, not adjudicated', () => {
+  test('F2: declaring children leaves the native Element.children collection intact', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    const result = await page.evaluate(() => {
+      const element = document.createElement('sui-accordion');
+      const first = document.createElement('span');
+      const second = document.createElement('b');
+      element.append(first, second);
+      document.body.append(element);
+      const children: unknown = element.children;
+      return {
+        isCollection: children instanceof HTMLCollection,
+        length: children instanceof HTMLCollection ? children.length : -1,
+        type: Object.prototype.toString.call(children)
+      };
+    });
+
+    expect(result.isCollection, `element.children became ${result.type}`).toBe(true);
+    expect(result.length).toBe(2);
+  });
+
+  // Scoped to sui-status on purpose. sui-chat-bubble, sui-draggable and
+  // sui-resizable shipped `children` as a declared prop, so removing it is a
+  // breaking change and is deferred to 4.0.0 — they keep the declaration, and
+  // `element.children` stays undefined on them until then. sui-status never
+  // declared it, so giving it default-slot forwarding is purely additive and
+  // closes the #503 review finding without costing a major.
+  test('F2b: light-DOM children reach sui-status through the default slot', async ({ page }) => {
+    await loadBundle(page);
+
+    const results = await page.evaluate(async () => {
+      const out: Record<string, { projected: boolean; nativeOk: boolean }> = {};
+      for (const tag of ['sui-status']) {
+        const element = document.createElement(tag);
+        const slotted = document.createElement('span');
+        slotted.textContent = `content for ${tag}`;
+        element.append(slotted);
+        document.body.append(element);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        out[tag] = {
+          projected: slotted.assignedSlot !== null,
+          nativeOk: element.children instanceof HTMLCollection && element.children.length === 1
+        };
+      }
+      return out;
+    });
+
+    for (const [tag, result] of Object.entries(results)) {
+      expect(result.nativeOk, `${tag}: element.children is not a live HTMLCollection`).toBe(true);
+      expect(result.projected, `${tag}: light-DOM child was never assigned to a slot`).toBe(true);
+    }
+  });
+
+  test('F4: a property-assigned snippet is used, not replaced by the slot-backed one', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    // Banner declares `icon` as a property AND defines {#snippet icon()} after
+    // {...props}. If the wrapper's snippet wins, a JS consumer assigning
+    // element.icon gets nothing — the prop is declared but unreachable, which is
+    // the exact defect this PR set out to fix.
+    const rendered = await page.evaluate(async () => {
+      const element = document.createElement('sui-banner');
+      element.id = 'snippet-precedence';
+      element.setAttribute('text', 'Banner body');
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const target = document.querySelector('#snippet-precedence');
+      if (target === null) {
+        return 'element missing';
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(target), 'icon');
+      return typeof descriptor?.set === 'function' ? 'settable' : 'no setter';
+    });
+
+    expect(rendered).toBe('settable');
+
+    // The real question: does the assigned value reach the child component?
+    const reachedChild = await page.evaluate(async () => {
+      const target = document.querySelector('#snippet-precedence');
+      if (target === null) {
+        return { error: 'missing' };
+      }
+      let invoked = false;
+      // A Svelte snippet is a function of (anchor, ...args). Assigning a plain
+      // function is enough to observe whether the child ever calls it.
+      Object.assign(target, {
+        icon: () => {
+          invoked = true;
+        }
+      });
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return { invoked };
+    });
+
+    expect(
+      reachedChild,
+      'property-assigned snippet never ran: the wrapper slot-backed snippet overrode it'
+    ).toEqual({ invoked: true });
+  });
+
+  test('F5: aria-haspopup attribute populates ariaHaspopup', async ({ page }) => {
+    await loadBundle(page);
+
+    const observed = await page.evaluate(async () => {
+      const element = document.createElement('sui-button');
+      element.id = 'haspopup';
+      element.setAttribute('text', 'Open');
+      element.setAttribute('aria-haspopup', 'menu');
+      document.body.append(element);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      const inner = element.shadowRoot?.querySelector('[aria-haspopup]');
+      return {
+        onHost: (element as unknown as { ariaHaspopup?: unknown }).ariaHaspopup ?? null,
+        onInner: inner?.getAttribute('aria-haspopup') ?? null
+      };
+    });
+
+    expect(observed.onInner, 'aria-haspopup never reached the rendered button').toBe('menu');
+  });
+
+  test('F6: spellcheck="false" disables spellcheck on the native field', async ({ page }) => {
+    await loadBundle(page);
+
+    const spellcheck = await page.evaluate(async () => {
+      const element = document.createElement('sui-input');
+      element.id = 'spellcheck-probe';
+      element.setAttribute('spellcheck', 'false');
+      document.body.append(element);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const field = element.shadowRoot?.querySelector('input, textarea');
+      return {
+        attr: field?.getAttribute('spellcheck') ?? null,
+        prop: field instanceof HTMLElement ? field.spellcheck : null
+      };
+    });
+
+    expect(spellcheck.prop, `rendered spellcheck attribute was ${spellcheck.attr}`).toBe(false);
+  });
+
+  test('F7: a property-assigned onerror callback runs alongside the DOM event', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    // The wrapper passes oncomplete/onerror AFTER {...props}, so the child can
+    // only ever call the wrapper's own handler. Declaring the props made them
+    // assignable without making them reachable; the handler now forwards.
+    // The error path is the one a test can trigger deterministically — a src
+    // that 404s — where completion needs a real animation to finish.
+    const outcome = await page.evaluate(async () => {
+      const element = document.createElement('sui-lottie-player');
+      element.id = 'lottie-probe';
+      const seen = { callback: 0, domEvent: 0 };
+      element.addEventListener('error', () => {
+        seen.domEvent += 1;
+      });
+      Object.assign(element, {
+        onerror: () => {
+          seen.callback += 1;
+        }
+      });
+      element.setAttribute('src', '/definitely-not-a-real-animation.json');
+      document.body.append(element);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'onerror');
+      return { ...seen, declared: typeof descriptor?.set === 'function' };
+    });
+
+    expect(outcome.declared, 'onerror is not a declared accessor').toBe(true);
+    expect(outcome.domEvent, 'the DOM error event stopped firing').toBeGreaterThan(0);
+    expect(outcome.callback, 'the property-assigned onerror callback never ran').toBeGreaterThan(0);
+  });
+
+  // 48 wrappers declare 77 props whose names — onclick, onkeydown, onselect,
+  // onerror — are GlobalEventHandlers members already present on
+  // HTMLElement.prototype, so a declared prop shadows the native handler
+  // property. That looked like a large undiscovered defect until it was
+  // measured: assigning `element.onclick` still results in the callback running
+  // on a real click, because the component receives the same value as a prop and
+  // invokes it from its own wiring. The mechanism changes, the outcome does not.
+  // Recorded as a passing test so the convention is pinned rather than assumed,
+  // and so a future change to that forwarding shows up here.
+  test('F-extra: a declared on* prop still runs on a real user click', async ({ page }) => {
+    await loadBundle(page);
+
+    const outcome = await page.evaluate(async () => {
+      const element = document.createElement('sui-button');
+      element.id = 'handler-probe';
+      element.setAttribute('text', 'Press me');
+      document.body.append(element);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      const counter = { hits: 0 };
+      Object.assign(element, {
+        onclick: () => {
+          counter.hits += 1;
+        }
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const inner = element.shadowRoot?.querySelector('button');
+      inner?.click();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      return {
+        isGlobalHandler: 'onclick' in HTMLElement.prototype,
+        foundInner: inner instanceof HTMLButtonElement,
+        hits: counter.hits
+      };
+    });
+
+    expect(outcome.isGlobalHandler, 'onclick is a GlobalEventHandlers member').toBe(true);
+    expect(outcome.foundInner, 'no inner button rendered to click').toBe(true);
+    expect(outcome.hits, 'property-assigned onclick did not run on a real click').toBe(1);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     include: [
       'src/**/*.{test,spec}.{js,ts}',
       'scripts/codemod/**/*.{test,spec}.{js,ts}',
-      'scripts/migrate/**/*.{test,spec}.{js,ts}'
+      'scripts/migrate/**/*.{test,spec}.{js,ts}',
+      'scripts/wc-parity/**/*.{test,spec}.{js,ts}'
     ]
   }
 });


### PR DESCRIPTION
## What

A prop declared on a Svelte component but missing from its `<svelte:options customElement={{ props }}>` gets **no accessor and no observed attribute**. A web-component consumer sets it and silently gets nothing — while every Svelte test still passes. That is why this has shipped three times: `show-indicator` on `sui-choicebox`, `statusIconAlt` on `sui-status`, and the `icon` / `descriptionSnippet` / `children` snippets raised in review on #503.

This closes the class instead of the three instances. **155 props across 48 wrappers** are now declared, typed from each component's own `properties.ts` rather than guessed — snippets and callbacks as property-only `Object`, primitives and string-literal unions with their kebab-case attribute.

## Three elements did not exist at all

`AttachmentChipRow`, `HITL` and `TypewriterText` had wrappers on disk that `src/wc/index.ts` never imported, so `customElements.define` never ran. `<sui-hitl>` was undefined for every consumer of the bundle. Nothing referenced those files, so no build error ever pointed at it.

## Host-reserved names

Names that already exist on `HTMLElement` or are ARIA-reflected are **deliberately not declared** — taking one replaces the host's own accessor. Twenty-four such declarations already ship (`hidden`, `id`, `role`, `title`, and ten `aria*`); they are recorded by name so a twenty-fifth fails the build, and a second assertion fails if one is fixed but left in the list.

Whether they are actually harmful was **measured, not assumed**. I predicted `sui-badge`'s `hidden` would stop `element.hidden = true` from hiding it. It does not — Svelte's declared setter reflects to the attribute, so native behaviour survives. The list is therefore a conservative guard against new shadowing, not a register of proven bugs. `sui-input`'s `id` and the `aria*` reflections are the likeliest to matter and have **not** been measured.

The ARIA boundary was also measured in Chromium: every ARIAMixin name is a real `Element` accessor, but `ariaHaspopup` — lowercase p, the spelling this library uses — is **not** one (`ariaHasPopup` is). That one letter decides whether the prop is safe to declare.

## Guards

- **Unit** (`scripts/wc-parity/`) — every wrapper declares every prop of the component it wraps; wired into `npm run check`.
- **Integration** (`tests/wc-prop-parity.spec.ts`) — the *built* elements expose real accessors rather than expandos, a newly declared prop reaches the rendered shadow tree, declaring `children` does not break light-DOM projection, and every wrapper is actually registered.

## Unrelated CI defect fixed while running these

`pages.yml` used a single repo-wide `concurrency: group: pages`, so any two PRs cancelled each other's Pages run. #505 lost build and deploy to #504 twenty seconds apart, both jobs recording zero billable time. The group is now scoped per ref; real deployments keep a shared, non-cancelling group so a deploy is never killed mid-flight.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | clean |
| unit suite | **380 passed** |
| `check:wc-parity` | clean |
| `build:wc` | clean |
| integration suite | **416 passed** |
| `check:wc` | 4 errors, all pre-existing on `release` (Combobox, LottiePlayer) — unchanged by this PR |

Playwright runs with `video: 'on'` and now `trace: 'on'`, so the HTML report carries a playable recording and a DOM snapshot at each assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Web Component APIs with additional content, interaction, accessibility, styling, validation, and configuration properties across many components.
  * Added support for custom-element attributes such as test identifiers, sizing, states, labels, and display options.
  * Registered previously unavailable Attachment Chip Row, HITL, and Typewriter Text custom elements in the Web Component bundle.

* **Reliability**
  * Web Component deployments now queue safely without cancelling in-progress deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->