### PR TITLE
docs(principles): a token can only reach a state the component paints

### DIFF
--- a/DESIGN_PRINCIPLES.md
+++ b/DESIGN_PRINCIPLES.md
@@ -17,6 +17,20 @@ this pattern.** That's the baseline to hold new code to and gradually bring old 
 to — not a rewrite. A hardcoded color or size in a new `<style>` block should be treated
 as a bug, the same as an unhandled `null`.
 
+**A token can only reach a state the component actually paints.** The cascade cannot add a
+declaration that does not exist: a `.toggle-button:hover` rule with no `:active` beside it
+leaves nothing for `--theme-switcher-bg-pressed` to land in, so no consumer can supply a
+pressed state however carefully they arrange their own stylesheet. It is the one gap in the
+contract a consumer cannot work around, and it is invisible from the source — the component
+reads as fully tokenised, because every rule it *does* have is.
+
+Measured on an embedded Shopify Admin surface (42 routes, 573 elements, five interaction
+states each, states forced through CDP rather than inferred): every divergence from the host
+closed by feeding tokens from the consumer's stylesheet except two, and both were a state no
+rule painted. So enumerate the states when adding a component — rest, hover, focus-visible,
+active, disabled — and give each one a rule and a token. A missing state is a missing API,
+not a missing style.
+
 ## 2. Framework-agnosticism is a real target, not just a Svelte library
 
 This library ships both a Svelte 5 package and a web-component build (`sui-*` custom


### PR DESCRIPTION
Documentation only. No behaviour, tests or public API change — one paragraph pair added to `DESIGN_PRINCIPLES.md` §1.

## The gap

§1 commits to every visual decision being a custom property with a fallback, and to the cascade as the customization mechanism. What it does not say is what happens when there is **no declaration at all** — and that turns out to be the one gap in the contract a consumer cannot work around. The cascade can override a rule. It cannot invent one.

## Where it came from

#515. `.toggle-button` had a `:hover` rule and no `:active` rule, so `--theme-switcher-bg-pressed` had nowhere to land, and no arrangement of a consumer's stylesheet could have produced a pressed state. The component read as fully tokenised the entire time, because every rule it *did* have was — which is exactly what makes this class of gap hard to see from the source.

## Why it's worth stating rather than asserting

The claim is measured, not argued. On an embedded Shopify Admin surface — 42 routes, 573 elements, five interaction states each, states forced through CDP `DOM.forcePseudoState` rather than inferred — every divergence from the host closed by feeding tokens from the consumer's stylesheet **except two**, and both of those were a state no rule painted. That ratio is the argument: the theming contract holds almost everywhere, and where it fails it fails for one specific, checkable reason.

The addition ends with the practical form: enumerate the states when adding a component — rest, hover, focus-visible, active, disabled — and give each one a rule and a token. A missing state is a missing API, not a missing style.

## Note on formatting

`DESIGN_PRINCIPLES.md` is not prettier-formatted in the repo (it uses `*emphasis*`; prettier wants `_emphasis_`, on two pre-existing lines), and root markdown is outside `pnpm lint`'s `src scripts tests` scope. I matched the file's existing style rather than running `prettier --write`, which would have churned two lines unrelated to this change. Happy to reformat the whole file separately if that's wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified theming guidance for component interaction states.
  - Documented rest, hover, focus-visible, active, and disabled states as part of the theming API.
  - Added evidence showing consumer-provided tokens resolve most host-style differences when corresponding component rules are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->