### PR TITLE
feat(events): warn once, in dev only, when a deprecated prop spelling is used

### DIFF
--- a/src/lib/deprecation.test.ts
+++ b/src/lib/deprecation.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEPRECATION_REMOVAL_VERSION,
+  resetDeprecationWarnings,
+  warnDeprecatedProp
+} from './deprecation.js';
+
+describe('deprecated-prop warnings', () => {
+  beforeEach(() => {
+    // The suppression set is module-level, so without this a later case would
+    // pass by inheriting an earlier case's suppression rather than earning it.
+    resetDeprecationWarnings();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Unconditional, rather than at the end of the one case that stubs DEV.
+    // A failing assertion there would throw before the cleanup line and leak
+    // DEV=false into every later case in the same worker, which silences the
+    // warnings they are asserting and reports the failure somewhere else.
+    vi.unstubAllEnvs();
+  });
+
+  it('names the old spelling, the replacement, and the version that removes it', () => {
+    warnDeprecatedProp('Status', 'onbuttonClick', 'onButtonClick');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(console.warn).mock.calls[0][0];
+    expect(message).toContain('onbuttonClick');
+    expect(message).toContain('onButtonClick');
+    expect(message).toContain('<Status>');
+    expect(message).toContain(DEPRECATION_REMOVAL_VERSION);
+  });
+
+  it('names 4.0.0 as the removal release, so moving it is a deliberate edit', () => {
+    // Pinned separately from the message assertion above. That one would keep
+    // passing against any value the constant held, including one changed by
+    // accident; this one makes the migration's committed target visible in a
+    // diff, which is the whole point of it not being a loose string any more.
+    expect(DEPRECATION_REMOVAL_VERSION).toBe('4.0.0');
+  });
+
+  it('says both spellings work today, so the warning is not read as breakage', () => {
+    warnDeprecatedProp('Toggle', 'onclick', 'onClick');
+
+    expect(vi.mocked(console.warn).mock.calls[0][0]).toContain('both work today');
+  });
+
+  it('points at the codemod rather than leaving the consumer to grep', () => {
+    warnDeprecatedProp('Table', 'onrowClick', 'onRowClick');
+
+    expect(vi.mocked(console.warn).mock.calls[0][0]).toContain('sui-codemod --dry-run');
+  });
+
+  it('warns once per prop however many times it is rendered', () => {
+    for (let i = 0; i < 500; i += 1) {
+      warnDeprecatedProp('ListItem', 'onitemClick', 'onItemClick');
+    }
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('says nothing in a production build', () => {
+    // The half that actually matters. A dev warning that also fires in
+    // production would put 142 lines into a consumer's console during an
+    // incident, and the guard is the only thing standing between those two
+    // outcomes — so it is worth a test rather than a reading of the source.
+    vi.stubEnv('DEV', false);
+
+    warnDeprecatedProp('Banner', 'ondismiss', 'onDismiss');
+
+    expect(console.warn).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it('keys on the component too, so the same prop name on two components both warn', () => {
+    // `onclick` is deprecated on many components. Deduplicating on the prop
+    // alone would tell a consumer about the first one and silently hide the
+    // rest, which is worse than not warning at all.
+    warnDeprecatedProp('Avatar', 'onclick', 'onClick');
+    warnDeprecatedProp('Pill', 'onclick', 'onClick');
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/deprecation.ts
+++ b/src/lib/deprecation.ts
@@ -1,0 +1,63 @@
+/**
+ * Phase 2 of `docs/EVENT_CASING_MIGRATION.md`: tell a consumer, once, that a
+ * prop spelling is going away and what replaces it.
+ *
+ * Two constraints shape this.
+ *
+ * It is dev-only. A production warning is noise a consumer cannot act on
+ * mid-incident, and 142 props warning in a production console would bury real
+ * output. `import.meta.env.DEV` is the guard because it is what the bundler
+ * this library is built with statically replaces, so the whole call is removed
+ * from a production build rather than merely skipped at runtime.
+ *
+ * It warns once per component-and-prop, not once per render. A deprecated prop
+ * on a list row would otherwise warn on every one of a thousand rows, and a
+ * consumer would learn less from a thousand identical lines than from one.
+ *
+ * Internal. Nothing here is re-exported from `src/lib/index.ts`, because a
+ * consumer has no call for it: the components invoke it themselves when they
+ * are handed a deprecated spelling. That is this library's normal way of
+ * marking a module internal rather than an omission -- `src/lib/utils.ts`
+ * exports ten functions and the barrel re-exports three, leaving
+ * `getStorageItem`, `hexToRgb` and five others reachable only from inside.
+ * Exporting these two would add public API that 4.0.0 then has to keep.
+ */
+
+/**
+ * The release that removes the old spellings, named in one place so the message
+ * and the migration plan cannot drift apart.
+ *
+ * 4.0.0 is a commitment, not a placeholder. An earlier draft of this string was
+ * written while #506 was expected to cut the major; it shipped inside 3.2.0 as
+ * a minor instead, which briefly left this warning promising a version nothing
+ * was committed to. `docs/EVENT_CASING_MIGRATION.md` holds the plan; a test
+ * pins this value so moving it is a deliberate edit and not a silent one.
+ */
+export const DEPRECATION_REMOVAL_VERSION = '4.0.0';
+
+const seen = new Set<string>();
+
+/**
+ * Exposed for tests. A module-level Set survives between test cases, so a
+ * second case asserting "warns once" would pass vacuously by inheriting the
+ * first case's suppression rather than by exercising it.
+ */
+export const resetDeprecationWarnings = (): void => {
+  seen.clear();
+};
+
+export const warnDeprecatedProp = (component: string, oldName: string, newName: string): void => {
+  if (import.meta.env.DEV !== true) {
+    return;
+  }
+  const key = `${component}.${oldName}`;
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  console.warn(
+    `[svelte-ui-components] \`${oldName}\` on <${component}> is deprecated and will be ` +
+      `removed in ${DEPRECATION_REMOVAL_VERSION}. Use \`${newName}\` instead — both work today. ` +
+      `Run \`npx sui-codemod --dry-run ./src\` to see every affected call site.`
+  );
+};


### PR DESCRIPTION
Phase 2 of `docs/EVENT_CASING_MIGRATION.md`. Phase 1 (#505) gave every grandfathered event prop its correct spelling alongside the old one; this tells a consumer which of the two they are using, once, and what to run to move.

Dev-only, because a production warning is noise a consumer cannot act on mid-incident and 142 of them would bury real output. `import.meta.env.DEV` is the guard specifically because the bundler statically replaces it, so the call is removed from a production build rather than merely skipped at runtime.

Once per component-and-prop rather than per render: a deprecated prop on a list row would otherwise warn a thousand times. The key includes the component because `onclick` is deprecated on many of them — deduplicating on the prop alone would report the first and silently hide the rest.

Rebased onto 3.2.0. **1 commit, 2 files.**

---

# Review responses

## ⚠️ MAJOR — "not exported from `src/lib/index.ts`"

> *A library-wide helper that consumers cannot import is either an internal module that should say so, or an oversight.*

**It is internal, and this codebase already marks internal modules exactly this way.** `src/lib/utils.ts` exports ten functions; the barrel re-exports **three** (`validateInput`, `lockBodyScroll`, `unlockBodyScroll`). `getStorageItem`, `setStorageItem`, `hexToRgb`, `rgbToHsv`, `hsvToRgb`, `hsvToHex` and `hexToHsv` are reachable only from inside `src/lib`. Selective re-export from the barrel is the existing convention for precisely this, not an accident — so "absent from `index.ts`" does not imply oversight here.

Components call `warnDeprecatedProp` themselves when handed a deprecated spelling; a consumer has no call for it. Exporting it would add public API that 4.0.0 then has to carry.

The finding's real substance was the *ambiguity* — nothing said which it was. The module now states it outright, with the `utils.ts` precedent cited, rather than leaving a reader to infer it.

## 💡 MINOR — "hard-coded `4.0.0`" — **taken, and it had stopped being minor**

`DEPRECATION_REMOVAL_VERSION` now names it in one place.

Worth recording why this mattered more than it looked. That string was written while #506 was expected to cut 4.0.0. **#506 shipped inside 3.2.0 as a minor instead** — so this warning was promising consumers a removal version that nothing was committed to, and Phase 3's window was genuinely unanchored rather than merely un-reached.

4.0.0 is now the agreed target. A test pins the constant's value separately from the message assertion: the message test would keep passing against any value the constant held, including one changed by accident, so the pin is what makes the committed target visible in a diff.

## 💡 MINOR — "env stub leaks on assertion failure" — **taken**

`vi.unstubAllEnvs()` moves into `afterEach`. It sat after the assertion in the production-silence case, so a failure there would throw before the cleanup line and leave `DEV=false` set for every later case in the same worker — silencing the warnings those cases assert and surfacing the failure somewhere it did not happen.

---

## CI

7 unit tests here, all passing. The suite reports **49 failures in `scripts/wc-parity/prop-parity.test.ts`** — inherited from the `release` tip this is rebased onto, not from anything in this branch. `prop-parity` is the only failing file, and #512 fixes it. `lint` 0 errors.