### PR TITLE
fix(ThemeSwitcher): add a pressed state to the toggle button

### DIFF
--- a/docs/ThemeSwitcher.md
+++ b/docs/ThemeSwitcher.md
@@ -62,6 +62,7 @@ Override these custom properties to theme the component.
 | `--theme-switcher-border-radius`       | `8px`         | border-radius    | Border radius of the toggle button (also used by segment control). |
 | `--theme-switcher-bg`                  | `transparent` | background-color | Background color of the toggle button.                             |
 | `--theme-switcher-bg-hover`            | `#f3f4f6`     | background-color | Background color of the toggle button on hover.                    |
+| `--theme-switcher-bg-pressed`          | `#e5e7eb`     | background-color | Background color of the toggle button while pressed.               |
 | `--theme-switcher-icon-color`          | `#374151`     | color            | Color of the icons (also used by segment buttons).                 |
 | `--theme-switcher-transition-duration` | `0.3s`        | transition       | Duration of the icon animation and all transitions.                |
 

--- a/src/lib/ThemeSwitcher/ThemeSwitcher.svelte
+++ b/src/lib/ThemeSwitcher/ThemeSwitcher.svelte
@@ -183,6 +183,10 @@
     background-color: var(--theme-switcher-bg-hover, #f3f4f6);
   }
 
