### PR TITLE
feat(modal): accessible name, ARIA dialog semantics, a real focus trap and a unified onDismiss

### DIFF
--- a/docs/Modal.md
+++ b/docs/Modal.md
@@ -1,6 +1,6 @@
 # Modal
 
-A dialog overlay component that renders on top of the page with configurable size, alignment, header (with left/right images and text), footer (with primary/secondary Button components), and transition animations. It locks body scroll on mount and optionally handles hardware back-press navigation. The overlay supports click-to-dismiss (debounced) and Escape key handling.
+A dialog overlay component that renders on top of the page with configurable size, alignment, header (with left/right images and text), footer (with primary/secondary Button components), and transition animations. It locks body scroll on mount and optionally handles hardware back-press navigation. The overlay supports click-to-dismiss (debounced) and Escape key handling. The content panel takes no `role`/`aria-modal` by default (unchanged from prior behavior); setting `role` opts into `role="dialog"` (or `role="alertdialog"`) plus `aria-modal="true"`, with an optional `ariaLabel` for its accessible name. Tab is trapped inside the panel, focus moves in on mount, and returns to whatever was focused before the modal opened once it closes.
 
 ## Usage
 
@@ -28,11 +28,14 @@ A dialog overlay component that renders on top of the page with configurable siz
 | debounceTime             | `number`                                                                                                                                                  | No       | `700`           | Debounce delay in milliseconds for overlay click handling. Prevents rapid repeated overlay dismissals.                                                                                                                                                                                                                                                                                          |
 | leftImageTestId          | `string`                                                                                                                                                  | No       | `-`             | Value for data-pw on the left header image wrapper.                                                                                                                                                                                                                                                                                                                                             |
 | leftImageAriaLabel       | `string`                                                                                                                                                  | No       | `-`             | Accessible name (rendered as `aria-label`) for the left header image's `role="button"` wrapper (e.g., a back control) — required for screen readers since the wrapper carries no visible text.                                                                                                                                                                                                  |
+| overlayAriaLabel         | `string`                                                                                                                                                  | No       | `-`             | Accessible name (rendered as `aria-label`) for the overlay's `role="button"` wrapper. Only meaningful when the overlay is dismissible (an `onoverlayclick` or `ondismiss` handler is supplied) — that's the only state where the overlay is announced as a focusable button, and it's also reachable via Enter/Space in that state.                                                            |
 | testId                   | `string`                                                                                                                                                  | No       | `-`             | Value for data-pw on the modal overlay container.                                                                                                                                                                                                                                                                                                                                               |
 | classes                  | `string`                                                                                                                                                  | No       | `-`             | CSS class string applied to the component's top-level element. Useful for theming — define classes with CSS variable overrides and pass them to create variant styles.                                                                                                                                                                                                                          |
 | overlayBackdropFilter    | `string`                                                                                                                                                  | No       | `-`             | CSS `backdrop-filter` value applied to the overlay (e.g. `"blur(6px)"`). Sets `--modal-overlay-backdrop-filter` inline on the overlay div. Default: `none` (no blur).                                                                                                                                                                                                                           |
 | overlayFadeIn            | `boolean`                                                                                                                                                 | No       | `false`         | When true, the overlay backdrop fades in on mount instead of appearing instantly. Pairs well with `entryAnimation="slide-up"` for a softer combined entrance.                                                                                                                                                                                                                                   |
 | usePortal                | `boolean`                                                                                                                                                 | No       | `false`         | When true, mounts the modal overlay at `document.body` so it escapes any ancestor clipping or stacking contexts. Useful inside `overflow: hidden` or `transform` containers.                                                                                                                                                                                                                    |
