### PR TITLE
feat(markdowntext): add a sanitize prop with protocol and tag allow-lists

### DIFF
--- a/docs/MarkdownText.md
+++ b/docs/MarkdownText.md
@@ -36,13 +36,14 @@ The `marked` package is a peer dependency, needed only when you actually use `Ma
 
 ## Props
 
-| Prop       | Type      | Required | Default | Description                                                                                                                                                                  |
-| ---------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| markdown   | `string`  | Yes      | `-`     | Markdown source. Raw HTML inside it is escaped and shown as text; unsafe link/image protocols are stripped while their text stays.                                           |
-| breaks     | `boolean` | No       | `false` | Render single newlines as `<br>` (GFM "breaks" mode).                                                                                                                        |
-| testId     | `string`  | No       | `-`     | `data-pw` (and native `testID`) on the root element.                                                                                                                         |
-| classes    | `string`  | No       | `-`     | Class string on the root element.                                                                                                                                            |
-| tableLabel | `string`  | No       | `-`     | Names the scrollable table region: adds `role="region"` and `aria-label` to the wrapper. Without it the wrapper is still focusable and scrollable but announces no landmark. |
+| Prop       | Type                     | Required | Default | Description                                                                                                                                                                  |
+| ---------- | ------------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| markdown   | `string`                 | Yes      | `-`     | Markdown source. Raw HTML inside it is escaped and shown as text; unsafe link/image protocols are stripped while their text stays.                                           |
+| breaks     | `boolean`                | No       | `false` | Render single newlines as `<br>` (GFM "breaks" mode).                                                                                                                        |
+| testId     | `string`                 | No       | `-`     | `data-pw` (and native `testID`) on the root element.                                                                                                                         |
+| classes    | `string`                 | No       | `-`     | Class string on the root element.                                                                                                                                            |
+| tableLabel | `string`                 | No       | `-`     | Names the scrollable table region: adds `role="region"` and `aria-label` to the wrapper. Without it the wrapper is still focusable and scrollable but announces no landmark. |
+| sanitize   | `MarkdownSanitizeOptions` | No       | `-`     | Narrows the link/image protocol allow-list, the set of tags allowed to render as themselves, and whether task-list checkboxes render. See the Security model section below.  |
 
 ## Security model
 
@@ -50,6 +51,21 @@ The `marked` package is a peer dependency, needed only when you actually use `Ma
 - **URL protocol allow-list.** `[x](javascript:…)` and `[x](data:…)` render as plain text without an anchor; `![x](javascript:…)` renders the alt text without an `<img>`. Entity-smuggled protocols (`jav&#x09;ascript:`) fail scheme parsing and are treated as relative paths, where attribute-escaping keeps them inert.
 - **External links are tab-safe.** `http:`/`https:` links open with `target="_blank" rel="noopener noreferrer"` (the same default the library's Button/Card apply); relative, `mailto:` and `tel:` links keep same-tab navigation. Autolinks and bare URLs go through the same protocol guard as explicit links.
 - **Pre-sanitized HTML has its own prop.** If you already hold trusted, sanitized HTML, use `ChatMessage`'s `html` prop — `markdown` is for untrusted source text.
+- **The allow-list can be narrowed, never widened.** Pass `sanitize={{ allowedProtocols: [...] }}` when your own link policy is stricter than the library default (for example, no live `mailto:`/`tel:` in a support chat). It is intersected with the library's own allow-list for each surface (links vs. images), so listing an unsafe scheme like `javascript:` is a no-op, not a hole. Omitting `sanitize` keeps today's defaults exactly as they are — this is additive, not a replacement for the built-in list:
+
+  ```svelte
+  <!-- Only http(s) links/images; mailto: and tel: are dropped, keeping their text. -->
+  <MarkdownText {markdown} sanitize={{ allowedProtocols: ['http:', 'https:'] }} />
+  ```
+
+- **The tag allow-list narrows from "everything", never from a preset list.** Unlike `allowedProtocols`, there is no built-in default to intersect with — every tag `marked`'s GFM output can produce (`a`, `img`, `strong`, `em`, `del`, `code`, `pre`, `blockquote`, `ul`, `ol`, `table`, `hr`, `h1`–`h6`) renders normally until `sanitize.allowedTags` is supplied. Once it is, a disallowed tag renders its parsed inner content as plain text instead of the element — the same "keep the text, drop the element" contract the protocol allow-list uses. An unrecognised name is ignored, not an error. This is independent of the raw-HTML escaping guarantee above, which has no opt-out:
+
+  ```svelte
+  <!-- Headings, lists and tables render as plain text; links/emphasis still render. -->
+  <MarkdownText {markdown} sanitize={{ allowedTags: ['a', 'strong', 'em'] }} />
+  ```
+
+- **Task-list checkboxes can render as plain text instead.** GFM task items (`- [ ] done`) already render a `disabled` checkbox by default — it never submits or toggles — so `sanitize={{ disableTaskLists: true }}` is a presentation choice, not a safety one, for surfaces that would rather show the list item's text with no checkbox glyph at all. Defaults to `false`, keeping today's checkbox rendering.
 
 ## Wide tables
 
@@ -120,11 +136,26 @@ export type MarkdownTextProperties = {
   testId?: string;
   classes?: string;
   tableLabel?: string;
+  sanitize?: MarkdownSanitizeOptions;
+};
+
+export type MarkdownSanitizeOptions = {
+  // Intersected with the library's own default allow-list per surface (links,
+  // images), so it can only narrow what renders, never widen it.
+  allowedProtocols?: string[];
+  // No preset default to intersect with -- every tag renders until this is
+  // supplied, then it narrows from "everything". A disallowed tag keeps its
+  // text and drops the element.
+  allowedTags?: string[];
+  // Render task-list items as plain text instead of a (already-disabled)
+  // checkbox. Defaults to false.
+  disableTaskLists?: boolean;
 };
 
 export type RenderMarkdownOptions = {
   breaks?: boolean;
   inline?: boolean;
   tableLabel?: string;
+  sanitize?: MarkdownSanitizeOptions;
 };
 ```

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -321,7 +321,7 @@
   },
   {
     "name": "MarkdownText",
-    "description": "Renders markdown as HTML through a sanitized-by-construction pipeline built for chat/agent content: raw HTML (block and inline) is escaped to visible text, and link/image URLs keep their href only on an allow-listed protocol (http/https/mailto/tel for links, http/https for images; relative URLs pass). GFM enabled; optional `breaks` mode renders single newlines as <br>. Pure string transform — SSR-identical, no DOM. The same pipeline is exported as `renderMarkdown(markdown, {breaks?})` and powers ChatMessage's `markdown` prop."
+    "description": "Renders markdown as HTML through a sanitized-by-construction pipeline built for chat/agent content: raw HTML (block and inline) is escaped to visible text, and link/image URLs keep their href only on an allow-listed protocol (http/https/mailto/tel for links, http/https for images; relative URLs pass). GFM enabled; optional `breaks` mode renders single newlines as <br>. The optional `sanitize` prop narrows further per instance: `allowedProtocols` narrows the protocol allow-list, `allowedTags` narrows which markdown-generated tags render as themselves (everything renders until supplied), and `disableTaskLists` renders task-list items as plain text instead of a checkbox — all default to today's behavior when omitted. `tableLabel` names the scrollable region wrapping a rendered table. Pure string transform — SSR-identical, no DOM. The same pipeline is exported as `renderMarkdown(markdown, {breaks?, inline?, tableLabel?, sanitize?})` and powers ChatMessage's `markdown` prop."
   },
   {
     "name": "ChatComposer",

--- a/src/lib/MarkdownText/MarkdownText.svelte
+++ b/src/lib/MarkdownText/MarkdownText.svelte
@@ -2,9 +2,16 @@
   import { renderMarkdown } from './markdown';
   import type { MarkdownTextProperties } from './properties';
 
-  let { markdown, breaks = false, testId, classes, tableLabel }: MarkdownTextProperties = $props();
+  let {
+    markdown,
+    breaks = false,
+    testId,
+    classes,
+    tableLabel,
+    sanitize
+  }: MarkdownTextProperties = $props();
 
-  let html = $derived(renderMarkdown(markdown, { breaks, tableLabel }));
+  let html = $derived(renderMarkdown(markdown, { breaks, tableLabel, sanitize }));
 </script>
 
 <div

--- a/src/lib/MarkdownText/markdown-sanitize.test.ts
+++ b/src/lib/MarkdownText/markdown-sanitize.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+// Regression coverage for #524: MarkdownText's link/image protocol allow-list
+// was fixed (http/https/mailto/tel for links, http/https for images) with no
+// way to narrow it, forcing consumers whose own link policy is stricter (e.g.
+// http(s)-only, no live mailto:/tel:) to pre-mangle the markdown SOURCE with
+// their own regex before it ever reached this component. `sanitize.
+// allowedProtocols` removes that workaround by letting a caller restrict
+// which of the library's own default protocols survive, without touching the
+// "raw HTML never passes through" guarantee, which stays unconditional.
+describe('renderMarkdown — configurable protocol allow-list (sanitize.allowedProtocols)', () => {
+  it('keeps the default allow-list when sanitize is not supplied', () => {
+    expect(renderMarkdown('[a](https://example.com)')).toContain('href="https://example.com"');
+    expect(renderMarkdown('[a](mailto:x@y.z)')).toContain('href="mailto:x@y.z"');
+    expect(renderMarkdown('[a](tel:+15550100)')).toContain('href="tel:+15550100"');
+  });
+
+  it('drops mailto: and tel: links when allowedProtocols narrows to http(s) only', () => {
+    const sanitize = { allowedProtocols: ['http:', 'https:'] };
+
+    const https = renderMarkdown('[a](https://example.com)', { sanitize });
+    expect(https).toContain('href="https://example.com"');
+
+    const mail = renderMarkdown('[a](mailto:x@y.z)', { sanitize });
+    expect(mail).not.toContain('href="mailto:');
+    expect(mail).not.toContain('<a');
+    expect(mail).toContain('a');
+
+    const tel = renderMarkdown('[a](tel:+15550100)', { sanitize });
+    expect(tel).not.toContain('href="tel:');
+    expect(tel).not.toContain('<a');
+  });
+
+  it('cannot widen the allow-list beyond the library default for that surface', () => {
+    // javascript: was never a default-safe link protocol, so listing it here
+    // must not resurrect it -- allowedProtocols can only narrow.
+    const output = renderMarkdown('[x](javascript:alert(1))', {
+      sanitize: { allowedProtocols: ['javascript:', 'http:', 'https:'] }
+    });
+    expect(output).not.toContain('javascript:');
+    expect(output).not.toContain('<a');
+  });
+
+  it('applies the same narrowed allow-list to images', () => {
+    const sanitize = { allowedProtocols: ['https:'] };
+    const httpImage = renderMarkdown('![alt](http://example.com/a.png)', { sanitize });
+    expect(httpImage).not.toContain('<img');
+    expect(httpImage).toContain('alt');
+
+    const httpsImage = renderMarkdown('![alt](https://example.com/a.png)', { sanitize });
+    expect(httpsImage).toContain('<img');
+    expect(httpsImage).toContain('src="https://example.com/a.png"');
+  });
+
+  it('an empty allow-list drops every link and image, keeping their text', () => {
+    const sanitize = { allowedProtocols: [] as string[] };
+    const link = renderMarkdown('[a](https://example.com)', { sanitize });
+    expect(link).not.toContain('<a');
+    expect(link).toContain('a');
+
+    const image = renderMarkdown('![alt](https://example.com/a.png)', { sanitize });
+    expect(image).not.toContain('<img');
+    expect(image).toContain('alt');
+  });
+
+  it('raw HTML still always escapes regardless of sanitize', () => {
+    const output = renderMarkdown('<script>alert(1)</script>', {
+      sanitize: { allowedProtocols: ['http:', 'https:'] }
+    });
+    expect(output).not.toContain('<script>');
+    expect(output).toContain('&lt;script&gt;');
+  });
+
+  it('is case-insensitive and does not carry state between differently-configured renders', () => {
+    const upper = renderMarkdown('[a](mailto:x@y.z)', {
+      sanitize: { allowedProtocols: ['HTTP:', 'HTTPS:'] }
+    });
+    expect(upper).not.toContain('href="mailto:');
+
+    // Re-requesting the unrestricted default after a narrowed render must not
+    // have been left narrowed by a shared cache entry.
+    expect(renderMarkdown('[a](mailto:x@y.z)')).toContain('href="mailto:x@y.z"');
+  });
+});
+
+// Regression coverage for #524's second half: the only escape hatch from a
+// markdown-generated tag the library itself decided to allow (images, in
+// particular) used to be pre-mangling the SOURCE by hand or keeping a whole
+// second hand-rolled renderer around, because MarkdownText's own tags were
+// not configurable at all. `sanitize.allowedTags` narrows which
+// markdown-GENERATED tags render as themselves; everything else still comes
+// through as plain text, never dropped outright.
+describe('renderMarkdown — configurable tag allow-list (sanitize.allowedTags)', () => {
+  it('renders every tag normally when allowedTags is not supplied', () => {
+    const output = renderMarkdown('# Title\n\n**bold** and ![alt](https://example.com/a.png)');
+    expect(output).toContain('<h1>');
+    expect(output).toContain('<strong>');
+    expect(output).toContain('<img');
+  });
+
+  it('drops images (keeping alt text) when "img" is left out of allowedTags', () => {
+    const output = renderMarkdown('![a cat](https://example.com/cat.png)', {
+      sanitize: { allowedTags: ['p'] }
+    });
+    expect(output).not.toContain('<img');
+    expect(output).toContain('a cat');
+  });
+
+  it('an unsafe protocol is still stripped even when its tag is in allowedTags', () => {
+    // allowedTags narrows further than the protocol guard; it must never
+    // reopen a hole the protocol allow-list already closed.
+    const output = renderMarkdown('[x](javascript:alert(1))', {
+      sanitize: { allowedTags: ['a'] }
+    });
+    expect(output).not.toContain('javascript:');
+    expect(output).not.toContain('<a');
+  });
+
+  it('flattens headings to plain inline text, keeping nested formatting', () => {
+    const output = renderMarkdown('# **Loud** Title', {
+      sanitize: { allowedTags: ['strong'] }
+    });
+    expect(output).not.toContain('<h1>');
+    expect(output).toContain('<strong>Loud</strong>');
+  });
+
+  it('drops list markup but keeps each item\'s content when "ul" is excluded', () => {
+    const output = renderMarkdown('- one\n- two', { sanitize: { allowedTags: ['p'] } });
+    expect(output).not.toContain('<ul>');
+    expect(output).not.toContain('<li>');
+    expect(output).toContain('one');
+    expect(output).toContain('two');
+  });
+
+  it('degrades a table to plain text rows when "table" is excluded', () => {
+    const output = renderMarkdown('| A | B |\n| --- | --- |\n| 1 | 2 |', {
+      sanitize: { allowedTags: ['p'] }
+    });
+    expect(output).not.toContain('<table>');
+    expect(output).toContain('A');
+    expect(output).toContain('1');
+  });
+
+  it('raw HTML still always escapes regardless of allowedTags', () => {
+    const output = renderMarkdown('<script>alert(1)</script>', {
+      sanitize: { allowedTags: ['script'] }
+    });
+    expect(output).not.toContain('<script>alert');
+    expect(output).toContain('&lt;script&gt;');
+  });
+
+  it('an unrecognised tag name is ignored rather than erroring', () => {
+    expect(() =>
+      renderMarkdown('**bold**', { sanitize: { allowedTags: ['not-a-real-tag'] } })
+    ).not.toThrow();
+  });
+});
+
+// Regression coverage for #524's task-list half: GFM task-list checkboxes
+// always render, with no way to keep the plain list text instead.
+describe('renderMarkdown — task-list checkboxes (sanitize.disableTaskLists)', () => {
+  it('renders a disabled checkbox by default', () => {
+    const output = renderMarkdown('- [ ] todo\n- [x] done');
+    expect(output).toContain('type="checkbox"');
+    expect(output).toContain('disabled');
+  });
+
+  it('drops the checkbox but keeps the item text when disableTaskLists is true', () => {
+    const output = renderMarkdown('- [ ] todo\n- [x] done', {
+      sanitize: { disableTaskLists: true }
+    });
+    expect(output).not.toContain('type="checkbox"');
+    expect(output).toContain('todo');
+    expect(output).toContain('done');
+    expect(output).toContain('<li>');
+  });
+
+  it('does not carry the toggle between differently-configured renders', () => {
+    const off = renderMarkdown('- [ ] todo', { sanitize: { disableTaskLists: true } });
+    expect(off).not.toContain('type="checkbox"');
+    expect(renderMarkdown('- [ ] todo')).toContain('type="checkbox"');
+  });
+});

--- a/src/lib/MarkdownText/markdown.ts
+++ b/src/lib/MarkdownText/markdown.ts
@@ -1,6 +1,6 @@
 import { Marked } from 'marked';
 import type { RendererObject, Tokens } from 'marked';
-import type { RenderMarkdownOptions } from './properties';
+import type { MarkdownSanitizeOptions, RenderMarkdownOptions } from './properties';
 
 /**
  * Chat content comes from models and users, not from the app's own templates,
@@ -68,27 +68,140 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-const sanitizingRenderer: RendererObject = {
-  html(token: Tokens.HTML | Tokens.Tag): string {
-    return escapeHtml(token.text);
-  },
-  link(token: Tokens.Link): string | false {
-    if (hasSafeProtocol(token.href, SAFE_LINK_PROTOCOLS)) {
-      return false;
-    }
-    return escapeHtml(token.text);
-  },
-  image(token: Tokens.Image): string | false {
-    if (hasSafeProtocol(token.href, SAFE_IMAGE_PROTOCOLS)) {
-      return false;
-    }
-    return escapeHtml(token.text);
+/**
+ * `allowedProtocols` can only NARROW a surface's default allow-list, never
+ * widen it -- intersecting with the library default (rather than substituting
+ * it) is what makes listing an unsafe scheme like `javascript:` a no-op
+ * instead of a hole. Casing is normalised so `'HTTPS:'` narrows the same as
+ * `'https:'`, matching how `hasSafeProtocol` reads `URL.protocol` (always
+ * lower-case).
+ */
+function narrow(defaults: Set<string>, allowedProtocols?: string[]): Set<string> {
+  if (!allowedProtocols) {
+    return defaults;
   }
-};
+  const requested = new Set(allowedProtocols.map((protocol) => protocol.toLowerCase()));
+  return new Set([...defaults].filter((protocol) => requested.has(protocol)));
+}
+
+function resolveProtocolSets(sanitize?: MarkdownSanitizeOptions): {
+  links: Set<string>;
+  images: Set<string>;
+} {
+  return {
+    links: narrow(SAFE_LINK_PROTOCOLS, sanitize?.allowedProtocols),
+    images: narrow(SAFE_IMAGE_PROTOCOLS, sanitize?.allowedProtocols)
+  };
+}
+
+/**
+ * `null` means "no restriction" (today's default: every tag marked's GFM
+ * output can produce renders normally) -- unlike the protocol allow-lists,
+ * there is no built-in default set to fall back to once this exists, so its
+ * absence is what keeps old behaviour byte-for-byte.
+ */
+function resolveTagAllowList(allowedTags?: string[]): Set<string> | null {
+  return allowedTags ? new Set(allowedTags) : null;
+}
+
+function tagAllowed(allowed: Set<string> | null, tag: string): boolean {
+  return allowed === null || allowed.has(tag);
+}
+
+function createSanitizingRenderer(
+  protocols: { links: Set<string>; images: Set<string> },
+  allowedTags: Set<string> | null,
+  disableTaskLists: boolean
+): RendererObject {
+  return {
+    html(token: Tokens.HTML | Tokens.Tag): string {
+      return escapeHtml(token.text);
+    },
+    link(token: Tokens.Link): string | false {
+      if (hasSafeProtocol(token.href, protocols.links) && tagAllowed(allowedTags, 'a')) {
+        return false;
+      }
+      return escapeHtml(token.text);
+    },
+    image(token: Tokens.Image): string | false {
+      if (hasSafeProtocol(token.href, protocols.images) && tagAllowed(allowedTags, 'img')) {
+        return false;
+      }
+      return escapeHtml(token.text);
+    },
+    strong(token: Tokens.Strong): string | false {
+      if (tagAllowed(allowedTags, 'strong')) {
+        return false;
+      }
+      return this.parser.parseInline(token.tokens);
+    },
+    em(token: Tokens.Em): string | false {
+      if (tagAllowed(allowedTags, 'em')) {
+        return false;
+      }
+      return this.parser.parseInline(token.tokens);
+    },
+    del(token: Tokens.Del): string | false {
+      if (tagAllowed(allowedTags, 'del')) {
+        return false;
+      }
+      return this.parser.parseInline(token.tokens);
+    },
+    codespan(token: Tokens.Codespan): string | false {
+      if (tagAllowed(allowedTags, 'code')) {
+        return false;
+      }
+      return escapeHtml(token.text);
+    },
+    code(token: Tokens.Code): string | false {
+      if (tagAllowed(allowedTags, 'pre')) {
+        return false;
+      }
+      return `${escapeHtml(token.text)}\n`;
+    },
+    blockquote(token: Tokens.Blockquote): string | false {
+      if (tagAllowed(allowedTags, 'blockquote')) {
+        return false;
+      }
+      return this.parser.parse(token.tokens);
+    },
+    heading(token: Tokens.Heading): string | false {
+      if (tagAllowed(allowedTags, `h${token.depth}`)) {
+        return false;
+      }
+      return `${this.parser.parseInline(token.tokens)}\n`;
+    },
+    list(token: Tokens.List): string | false {
+      if (tagAllowed(allowedTags, token.ordered ? 'ol' : 'ul')) {
+        return false;
+      }
+      return token.items.map((item) => this.parser.parse(item.tokens)).join('');
+    },
+    table(token: Tokens.Table): string | false {
+      if (tagAllowed(allowedTags, 'table')) {
+        return false;
+      }
+      const rowText = (cells: Tokens.TableCell[]): string =>
+        cells.map((cell) => this.parser.parseInline(cell.tokens)).join(' | ');
+      const lines = [rowText(token.header), ...token.rows.map(rowText)];
+      return `<p>${lines.join('<br>')}</p>`;
+    },
+    hr(): string | false {
+      return tagAllowed(allowedTags, 'hr') ? false : '';
+    },
+    checkbox(): string | false {
+      return disableTaskLists ? '' : false;
+    }
+  };
+}
 
 /* Safe to share across SSR requests: each instance's configuration (renderer,
    gfm, breaks) is fixed at construction and parse() takes no per-request state,
-   so the cache only ever holds config-immutable parsers keyed by option shape. */
+   so the cache only ever holds config-immutable parsers keyed by option shape.
+   The key folds in the resolved protocol sets, tag allow-list and task-list
+   toggle (sorted for a stable string) so differently-configured `sanitize`
+   options get their own cached instance and never share a renderer with a
+   different allow-list. */
 const instances = new Map<string, Marked>();
 
 /* External links open in a new tab with `rel="noopener noreferrer"` — the same
@@ -131,10 +244,23 @@ function wrapTables(html: string, label?: string): string {
 
 function instanceFor(options: RenderMarkdownOptions): Marked {
   const breaks = options.breaks === true;
-  const key = breaks ? 'breaks' : 'default';
+  const protocols = resolveProtocolSets(options.sanitize);
+  const allowedTags = resolveTagAllowList(options.sanitize?.allowedTags);
+  const disableTaskLists = options.sanitize?.disableTaskLists === true;
+  const key = [
+    breaks ? 'breaks' : 'default',
+    [...protocols.links].sort().join(','),
+    [...protocols.images].sort().join(','),
+    allowedTags ? [...allowedTags].sort().join(',') : '*',
+    disableTaskLists ? 'no-tasks' : 'tasks'
+  ].join('|');
   let instance = instances.get(key);
   if (!instance) {
-    instance = new Marked({ gfm: true, breaks, renderer: sanitizingRenderer });
+    instance = new Marked({
+      gfm: true,
+      breaks,
+      renderer: createSanitizingRenderer(protocols, allowedTags, disableTaskLists)
+    });
     instances.set(key, instance);
   }
   return instance;

--- a/src/lib/MarkdownText/properties.ts
+++ b/src/lib/MarkdownText/properties.ts
@@ -23,6 +23,58 @@ export type OptionalMarkdownTextProperties = {
    * worse than none.
    */
   tableLabel?: string;