+  .toggle-button:active {
+    background-color: var(--theme-switcher-bg-pressed, #e5e7eb);
+  }
+
   .icon {
     display: inline-flex;
     align-items: center;

--- a/tests/theme-switcher-pressed-state.spec.ts
+++ b/tests/theme-switcher-pressed-state.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Locator } from '@playwright/test';
+
+// The toggle button had a hover rule but no `:active` rule at all, so pressing it
+// looked identical to hovering it and the control gave no confirmation of the press.
+// Defaults: rest = transparent, hover = #f3f4f6 (rgb(243,244,246)), pressed =
+// #e5e7eb (rgb(229,231,235)). All three are asserted, because a pressed state that
+// resolves to the same colour as hover is the same defect wearing a new token.
+//
+// Every read polls rather than sleeping: `--theme-switcher-transition-duration`
+// defaults to 0.3s, so a fixed wait samples a composited mid-transition colour
+// (`rgba(243,244,246,0.667)` two-thirds of the way in) and fails on a value that is
+// on its way to being correct.
+const settlesTo = (locator: Locator, expected: string) =>
+  expect
+    .poll(
+      () => locator.evaluate((element: HTMLElement) => getComputedStyle(element).backgroundColor),
+      { timeout: 2_000 }
+    )
+    .toBe(expected);
+
+test.describe('ThemeSwitcher pressed state', () => {
+  test('the toggle button paints three distinct states', async ({ page }) => {
+    await page.goto('/components/theme-switcher');
+
+    const toggle = page.locator('.toggle-button').first();
+    await expect(toggle).toBeVisible();
+
+    await settlesTo(toggle, 'rgba(0, 0, 0, 0)');
+
+    const box = await toggle.boundingBox();
+    expect(box).not.toBeNull();
+    const centreX = box!.x + box!.width / 2;
+    const centreY = box!.y + box!.height / 2;
+
+    await page.mouse.move(centreX, centreY);
+    await settlesTo(toggle, 'rgb(243, 244, 246)');
+
+    await page.mouse.down();
+    try {
+      await settlesTo(toggle, 'rgb(229, 231, 235)');
+    } finally {
+      await page.mouse.up();
+    }
+  });
+
+  test('the pressed colour is driven by --theme-switcher-bg-pressed', async ({ page }) => {
+    await page.goto('/components/theme-switcher');
+
+    const toggle = page.locator('.toggle-button').first();
+    await expect(toggle).toBeVisible();
+    await toggle.evaluate((element: HTMLElement) => {
+      element.style.setProperty('--theme-switcher-bg-pressed', 'rgb(1, 2, 3)');
+    });
+
+    const box = await toggle.boundingBox();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    try {
+      await settlesTo(toggle, 'rgb(1, 2, 3)');
+    } finally {
+      await page.mouse.up();
+    }
+  });
+});


### PR DESCRIPTION
## What

`.toggle-button` had a `:hover` rule and **no `:active` rule at all**. Pressing it looked identical to hovering it, so the control never confirmed the press. This adds the rule and the `--theme-switcher-bg-pressed` token that feeds it.

```css
.toggle-button:active {
  background-color: var(--theme-switcher-bg-pressed, #e5e7eb);
}
```

Three lines plus a docs row and a spec. Additive and backwards-compatible — a consumer that sets nothing gets the literal fallback, one step darker than the existing `#f3f4f6` hover.

## How it was found

Measuring every interactive control on 42 routes in five interaction states, on a Shopify-embedded surface, against the host's own Polaris tokens. 424 divergences closed down to 2 — and both remaining ones were this component, on `/onboard` and `/agents`.

Every other pressed-state finding closed by feeding host tokens from the consumer's stylesheet. These two could not, because **a token cannot feed a state the component never paints**. There was nothing on the consumer side to reach.

## Why not `--theme-switcher-bg-active`

That was the first name I proposed, and reading the file showed it was wrong. In this component **"active" already means the *selected* segment** — `--theme-switcher-icon-color-active`, `--theme-switcher-segment-active-bg`, `.icon.active`. Reusing the word for "pressed" would make two different meanings share a name. `-bg-pressed` says what it does and sits cleanly beside `-bg` / `-bg-hover`.

## Scope: `.segment-button` is deliberately untouched

It paints selection through a sliding `.segment-indicator` behind a `background: transparent` button. A pressed background there has to not fight the indicator, which is a design question rather than the same one-line fix. Worth doing, separately.

## Verification

New spec: `tests/theme-switcher-pressed-state.spec.ts`, modelled on the existing `choicebox-selected-hover.spec.ts`.

- **Test 1** asserts all three states resolve to *distinct* colours — rest `rgba(0,0,0,0)` → hover `rgb(243,244,246)` → pressed `rgb(229,231,235)`. Asserting all three on purpose: a pressed state that resolves to the same value as hover is the same defect wearing a new token. (That exact collision is what caused ~30 of the findings on the consumer side, where two tokens both resolved to `#f7f7f7` and hover was a silent no-op.)
- **Test 2** overrides `--theme-switcher-bg-pressed` to `rgb(1,2,3)` and asserts the pressed colour follows, so the seam is proven wired rather than assumed.

Both reads **poll** rather than sleep. A fixed 100 ms wait samples a composited mid-transition value (`rgba(243,244,246,0.667)`, two-thirds through the default 0.3 s transition) and fails on a colour that is on its way to being correct — that was the first run's failure, and it is in the spec's comment so the next person doesn't rediscover it.

**Negative control** — with the `:active` rule removed and the preview server confirmed torn down first, so the control could not reuse the previous build:

| | Expected | Received |
|---|---|---|
| Test 1 | `rgb(229, 231, 235)` | `rgb(243, 244, 246)` ← the hover colour |
| Test 2 | `rgb(1, 2, 3)` | `rgb(243, 244, 246)` |

The failure is the defect reproducing with a specific wrong colour, not a timeout or a missing element. Restored and confirmed byte-identical by sha256 to the tree that passed.

**Local gates:** `pnpm lint` ✅ (0 errors, 0 new event-casing violations) · `pnpm check` ✅ · new spec 2/2 ✅

## CI will be red, and not because of this

`release` currently fails its own unit suite: **49 failed / 343 passed**, all in `scripts/wc-parity/prop-parity.test.ts`, from #505 and #506 merging 14 seconds apart with #506 rebased onto a base predating #505.

Controlled for it — stashed this change and ran that file on the clean base: **49 failed, identical**. This change is CSS-only and touches no props, so it cannot affect prop parity. Nothing else in the suite fails.

#512 fixes that. This should merge after it.
