### PR TITLE
fix(wc): declare the corrected event spellings on every custom-element wrapper

### DIFF
--- a/scripts/migrate/alias-wc-props.test.ts
+++ b/scripts/migrate/alias-wc-props.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { declareProps, isEventProp, lastPropertyEnd, planWrapperProps } from './alias-wc-props.ts';
+
+const root = process.cwd();
+
+const wrapper = (props: string): string => `<svelte:options
+  customElement={{
+    tag: 'sui-demo',
+    shadow: 'open',
+    props: {
+${props}
+    }
+  }}
+/>
+
+<script lang="ts">
+  import Demo from '$lib/Demo/Demo.svelte';
+  let props = $props();
+</script>
+
+<Demo {...props} />
+`;
+
+describe('phase 1 wrapper declarations', () => {
+  it('has nothing left to do, because every declaration is already applied', () => {
+    // The idempotence check, and the reason the transform is safe to keep in the
+    // tree: it plans from the parity ratchet's `missing` list, which is empty
+    // once the declarations exist, so a second --apply rewrites nothing.
+    const { additions } = planWrapperProps(root);
+
+    expect(additions).toEqual([]);
+  });
+
+  it('appends a declaration at the indentation the existing entries use', () => {
+    const source = wrapper("      checked: { type: 'Boolean', reflect: true }");
+
+    const next = declareProps(source, ['onClick']);
+
+    expect(next).toContain("      checked: { type: 'Boolean', reflect: true },\n");
+    expect(next).toContain("      onClick: { type: 'Object' }\n");
+  });
+
+  it('appends several declarations in one pass', () => {
+    const source = wrapper("      classes: { type: 'String' }");
+
+    const next = declareProps(source, ['onOpen', 'onClose']);
+
+    expect(next).toContain("      onOpen: { type: 'Object' },\n      onClose: { type: 'Object' }");
+  });
+
+  it('leaves the source untouched when there is nothing to add', () => {
+    const source = wrapper("      classes: { type: 'String' }");
+
+    expect(declareProps(source, [])).toBe(source);
+  });
+
+  it('refuses a wrapper whose props object is empty rather than inventing formatting', () => {
+    // An empty object gives the transform no entry to match indentation or
+    // trailing-comma style against. Returning null makes that a reported skip
+    // instead of a guess that happens to look plausible.
+    const source = wrapper('');
+
+    expect(lastPropertyEnd(source)).toBe(-1);
+    expect(declareProps(source, ['onClick'])).toBeNull();
+  });
+
+  it('refuses a wrapper with no customElement options at all', () => {
+    const source = '<script lang="ts">\n  let props = $props();\n</script>\n';
+
+    expect(lastPropertyEnd(source)).toBe(-1);
+  });
+
+  it('recognises both spellings of an event prop and nothing else', () => {
+    // Both directions are real targets: DESIGN_PRINCIPLES keeps the lowercase
+    // spelling for a native DOM event forwarded as-is, so `onfocus` is as much a
+    // corrected name as `onRowSelect`.
+    expect(isEventProp('onClick')).toBe(true);
+    expect(isEventProp('onRowSelect')).toBe(true);
+    expect(isEventProp('onfocus')).toBe(true);
+    expect(isEventProp('onvolumechange')).toBe(true);
+
+    // The whole point of not matching a bare /^on[A-Za-z]/: each of these would
+    // otherwise be declared `{ type: 'Object' }` and silently mistyped.
+    expect(isEventProp('once')).toBe(false);
+    expect(isEventProp('onboarding')).toBe(false);
+    expect(isEventProp('only')).toBe(false);
+    expect(isEventProp('on')).toBe(false);
+    expect(isEventProp('classes')).toBe(false);
+  });
+
+  it('declares every added prop as an Object, which is what a callback needs', () => {
+    // A callback cannot survive an HTML attribute, so it takes no attribute
+    // mapping and no reflection -- matching every function prop already declared
+    // by hand in these wrappers.
+    const next = declareProps(wrapper("      classes: { type: 'String' }"), ['onSend']);
+
+    expect(next).toContain("onSend: { type: 'Object' }");
+    expect(next).not.toContain("onSend: { type: 'Object', attribute");
+    expect(next).not.toContain("onSend: { type: 'Object', reflect");
+  });
+});