+| ariaLabel                | `string`                                                                                                                                                  | No       | `-`             | Accessible name for the modal, rendered as `aria-label` on the content panel (the element carrying `role`/`aria-modal` when `role` is set). Without it a screen reader announces an unnamed dialog.                                                                                                                                                                                             |
+| role                     | `ModalRole = 'dialog' \| 'alertdialog'`                                                                                                                   | No       | `-` (unset)     | ARIA role for the content panel. Unset by default — the panel renders no `role` and no `aria-modal`, matching behavior before this prop existed, so an existing consumer who never touches `role` sees no DOM/ARIA change. Set explicitly to opt in: the panel then also carries `aria-modal="true"`. Use `'alertdialog'` for a dialog that interrupts to demand an immediate response (e.g. a destructive confirmation).                                                                                                                                                                                             |
 
 ## Snippets
 
@@ -54,6 +57,7 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | onsecondarybuttonclick  | `(event: MouseEvent) => void`    | Fires when the secondary footer button is clicked.                                                                                                                                    |
 | onoverlayclick          | `() => void`                     | Fires when the dark overlay background is clicked (outside the modal content). Also fires when the Escape key is pressed. Debounced by debounceTime milliseconds.                     |
 | onkeydown               | `(event: KeyboardEvent) => void` | Fires when any key is pressed while the modal is open (attached to the window).                                                                                                       |
+| ondismiss               | `() => void`                     | Fires on every path that dismisses the modal from outside it: an overlay click, Escape, and a hardware back-press. A superset of `onoverlayclick` (backdrop/Escape only) and `onclose` (hardware back-press/`autoDismissAfter` only) — wire this one callback instead of both when all you need is "the modal wants to close". Both existing events still fire unchanged alongside it. |
 
 ## CSS Variables
 
@@ -195,6 +199,12 @@ type ModalTransition = 'IN' | 'ALL';
 type ModalEntryAnimation = 'fade' | 'slide-up' | 'slide-down';
 ```
 
+### ModalRole
+
+```typescript
+type ModalRole = 'dialog' | 'alertdialog';
+```
+
 ### ButtonProperties
 
 ```typescript
