### PR TITLE
fix(release): push the MCP release before publishing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,31 +633,12 @@ jobs:
         working-directory: mcp
         run: npm run build
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npx -y npm@${NPM_CLI_VERSION} install -g npm@${NPM_CLI_VERSION}
-
-      - name: Publish MCP to NPM
-        id: npm-publish
-        working-directory: mcp
-        run: |
-          # No token: npm >=11.15 exchanges this workflow's OIDC token for a
-          # short-lived publish credential itself, via the trusted-publisher
-          # config on npmjs.com for this repo + this workflow file.
-
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
-
-          echo "Checking if $PACKAGE_NAME@$NEW_VERSION already exists..."
-          if npm view "$PACKAGE_NAME@$NEW_VERSION" version 2>/dev/null; then
-            echo "Version $NEW_VERSION already exists on NPM, skipping publish"
-            exit 0
-          fi
-
-          # Scoped package -> publish publicly
-          echo "Publishing $PACKAGE_NAME@$NEW_VERSION to NPM..."
-          npm publish --access public --provenance
-          echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"
-
+      # Before the publish, for the reason the root release job already does it:
+      # an npm version cannot be re-published and unpublishing is restricted, while
+      # a commit and a tag can both be deleted. Published first, anything that stops
+      # this step strands a version on the registry that this repository has no
+      # record of -- which is exactly how 3.4.1 ended up on npm with no tag, no
+      # `chore(release)` commit and no GitHub Release.
       - name: Commit and tag MCP release
         run: |
           NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
@@ -691,10 +672,27 @@ jobs:
 
           echo "Released @juspay/svelte-ui-components-mcp $NEW_VERSION"
 
-      - name: Rollback MCP version on failure
-        if: failure() && steps.npm-publish.conclusion == 'failure'
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npx -y npm@${NPM_CLI_VERSION} install -g npm@${NPM_CLI_VERSION}
+
+      - name: Publish MCP to NPM
+        id: npm-publish
         working-directory: mcp
         run: |
-          echo "MCP publish failed, rolling back version change..."
-          git checkout -- package.json
-          echo "Version rollback completed"
+          # No token: npm >=11.15 exchanges this workflow's OIDC token for a
+          # short-lived publish credential itself, via the trusted-publisher
+          # config on npmjs.com for this repo + this workflow file.
+
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
+
+          echo "Checking if $PACKAGE_NAME@$NEW_VERSION already exists..."
+          if npm view "$PACKAGE_NAME@$NEW_VERSION" version 2>/dev/null; then
+            echo "Version $NEW_VERSION already exists on NPM, skipping publish"
+            exit 0
+          fi
+
+          # Scoped package -> publish publicly
+          echo "Publishing $PACKAGE_NAME@$NEW_VERSION to NPM..."
+          npm publish --access public --provenance
+          echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"


### PR DESCRIPTION
## Problem

`publish-mcp` still does what the root release job stopped doing in #514: **publish to npm first, then commit, tag and push.**

That ordering is exactly what put **3.4.1 on the registry with no tag, no `chore(release)` commit and no GitHub Release** — run [33961677670](https://github.com/juspay/svelte-ui-components/actions/runs/33961677670) published successfully and then failed at the push with `GH006: Protected branch update failed`. Same shape, same latent outcome, just in the MCP job.

It was called out and deliberately left alone in #514 rather than refactored under an open review. This is that follow-up.

## Change

An npm version cannot be re-published and unpublishing is restricted; a commit and a tag can both be deleted. So the revertible writes go first and the irreversible one last:

```
Bump MCP version → Build → Commit and tag MCP release → Upgrade npm → Publish MCP to NPM
```

Anything that blocks the git side now stops the run with the registry untouched, instead of stranding a version this repository has no record of. Identical to the root `release` job after #514.

## The rollback step is removed, not kept as decoration

```yaml
- name: Rollback MCP version on failure
  if: failure() && steps.npm-publish.conclusion == 'failure'
  run: git checkout -- package.json
```

It restored `mcp/package.json` from HEAD, which was only meaningful while the bump was still uncommitted. With the commit ahead of the publish, **HEAD already carries the bumped version**, so the step would revert a file to the value it already has — an inert step named "Rollback", which reads to the next person as a safety net that isn't there.

The real recovery is a re-run: `Publish MCP to NPM` already guards with `npm view "$PACKAGE_NAME@$NEW_VERSION" && exit 0`, so a version that did reach the registry is not published twice, and one that did not is published.

## Impact

One file, `.github/workflows/release.yml`, +28/−30 — the two moved blocks plus the removed step. `publish-mcp` runs only when `needs.release.result == 'skipped'` (an MCP-only push), and no successful release changes behaviour: the same commit, tag and publish happen, in an order where a failure cannot desynchronise npm from git.

YAML validated; prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow so package version commits and tags are created before publishing to npm.
  - Adjusted the npm publishing sequence to support the updated release process.
  - Removed the automatic version rollback step when publishing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->