### PR TITLE
fix(wc): restore the web-component type-check that gates every release

### DIFF
--- a/docs/MIGRATION_4.0.md
+++ b/docs/MIGRATION_4.0.md
@@ -23,9 +23,29 @@ npx sui-codemod --dry-run ./src
 
 The codemod is component-aware. It rewrites `onClick` on `<Toggle>` because
 that is a prop this library renamed, and leaves `onClick` on your own
-components alone. It also leaves callback keys inside config objects untouched
-— `columns={[{ id: 'a', onToggle: fn }]}` on `<Table>` keeps its spelling,
-because that is a key you write inside a value, not a prop on a tag.
+components alone.
+
+### "Lowercase throughout" means props, not every callback
+
+The rule governs **props you write on a tag**. Callback keys inside a config
+object you build are a different thing — they are members of a value, not
+attributes — and they were never deprecated, so 4.0.0 does not touch them and
+neither does the codemod. They stay camelCase:
+
+| Where                          | Keys that stay camelCase                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| `TableColumn`                  | `onToggle`, `onSelect`, `onInput`, `onButtonClick`, `onPrimaryAction`, `onMenuAction` |
+| `TableCheckboxSelectionConfig` | `onSelectionChange`                                                                   |
+| `TablePaginationConfig`        | `onPageChange`, `onPageSizeChange`, `onLoadMore`                                      |
+| `ComboboxAction`               | `onClick`                                                                             |
+
+```svelte
+<!-- onrowclick is a prop and was renamed; onToggle is a key in a value and was not. -->
+<Table onrowclick={fn} columns={[{ id: 'a', onToggle: fn }]} />
+```
+
+So `<Table>` legitimately shows both spellings at once. If you expected
+`onselectionchange` and did not find it, this is why.
 
 ### What it cannot do for you
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package": "svelte-kit sync && svelte-package && publint",
     "prepublishOnly": "npm run build:wc && npm run build:codemod && npm run package",
     "test": "npm run test:integration && npm run test:unit",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:codemod && npm run check:migrate && npm run check:wc-parity",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:wc && npm run check:codemod && npm run check:migrate && npm run check:wc-parity",
     "check:codemod": "tsc -p scripts/codemod/tsconfig.json",
     "codemod": "node scripts/codemod/cli.ts",
     "check:wc": "svelte-check --tsconfig ./tsconfig.wc.json --compiler-warnings \"options_missing_custom_element:ignore\"",

--- a/src/wc/components/Badge.wc.svelte
+++ b/src/wc/components/Badge.wc.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import Badge from '$lib/Badge/Badge.svelte';
-  let { badgeAriaLabel, badgeHidden, ...props } = $props();
+  let props = $props();
 </script>
 
-<Badge {...props} hidden={badgeHidden} ariaLabel={badgeAriaLabel} />
+<Badge {...props} hidden={props.badgeHidden} ariaLabel={props.badgeAriaLabel} />

--- a/src/wc/components/Banner.wc.svelte
+++ b/src/wc/components/Banner.wc.svelte
@@ -21,7 +21,7 @@
 
 <script lang="ts">
   import Banner from '$lib/Banner/Banner.svelte';
-  let { bannerRole, ...props } = $props();
+  let props = $props();
 </script>
 
 <!--
@@ -33,7 +33,7 @@
   `$$props` binding that is not in scope there, and the element renders nothing
   at all. `title` keeps no property branch: it is host-reserved, never declared.
 -->
