### PR TITLE
test(parity,wc): close every open review finding across the parity harness and wrappers

### DIFF
--- a/DESIGN_PRINCIPLES.md
+++ b/DESIGN_PRINCIPLES.md
@@ -20,9 +20,17 @@ as a bug, the same as an unhandled `null`.
 **A token can only reach a state the component actually paints.** The cascade cannot add a
 declaration that does not exist: a `.toggle-button:hover` rule with no `:active` beside it
 leaves nothing for `--theme-switcher-bg-pressed` to land in, so no consumer can supply a
-pressed state however carefully they arrange their own stylesheet. It is the one gap in the
-contract a consumer cannot work around, and it is invisible from the source — the component
-reads as fully tokenised, because every rule it *does* have is.
+pressed state through the token contract however carefully they arrange their own
+stylesheet. It is invisible from the source, too — the component reads as fully tokenised,
+because every rule it _does_ have is.
+
+How far that goes depends on which build a consumer is on, and the distinction is worth
+keeping straight. Through the custom elements the shadow boundary is the end of it: an
+outside stylesheet cannot reach a rule that does not exist, and cannot add one. Importing
+the Svelte components directly, styles are scoped rather than encapsulated, so a consumer
+can still write the missing rule themselves — at the cost of reaching past the token API
+into class names that are not part of it. Neither case makes the missing declaration
+acceptable; the first leaves no way out at all, and the second only an unsupported one.
 
 Measured on an embedded Shopify Admin surface (42 routes, 573 elements, five interaction
 states each, states forced through CDP rather than inferred): every divergence from the host
@@ -56,7 +64,7 @@ hook for Playwright.
   `onSelectionChange`. This matches the wider Svelte-component ecosystem's convention for
   invented callback props.
 
-This is deliberately *not* polymorph's rule (lowercase for everything, including
+This is deliberately _not_ polymorph's rule (lowercase for everything, including
 synthesized events). That's a real, coherent choice, but it trades away the native/synthetic
 distinction that Svelte 5 itself draws, and it isn't obviously better — just different.
 What actually needed fixing here wasn't the rule, it was that this codebase had never
@@ -81,6 +89,6 @@ otherwise it stays a plain element.
 ## 5. Documentation is built for machines, not just humans
 
 This library ships an MCP server (`mcp/`) exposing `list_components`-style tools over
-`docs/*.md` — components are increasingly composed and themed *through* AI assistants, not
+`docs/*.md` — components are increasingly composed and themed _through_ AI assistants, not
 just read about by humans. `docs/_index.json` is the source of truth; keep it current when
 a component is added, the same way you'd keep an export current.

--- a/tests/wc-event-casing-parity.spec.ts
+++ b/tests/wc-event-casing-parity.spec.ts
@@ -261,3 +261,85 @@ test.describe('a declared prop whose name is also a native handler', () => {
     ]);
   });
 });
+
+test.describe('declaring a native handler name does not take the DOM path with it', () => {
+  test('addEventListener still works on an element that declares the same name', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    // Review on #512 held that declaring `onclick`/`onfocus`/`oninput` shadows
+    // the native GlobalEventHandlers accessor, and so changes web-component
+    // behaviour. The shadowing is real and measured in the test above. What
+    // matters for a consumer is whether it costs them the DOM, and it does not:
+    // the declaration replaces one property, not the event system. This asserts
+    // the escape hatch actually exists rather than assuming it does, because
+    // "use addEventListener instead" is the whole mitigation.
+    const seen = await page.evaluate(async () => {
+      const order: string[] = [];
+
+      const element = document.createElement('sui-toggle');
+      element.addEventListener('click', () => order.push('addEventListener'));
+      Reflect.set(element, 'onClick', () => order.push('declared-prop'));
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      element.shadowRoot?.querySelector('input')?.click();
+
+      return order;
+    });
+
+    // Both run. The listener is not displaced by the prop, and the prop is not
+    // displaced by the listener.
+    expect(seen, 'declaring the prop cost the element its DOM event').toContain('addEventListener');
+    expect(seen).toContain('declared-prop');
+  });
+
+  test('the shared observed attribute resolves to the legacy spelling', async ({ page }) => {
+    await loadBundle(page);
+
+    // The other half of that review: `onclick` and `onClick` both lowercase to
+    // the `onclick` attribute, so Svelte's `$$g_p` returns whichever key
+    // `Object.keys` yields first, and the finding called that undocumented
+    // key-enumeration behaviour to rely on. It is -- for the attribute path,
+    // which is inert here because a function cannot be written as an HTML
+    // attribute. Property assignment is unaffected: each declared key gets its
+    // own accessor, which is why precedence holds in the tests above.
+    //
+    // Pinned by driving the attribute rather than by counting it. An earlier
+    // version asserted only that `onclick` appears twice in observedAttributes,
+    // while the comment claimed it would catch a reordering -- which it would
+    // not have, since both entries are the same string. Review caught the gap.
+    // Setting the attribute and reading both properties back shows which key
+    // actually won, so a reordering of the declarations fails here.
+    const resolved = await page.evaluate(async () => {
+      const constructor = customElements.get('sui-toggle');
+      const observed =
+        typeof constructor === 'function' ? Reflect.get(constructor, 'observedAttributes') : [];
+      const list: string[] = Array.isArray(observed) ? observed : [];
+
+      const element = document.createElement('sui-toggle');
+      document.body.append(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      // `type: 'Object'` runs the attribute through JSON.parse, so a parseable
+      // marker lands on whichever prop the attribute resolved to.
+      element.setAttribute('onclick', '{"marker":true}');
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      return {
+        onclickCount: list.filter((name) => name === 'onclick').length,
+        legacyGotIt: JSON.stringify(Reflect.get(element, 'onclick')),
+        correctedGotIt: JSON.stringify(Reflect.get(element, 'onClick'))
+      };
+    });
+
+    // Both declarations really do claim the same attribute -- the premise the
+    // finding rests on, confirmed rather than taken on trust.
+    expect(resolved.onclickCount, 'the two spellings no longer share an attribute').toBe(2);
+
+    // And the legacy key is the one it resolves to, because it is declared
+    // first. This is the assertion a reordering would break.
+    expect(resolved.legacyGotIt, 'the attribute stopped resolving to the legacy spelling').toBe(
+      '{"marker":true}'
+    );
+  });
+});