+  /**
+   * Narrow which URL protocols survive on rendered links/images. See
+   * `MarkdownSanitizeOptions`.
+   */
+  sanitize?: MarkdownSanitizeOptions;
+};
+
+/**
+ * A consumer's own link policy can be stricter than the library default
+ * (`http:`/`https:`/`mailto:`/`tel:` for links, `http:`/`https:` for images) —
+ * for example, no live `mailto:`/`tel:` in a chat surface. `allowedProtocols`
+ * lets a caller restrict which of those defaults survive; it is intersected
+ * with the library's own allow-list for each surface, so it can only NARROW
+ * what already renders, never widen it (listing `javascript:` here can never
+ * resurrect it). Omitting `sanitize`, or `allowedProtocols`, keeps today's
+ * defaults untouched. This is independent of the "raw HTML is always escaped"
+ * guarantee, which has no opt-out.
+ */
+export type MarkdownSanitizeOptions = {
+  /**
+   * Protocols (e.g. `'https:'`, `'mailto:'`) allowed to survive on rendered
+   * links and images, intersected with the library's own default allow-list
+   * for each surface. An empty array drops every link and image, keeping
+   * their text.
+   */
+  allowedProtocols?: string[];
+  /**
+   * Narrows which markdown-GENERATED tags are allowed to render as
+   * themselves. Unlike `allowedProtocols` there is no pre-set default list to
+   * intersect with — every tag `marked`'s own GFM output can produce renders
+   * normally until this is supplied, so passing it narrows from "everything"
+   * rather than from a built-in allow-list. A disallowed tag renders its
+   * parsed inner content as plain markup-free text instead of the element —
+   * the same "keep the text, drop the element" contract `allowedProtocols`
+   * uses for an unsafe link/image. Recognised names: `'a'`, `'img'`,
+   * `'strong'`, `'em'`, `'del'`, `'code'` (inline), `'pre'` (code block),
+   * `'blockquote'`, `'ul'`, `'ol'`, `'table'`, `'hr'`, and `'h1'`–`'h6'`. An
+   * unrecognised name is simply ignored — it narrows nothing, it does not
+   * error. Omitting `allowedTags` keeps today's defaults untouched: every tag
+   * renders as it does now. This is independent of the "raw HTML is always
+   * escaped" guarantee, which has no opt-out and is never affected by this
+   * list.
+   */
+  allowedTags?: string[];
+  /**
+   * Render GFM task-list items (`- [ ] done`) as plain list text instead of
+   * an `<input type="checkbox">`. The checkbox already renders `disabled` by
+   * default (it never submits or toggles), so this is a presentation choice
+   * for surfaces that would rather not show checkbox glyphs at all, not a
+   * safety one. Defaults to `false`, keeping today's checkbox rendering.
+   */
+  disableTaskLists?: boolean;
 };
 
 export type RenderMarkdownOptions = {
@@ -37,4 +89,6 @@ export type RenderMarkdownOptions = {
   inline?: boolean;
   /** Accessible name for the scroll region wrapping each table. See `MarkdownTextProperties.tableLabel`. */
   tableLabel?: string;
+  /** Narrow the protocol allow-list. See `MarkdownSanitizeOptions`. */
+  sanitize?: MarkdownSanitizeOptions;
 };

--- a/src/wc/components/MarkdownText.wc.svelte
+++ b/src/wc/components/MarkdownText.wc.svelte
@@ -7,7 +7,8 @@
       breaks: { type: 'Boolean' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
-      tableLabel: { type: 'String', attribute: 'table-label' }
+      tableLabel: { type: 'String', attribute: 'table-label' },
+      sanitize: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
Closes #524.

TARA's chat UI (apps/web/src/lib/components/ApprovalCard.svelte,
DecisionBubble.svelte, Transcript.svelte) could not use MarkdownText's
`markdown` prop directly: the component's sanitizer had no way to drop
markdown-generated elements it didn't want (images in particular), so
the app pre-mangled the raw source through DOMPurify's `sanitiseMarkdownSource`
before ever handing it to MarkdownText, and kept a second, unused,
hand-rolled `renderMarkdown`/DOMPurify pipeline around as a fallback.

MarkdownText gains an optional `sanitize` object (type
`MarkdownSanitizeOptions`) with three narrowing options, all of them new
in this commit and all off by default:

- `allowedProtocols?: string[]` -- restricts which URL protocols survive
  on rendered links and images, intersected with the library's own
  defaults for each surface (`http:`/`https:`/`mailto:`/`tel:` for links,
  `http:`/`https:` for images). Because it intersects, it can only narrow
  what already renders, never widen it: listing `javascript:` cannot
  resurrect it. An empty array drops every link and image, keeping their
  text.
- `allowedTags?: string[]` -- restricts which markdown-generated tags
  render as themselves (`a`, `img`, `strong`, `em`, `del`, `code`,
  `pre`, `blockquote`, `ul`, `ol`, `table`, `hr`, `h1`-`h6`). There is
  no preset default to intersect with here, unlike `allowedProtocols`:
  omitting it keeps every tag rendering exactly as it does today.
  A disallowed tag keeps its parsed inner content as plain text instead
  of the element -- the same "keep the text, drop the element" contract
  the protocol allow-list uses for an unsafe link or image.
  Raw HTML is still escaped unconditionally regardless of this list;
  there is still no opt-out from that guarantee.
- `disableTaskLists?: boolean` -- renders GFM task-list items
  (`- [ ] done`) as plain list text instead of a checkbox. The checkbox
  already renders `disabled` by default, so this is a presentation
  choice, not a safety one. Defaults to `false`.

All three are additive and off by default, so `renderMarkdown`/`MarkdownText`
without a `sanitize` prop (or without these keys inside it) behave
byte-for-byte as before. Implemented as per-token `RendererObject`
overrides in a `Marked` instance cached by a key that folds in the
resolved protocol sets, tag set and task-list toggle, so a
differently-configured `sanitize` never shares a renderer with another.

Also documents the options in docs/MarkdownText.md and docs/_index.json.


---

### Verification

**Spec runs on this branch** — `src/lib/MarkdownText/markdown-sanitize.test.ts` — 17 vitest cases across three describe blocks (`allowedProtocols`, `allowedTags`, `disableTaskLists`), part of a green 431-test suite.

**Fail-before** — Source reverted to `origin/release` with only the spec kept: **fails**.

`pnpm check`, `pnpm lint` and `pnpm build` all exit 0 on this branch; exit codes captured directly, never through a pipe.