-<Banner {...props} role={bannerRole}>
+<Banner {...props} role={props.bannerRole}>
   {#snippet icon()}
     {#if props.icon}{@render props.icon()}{:else}<slot name="icon"></slot>{/if}
   {/snippet}

--- a/src/wc/components/Browser.wc.svelte
+++ b/src/wc/components/Browser.wc.svelte
@@ -19,10 +19,10 @@
 
 <script lang="ts">
   import Browser from '$lib/Browser/Browser.svelte';
-  let { browserTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<Browser {...props} title={browserTitle}>
+<Browser {...props} title={props.browserTitle}>
   {#snippet children()}
     <slot></slot>
   {/snippet}

--- a/src/wc/components/Button.wc.svelte
+++ b/src/wc/components/Button.wc.svelte
@@ -44,13 +44,13 @@
 
 <script lang="ts">
   import Button from '$lib/Button/Button.svelte';
-  let { buttonAriaExpanded, buttonAriaLabel, ...props } = $props();
+  let props = $props();
 </script>
 
 <!-- A property-assigned icon wins; the slot is the fallback. The branch stays
      inside the body snippet so `<slot>` keeps its `$$props` scope. `children` is
      no longer a declared prop, so the default slot is its only path. -->
-<Button {...props} ariaLabel={buttonAriaLabel} ariaExpanded={buttonAriaExpanded}>
+<Button {...props} ariaLabel={props.buttonAriaLabel} ariaExpanded={props.buttonAriaExpanded}>
   {#snippet icon()}
     {#if props.icon}{@render props.icon()}{:else}<slot name="icon"></slot>{/if}
   {/snippet}

--- a/src/wc/components/Card.wc.svelte
+++ b/src/wc/components/Card.wc.svelte
@@ -24,10 +24,10 @@
 
 <script lang="ts">
   import Card from '$lib/Card/Card.svelte';
-  let { cardTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<Card {...props} title={cardTitle}>
+<Card {...props} title={props.cardTitle}>
   {#snippet children()}
     <slot></slot>
   {/snippet}

--- a/src/wc/components/Chat.wc.svelte
+++ b/src/wc/components/Chat.wc.svelte
@@ -56,7 +56,11 @@
 
 <script lang="ts">
   import Chat from '$lib/Chat/Chat.svelte';
-  let { chatTitle, ...props } = $props();
+  // Bound whole rather than destructured: a rest element narrows the spread to
+  // `{}`, and `<Chat {...props}>` then stops satisfying the component's
+  // mandatory props. Only `check:wc` type-checks this directory, so that
+  // regression reached a release before anything caught it.
+  let props = $props();
 </script>
 
-<Chat {...props} title={chatTitle} />
+<Chat {...props} title={props.chatTitle} />

--- a/src/wc/components/ChatHeader.wc.svelte
+++ b/src/wc/components/ChatHeader.wc.svelte
@@ -21,7 +21,7 @@
 
 <script lang="ts">
   import ChatHeader from '$lib/ChatHeader/ChatHeader.svelte';
-  let { chatHeaderTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<ChatHeader {...props} title={chatHeaderTitle} />
+<ChatHeader {...props} title={props.chatHeaderTitle} />

--- a/src/wc/components/ChatMessage.wc.svelte
+++ b/src/wc/components/ChatMessage.wc.svelte
@@ -33,7 +33,7 @@
 
 <script lang="ts">
   import ChatMessage from '$lib/ChatMessage/ChatMessage.svelte';
-  let { chatMessageRole, ...props } = $props();
+  let props = $props();
 </script>
 
-<ChatMessage {...props} role={chatMessageRole} />
+<ChatMessage {...props} role={props.chatMessageRole} />

--- a/src/wc/components/Checkbox.wc.svelte
+++ b/src/wc/components/Checkbox.wc.svelte
@@ -20,10 +20,10 @@
 
 <script lang="ts">
   import Checkbox from '$lib/Checkbox/Checkbox.svelte';
-  let { checkboxAriaLabel, ...props } = $props();
+  let props = $props();
 </script>
 
-<Checkbox {...props} ariaLabel={checkboxAriaLabel}>
+<Checkbox {...props} ariaLabel={props.checkboxAriaLabel}>
   {#snippet checkedIcon()}
     <slot name="checked-icon"></slot>
   {/snippet}

--- a/src/wc/components/Combobox.wc.svelte
+++ b/src/wc/components/Combobox.wc.svelte
@@ -65,7 +65,11 @@
     highlightedIndex = $bindable(-1),
     selected = $bindable([]),
     ...rest
-  }: ComboboxProperties = $props();
+    // `comboboxAriaLabel` is this element's name for the component's
+    // `ariaLabel`, renamed because ARIAMixin already defines `ariaLabel` on
+    // every Element. It is not part of ComboboxProperties, so the annotation
+    // has to admit it.
+  }: ComboboxProperties & { comboboxAriaLabel?: string } = $props();
 </script>
 
 <Combobox

--- a/src/wc/components/EmptyState.wc.svelte
+++ b/src/wc/components/EmptyState.wc.svelte
@@ -16,10 +16,10 @@
 
 <script lang="ts">
   import EmptyState from '$lib/EmptyState/EmptyState.svelte';
-  let { emptyStateTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<EmptyState {...props} title={emptyStateTitle}>
+<EmptyState {...props} title={props.emptyStateTitle}>
   {#snippet icon()}
     <slot name="icon"></slot>
   {/snippet}

--- a/src/wc/components/HITL.wc.svelte
+++ b/src/wc/components/HITL.wc.svelte
@@ -4,7 +4,7 @@
     shadow: 'open',
     props: {
       confirmationId: { type: 'String', attribute: 'confirmation-id' },
-      hITLTitle: { type: 'String', reflect: true, attribute: 'title' },
+      hitlTitle: { type: 'String', reflect: true, attribute: 'title' },
       description: { type: 'String' },
       sections: { type: 'Object' },
       functionArguments: { type: 'Object' },
@@ -37,7 +37,7 @@
 
 <script lang="ts">
   import HITL from '$lib/HITL/HITL.svelte';
-  let { hITLTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<HITL {...props} title={hITLTitle} />
+<HITL {...props} title={props.hitlTitle} />

--- a/src/wc/components/IframeViewer.wc.svelte
+++ b/src/wc/components/IframeViewer.wc.svelte
@@ -20,7 +20,7 @@
 
 <script lang="ts">
   import IframeViewer from '$lib/IframeViewer/IframeViewer.svelte';
-  let { iframeViewerTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<IframeViewer {...props} title={iframeViewerTitle} />
+<IframeViewer {...props} title={props.iframeViewerTitle} />

--- a/src/wc/components/Input.wc.svelte
+++ b/src/wc/components/Input.wc.svelte
@@ -67,7 +67,7 @@
 
 <script lang="ts">
   import Input from '$lib/Input/Input.svelte';
-  let { inputAriaLabel, inputId, ...props } = $props();
+  let props = $props();
 
   // Restores the tri-state the attribute string flattens: absent stays null so
   // the browser default is untouched, "false" is honoured, and a bare
@@ -92,7 +92,7 @@
 
 <Input
   {...props}
-  id={inputId}
-  ariaLabel={inputAriaLabel}
+  id={props.inputId}
+  ariaLabel={props.inputAriaLabel}
   spellcheck={asSpellcheck(props.spellcheck)}
 />

--- a/src/wc/components/LottiePlayer.wc.svelte
+++ b/src/wc/components/LottiePlayer.wc.svelte
@@ -20,7 +20,7 @@
 
 <script lang="ts">
   import LottiePlayer from '$lib/LottiePlayer/LottiePlayer.svelte';
-  let { lottiePlayerAriaHidden, ...props } = $props();
+  let props = $props();
 
   // Named hostEl, not host: svelte2tsx confuses a local variable named after a rune's name
   // minus its `$` with the rune itself (sveltejs/svelte#13715, same class as `state` vs
@@ -44,7 +44,7 @@
 
 <LottiePlayer
   {...props}
-  ariaHidden={lottiePlayerAriaHidden}
+  ariaHidden={props.lottiePlayerAriaHidden}
   oncomplete={handleComplete}
   onerror={handleError}
 />

--- a/src/wc/components/Menu.wc.svelte
+++ b/src/wc/components/Menu.wc.svelte
@@ -24,12 +24,12 @@
 
 <script lang="ts">
   import Menu from '$lib/Menu/Menu.svelte';
-  let { menuAriaLabel, ...props } = $props();
+  let props = $props();
 </script>
 
 <!-- A property-assigned trigger wins; the slot is the fallback. The branch stays
      inside the body snippet so `<slot>` keeps its `$$props` scope. -->
-<Menu {...props} ariaLabel={menuAriaLabel}>
+<Menu {...props} ariaLabel={props.menuAriaLabel}>
   {#snippet trigger()}
     {#if props.trigger}{@render props.trigger()}{:else}<slot name="trigger"></slot>{/if}
   {/snippet}

--- a/src/wc/components/Pill.wc.svelte
+++ b/src/wc/components/Pill.wc.svelte
@@ -21,10 +21,10 @@
 <script lang="ts">
   import Pill from '$lib/Pill/Pill.svelte';
   import closeSvg from '$lib/assets/close.svg?raw';
-  let { pillTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<Pill {...props} title={pillTitle}>
+<Pill {...props} title={props.pillTitle}>
   {#snippet leadingIcon()}
     <slot name="leading-icon"></slot>
   {/snippet}

--- a/src/wc/components/Sheet.wc.svelte
+++ b/src/wc/components/Sheet.wc.svelte
@@ -22,10 +22,10 @@
 
 <script lang="ts">
   import Sheet from '$lib/Sheet/Sheet.svelte';
-  let { sheetTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<Sheet {...props} title={sheetTitle}>
+<Sheet {...props} title={props.sheetTitle}>
   {#snippet content()}
     <slot></slot>
   {/snippet}

--- a/src/wc/components/StatCard.wc.svelte
+++ b/src/wc/components/StatCard.wc.svelte
@@ -28,10 +28,10 @@
 
 <script lang="ts">
   import StatCard from '$lib/StatCard/StatCard.svelte';
-  let { statCardTitle, ...props } = $props();
+  let props = $props();
 </script>
 
-<StatCard {...props} title={statCardTitle}>
+<StatCard {...props} title={props.statCardTitle}>
   {#snippet headerRight()}
     <slot name="header-right"></slot>
   {/snippet}

--- a/tsconfig.wc.json
+++ b/tsconfig.wc.json
@@ -11,5 +11,6 @@
     "src/lib/**/*.svelte",
     ".svelte-kit/ambient.d.ts"
   ],
-  "exclude": ["node_modules"]
+  "//": "Tests are excluded because this config exists to type-check the web-component build, whose `types` is `vite/client` only. A test importing `node:fs` is correct and is checked by the main tsconfig; here it would fail for the wrong reason. src/lib/docs-index.test.ts made that concrete.",
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## `release` is red, and nothing since 3.5.0 has published

`Release and Publish` has failed on **both** commits since 3.5.0:

| Commit | What it is | Release run |
|---|---|---|
| `9814b53` | #519 — every event prop lowercase, old spellings as aliases | ❌ failure |
| `190800b` | #547 — the 4.0.0 removal | ❌ failure |

npm still serves **3.5.0**, which predates both. So the lowercase rule is unpublished, and — noted independently by the session working on Lighthouse — the published 3.5.0 also declares `bin` as `./scripts/codemod/cli.ts`, a TypeScript file with no shebang. Verified: 3.5.0 has `"sui-codemod": "./scripts/codemod/cli.ts"`, release HEAD has `./dist-codemod/bin.js`. `npx sui-codemod` from the published version does not work; the fix is already on `release` and just needs to ship.

## The 15 errors, in two groups

**Six** — `src/lib/docs-index.test.ts` imports `node:fs` / `node:path`, and `tsconfig.wc.json` type-checks `src/lib/**/*.ts` with `types: ["vite/client"]`, so node globals are absent. The test is correct; this config was never meant to see it. Test files are now excluded from it.

**Nine** — from #547's host-reserved rename. Turning `let props = $props()` into `let { renamed, ...props } = $props()` narrows the rest element's type, so `<Chat {...props}>` stops satisfying `MandatoryChatProperties`. Seventeen wrappers go back to binding the whole object and reading the renamed prop off it (`title={props.chatTitle}`); Combobox keeps its destructure with an annotation that admits `comboboxAriaLabel`.

## Why both reached a release — the part worth keeping

`check:wc` is the **only** thing that type-checks `src/wc/**`, and it was not in `pnpm check`. Local `check` covered 864 files, none of them the wrappers being edited, so six clean local gate runs said nothing. The gap only appeared in CI, inside the release job, after merge.

`pnpm check` now runs it. The same mistake fails on a laptop, and in `ci.yml`, before it can reach `release`.

Also: `hITLTitle` → `hitlTitle`, from a rename script that lowercased only the first character of `HITL`.

## ⚠️ This publishes 4.0.0, and the footer is load-bearing

`release.yml` derives the version from **`git log -1` alone** — the latest commit, not the range since the last tag. With a plain `fix:` subject this commit would publish `190800b`'s breaking removal as **3.5.1**.

The `BREAKING CHANGE:` footer is therefore not decoration; it is what makes the bump correct, and it is truthful — this release does carry the removal. Replayed against the workflow's own logic on the real commit:

```
commit: fix(wc): restore the web-component type-check that gates every release
HAS_BREAKING_CHANGE=true
=> version_type=major
```

**Separately worth a decision:** deriving the bump from one commit is fragile in exactly this way — any `fix` or `chore` landing on top of an unreleased `feat!` silently downgrades the release. That is a change to release logic while the pipeline is red, so I have not touched it here.

## Gates

| Gate | Result |
|---|---|
| `pnpm check` | **0 errors** in both passes — 864 files and 432 files |
| `check:wc` alone | 15 errors → **0** |
| Lint | exit 0 |
| Unit | **828 passed** |
| Build | exit 0 |
| Playwright | **486 passed** |
| Visual | **93 passed** |

One Playwright run showed `typewriter-text-pacing-progress-render` at 7045ms against a 2500ms wall-clock ceiling. It passed **20/20** on repeat, and this branch does not touch `TypewriterText` — the diff is `package.json`, `tsconfig.wc.json` and 19 wrappers. Reported rather than omitted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the migration guide with clarification on lowercase prop naming versus camelCase callback keys, including configuration examples and Svelte usage.

- **Bug Fixes**
  - Corrected the web component property name from `hITLTitle` to `hitlTitle`.

- **Refactor**
  - Improved web component prop forwarding and type-checking consistency without changing component behavior.

- **Chores**
  - Extended validation to cover web-component type checking and excluded test files from that configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->