### PR TITLE
fix(demo,ChatBubble): stop binding to a derived, and say why the gap is reset

### DIFF
--- a/src/lib/ChatBubble/ChatBubble.svelte
+++ b/src/lib/ChatBubble/ChatBubble.svelte
@@ -392,6 +392,10 @@
     --button-border-radius: var(--chat-bubble-border-radius, 50%);
     --button-color: var(--chat-bubble-background-color, #18181b);
     --button-text-color: var(--chat-bubble-color, #ffffff);
+    /* Button spaces its icon from its label with this gap. The launcher renders an
+       icon alone inside a circle, so that gap would push the glyph off-centre --
+       reset to 0 here rather than in Button, whose default is right for a labelled
+       button. docs/ChatBubble.md records this as a pill-launcher caveat. */
     --button-content-gap: 0px;
     --button-box-shadow: var(--chat-bubble-box-shadow, 0 8px 24px rgba(0, 0, 0, 0.25));
     --button-hover-color: var(--chat-bubble-hover-background-color, #27272a);

--- a/src/routes/components/speech-to-text/+page.svelte
+++ b/src/routes/components/speech-to-text/+page.svelte
@@ -68,6 +68,10 @@
       }
     }
   });
+  // Display state only. `bind:value` here would write the user's keystrokes into a
+  // $derived override that is discarded the moment `committed` or `listening` changes;
+  // the write path is `oninput` below, which puts them in `committed` where the
+  // controller's seedTranscript can read them back.
   let simulatedValue = $derived(simulated.listening ? simulated.interimText : committed);
 
   let browserCommitted = $state('');
@@ -111,7 +115,7 @@
 <div class="demo-row">
   <div class="composer-host">
     <ChatComposer
-      bind:value={simulatedValue}
+      value={simulatedValue}
       placeholder="Tap the mic — a scripted transcript streams in"
       recording={simulated.listening}
       oninput={(value) => {
@@ -133,7 +137,7 @@
 <div class="demo-row">
   <div class="composer-host">
     <ChatComposer
-      bind:value={browserValue}
+      value={browserValue}
       placeholder="Uses the real microphone where the browser supports it"
       recording={browserEngine.listening}
       oninput={(value) => {


### PR DESCRIPTION
## What this closes

A transcript audit of this session found **23 unresolved review threads on PRs #458, #459, #460 and #461** — the chat-primitive PRs from 24–26 August. An earlier sweep covered 18 other merged library PRs and never touched these four, so the threads sat unanswered.

I checked all 23 against the code on release `2d3a35e` (3.1.5). **Twenty-one are already fixed.** Two were genuinely open, and this PR lands them.

## The two that were open

**`speech-to-text` demo — binding to a `$derived`.** `bind:value` wrote the user's keystrokes into a `$derived` override that is discarded the moment `committed` or `listening` changes.

One correction to the finding, since it matters for how the fix is judged: the reviewer said the typed text is lost. It is not. The `oninput` handler already writes it into `committed`, so the demo works. What was wrong is that a two-way binding depended entirely on a sibling handler for its correctness. Both composers are now one-way, so the derived is display state and `oninput` is the only write path — which is what it was doing anyway.

**`ChatBubble` — an unexplained token reset.** `--button-content-gap: 0px` had no comment. Button uses that gap to space an icon from its label; the launcher renders an icon alone inside a circle, where the gap pushes the glyph off-centre. The comment now says that, and says why the reset belongs here rather than in Button.

## The twenty-one already closed

| finding | where it is closed |
|---|---|
| document the fold-color token | `docs/AttachmentChipRow.md` |
| document ChatComposer's public additions | all 7 names present in `docs/ChatComposer.md` |
| document `toggleIcon` | `docs/ThinkingIndicator.md` |
| `labelTestId` in the `bare` branch | `ThinkingIndicator.svelte:409`, child span |
| reserve the HITL decision before awaiting | `decisionPending` latched before the await, `HITL.svelte:122` |
| reset TypewriterText on a new response | non-continuation branch resets all four fields |
| clear the demo's attachment model | `onsubmit` clears images, videos and files |
| complete the `sui-chat-confirmation` map | 17 attribute mappings on `HITL.wc.svelte` |
| expose ThinkingIndicator's wc props | all four declared |
| clamp negative `maxVisible` | `Math.max(0, maxVisible)`, with a comment |
| align the `icon` contract | `properties.ts:15` says URL, directs markup to the snippet |
| replace `undefined` sentinels | zero `undefined` in the file |
| expose `chipClasses` | declared and documented |
| reset `listening` in `destroy` | `controller.svelte.ts`, with a comment |
| destroy controllers on route teardown | `onDestroy` at line 92 |
| error messages as live alerts | `role="alert"` on both paragraphs |

Two more are moot: `AgentPicker` and `ChatConfirmation` no longer exist on release.

Three ask for kebab-case attribute mappings on props typed `Object` — `renderText`, `attachmentsPreview`, `actionIcon`, and the AttachmentChipRow callbacks. Declined on the repo's own convention: an attribute is a string, so object and function props are set as properties, and every `Object` entry in the wrappers is declared without one. Adding attributes there would advertise a channel that cannot carry the value.

## Verification

| gate | result |
|---|---|
| `pnpm run check` | exit 0 |
| prettier, eslint on both files | clean |
| `chat-bubble` and `speech-to-text` visual baselines | 2 passed, unchanged |

Every one of the 23 threads is answered on-thread with the file and line that closes it, or the reason it is declined.