--- a/scripts/migrate/alias-wc-props.ts
+++ b/scripts/migrate/alias-wc-props.ts
@@ -1,0 +1,216 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parse } from 'svelte/compiler';
+import { readWrapperParity } from '../wc-parity/prop-parity.ts';
+import { NATIVE_EVENTS } from './casing.ts';
+
+/**
+ * Phase 1 of the event-casing migration stopped at the Svelte layer.
+ * alias-event-props.ts gave each grandfathered event prop a second spelling on
+ * the component, but a custom element only forwards what `customElement.props`
+ * declares, so none of the corrected spellings were reachable through a web
+ * component. This closes that half.
+ *
+ * Committed rather than run once and thrown away, for the same reason its
+ * sibling is: 126 declarations across 49 wrappers is not a diff anyone can
+ * meaningfully review by eye, and the transform is the only honest description
+ * of what was done to them. Re-running it is a no-op, and a test asserts that.
+ *
+ * Scope is deliberately narrow. It adds declarations the parity ratchet already
+ * reports as missing, and only for props named like event handlers. Anything
+ * else is reported and skipped rather than guessed at: `{ type: 'Object' }` is
+ * right for a callback and wrong for a string, and a wrong declaration is worse
+ * than an absent one because it looks settled.
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+type Addition = {
+  readonly wrapper: string;
+  readonly props: readonly string[];
+};
+
+type Skip = { readonly wrapper: string; readonly prop: string; readonly reason: string };
+
+/** Mirrors scripts/wc-parity/prop-parity.ts; assertions and predicates are banned repo-wide. */
+function asRecord(value: unknown): UnknownRecord {
+  if (typeof value !== 'object' || value === null) {
+    return {};
+  }
+  const record: UnknownRecord = {};
+  for (const key of Object.keys(value)) {
+    Object.defineProperty(record, key, {
+      value: Reflect.get(value, key),
+      enumerable: true,
+      writable: true,
+      configurable: true
+    });
+  }
+  return record;
+}
+
+function asList(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function keyName(node: unknown): string | null {
+  const key = asRecord(asRecord(node).key);
+  if (typeof key.name === 'string') {
+    return key.name;
+  }
+  return typeof key.value === 'string' ? key.value : null;
+}
+
+function offsetOf(node: unknown, key: 'start' | 'end'): number {
+  const value = asRecord(node)[key];
+  return typeof value === 'number' ? value : -1;
+}
+
+/**
+ * Whether a prop is an event callback, and so safe to declare as `type: 'Object'`.
+ *
+ * Both spellings the casing rule produces are accepted, and nothing else. A
+ * synthesized event is camelCase from the character after `on`, and a native DOM
+ * event forwarded as-is keeps Svelte's lowercase spelling — so `onClick` and
+ * `onfocus` both qualify while `once` does not. A bare `/^on[A-Za-z]/` would
+ * have taken `once` too and declared it a callback; there is no such prop today,
+ * which is exactly why the guard belongs here rather than after one appears.
+ *
+ * A grandfathered lowercase *synthesized* name (`onbarclick`) is deliberately
+ * not matched. Every one of those is already declared, so none can reach this;
+ * if one ever does, a reported skip that leaves the ratchet red is a better
+ * outcome than a guessed declaration that looks settled.
+ */
+export function isEventProp(name: string): boolean {
+  if (/^on[A-Z]/.test(name)) {
+    return true;
+  }
+  return name.startsWith('on') && NATIVE_EVENTS.has(name.slice(2));
+}
+
+/**
+ * The end offset of the last entry inside `customElement.props`, which is where
+ * a new declaration is appended. Returns -1 when the wrapper has no props object
+ * or an empty one: both mean this transform has nothing safe to do, since it
+ * would have to invent the object's formatting rather than match it.
+ */
+export function lastPropertyEnd(source: string): number {
+  const root = asRecord(parse(source, { modern: true }));
+  const options = asRecord(root.options);
+  for (const attribute of asList(options.attributes)) {
+    const record = asRecord(attribute);
+    if (record.name !== 'customElement') {
+      continue;
+    }
+    const single = Array.isArray(record.value) ? record.value[0] : record.value;
+    const object = asRecord(asRecord(single).expression);
+    for (const property of asList(object.properties)) {
+      if (keyName(property) !== 'props') {
+        continue;
+      }
+      const entries = asList(asRecord(asRecord(property).value).properties);
+      return entries.length === 0 ? -1 : offsetOf(entries[entries.length - 1], 'end');
+    }
+  }
+  return -1;
+}
+
+/**
+ * Indentation of the line the given offset sits on, so appended entries line up
+ * with the ones already there instead of assuming a fixed depth.
+ */
+function indentAt(source: string, offset: number): string {
+  const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+  const line = source.slice(lineStart, offset);
+  return line.slice(0, line.length - line.trimStart().length);
+}
+
+export function declareProps(source: string, props: readonly string[]): string | null {
+  if (props.length === 0) {
+    return source;
+  }
+  const insertAt = lastPropertyEnd(source);
+  if (insertAt === -1) {
+    return null;
+  }
+  const indent = indentAt(source, insertAt);
+  const entries = props.map((prop) => `${indent}${prop}: { type: 'Object' }`).join(',\n');
+  return `${source.slice(0, insertAt)},\n${entries}${source.slice(insertAt)}`;
+}
+
+export function planWrapperProps(root: string): {
+  readonly additions: readonly Addition[];
+  readonly skipped: readonly Skip[];
+} {
+  const additions: Addition[] = [];
+  const skipped: Skip[] = [];
+
+  for (const entry of readWrapperParity()) {
+    if (entry.missing.length === 0) {
+      continue;
+    }
+    const events = entry.missing.filter((prop) => isEventProp(prop));
+    for (const prop of entry.missing) {
+      if (!isEventProp(prop)) {
+        skipped.push({
+          wrapper: entry.wrapper,
+          prop,
+          reason: 'not an event prop; its type cannot be inferred safely'
+        });
+      }
+    }
+    if (events.length === 0) {
+      continue;
+    }
+    const source = readFileSync(join(root, 'src/wc/components', entry.wrapper), 'utf8');
+    if (lastPropertyEnd(source) === -1) {
+      for (const prop of events) {
+        skipped.push({ wrapper: entry.wrapper, prop, reason: 'no non-empty customElement props' });
+      }
+      continue;
+    }
+    additions.push({ wrapper: entry.wrapper, props: events });
+  }
+
+  return { additions, skipped };
+}
+
+export function applyWrapperProps(
+  root: string,
+  apply: boolean,
+  log: (line: string) => void
+): { readonly changed: number; readonly skipped: number } {
+  const { additions, skipped } = planWrapperProps(root);
+  let changed = 0;
+
+  for (const addition of additions) {
+    const path = join(root, 'src/wc/components', addition.wrapper);
+    const next = declareProps(readFileSync(path, 'utf8'), addition.props);
+    if (next === null) {
+      log(`SKIP  ${addition.wrapper}: could not locate customElement props`);
+      continue;
+    }
+    if (apply) {
+      writeFileSync(path, next);
+    }
+    changed += addition.props.length;
+    log(`${addition.wrapper}: +${addition.props.join(', +')}`);
+  }
+
+  for (const skip of skipped) {
+    log(`SKIP  ${skip.wrapper}.${skip.prop}: ${skip.reason}`);
+  }
+  log('');
+  log(
+    `${changed} declaration(s) across ${additions.length} wrapper(s); ${skipped.length} skipped${apply ? '' : ' (dry run, nothing written)'}`
+  );
+  return { changed, skipped: skipped.length };
+}
+
+const entrypoint = process.argv[1];
+const invokedDirectly =
+  typeof entrypoint === 'string' && import.meta.url.endsWith(entrypoint.split('/').at(-1) ?? '');
+
+if (invokedDirectly) {
+  applyWrapperProps(resolve('.'), process.argv.includes('--apply'), (line) => console.log(line));
+}

--- a/scripts/migrate/casing.ts
+++ b/scripts/migrate/casing.ts
@@ -15,7 +15,7 @@
  * public API.
  */
 
-const NATIVE_EVENTS: ReadonlySet<string> = new Set([
+export const NATIVE_EVENTS: ReadonlySet<string> = new Set([
   'click',
   'dblclick',
   'auxclick',

--- a/src/wc/components/Accordion.wc.svelte
+++ b/src/wc/components/Accordion.wc.svelte
@@ -10,7 +10,8 @@
       panelId: { type: 'String', attribute: 'panel-id' },
       trigger: { type: 'Object' },
       ontoggle: { type: 'Object' },
-      disabled: { type: 'Boolean', reflect: true, attribute: 'disabled' }
+      disabled: { type: 'Boolean', reflect: true, attribute: 'disabled' },
+      onToggle: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Banner.wc.svelte
+++ b/src/wc/components/Banner.wc.svelte
@@ -14,7 +14,8 @@
       ondismiss: { type: 'Object' },
       icon: { type: 'Object' },
       rightContent: { type: 'Object' },
-      dismissIcon: { type: 'Object' }
+      dismissIcon: { type: 'Object' },
+      onDismiss: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Book.wc.svelte
+++ b/src/wc/components/Book.wc.svelte
@@ -13,7 +13,8 @@
       previousIcon: { type: 'Object' },
       nextIcon: { type: 'Object' },
       classes: { type: 'String' },
-      onpagechange: { type: 'Object' }
+      onpagechange: { type: 'Object' },
+      onPageChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Calendar.wc.svelte
+++ b/src/wc/components/Calendar.wc.svelte
@@ -19,7 +19,10 @@
       onselect: { type: 'Object' },
       onrangeselect: { type: 'Object' },
       onmonthchange: { type: 'Object' },
-      initialMonth: { type: 'Object' }
+      initialMonth: { type: 'Object' },
+      onSelect: { type: 'Object' },
+      onRangeSelect: { type: 'Object' },
+      onMonthChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Chat.wc.svelte
+++ b/src/wc/components/Chat.wc.svelte
@@ -49,7 +49,16 @@
       onretry: { type: 'Object' },
       onfeedback: { type: 'Object' },
       onscrollstate: { type: 'Object' },
-      headerContent: { type: 'Object' }
+      headerContent: { type: 'Object' },
+      onSend: { type: 'Object' },
+      onSuggestion: { type: 'Object' },
+      onClose: { type: 'Object' },
+      onStop: { type: 'Object' },
+      onVoice: { type: 'Object' },
+      onAttach: { type: 'Object' },
+      onRetry: { type: 'Object' },
+      onFeedback: { type: 'Object' },
+      onScrollState: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatBubble.wc.svelte
+++ b/src/wc/components/ChatBubble.wc.svelte
@@ -26,7 +26,10 @@
       classes: { type: 'String' },
       onopen: { type: 'Object' },
       onclose: { type: 'Object' },
-      ontoggle: { type: 'Object' }
+      ontoggle: { type: 'Object' },
+      onOpen: { type: 'Object' },
+      onClose: { type: 'Object' },
+      onToggle: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatComposer.wc.svelte
+++ b/src/wc/components/ChatComposer.wc.svelte
@@ -57,7 +57,19 @@
       onattachclick: { type: 'Object' },
       onaction: { type: 'Object' },
       actionIcon: { type: 'Object' },
-      actionLabel: { type: 'String', attribute: 'action-label' }
+      actionLabel: { type: 'String', attribute: 'action-label' },
+      onRemoveRichImage: { type: 'Object' },
+      onRemoveRichFile: { type: 'Object' },
+      onRemoveRichVideo: { type: 'Object' },
+      onOpenRichImage: { type: 'Object' },
+      onOpenRichVideo: { type: 'Object' },
+      onOpenRichFile: { type: 'Object' },
+      onSubmit: { type: 'Object' },
+      onStop: { type: 'Object' },
+      onVoice: { type: 'Object' },
+      onAttach: { type: 'Object' },
+      onAttachClick: { type: 'Object' },
+      onAction: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatHeader.wc.svelte
+++ b/src/wc/components/ChatHeader.wc.svelte
@@ -14,7 +14,8 @@
       showClose: { type: 'Boolean', attribute: 'show-close' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onclose: { type: 'Object' }
+      onclose: { type: 'Object' },
+      onClose: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatMessage.wc.svelte
+++ b/src/wc/components/ChatMessage.wc.svelte
@@ -23,7 +23,10 @@
       classes: { type: 'String' },
       onretry: { type: 'Object' },
       onfeedback: { type: 'Object' },
-      oncopy: { type: 'Object' }
+      oncopy: { type: 'Object' },
+      onRetry: { type: 'Object' },
+      onFeedback: { type: 'Object' },
+      onCopy: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatMessageList.wc.svelte
+++ b/src/wc/components/ChatMessageList.wc.svelte
@@ -19,7 +19,10 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onretry: { type: 'Object' },
-      onfeedback: { type: 'Object' }
+      onfeedback: { type: 'Object' },
+      onScrollState: { type: 'Object' },
+      onRetry: { type: 'Object' },
+      onFeedback: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChatSuggestions.wc.svelte
+++ b/src/wc/components/ChatSuggestions.wc.svelte
@@ -13,7 +13,8 @@
       classes: { type: 'String' },
       chipClasses: { type: 'String', attribute: 'chip-classes' },
       onselect: { type: 'Object' },
-      icon: { type: 'Object' }
+      icon: { type: 'Object' },
+      onSelect: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/CheckListItem.wc.svelte
+++ b/src/wc/components/CheckListItem.wc.svelte
@@ -9,7 +9,8 @@
       classes: { type: 'String' },
       testId: { type: 'String', attribute: 'test-id' },
       onclick: { type: 'Object' },
-      checkboxLabel: { type: 'Object' }
+      checkboxLabel: { type: 'Object' },
+      onClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Checkbox.wc.svelte
+++ b/src/wc/components/Checkbox.wc.svelte
@@ -13,7 +13,8 @@
       classes: { type: 'String' },
       ariaLabel: { type: 'String', attribute: 'aria-label' },
       ariaControls: { type: 'String', attribute: 'aria-controls' },
-      onclick: { type: 'Object' }
+      onclick: { type: 'Object' },
+      onClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ChipInput.wc.svelte
+++ b/src/wc/components/ChipInput.wc.svelte
@@ -13,7 +13,11 @@
       onadd: { type: 'Object' },
       ondismiss: { type: 'Object' },
       onedit: { type: 'Object' },
-      onchange: { type: 'Object' }
+      onchange: { type: 'Object' },
+      onAdd: { type: 'Object' },
+      onDismiss: { type: 'Object' },
+      onEdit: { type: 'Object' },
+      onChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Choicebox.wc.svelte
+++ b/src/wc/components/Choicebox.wc.svelte
@@ -9,7 +9,8 @@
       showIndicator: { type: 'Boolean', reflect: true, attribute: 'show-indicator' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onclick: { type: 'Object' }
+      onclick: { type: 'Object' },
+      onClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ColorPicker.wc.svelte
+++ b/src/wc/components/ColorPicker.wc.svelte
@@ -10,7 +10,9 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onchange: { type: 'Object' },
-      oninput: { type: 'Object' }
+      oninput: { type: 'Object' },
+      onChange: { type: 'Object' },
+      onInput: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Combobox.wc.svelte
+++ b/src/wc/components/Combobox.wc.svelte
@@ -46,7 +46,15 @@
       onchange: { type: 'Object' },
       onadd: { type: 'Object' },
       onremove: { type: 'Object' },
-      oncreate: { type: 'Object' }
+      oncreate: { type: 'Object' },
+      onSelect: { type: 'Object' },
+      onInput: { type: 'Object' },
+      onOpen: { type: 'Object' },
+      onClose: { type: 'Object' },
+      onChange: { type: 'Object' },
+      onAdd: { type: 'Object' },
+      onRemove: { type: 'Object' },
+      onCreate: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/CommandMenu.wc.svelte
+++ b/src/wc/components/CommandMenu.wc.svelte
@@ -12,7 +12,9 @@
       classes: { type: 'String' },
       onselect: { type: 'Object' },
       onclose: { type: 'Object' },
-      itemIcon: { type: 'Object' }
+      itemIcon: { type: 'Object' },
+      onSelect: { type: 'Object' },
+      onClose: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ContextMenu.wc.svelte
+++ b/src/wc/components/ContextMenu.wc.svelte
@@ -10,7 +10,10 @@
       classes: { type: 'String' },
       onselect: { type: 'Object' },
       onopen: { type: 'Object' },
-      onclose: { type: 'Object' }
+      onclose: { type: 'Object' },
+      onSelect: { type: 'Object' },
+      onOpen: { type: 'Object' },
+      onClose: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/DateRangePicker.wc.svelte
+++ b/src/wc/components/DateRangePicker.wc.svelte
@@ -39,7 +39,13 @@
       compareCalendar: { type: 'Object' },
       triggerSnippet: { type: 'Object' },
       triggerIcon: { type: 'Object' },
-      compareTrigger: { type: 'Object' }
+      compareTrigger: { type: 'Object' },
+      onApply: { type: 'Object' },
+      onApplySingle: { type: 'Object' },
+      onApplyCompare: { type: 'Object' },
+      onCancel: { type: 'Object' },
+      onOpenToggle: { type: 'Object' },
+      onClear: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/FileDropzoneTrigger.wc.svelte
+++ b/src/wc/components/FileDropzoneTrigger.wc.svelte
@@ -9,7 +9,8 @@
       compact: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onclick: { type: 'Object' }
+      onclick: { type: 'Object' },
+      onClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/FileInput.wc.svelte
+++ b/src/wc/components/FileInput.wc.svelte
@@ -11,7 +11,9 @@
       classes: { type: 'String' },
       onfiles: { type: 'Object' },
       onerror: { type: 'Object' },
-      trigger: { type: 'Object' }
+      trigger: { type: 'Object' },
+      onFiles: { type: 'Object' },
+      onError: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Img.wc.svelte
+++ b/src/wc/components/Img.wc.svelte
@@ -10,7 +10,8 @@
       classes: { type: 'String' },
       onerror: { type: 'Object' },
       inlineSvg: { type: 'Boolean', attribute: 'inline-svg' },
-      transformSvg: { type: 'Object' }
+      transformSvg: { type: 'Object' },
+      onError: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Input.wc.svelte
+++ b/src/wc/components/Input.wc.svelte
@@ -60,7 +60,14 @@
       minRows: { type: 'Number', attribute: 'min-rows' },
       maxRows: { type: 'Number', attribute: 'max-rows' },
       resize: { type: 'String', attribute: 'resize' },
-      showCount: { type: 'Boolean', attribute: 'show-count' }
+      showCount: { type: 'Boolean', attribute: 'show-count' },
+      onfocus: { type: 'Object' },
+      onfocusout: { type: 'Object' },
+      onblur: { type: 'Object' },
+      oninput: { type: 'Object' },
+      onpaste: { type: 'Object' },
+      onclick: { type: 'Object' },
+      onkeydown: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ListItem.wc.svelte
+++ b/src/wc/components/ListItem.wc.svelte
@@ -30,7 +30,12 @@
       leftContent: { type: 'Object' },
       centerContent: { type: 'Object' },
       rightContent: { type: 'Object' },
-      bottomContent: { type: 'Object' }
+      bottomContent: { type: 'Object' },
+      onLeftImageClick: { type: 'Object' },
+      onRightImageClick: { type: 'Object' },
+      onCenterTextClick: { type: 'Object' },
+      onItemClick: { type: 'Object' },
+      onTopSectionClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/LottiePlayer.wc.svelte
+++ b/src/wc/components/LottiePlayer.wc.svelte
@@ -13,7 +13,9 @@
       classes: { type: 'String' },
       testId: { type: 'String', attribute: 'test-id' },
       oncomplete: { type: 'Object' },
-      onerror: { type: 'Object' }
+      onerror: { type: 'Object' },
+      onComplete: { type: 'Object' },
+      onError: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/MediaPlayer.wc.svelte
+++ b/src/wc/components/MediaPlayer.wc.svelte
@@ -23,7 +23,8 @@
       classes: { type: 'String' },
       onplay: { type: 'Object' },
       onpause: { type: 'Object' },
-      onvolumechange: { type: 'Object' }
+      onvolumechange: { type: 'Object' },
+      onVolumeChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Menu.wc.svelte
+++ b/src/wc/components/Menu.wc.svelte
@@ -17,7 +17,10 @@
       interactiveTrigger: { type: 'Boolean', attribute: 'interactive-trigger' },
       selectedValue: { type: 'String', attribute: 'selected-value' },
       placement: { type: 'String', attribute: 'placement' },
-      usePortal: { type: 'Boolean', attribute: 'use-portal' }
+      usePortal: { type: 'Boolean', attribute: 'use-portal' },
+      onSelect: { type: 'Object' },
+      onOpen: { type: 'Object' },
+      onClose: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Modal.wc.svelte
+++ b/src/wc/components/Modal.wc.svelte
@@ -30,7 +30,13 @@
       content: { type: 'Object' },
       footerSnippet: { type: 'Object' },
       lockScroll: { type: 'Boolean', attribute: 'lock-scroll' },
-      autoDismissAfter: { type: 'Number', attribute: 'auto-dismiss-after' }
+      autoDismissAfter: { type: 'Number', attribute: 'auto-dismiss-after' },
+      onClose: { type: 'Object' },
+      onHeaderRightImageClick: { type: 'Object' },
+      onHeaderLeftImageClick: { type: 'Object' },
+      onPrimaryButtonClick: { type: 'Object' },
+      onSecondaryButtonClick: { type: 'Object' },
+      onOverlayClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Pagination.wc.svelte
+++ b/src/wc/components/Pagination.wc.svelte
@@ -13,7 +13,8 @@
       prevButtonTestId: { type: 'String', attribute: 'prev-button-test-id' },
       nextButtonTestId: { type: 'String', attribute: 'next-button-test-id' },
       onchange: { type: 'Object' },
-      onLoadMore: { type: 'Object' }
+      onLoadMore: { type: 'Object' },
+      onChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Pill.wc.svelte
+++ b/src/wc/components/Pill.wc.svelte
@@ -12,7 +12,8 @@
       dismissIcon: { type: 'Object' },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      ondismiss: { type: 'Object' }
+      ondismiss: { type: 'Object' },
+      onDismiss: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Radio.wc.svelte
+++ b/src/wc/components/Radio.wc.svelte
@@ -10,7 +10,8 @@
       disabled: { type: 'Boolean', reflect: true },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onchange: { type: 'Object' }
+      onchange: { type: 'Object' },
+      onChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Resizable.wc.svelte
+++ b/src/wc/components/Resizable.wc.svelte
@@ -18,7 +18,10 @@
       classes: { type: 'String' },
       onresize: { type: 'Object' },
       onresizestart: { type: 'Object' },
-      onresizeend: { type: 'Object' }
+      onresizeend: { type: 'Object' },
+      onResize: { type: 'Object' },
+      onResizeStart: { type: 'Object' },
+      onResizeEnd: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Scroller.wc.svelte
+++ b/src/wc/components/Scroller.wc.svelte
@@ -16,7 +16,8 @@
       classes: { type: 'String' },
       onscrollposition: { type: 'Object' },
       arrowPrevious: { type: 'Object' },
-      arrowNext: { type: 'Object' }
+      arrowNext: { type: 'Object' },
+      onScrollPosition: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Select.wc.svelte
+++ b/src/wc/components/Select.wc.svelte
@@ -26,7 +26,10 @@
       onopen: { type: 'Object' },
       onclose: { type: 'Object' },
       hierarchy: { type: 'String', attribute: 'hierarchy' },
-      usePortal: { type: 'Boolean', attribute: 'use-portal' }
+      usePortal: { type: 'Boolean', attribute: 'use-portal' },
+      onChange: { type: 'Object' },
+      onOpen: { type: 'Object' },
+      onClose: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Sheet.wc.svelte
+++ b/src/wc/components/Sheet.wc.svelte
@@ -15,7 +15,10 @@
       onafterclose: { type: 'Object' },
       dismissOnOutsideClick: { type: 'Boolean', attribute: 'dismiss-on-outside-click' },
       content: { type: 'Object' },
-      footer: { type: 'Object' }
+      footer: { type: 'Object' },
+      onClose: { type: 'Object' },
+      onAfterOpen: { type: 'Object' },
+      onAfterClose: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Slider.wc.svelte
+++ b/src/wc/components/Slider.wc.svelte
@@ -13,7 +13,9 @@
       classes: { type: 'String' },
       oninput: { type: 'Object' },
       onchange: { type: 'Object' },
-      labelFormatter: { type: 'Object' }
+      labelFormatter: { type: 'Object' },
+      onChange: { type: 'Object' },
+      onInput: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Snippet.wc.svelte
+++ b/src/wc/components/Snippet.wc.svelte
@@ -9,7 +9,8 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       oncopy: { type: 'Object' },
-      copyIcon: { type: 'Object' }
+      copyIcon: { type: 'Object' },
+      onCopy: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/SplitButton.wc.svelte
+++ b/src/wc/components/SplitButton.wc.svelte
@@ -10,7 +10,8 @@
       classes: { type: 'String' },
       onclick: { type: 'Object' },
       onselect: { type: 'Object' },
-      dropdownIcon: { type: 'Object' }
+      dropdownIcon: { type: 'Object' },
+      onSelect: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/SplitInput.wc.svelte
+++ b/src/wc/components/SplitInput.wc.svelte
@@ -13,7 +13,10 @@
       classes: { type: 'String' },
       onchange: { type: 'Object' },
       oninput: { type: 'Object' },
-      oncomplete: { type: 'Object' }
+      oncomplete: { type: 'Object' },
+      onChange: { type: 'Object' },
+      onInput: { type: 'Object' },
+      onComplete: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Status.wc.svelte
+++ b/src/wc/components/Status.wc.svelte
@@ -13,7 +13,8 @@
       onbuttonClick: { type: 'Object' },
       icon: { type: 'Object' },
       descriptionSnippet: { type: 'Object' },
-      testId: { type: 'String', attribute: 'test-id' }
+      testId: { type: 'String', attribute: 'test-id' },
+      onButtonClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Stepper.wc.svelte
+++ b/src/wc/components/Stepper.wc.svelte
@@ -11,7 +11,9 @@
       onstepclick: { type: 'Object' },
       onhandleStepClick: { type: 'Object' },
       suppressRoleAndTabindex: { type: 'Boolean', attribute: 'suppress-role-and-tabindex' },
-      suppressContainerTestId: { type: 'Boolean', attribute: 'suppress-container-test-id' }
+      suppressContainerTestId: { type: 'Boolean', attribute: 'suppress-container-test-id' },
+      onStepClick: { type: 'Object' },
+      onHandleStepClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Tabs.wc.svelte
+++ b/src/wc/components/Tabs.wc.svelte
@@ -14,7 +14,9 @@
       activeKey: { type: 'String', attribute: 'active-key' },
       orientation: { type: 'String', attribute: 'orientation' },
       tab: { type: 'Object' },
-      onkeychange: { type: 'Object' }
+      onkeychange: { type: 'Object' },
+      onChange: { type: 'Object' },
+      onKeyChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/TaskList.wc.svelte
+++ b/src/wc/components/TaskList.wc.svelte
@@ -6,7 +6,8 @@
       rows: { type: 'Array' },
       onretry: { type: 'Object' },
       testId: { type: 'String', attribute: 'test-id' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      onRetry: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ThemeSwitcher.wc.svelte
+++ b/src/wc/components/ThemeSwitcher.wc.svelte
@@ -9,7 +9,8 @@
       storageKey: { type: 'String', reflect: true, attribute: 'storage-key' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      onchange: { type: 'Object' }
+      onchange: { type: 'Object' },
+      onChange: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ThinkingIndicator.wc.svelte
+++ b/src/wc/components/ThinkingIndicator.wc.svelte
@@ -25,7 +25,9 @@
       selected: { type: 'Object' },
       onrowselect: { type: 'Object' },
       onsettled: { type: 'Object' },
-      collapseDelayMs: { type: 'Object', attribute: 'collapse-delay-ms' }
+      collapseDelayMs: { type: 'Object', attribute: 'collapse-delay-ms' },
+      onRowSelect: { type: 'Object' },
+      onSettled: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Toggle.wc.svelte
+++ b/src/wc/components/Toggle.wc.svelte
@@ -8,7 +8,8 @@
       disabled: { type: 'Boolean', reflect: true },
       classes: { type: 'String' },
       onclick: { type: 'Object' },
-      testId: { type: 'String', attribute: 'test-id' }
+      testId: { type: 'String', attribute: 'test-id' },
+      onClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/ToolCallLog.wc.svelte
+++ b/src/wc/components/ToolCallLog.wc.svelte
@@ -6,7 +6,8 @@
       chips: { type: 'Array' },
       onchipclick: { type: 'Object' },
       testId: { type: 'String', attribute: 'test-id' },
-      classes: { type: 'String' }
+      classes: { type: 'String' },
+      onChipClick: { type: 'Object' }
     }
   }}
 />

--- a/src/wc/components/Toolbar.wc.svelte
+++ b/src/wc/components/Toolbar.wc.svelte
@@ -15,7 +15,8 @@
       leftContent: { type: 'Object' },
       centerContent: { type: 'Object' },
       rightContent: { type: 'Object' },
-      additionalContent: { type: 'Object' }
+      additionalContent: { type: 'Object' },
+      onBackClick: { type: 'Object' }
     }
   }}
 />

--- a/tests/wc-event-casing-parity.spec.ts
+++ b/tests/wc-event-casing-parity.spec.ts
@@ -1,0 +1,263 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
+import {
+  readComponentProps,
+  readCustomElementDeclaration,
+  wrappedComponentPath
+} from '../scripts/wc-parity/prop-parity';
+
+/**
+ * Phase 1 of the event-casing migration gave 56 components a second spelling for
+ * each grandfathered event prop, both wired to the same handler. It stopped at
+ * the Svelte layer. A custom element only forwards what `customElement.props`
+ * declares, so every corrected spelling was unreachable from a web component --
+ * `<sui-toggle onClick={fn}>` set an expando the component never read.
+ *
+ * The unit ratchet in scripts/wc-parity proves the wrapper *source* declares
+ * both. This proves the built element honours them: that both spellings are real
+ * accessors, that each one actually reaches the component, and that declaring
+ * them together did not break the one that already worked.
+ *
+ * That last point is the reason this file exists rather than a line in the
+ * ratchet. No wrapper had ever declared both spellings of the same event before,
+ * and Svelte derives an observed attribute by lowercasing the prop name, so
+ * `onclick` and `onClick` resolve to the same attribute and `$$g_p` returns
+ * whichever key `Object.keys` yields first. Reasoning says that is harmless for
+ * function props, which cannot come from an attribute anyway. Measuring it is
+ * cheap, and the last time this library reasoned about a custom-element prop
+ * instead of measuring it -- `children` -- the reasoning was wrong.
+ */
+
+const WC_DIR = join(process.cwd(), 'src/wc/components');
+
+const loadBundle = async (page: Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(() => typeof customElements.get('sui-status') !== 'undefined', null, {
+    timeout: 15_000
+  });
+};
+
+type CasingPair = { readonly tag: string; readonly spellings: readonly string[] };
+
+/**
+ * Event props a component accepts under two spellings that differ only by case.
+ *
+ * Derived from the components rather than from the ratchet's `missing` list on
+ * purpose: `missing` empties out the moment the declarations land, which would
+ * leave this test asserting nothing. The pairs survive, so the browser keeps
+ * being asked the question after the fix.
+ *
+ * Direction is deliberately not inferred here. It is not always "camelCase is
+ * the correct one": DESIGN_PRINCIPLES keeps Svelte's lowercase spelling for a
+ * native DOM event forwarded as-is, so Input's `onFocus(event: FocusEvent)`
+ * corrects *to* `onfocus` while Toggle's `onclick(checked: boolean)` corrects to
+ * `onClick`. Both spellings have to work either way, which is all this asks.
+ */
+const casingPairs = (): readonly CasingPair[] => {
+  const pairs: CasingPair[] = [];
+  for (const wrapper of readdirSync(WC_DIR)
+    .filter((file) => file.endsWith('.wc.svelte'))
+    .sort()) {
+    const source = readFileSync(join(WC_DIR, wrapper), 'utf8');
+    const { tag } = readCustomElementDeclaration(source);
+    const componentPath = wrappedComponentPath(source);
+    if (tag === null || componentPath === null) {
+      continue;
+    }
+    const grouped = new Map<string, string[]>();
+    for (const name of readComponentProps(readFileSync(componentPath, 'utf8')).names) {
+      if (!name.startsWith('on')) {
+        continue;
+      }
+      const key = name.toLowerCase();
+      grouped.set(key, [...(grouped.get(key) ?? []), name]);
+    }
+    for (const spellings of grouped.values()) {
+      if (spellings.length > 1) {
+        pairs.push({ tag, spellings });
+      }
+    }
+  }
+  return pairs;
+};
+
+const PAIRS = casingPairs();
+
+test.describe('custom elements accept both spellings of every aliased event prop', () => {
+  test('both spellings are real accessors on the built element', async ({ page }) => {
+    await loadBundle(page);
+
+    expect(PAIRS.length, 'no aliased event pairs found -- the fixture is broken').toBeGreaterThan(
+      100
+    );
+
+    const gaps = await page.evaluate((pairs) => {
+      const missing: string[] = [];
+      for (const { tag, spellings } of pairs) {
+        if (typeof customElements.get(tag) !== 'function') {
+          missing.push(`${tag}: element never defined`);
+          continue;
+        }
+        const element = document.createElement(tag);
+        for (const prop of spellings) {
+          // Stops at HTMLElement.prototype so a native handler accessor
+          // (onclick, onfocus and friends all live there) is never mistaken for
+          // a declared prop. Only a setter the generated class owns counts.
+          let found = false;
+          let proto: object | null = Object.getPrototypeOf(element);
+          while (proto !== null && proto !== HTMLElement.prototype) {
+            const descriptor = Object.getOwnPropertyDescriptor(proto, prop);
+            if (typeof descriptor?.set === 'function') {
+              found = true;
+              break;
+            }
+            proto = Object.getPrototypeOf(proto);
+          }
+          if (!found) {
+            missing.push(`${tag}.${prop}`);
+          }
+        }
+      }
+      return missing;
+    }, PAIRS);
+
+    expect(
+      gaps,
+      `spellings accepted by the component but not by the element: ${gaps.join(', ')}`
+    ).toEqual([]);
+  });
+
+  test('the corrected spelling reaches the component through the element', async ({ page }) => {
+    await loadBundle(page);
+
+    // sui-toggle corrects onclick -> onClick, and its handler is observable:
+    // clicking the shadow checkbox calls it with the new checked state.
+    const calls = await page.evaluate(async () => {
+      const element = document.createElement('sui-toggle');
+      const seen: boolean[] = [];
+      Reflect.set(element, 'onClick', (checked: boolean) => seen.push(checked));
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      element.shadowRoot?.querySelector('input')?.click();
+      return seen;
+    });
+
+    expect(calls, 'onClick never fired -- the corrected spelling is unreachable').toEqual([true]);
+  });
+
+  test('the legacy spelling still reaches the component', async ({ page }) => {
+    await loadBundle(page);
+
+    // The regression guard for declaring both. If adding onClick had cost the
+    // element its onclick, this is where it would show.
+    const calls = await page.evaluate(async () => {
+      const element = document.createElement('sui-toggle');
+      const seen: boolean[] = [];
+      Reflect.set(element, 'onclick', (checked: boolean) => seen.push(checked));
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      element.shadowRoot?.querySelector('input')?.click();
+      return seen;
+    });
+
+    expect(calls, 'onclick stopped firing once onClick was declared alongside it').toEqual([true]);
+  });
+
+  test('the corrected spelling wins when both are set', async ({ page }) => {
+    await loadBundle(page);
+
+    // Matches the component's own precedence, `$derived(onClick ?? onclickLegacy)`.
+    // A web-component consumer setting both must get the same answer a Svelte
+    // consumer passing both would get, or the two entry points disagree.
+    const winner = await page.evaluate(async () => {
+      const element = document.createElement('sui-toggle');
+      const seen: string[] = [];
+      Reflect.set(element, 'onclick', () => seen.push('legacy'));
+      Reflect.set(element, 'onClick', () => seen.push('corrected'));
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      element.shadowRoot?.querySelector('input')?.click();
+      return seen;
+    });
+
+    expect(winner, 'the element disagrees with the component about which spelling wins').toEqual([
+      'corrected'
+    ]);
+  });
+
+  test('a native-event prop corrected to lowercase reaches the component', async ({ page }) => {
+    await loadBundle(page);
+
+    // The other direction. sui-input forwards real DOM events, so its correct
+    // spelling is Svelte's lowercase one: onFocus is the legacy name and onfocus
+    // is the target. Declaring `onfocus` also shadows the host's own handler
+    // accessor, which is exactly why it is worth watching in a browser.
+    const fired = await page.evaluate(async () => {
+      const element = document.createElement('sui-input');
+      let count = 0;
+      Reflect.set(element, 'onfocus', () => {
+        count += 1;
+      });
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      element.shadowRoot?.querySelector('input')?.dispatchEvent(new FocusEvent('focus'));
+      return count;
+    });
+
+    expect(fired, 'onfocus never reached sui-input').toBeGreaterThan(0);
+  });
+});
+
+test.describe('a declared prop whose name is also a native handler', () => {
+  test('the declared prop wins over the host accessor it shadows', async ({ page }) => {
+    await loadBundle(page);
+
+    // Raised by a reviewer about `ontoggle`: several of these prop names are
+    // real GlobalEventHandlers properties on HTMLElement.prototype, so an
+    // assignment might reach the browser's accessor rather than the component's
+    // -- the `children` hazard again, where declaring a host name cost the host
+    // its own behaviour.
+    //
+    // Measured on sui-toggle rather than sui-accordion. `onclick` is native in
+    // exactly the same way `ontoggle` is, and Toggle renders its control
+    // unconditionally, whereas Accordion's trigger lives behind `{#if trigger}`
+    // and needs a snippet prop -- an element with no trigger has nothing to
+    // click, which makes the observation about the fixture rather than the
+    // library. The mechanism under test is identical.
+    const result = await page.evaluate(async () => {
+      const nativeNames = ['onclick', 'ontoggle', 'onchange', 'onclose'].filter(
+        (name) => name in HTMLElement.prototype
+      );
+
+      const fired: string[] = [];
+      const legacy = document.createElement('sui-toggle');
+      Reflect.set(legacy, 'onclick', () => fired.push('legacy'));
+      document.body.append(legacy);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      legacy.shadowRoot?.querySelector('input')?.click();
+
+      const corrected = document.createElement('sui-toggle');
+      Reflect.set(corrected, 'onClick', () => fired.push('corrected'));
+      document.body.append(corrected);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      corrected.shadowRoot?.querySelector('input')?.click();
+
+      return { nativeNames, fired };
+    });
+
+    // The premise, confirmed rather than assumed: these names really are taken
+    // on the host, so the shadowing is happening and is not hypothetical.
+    expect(result.nativeNames, 'none of these are native, so the test proves nothing').toContain(
+      'onclick'
+    );
+    expect(result.nativeNames).toContain('ontoggle');
+
+    // And the declaration wins anyway, in both spellings.
+    expect(result.fired, 'a native handler name swallowed the declared prop').toEqual([
+      'legacy',
+      'corrected'
+    ]);
+  });
+});


### PR DESCRIPTION
Closes the MAJOR Yama raised on #505 an hour before it merged. It is correct, it shipped in **3.2.0**, and the shape of it is worse than "some wrappers are missing props".

## The documented upgrade path is the broken one

Measured against the published `@juspay/svelte-ui-components@3.2.0` bundle in Chromium, with a real click on the dismiss button:

```
<sui-banner>  el.ondismiss = fn   (deprecated spelling)  →  FIRES
<sui-banner>  el.onDismiss = fn   (corrected spelling)   →  DOES NOTHING
```

`ondismiss` is a real accessor on the element's prototype. `onDismiss` is absent, so assigning it creates an own expando the component never reads. **A web-component consumer who follows the migration guidance silently loses their handler; one who ignores it keeps working.** (Reproduction by `componen-reuse-63`.)

## How it happened

Phase 1 (#505) gave 56 components a second spelling for each grandfathered event prop. It stopped at the Svelte layer — a custom element only forwards what `customElement.props` declares. Verified in the published tarball, not the source:

```
sui-toggle: camelCase=NONE   lowercase=['onclick']
sui-button: camelCase=NONE   lowercase=['onclick','onkeydown','onkeyup',...]
sui-modal:  camelCase=NONE   lowercase=['onclose','onkeydown']
sui-select: camelCase=NONE   lowercase=['onchange']
sui-banner: camelCase=NONE   lowercase=['onclick','ondismiss']
```

`release` has also been failing its own suite since the merge — **49 failed / 343 passed**, all in `scripts/wc-parity/prop-parity.test.ts`, the ratchet #506 built to catch exactly this. It worked; nothing ran it, because every test workflow here is `pull_request`-only. #514 fixes that cause; this fixes the instance.

## Both directions are real

126 declarations across 49 wrappers — 119 camelCase and 7 native ones on `sui-input`. `DESIGN_PRINCIPLES.md` §3 keeps Svelte's lowercase spelling for a native DOM event forwarded as-is, so the target depends on the signature:

| Component | Signature | Corrects to |
|---|---|---|
| `Toggle.onclick` | `(checked: boolean) => void` — synthesized | `onClick` |
| `Input.onFocus` | `(event: FocusEvent) => void` — forwarded | `onfocus` |

#505's generator discriminates on the signature and had both right.

## The transform

`scripts/migrate/alias-wc-props.ts`, committed rather than run once and discarded, for the reason its sibling gives: 126 declarations across 49 files is not a diff anyone reviews by eye. Re-running is a no-op and a test pins that.

`isEventProp` deliberately does not match a bare `/^on[A-Za-z]/` — that would also take a prop named `once` and declare it a callback. `NATIVE_EVENTS` is exported from `casing.ts` so the rule is stated once.

## Measured, not reasoned

No wrapper had ever declared both spellings of the same event before. Svelte lowercases to derive the observed attribute, so `onclick` and `onClick` both claim `onclick` and `$$g_p` returns whichever key comes first. The last time this library reasoned about a custom-element prop instead of measuring it — `children` — the reasoning was wrong. So `tests/wc-event-casing-parity.spec.ts` asks a browser. Six tests, all passing:

- both spellings are real accessors on the built element
- the corrected spelling reaches the component
- **the legacy spelling still fires** — the regression guard for declaring both
- the corrected one wins when both are set, matching `$derived(onClick ?? onclickLegacy)`
- the lowercase direction works (`onfocus` on `sui-input`)
- **a declared prop beats the native handler accessor it shadows**

That last one answers a reviewer's caution that `ontoggle` is a native `GlobalEventHandlers` property and might swallow the declaration. The premise is right — `'onclick' in HTMLElement.prototype` and `'ontoggle' in HTMLElement.prototype` are both true, and the test asserts that so it cannot quietly stop testing anything. The conclusion is not: Svelte defines its accessors on the generated class, which sits below `HTMLElement.prototype`, so the declaration shadows the native name rather than the reverse. Both spellings still fire.

## Verification

| Gate | Before (on `release`) | After |
|---|---|---|
| Unit | 343 passed / **49 failed** | **400 passed** |
| Integration | — | **437 passed** |
| Lint | — | 0 errors |
| Type-check | — | 832 files, 0 errors |