### PR TITLE
fix(visual): allow 12 pixels on task-list only, for one unstable arc edge

### DIFF
--- a/tests/visual/components.visual.ts
+++ b/tests/visual/components.visual.ts
@@ -44,6 +44,28 @@ const MASKS: Readonly<Record<string, readonly string[]>> = {
  * problem, fixed since, and it is baselined now: re-check an entry here before
  * assuming the reason still holds.
  */
+/**
+ * Per-route pixel allowances, for a route whose baseline is stable everywhere
+ * except one antialiased edge. Scoped to the named route only: every other
+ * snapshot stays on the exact match below.
+ *
+ * The allowance is a COUNT, not a ratio, and it is deliberately far below the
+ * smallest real change this suite has ever caught, so a genuine regression
+ * cannot hide underneath it. For reference, the real diffs seen so far were
+ * 415px (a one-line demo row added to Toggle), 1577px (the Toolbar back-control
+ * rewrite) and 137982px (a new section on the Input page).
+ */
+const TOLERANCES: Readonly<Record<string, number>> = {
+  // Measured, not assumed. Two failures on two different branches, neither of
+  // which touches TaskList, produced the SAME five pixels: x=83, y=332-336.
+  // That column is the antialiased left edge of the part-filled progress circle
+  // beside "Draft migration plan"; it rasterises at rgb(220) in the baseline and
+  // rgb(107) when the arc boundary lands one column over. A re-run on unchanged
+  // code cleared it both times. Two of the nine runs since this baseline landed
+  // hit it, so it is frequent enough to gate merges on noise.
+  'task-list': 12
+};
+
 const EXCLUDED: Readonly<Record<string, string>> = {
   // Measured across full-suite runs rather than assumed: the captured height
   // walks 2029 -> 2035 -> 2121 -> 2150 -> 2059px within a single test's own
@@ -350,13 +372,22 @@ test.describe('visual baselines', () => {
 
       const masks = (MASKS[slug] ?? []).map((selector) => page.locator(selector));
 
+      const allowance = TOLERANCES[slug];
+
+      // Exact match is the default, and stays the default. A blanket tolerance
+      // would be a slow leak: it hides the sub-threshold drift that accumulates
+      // into a real regression, and the container pins rendering tightly enough
+      // that we don't need one. A route in TOLERANCES trades that exactness for
+      // a bounded pixel count on that route alone -- and only maxDiffPixels is
+      // passed there, since maxDiffPixelRatio: 0 alongside it is the stricter
+      // bound and would fail the comparison anyway.
+      const comparison =
+        typeof allowance === 'number' ? { maxDiffPixels: allowance } : { maxDiffPixelRatio: 0 };
+
       await expect(page.locator('main.content')).toHaveScreenshot(`${slug}.png`, {
         animations: 'disabled',
         mask: masks,
-        // Exact match. A tolerance here would be a slow leak: it hides the
-        // sub-threshold drift that accumulates into a real regression, and the
-        // container pins rendering tightly enough that we don't need one.
-        maxDiffPixelRatio: 0
+        ...comparison
       });
     });
   }


### PR DESCRIPTION
## What this fixes

The `task-list` visual baseline fails intermittently on **five pixels**: `x=83`, `y=332-336`. That column is the antialiased left edge of the part-filled progress circle beside "Draft migration plan". It rasterises at `rgb(220,220,220)` in the baseline and `rgb(107,107,107)` when the arc boundary lands one column over. The two images are indistinguishable by eye.

**Measured, not assumed.** Two failures, on two different branches, at byte-identical coordinates:

| PR | head | pixels | coordinates |
|---|---|---|---|
| #506 | `e12a1372d` | 5 | x=83, y=332-336 |
| #505 | `577b81f57` | 5 | x=83, y=332-336 |

Neither branch touches `TaskList`. #506 cleared on a re-run of unchanged code. Two of the nine visual runs since this baseline landed have hit it, so roughly a fifth of runs currently gate on noise.

## Why a scoped allowance rather than an exclusion

Excluding the route would drop a whole page from the gate to fix one edge. This keeps the page covered and gives up only a bounded pixel count on it.

Exact match remains the default for the other 92 snapshots. The allowance is a **count**, not a ratio, and it is set far below the smallest real change this suite has caught:

| real change | pixels |
|---|---|
| demo row added to Toggle (#505) | 415 |
| Toolbar back-control rewrite (#493) | 1,577 |
| new section on the Input page (#502) | 137,982 |

Twelve is 35x under the smallest of those, so a genuine regression cannot hide beneath it.

One implementation note: only `maxDiffPixels` is passed for a toleranced route. Sending it alongside `maxDiffPixelRatio: 0` would leave the stricter bound in force and fail the comparison anyway.

## Proof

Verified three ways in the pinned container by perturbing baselines by known pixel counts, then restoring them byte-identical:

| perturbation | expected | result |
|---|---|---|
| 5px on `task-list` | passes, real-world count is inside the allowance | ✅ passed |
| 5px on `toggle` | fails, allowance must be scoped not global | ✅ failed |
| 19px on `task-list` | fails, bound must be real not a blanket pass | ✅ failed |

The middle row is the one that matters: the same perturbation that `task-list` now tolerates still fails on another snapshot, so nothing else has been loosened.

| gate | result |
|---|---|
| full visual suite | 93 passed |
| prettier, eslint | clean |
| `pnpm run check` | exit 0 |

Only `tests/visual/components.visual.ts` changes. No baseline is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated visual screenshot comparisons for the task list to allow up to 12 differing pixels.
  * All other routes continue to require exact pixel matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->