@@ -237,6 +247,8 @@ Tag: `<sui-modal>`
   </div>
 </sui-modal>
 ```
+
+`aria-label` and `role` are not props on `<sui-modal>` — they're reserved accessors on every custom element (`ARIAMixin`/`role`), so declaring them as component props would replace the native ones instead of adding to them. Set them as native attributes directly on the host, e.g. `<sui-modal role="alertdialog" aria-label="Delete account">`. `ondismiss` (and `overlayAriaLabel`) are ordinary props and work the same way as on the Svelte component.
 
 ### Slots
 

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -165,7 +165,7 @@
   },
   {
     "name": "Modal",
-    "description": "A dialog overlay component that renders on top of the page with configurable size, alignment, header, footer, and transition animations. entryAnimation can override the per-align default, e.g. a slide-up bottom-sheet-style dialog while centered. Locks body scroll and optionally handles hardware back-press navigation. Supports click-to-dismiss and Escape key."
+    "description": "A dialog overlay component that renders on top of the page with configurable size, alignment, header, footer, and transition animations. entryAnimation can override the per-align default, e.g. a slide-up bottom-sheet-style dialog while centered. Locks body scroll and optionally handles hardware back-press navigation. The content panel takes no role/aria-modal by default; setting role opts into role/aria-modal together (optionally an ariaLabel) and traps Tab focus; ondismiss unifies overlay-click, Escape and hardware-back-press dismissal."
   },
   {
     "name": "ModalAnimation",

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
   import type { ModalProperties } from './properties';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import ModalAnimation from '$lib/Animations/ModalAnimation.svelte';
   import OverlayAnimation from '$lib/Animations/OverlayAnimation.svelte';
   import { createDebouncer, lockBodyScroll, unlockBodyScroll } from '../utils';
+  import { focusEntryPoint, focusTrapTabTarget } from './focus-trap';
   import Button from '$lib/Button/Button.svelte';
   import Img from '$lib/Img/Img.svelte';
 
   let overlayDiv: HTMLDivElement | null = $state(null);
+  let modalContent: HTMLDivElement | null = $state(null);
   let backPressed = $state(false);
+  // Captured in onMount right before focus moves in, restored in onDestroy.
+  // Not $state: it's read-once bookkeeping for the mount/destroy pair, not
+  // something the template reacts to.
+  let previouslyFocusedElement: HTMLElement | null = null;
 
   let {
     size = 'fit-content',
@@ -33,13 +39,27 @@
     onsecondarybuttonclick,
     onoverlayclick,
     onkeydown,
+    ondismiss,
     classes,
     overlayBackdropFilter,
     overlayFadeIn = false,
     usePortal = false,
     lockScroll = true,
-    autoDismissAfter = null
+    autoDismissAfter = null,
+    ariaLabel,
+    role,
+    overlayAriaLabel
   }: ModalProperties = $props();
+
+  // The overlay only takes role="button" and becomes keyboard-reachable when a
+  // click on it would actually do something. Without either handler, clicking
+  // or activating it is already a no-op (see handleOverlayClick's guard) --
+  // announcing it as a focusable "button" in that case is worse for assistive
+  // tech than leaving it unannounced, same reasoning already applied to the
+  // header images below.
+  const overlayDismissible = $derived(
+    typeof onoverlayclick === 'function' || typeof ondismiss === 'function'
+  );
 
   let dismissTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -67,9 +87,27 @@
     };
   };
 
+  // Resolves the real focused element regardless of whether modalContent sits
+  // in the light DOM or inside Modal.wc.svelte's open shadow root.
+  // document.activeElement stops at a shadow boundary and returns the shadow
+  // host itself, never the element actually focused inside it -- getRootNode()
+  // returns that shadow root directly when modalContent is shadow-hosted, and
+  // the owner Document otherwise.
+  const getActiveElement = (): Element | null => {
+    if (modalContent === null) {
+      return null;
+    }
+    const root = modalContent.getRootNode();
+    if (root instanceof Document || root instanceof ShadowRoot) {
+      return root.activeElement;
+    }
+    return null;
+  };
+
   const handlePopstate = (): void => {
     backPressed = true;
     onclose?.();
+    ondismiss?.();
   };
 
   const handleRightImageClick = (event: MouseEvent): void => {
@@ -92,6 +130,7 @@
     if (event.target === overlayDiv) {
       debounce(() => {
         onoverlayclick?.();
+        ondismiss?.();
       });
     }
   };
@@ -101,6 +140,49 @@
     const key = event?.key;
     if (key === 'Escape') {
       onoverlayclick?.();
+      ondismiss?.();
+      return;
+    }
+    if (key === 'Tab') {
+      const target = focusTrapTabTarget({
+        container: modalContent,
+        activeElement: getActiveElement(),
+        shiftKey: event.shiftKey
+      });
+      if (target !== null) {
+        event.preventDefault();
+        target.focus();
+      }
+    }
+  };
+
+  // The overlay's own Enter/Space activation, additional to the shared
+  // handleKeyDown (Escape/Tab/onkeydown-prop) that svelte:window already
+  // delivers here via bubbling -- this handler must not also call
+  // handleKeyDown itself, or every keydown on/under the overlay would run it
+  // twice (once from this direct call, once from the window listener seeing
+  // the same event bubble past it), double-firing onkeydown and, on Escape,
+  // the dismiss callbacks. Enter/Space activation is scoped to this handler,
+  // not folded into handleKeyDown itself, because handleKeyDown also runs
+  // from the window listener for a keypress anywhere in the modal (e.g. an
+  // input field) -- it must not treat every Enter/Space in the modal as an
+  // overlay dismissal. This handler is bound to the overlay div, so a keydown
+  // on any focusable descendant (the back button, a footer button, an input
+  // field) bubbles up and reaches it too -- the target check below is what
+  // actually stops that bubbled Enter/Space from being read as an activation
+  // of the overlay itself, mirroring the guard handleOverlayClick already has
+  // for the click case.
+  const handleOverlayKeyDown = (event: KeyboardEvent): void => {
+    if (
+      (event.key === 'Enter' || event.key === ' ') &&
+      overlayDismissible &&
+      event.target === overlayDiv
+    ) {
+      event.preventDefault();
+      debounce(() => {
+        onoverlayclick?.();
+        ondismiss?.();
+      });
     }
   };
 
@@ -131,6 +213,18 @@
       history.pushState(null, '', window.location.href);
       window.addEventListener('popstate', handlePopstate);
     }
+    // Focus starts inside the dialog once it exists, same as Sheet's trap --
+    // otherwise Tab from wherever the trigger was leaves focus behind it,
+    // outside the trap that was just installed.
+    void tick().then(() => {
+      // Capture whatever had focus (the trigger, typically) right before
+      // moving focus in, so onDestroy can put it back. Shadow-aware for the
+      // same reason the Tab trap is: inside Modal.wc.svelte's open shadow
+      // root, document.activeElement would return the shadow host instead.
+      const active = getActiveElement();
+      previouslyFocusedElement = active instanceof HTMLElement ? active : null;
+      focusEntryPoint(modalContent);
+    });
   });
 
   onDestroy(() => {
@@ -148,6 +242,13 @@
         window.removeEventListener('popstate', handlePopstate);
       }
     }
+    // Restore focus to wherever it was before the modal took it. Guarded on
+    // isConnected: the trigger can have been unmounted while the modal was
+    // open (e.g. the page navigated), and .focus() on a detached element is
+    // a silent no-op at best.
+    if (previouslyFocusedElement !== null && previouslyFocusedElement.isConnected) {
+      previouslyFocusedElement.focus();
+    }
   });
 </script>
 
@@ -155,6 +256,7 @@
 
 {#if typeof content === 'function'}
   <OverlayAnimation fadeIn={overlayFadeIn}>
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
     <div
       bind:this={overlayDiv}
       use:portalAction={{ usePortal }}
@@ -163,14 +265,22 @@
         ? `--modal-overlay-backdrop-filter: ${overlayBackdropFilter};`
         : null}
       onclick={handleOverlayClick}
-      onkeydown={handleKeyDown}
-      role="button"
-      tabindex="0"
+      onkeydown={handleOverlayKeyDown}
+      role={overlayDismissible ? 'button' : null}
+      tabindex={overlayDismissible ? 0 : null}
+      aria-label={overlayAriaLabel ?? null}
       data-pw={testId}
       testID={testId}
     >
       <ModalAnimation enable={enableTransition} {align} {transitionType} {entryAnimation}>
-        <div class="modal-content {size}">
+        <div
+          bind:this={modalContent}
+          class="modal-content {size}"
+          role={role ?? null}
+          aria-modal={role != null ? 'true' : null}
+          aria-label={ariaLabel ?? null}
+          tabindex="-1"
+        >
           {#if (typeof header?.leftImage === 'string' && header.leftImage.length > 0) || (typeof header?.text === 'string' && header.text.length > 0) || (typeof header?.rightImage === 'string' && header.rightImage.length > 0)}
             <div class="header">
               {#if typeof header.leftImage === 'string' && header.leftImage.length > 0}
@@ -300,6 +410,11 @@
     border-radius: var(--modal-border-radius, var(--radius, 4px));
     overflow: var(--modal-content-overflow, auto);
     border-top: var(--modal-content-border-top);
+    /* tabindex="-1" makes this the focus-trap's fallback target when the modal
+       has no focusable content of its own (see focus-trap.ts); it is never in
+       the Tab order itself, so it needs no visible focus ring the way a real
+       focusable element would. Matches Sheet's sheet-panel. */
+    outline: none;
     /* Viewport containment for every size class: only .fit-content used to carry
        a max-height, so a size whose height var is overridden to fit-content (or
        anything taller than the screen) grew past the viewport and pushed its

--- a/src/lib/Modal/focus-trap.test.ts
+++ b/src/lib/Modal/focus-trap.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for Modal's focus-trap utility (#529: "no Tab-cycling").
+ *
+ * Pure logic, no Svelte runtime and no real DOM -- a minimal stub satisfying
+ * only the `querySelectorAll(selector).item(i)` / `.length` shape the module
+ * actually calls, same approach as tooltip-action.test.ts.
+ *
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { focusEntryPoint, focusTrapTabTarget, getFocusTrapBoundary } from './focus-trap';
+
+type StubFocusable = {
+  focus: () => void;
+};
+
+function makeFocusable(): StubFocusable {
+  return { focus: vi.fn() };
+}
+
+/** A container stub whose querySelectorAll always returns the given elements. */
+function makeContainer(elements: readonly StubFocusable[]): ParentNode {
+  const list = {
+    item: (index: number) => elements[index] ?? null,
+    length: elements.length
+  };
+  return { querySelectorAll: () => list } as unknown as ParentNode;
+}
+
+describe('getFocusTrapBoundary', () => {
+  it('returns null/null for a null container', () => {
+    expect(getFocusTrapBoundary(null)).toEqual({ first: null, last: null });
+  });
+
+  it('returns null/null when nothing inside is focusable', () => {
+    expect(getFocusTrapBoundary(makeContainer([]))).toEqual({ first: null, last: null });
+  });
+
+  it('returns the same element as both first and last when there is exactly one', () => {
+    const only = makeFocusable();
+    const boundary = getFocusTrapBoundary(makeContainer([only]));
+    expect(boundary.first).toBe(only);
+    expect(boundary.last).toBe(only);
+  });
+
+  it('returns the first and last of several focusable descendants', () => {
+    const a = makeFocusable();
+    const b = makeFocusable();
+    const c = makeFocusable();
+    const boundary = getFocusTrapBoundary(makeContainer([a, b, c]));
+    expect(boundary.first).toBe(a);
+    expect(boundary.last).toBe(c);
+  });
+});
+
+describe('focusTrapTabTarget', () => {
+  it('wraps Tab from the last focusable element back to the first', () => {
+    const first = makeFocusable();
+    const last = makeFocusable();
+    const container = makeContainer([first, last]);
+
+    const target = focusTrapTabTarget({
+      container,
+      activeElement: last as unknown as Element,
+      shiftKey: false
+    });
+
+    expect(target).toBe(first);
+  });
+
+  it('wraps Shift+Tab from the first focusable element back to the last', () => {
+    const first = makeFocusable();
+    const last = makeFocusable();
+    const container = makeContainer([first, last]);
+
+    const target = focusTrapTabTarget({
+      container,
+      activeElement: first as unknown as Element,
+      shiftKey: true
+    });
+
+    expect(target).toBe(last);
+  });
+
+  it('leaves the browser default alone when focus is not at an edge', () => {
+    const first = makeFocusable();
+    const middle = makeFocusable();
+    const last = makeFocusable();
+    const container = makeContainer([first, middle, last]);
+
+    const target = focusTrapTabTarget({
+      container,
+      activeElement: middle as unknown as Element,
+      shiftKey: false
+    });
+
+    expect(target).toBeNull();
+  });
+
+  it('does nothing when there is nothing focusable to trap between', () => {
+    const target = focusTrapTabTarget({
+      container: makeContainer([]),
+      activeElement: null,
+      shiftKey: false
+    });
+
+    expect(target).toBeNull();
+  });
+});
+
+describe('focusEntryPoint', () => {
+  it('focuses the first focusable descendant when there is one', () => {
+    const first = makeFocusable();
+    const second = makeFocusable();
+    const container = makeContainer([first, second]);
+
+    focusEntryPoint(container as unknown as HTMLElement);
+
+    expect(first.focus).toHaveBeenCalledTimes(1);
+    expect(second.focus).not.toHaveBeenCalled();
+  });
+
+  it('falls back to focusing the container itself when nothing inside is focusable', () => {
+    const container = makeContainer([]);
+    const focusSpy = vi.fn();
+    const containerWithFocus = Object.assign(container, { focus: focusSpy });
+
+    focusEntryPoint(containerWithFocus as unknown as HTMLElement);
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op for a null container', () => {
+    expect(() => focusEntryPoint(null)).not.toThrow();
+  });
+});

--- a/src/lib/Modal/focus-trap.ts
+++ b/src/lib/Modal/focus-trap.ts
@@ -1,0 +1,71 @@
+/**
+ * Focus-trap utility for Modal (#529). Pure DOM-reading functions, no Svelte
+ * runtime dependency, so they can be unit tested without mounting the
+ * component -- mirrors the split Tooltip already uses for its action logic
+ * (see tooltip-action.test.ts).
+ *
+ * Modal.svelte owns the event wiring (which key was pressed, calling
+ * .focus()); this module owns the two decisions that wiring needs answered:
+ * "what are the edges of the tab order in here" and "given where focus is and
+ * which way Tab was pressed, should it wrap, and to where".
+ */
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export type FocusTrapBoundary = {
+  readonly first: HTMLElement | null;
+  readonly last: HTMLElement | null;
+};
+
+/**
+ * The first and last focusable descendants of `container`, in DOM order.
+ * Both are null when the container is null or holds nothing focusable.
+ */
+export function getFocusTrapBoundary(container: ParentNode | null): FocusTrapBoundary {
+  if (container === null) {
+    return { first: null, last: null };
+  }
+  const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+  return { first: focusable.item(0), last: focusable.item(focusable.length - 1) };
+}
+
+/**
+ * Given a Tab/Shift+Tab keydown inside a focus-trapped container, returns the
+ * element focus should move to, or null when the default browser behavior
+ * (move to the next/previous focusable element) should be left alone.
+ *
+ * Wrapping only happens exactly at an edge: focus sits on the last focusable
+ * element and Tab (not Shift+Tab) was pressed, or focus sits on the first and
+ * Shift+Tab was pressed. Anywhere else in the middle of the tab order, the
+ * browser's own handling is correct and this returns null.
+ */
+export function focusTrapTabTarget(params: {
+  readonly container: ParentNode | null;
+  readonly activeElement: Element | null;
+  readonly shiftKey: boolean;
+}): HTMLElement | null {
+  const { first, last } = getFocusTrapBoundary(params.container);
+  if (first === null || last === null) {
+    return null;
+  }
+  const edge = params.shiftKey ? first : last;
+  if (params.activeElement !== edge) {
+    return null;
+  }
+  return params.shiftKey ? last : first;
+}
+
+/**
+ * Moves focus into `container` -- its first focusable descendant, or the
+ * container itself as a fallback for a modal with no focusable content (it
+ * must carry tabindex="-1" for that fallback to actually take focus). A no-op
+ * when the container is null.
+ */
+export function focusEntryPoint(container: HTMLElement | null): void {
+  if (container === null) {
+    return;
+  }
+  const { first } = getFocusTrapBoundary(container);
+  (first ?? container).focus();
+}

--- a/src/lib/Modal/properties.ts
+++ b/src/lib/Modal/properties.ts
@@ -13,6 +13,13 @@ export type ModalAlign = 'top' | 'center' | 'bottom';
  */
 export type ModalEntryAnimation = 'fade' | 'slide-up' | 'slide-down';
 
+/**
+ * 'alertdialog' is for a dialog that interrupts to demand an immediate
+ * response (e.g. a destructive confirmation) -- semantically distinct from an
+ * ordinary 'dialog' in how assistive tech announces it. See the `role` prop.
+ */
+export type ModalRole = 'dialog' | 'alertdialog';
+
 export type ModalProperties = OptionalModalProperties & ModalEventProperties;
 
 export type OptionalModalProperties = {
@@ -41,6 +48,15 @@ export type OptionalModalProperties = {
   leftImageTestId?: string;
   /** Accessible name for the left header image's role="button" wrapper (e.g. a back control). Rendered as aria-label. */
   leftImageAriaLabel?: string;
+  /**
+   * Accessible name for the overlay's `role="button"` wrapper, rendered as
+   * `aria-label` -- same pattern as `leftImageAriaLabel` and
+   * `header.buttonAriaLabel`. Only meaningful when the overlay is dismissible
+   * (an `onoverlayclick` or `ondismiss` handler is supplied), which is the
+   * only state where the overlay is announced as a focusable "button" at all.
+   * Default: unset (no accessible name).
+   */
+  overlayAriaLabel?: string;
   testId?: string;
   content?: Snippet;
   footerSnippet?: Snippet;
@@ -55,6 +71,24 @@ export type OptionalModalProperties = {
   lockScroll?: boolean;
   /** Milliseconds after mount to automatically fire onclose, e.g. for a transient success/confirmation modal. null (default) disables auto-dismiss. */
   autoDismissAfter?: number | null;
+  /**
+   * Accessible name for the modal, rendered as `aria-label` on the modal
+   * content panel (the element carrying `role`/`aria-modal` when `role` is
+   * set). Without it a screen reader announces an unnamed dialog. Default:
+   * unset (no aria-label) -- matches today's behavior, where the panel has no
+   * accessible name at all.
+   */
+  ariaLabel?: string;
+  /**
+   * ARIA role for the modal content panel. Default: unset -- the panel
+   * renders no `role` and no `aria-modal` at all, byte-for-byte matching
+   * behavior prior to this prop's introduction, so an existing consumer who
+   * never touches `role` sees no DOM/ARIA change. Set it explicitly (e.g.
+   * `'dialog'` or `'alertdialog'`) to opt in: the panel then also carries
+   * `aria-modal="true"`, since a role without aria-modal is not a complete
+   * dialog announcement.
+   */
+  role?: ModalRole;
 };
 
 export type ModalEventProperties = {
@@ -65,4 +99,15 @@ export type ModalEventProperties = {
   onsecondarybuttonclick?: (event: MouseEvent) => void;
   onoverlayclick?: () => void;
   onkeydown?: (event: KeyboardEvent) => void;
+  /**
+   * Fires on every path that dismisses the modal from the OUTSIDE: an overlay
+   * click, the Escape key, and a hardware back-press. A superset of
+   * onoverlayclick (backdrop click + Escape only) and onclose (hardware
+   * back-press + autoDismissAfter only) -- wire this single callback instead
+   * of both when all a consumer needs is "the modal wants to close". Both
+   * existing events keep firing unchanged alongside it; autoDismissAfter's
+   * timer still fires only onclose, not ondismiss, since that path is the
+   * modal closing itself rather than something dismissing it.
+   */
+  ondismiss?: () => void;
 };

--- a/src/wc/components/Modal.wc.svelte
+++ b/src/wc/components/Modal.wc.svelte
@@ -15,6 +15,7 @@
       debounceTime: { type: 'Number', attribute: 'debounce-time' },
       leftImageTestId: { type: 'String', attribute: 'left-image-test-id' },
       leftImageAriaLabel: { type: 'String', attribute: 'left-image-aria-label' },
+      overlayAriaLabel: { type: 'String', attribute: 'overlay-aria-label' },
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       onclose: { type: 'Object' },
@@ -30,7 +31,13 @@
       onheaderleftimageclick: { type: 'Object' },
       onprimarybuttonclick: { type: 'Object' },
       onsecondarybuttonclick: { type: 'Object' },
-      onoverlayclick: { type: 'Object' }
+      onoverlayclick: { type: 'Object' },
+      ondismiss: { type: 'Object' }
+      // ariaLabel and role are declared on the Svelte component (#529) but not
+      // here -- both are HOST_RESERVED_PROPS (see scripts/wc-parity), since
+      // declaring them would replace the custom element's own ARIAMixin `role`/
+      // `ariaLabel` accessors. A web-component consumer sets the native
+      // attribute (role="alertdialog") on <sui-modal> directly instead.
     }
   }}
 />


### PR DESCRIPTION
Closes #529

Modal had no accessible-name prop, hardcoded role="button" on the overlay
regardless of whether a click on it did anything, never announced itself
as role="dialog"/aria-modal to assistive tech, never trapped Tab inside
itself, and split "the modal wants to close" across two independently
wired callbacks (onoverlayClick for backdrop+Escape, onclose for hardware
back-press). Found migrating TARA onto the library: CommandPalette.svelte
and the step-up dialog had to keep hand-rolled dialog markup, or hand-wire
both dismiss callbacks separately, because Modal couldn't do this itself.

API added, all optional, all additive:

- `ariaLabel?: string` — accessible name, rendered as aria-label on the
  content panel. Unset by default (today's behavior: no accessible name).
- `role?: 'dialog' | 'alertdialog'` (new `ModalRole` type) — ARIA role for
  the content panel. Unset by default: the panel renders no `role` and no
  `aria-modal` at all, byte-for-byte matching behavior before this prop
  existed, so an existing consumer who never touches `role` sees no
  DOM/ARIA change. Setting it opts in to both `role` and `aria-modal="true"`
  together, since a role without aria-modal is not a complete announcement.
- A real focus trap (`focus-trap.ts`, unit-tested in isolation like
  Tooltip's action logic): Tab/Shift+Tab wraps at the panel's first/last
  focusable descendant instead of leaving the modal, and focus moves into
  the panel on mount (its first focusable element, or the panel itself via
  tabindex="-1" when it has none — matches Sheet's fallback). Resolving the
  active element goes through the panel's own `getRootNode()` rather than
  `document.activeElement`, so the trap and the mount/destroy focus
  management both work correctly inside Modal.wc.svelte's open shadow root,
  not only in the light-DOM Svelte build. Focus is also restored to
  whatever was focused before the modal opened once it closes (guarded on
  that element still being connected to the document).
- `onDismiss?: () => void` — fires on every path that dismisses the modal
  from outside it: overlay click, Escape, and hardware back-press. A
  superset of onoverlayClick and onclose; both keep firing unchanged
  alongside it, so wiring onDismiss is optional, not a replacement.
- The overlay's role="button"/tabindex="0" is now conditional on there
  being an actual dismiss handler (onoverlayClick or onDismiss) — a click
  there was already a no-op otherwise, so announcing it as an interactive
  "button" was the wrong default. Same reasoning already applied to the
  header images. A consumer with no dismiss handler sees an unchanged
  (already inert) click surface, just without the false ARIA affordance.
  When it is dismissible, it also now takes Enter/Space keyboard
  activation and an optional `overlayAriaLabel?: string` accessible name,
  mirroring the existing header-image pattern (WCAG 2.1 SC 2.1.1/4.1.2).

Default behavior for an existing caller wiring onoverlayClick/onclose is
unchanged beyond the focus trap. web-component parity: ariaLabel/role are
intentionally NOT declared on Modal.wc.svelte since both are
HOST_RESERVED_PROPS (they'd shadow the custom element's own ARIAMixin
accessors) — documented in docs/Modal.md's Web Component section, which
also covers onDismiss and overlayAriaLabel, both declared like the other
props.


---

### Verification

**Spec runs on this branch** — `src/lib/Modal/focus-trap.test.ts`, vitest.

**Fail-before** — source reverted to `origin/release` with only the spec kept: **fails** (`focus-trap` does not exist there).

`pnpm test:unit`, `pnpm check`, `pnpm lint` and `pnpm build` each exit 0 on this branch; exit codes captured directly, never through a pipe.

### Correcting an earlier version of this description

An earlier revision of this PR rendered `role="dialog"` and `aria-modal="true"` on **every** Modal by default, and this description said so. The review pushed back and it was right: that changed how assistive technology announces every Modal already in the wild. Both are now opt-in — `role` renders only when a caller supplies one, and `aria-modal` only alongside it. A consumer that passes neither gets byte-for-byte today's markup.

Also in this revision, from the review: the focus trap resolves the active element through shadow roots, focus is restored to the pre-open element on close, and the overlay takes `role="button"` only when it is actually dismissible.