### PR DESCRIPTION
One PR for every finding still outstanding after 3.2.3, rather than four. **Supersedes #509** — it carries that harness, because the findings cannot be fixed without the code they are about.

## 1. The parity harness asserted almost nothing (#509)

Three of its assertions were decorative:

| Assertion | Problem |
|---|---|
| `consoleErrors` | collected, written to `results.json`, attached — **never asserted** |
| `expect(Array.isArray(bothBlank)).toBe(true)` | true of every array; row count could fall to zero without failing |
| only `suiOnlyBroken` gated | while the description claimed *"asymmetric failures 0 in either direction"* |

`consoleErrors` is now asserted **first**, deliberately: `<svelte:boundary>` catches a render failure and turns it into a visible cell, which is the result this harness wants, but an error thrown from a timer, a promise or an event handler escapes it. A component that throws asynchronously can still leave a plausible DOM behind, so the rendering checks below would pass while the page was on fire.

The one-directional gate mattered because the claim rested on a number nobody could reproduce from the test. Both directions are asserted now.

**Measured after the change:**

```
components compared : 68
sui rendered        : 68        poly rendered      : 68
sui-only broken     : 0         poly-only broken   : 0
both blank          : 0         console errors     : 0
rows differing on computed style : 15 of 68
```

The description's claim is now something the suite enforces rather than something it was trusted on.

`Cell.svelte` also loses its `name` prop — it built a `data-pw` no selector used.

**On `$bindable`:** the finding is correct that `{...props}` does not establish a binding, and that is the right shape here. This harness asks whether both libraries render the same fixture — a question about first paint. Nothing types into a component or reads a value back, so a two-way binding would have nothing to carry. Documented in `Cell.svelte` rather than left to be rediscovered, and Input, Checkbox, Toggle and Select render on both sides, which the suite now asserts.

## 2. Both #512 findings hold up — and neither needs the code changed

**Native handler shadowing.** Declaring `onfocus`/`oninput`/`onclick` really does shadow the native `GlobalEventHandlers` accessor. What matters is whether that costs a consumer the DOM, and it does not — the declaration replaces one property, not the event system. A test now proves `addEventListener('click')` and the declared prop **both fire on the same element**, because *"use addEventListener instead"* is the entire mitigation and was until now an assertion rather than a fact.

**Attribute collision.** `onclick` and `onClick` do both claim the `onclick` attribute — confirmed, `observedAttributes` contains it twice, and the test asserts that so the premise cannot quietly stop being true. The finding calls this reliance on undocumented key-enumeration order. It is, *for the attribute path*, which is inert because a function cannot be written as an HTML attribute. Property assignment is per-key and unaffected, which is why precedence holds in the existing tests. Pinned anyway: the order is stable but incidental, and the generator appends corrected spellings after legacy ones, so a reordering would silently change which key the attribute resolves to and nothing else would notice.

## 3. One correction to DESIGN_PRINCIPLES (#516)

The pressed-state section claimed a missing declaration is *"the one gap in the contract a consumer cannot work around"*. True through the custom elements, where the shadow boundary ends it. Not true importing the Svelte components, where styles are scoped rather than encapsulated and a consumer **can** write the missing rule — at the cost of reaching past the token API into class names that are not part of it. Both cases are now stated, since the difference decides whether a consumer has no way out or only an unsupported one.

## Deliberately not here

The release workflow's version bump reads `git log -1` — the tip commit only — so two merges each with a `feat:` tip compute the same version. That is why 3.2.0 was computed twice. It belongs with #514's release-pipeline work, and putting it here would collide with that PR over the same file.

## Verification

**443 integration · 407 unit · lint 0 errors · check 978 files 0 errors**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visual comparison page for reviewing shared SUI and polymorph UI components side by side.
  - Displays component render results, styling differences, and isolated rendering errors for easier comparison.

- **Tests**
  - Added automated visual-parity checks covering shared components and expected styling differences.
  - Added browser tests validating custom-element event handling and event-name casing behavior.

- **Documentation**
  - Clarified theming limitations and updated formatting in the design principles documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->