### PR TITLE
fix(wc): restore the type coverage the host-reserved rename removed, and gate it

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package": "svelte-kit sync && svelte-package && publint",
     "prepublishOnly": "npm run build:wc && npm run build:codemod && npm run package",
     "test": "npm run test:integration && npm run test:unit",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:codemod && npm run check:migrate && npm run check:wc-parity",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:wc && npm run check:codemod && npm run check:migrate && npm run check:wc-parity",
     "check:codemod": "tsc -p scripts/codemod/tsconfig.json",
     "codemod": "node scripts/codemod/cli.ts",
     "check:wc": "svelte-check --tsconfig ./tsconfig.wc.json --compiler-warnings \"options_missing_custom_element:ignore\"",

--- a/src/wc/components/Banner.wc.svelte
+++ b/src/wc/components/Banner.wc.svelte
@@ -21,7 +21,18 @@
 
 <script lang="ts">
   import Banner from '$lib/Banner/Banner.svelte';
-  let { bannerRole, ...props } = $props();
+  import type { BannerProperties } from '$lib/Banner/properties';
+  // The element renames `role` to `bannerRole` because the platform already defines `role` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    bannerRole,
+    ...props
+    // `title` is omitted as well as `role`: it is host-reserved, so the element never
+    // declares it and the wrapper's own title snippet is unconditional. Including it
+    // would advertise a prop nothing can set.
+  }: Omit<BannerProperties, 'role' | 'title'> & { bannerRole?: BannerProperties['role'] } =
+    $props();
 </script>
 
 <!--

--- a/src/wc/components/Chat.wc.svelte
+++ b/src/wc/components/Chat.wc.svelte
@@ -56,7 +56,14 @@
 
 <script lang="ts">
   import Chat from '$lib/Chat/Chat.svelte';
-  let { chatTitle, ...props } = $props();
+  import type { ChatProperties } from '$lib/Chat/properties';
+  // The element renames `title` to `chatTitle` because the platform already defines `title` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    chatTitle,
+    ...props
+  }: Omit<ChatProperties, 'title'> & { chatTitle?: ChatProperties['title'] } = $props();
 </script>
 
 <Chat {...props} title={chatTitle} />

--- a/src/wc/components/Checkbox.wc.svelte
+++ b/src/wc/components/Checkbox.wc.svelte
@@ -20,7 +20,16 @@
 
 <script lang="ts">
   import Checkbox from '$lib/Checkbox/Checkbox.svelte';
-  let { checkboxAriaLabel, ...props } = $props();
+  import type { CheckboxProperties } from '$lib/Checkbox/properties';
+  // The element renames `ariaLabel` to `checkboxAriaLabel` because the platform already defines `ariaLabel` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    checkboxAriaLabel,
+    ...props
+  }: Omit<CheckboxProperties, 'ariaLabel'> & {
+    checkboxAriaLabel?: CheckboxProperties['ariaLabel'];
+  } = $props();
 </script>
 
 <Checkbox {...props} ariaLabel={checkboxAriaLabel}>

--- a/src/wc/components/Combobox.wc.svelte
+++ b/src/wc/components/Combobox.wc.svelte
@@ -65,7 +65,9 @@
     highlightedIndex = $bindable(-1),
     selected = $bindable([]),
     ...rest
-  }: ComboboxProperties = $props();
+  }: Omit<ComboboxProperties, 'ariaLabel'> & {
+    comboboxAriaLabel?: ComboboxProperties['ariaLabel'];
+  } = $props();
 </script>
 
 <Combobox

--- a/src/wc/components/HITL.wc.svelte
+++ b/src/wc/components/HITL.wc.svelte
@@ -37,7 +37,15 @@
 
 <script lang="ts">
   import HITL from '$lib/HITL/HITL.svelte';
-  let { hITLTitle, ...props } = $props();
+  import type { HITLProperties } from '$lib/HITL/properties';
+  // `title` is mandatory on HITL, so the renamed element property is too -- the same
+  // claim `Omit<HITLProperties, 'title'>` already makes about `confirmationId`.
+  let {
+    hITLTitle,
+    ...props
+  }: Omit<HITLProperties, 'title'> & {
+    hITLTitle: HITLProperties['title'];
+  } = $props();
 </script>
 
 <HITL {...props} title={hITLTitle} />

--- a/src/wc/components/IframeViewer.wc.svelte
+++ b/src/wc/components/IframeViewer.wc.svelte
@@ -20,7 +20,16 @@
 
 <script lang="ts">
   import IframeViewer from '$lib/IframeViewer/IframeViewer.svelte';
-  let { iframeViewerTitle, ...props } = $props();
+  import type { IframeViewerProperties } from '$lib/IframeViewer/properties';
+  // The element renames `title` to `iframeViewerTitle` because the platform already defines `title` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    iframeViewerTitle,
+    ...props
+  }: Omit<IframeViewerProperties, 'title'> & {
+    iframeViewerTitle?: IframeViewerProperties['title'];
+  } = $props();
 </script>
 
 <IframeViewer {...props} title={iframeViewerTitle} />

--- a/src/wc/components/Input.wc.svelte
+++ b/src/wc/components/Input.wc.svelte
@@ -67,7 +67,18 @@
 
 <script lang="ts">
   import Input from '$lib/Input/Input.svelte';
-  let { inputAriaLabel, inputId, ...props } = $props();
+  import type { InputProperties } from '$lib/Input/properties';
+  // The element renames `ariaLabel` to `inputAriaLabel` and `id` to `inputId` because the platform already defines `ariaLabel` and `id` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    inputAriaLabel,
+    inputId,
+    ...props
+  }: Omit<InputProperties, 'ariaLabel' | 'id'> & {
+    inputAriaLabel?: InputProperties['ariaLabel'];
+    inputId?: InputProperties['id'];
+  } = $props();
 
   // Restores the tri-state the attribute string flattens: absent stays null so
   // the browser default is untouched, "false" is honoured, and a bare

--- a/src/wc/components/Menu.wc.svelte
+++ b/src/wc/components/Menu.wc.svelte
@@ -24,13 +24,20 @@
 
 <script lang="ts">
   import Menu from '$lib/Menu/Menu.svelte';
-  let { menuAriaLabel, ...props } = $props();
+  import type { MenuProperties } from '$lib/Menu/properties';
+  // The element renames `ariaLabel` to `menuAriaLabel` because the platform already defines `ariaLabel` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    menuAriaLabel,
+    ...props
+  }: Omit<MenuProperties, 'ariaLabel'> & { menuAriaLabel?: MenuProperties['ariaLabel'] } = $props();
 </script>
 
 <!-- A property-assigned trigger wins; the slot is the fallback. The branch stays
      inside the body snippet so `<slot>` keeps its `$$props` scope. -->
 <Menu {...props} ariaLabel={menuAriaLabel}>
-  {#snippet trigger()}
-    {#if props.trigger}{@render props.trigger()}{:else}<slot name="trigger"></slot>{/if}
+  {#snippet trigger(triggerProps)}
+    {#if props.trigger}{@render props.trigger(triggerProps)}{:else}<slot name="trigger"></slot>{/if}
   {/snippet}
 </Menu>

--- a/src/wc/components/Pill.wc.svelte
+++ b/src/wc/components/Pill.wc.svelte
@@ -20,8 +20,15 @@
 
 <script lang="ts">
   import Pill from '$lib/Pill/Pill.svelte';
+  import type { PillProperties } from '$lib/Pill/properties';
   import closeSvg from '$lib/assets/close.svg?raw';
-  let { pillTitle, ...props } = $props();
+  // The element renames `title` to `pillTitle` because the platform already defines `title` on every
+  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // a destructured `$props()` no longer infers on its own.
+  let {
+    pillTitle,
+    ...props
+  }: Omit<PillProperties, 'title'> & { pillTitle?: PillProperties['title'] } = $props();
 </script>
 
 <Pill {...props} title={pillTitle}>

--- a/tests/wc-menu-trigger-props.spec.ts
+++ b/tests/wc-menu-trigger-props.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+// Menu hands its `trigger` snippet the interaction wiring (MenuTriggerProps) so a consumer
+// whose trigger is itself an interactive element can spread it and set `interactiveTrigger`.
+// The custom-element wrapper used to render `props.trigger()` with no argument, and declared
+// no parameter to forward, so through `sui-menu` that argument was always undefined and the
+// whole feature was unreachable. Nothing failed: the menu still opened, the trigger just
+// never received its wiring.
+const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(() => typeof customElements.get('sui-menu') !== 'undefined', null, {
+    timeout: 15_000
+  });
+};
+
+test.describe('sui-menu — trigger wiring', () => {
+  test('forwards MenuTriggerProps to a property-assigned trigger', async ({ page }) => {
+    await loadBundle(page);
+
+    const received = await page.evaluate(async () => {
+      const menu = document.createElement('sui-menu') as HTMLElement & Record<string, unknown>;
+      menu.items = [{ label: 'Edit', value: 'edit' }];
+
+      // A snippet is invoked as (anchor, ...argThunks); the wiring is the first thunk.
+      // Capturing it is the whole assertion — if the wrapper drops it, this stays null.
+      const captured: { value: unknown } = { value: null };
+      menu.trigger = (_anchor: unknown, getProps?: () => unknown) => {
+        captured.value = typeof getProps === 'function' ? getProps() : null;
+      };
+
+      document.body.append(menu);
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      const props = captured.value as Record<string, unknown> | null;
+      return {
+        gotSomething: typeof props === 'object' && props !== null,
+        keys: props ? Object.keys(props).sort() : [],
+        ariaHaspopup: props ? props.ariaHaspopup : null,
+        ariaExpandedType: props ? typeof props.ariaExpanded : null,
+        onclickType: props ? typeof props.onclick : null,
+        onkeydownType: props ? typeof props.onkeydown : null
+      };
+    });
+
+    expect(received.gotSomething).toBe(true);
+    expect(received.keys).toEqual(['ariaExpanded', 'ariaHaspopup', 'onclick', 'onkeydown']);
+    expect(received.ariaHaspopup).toBe('menu');
+    expect(received.ariaExpandedType).toBe('boolean');
+    expect(received.onclickType).toBe('function');
+    expect(received.onkeydownType).toBe('function');
+  });
+});

--- a/tsconfig.wc.json
+++ b/tsconfig.wc.json
@@ -11,5 +11,5 @@
     "src/lib/**/*.svelte",
     ".svelte-kit/ambient.d.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Why

`Release and Publish` has failed on **every commit since `9814b53`** — four runs, two of which carried merged features — at `Type-check web components`, with 15 errors.

```
03:41  5c8f209  SUCCESS   ← last publish (3.5.0)
07:13  9814b53  failure
11:43  190800b  failure
13:45  e96ec81  failure    #546 typewriter
16:59  713ec88  failure    #548 marker
```

```
npm latest = 3.5.0
```

`typewriter` and `marker` are both merged and **neither is installable**. The workflow status never said so — only the registry does.

## Two causes, neither a runtime bug

### 1. The host-reserved rename removed an `any`

`190800b` renamed the props the platform already defines on every element (`title` → `pillTitle`, `role` → `bannerRole`). That changed nine wrappers from:

```svelte
let props = $props();              <Pill {...props}>
```
to
```svelte
let { pillTitle, ...props } = $props();     <Pill {...props} title={pillTitle}>
```

Untyped `$props()` is `any`, and spreading `any` satisfies anything. **Destructuring takes that away**, so svelte-check started checking the attribute object properly and found the mandatory prop (`text`, `src`, `value`, `items`, `messages`, `confirmationId`) not provably present.

The rename didn't break these wrappers. It removed an `any` that had been hiding what they never declared. `Combobox` is the same thing from the other side — it *does* annotate `$props()`, and the annotation just wasn't updated for its own renamed prop.

Each wrapper now states the contract that was implicit:

```ts
let { pillTitle, ...props }: Omit<PillProperties, 'title'> & {
  pillTitle?: PillProperties['title'];
} = $props();
```

The renamed property keeps **the component's own optionality** — which is why HITL's is required, not optional: `title` is mandatory on HITL, and that's the same claim `Omit<HITLProperties, 'title'>` already makes about `confirmationId`.

### Two defects it had been hiding

Restoring the check surfaced these. Both are fixed here rather than annotated around:

- **`Menu` dropped its trigger's props.** The wrapper rendered `props.trigger()` with no argument, and its own `{#snippet trigger()}` declared no parameter to forward. But `trigger` is `Snippet<[MenuTriggerProps]>`, and Menu hands it the interaction wiring precisely so a consumer whose trigger is itself interactive can spread it and set `interactiveTrigger`. Through the custom element that argument was **always `undefined`**, making the feature unreachable.
- **`HITL`** was passing its renamed `title` where a required `string` is expected.

### 2. A vitest test in the web-component scope

Unrelated, and four hours earlier. `docs-index.test.ts` arrived in `9814b53`. `tsconfig.wc.json` includes `src/lib/**/*.ts` while overriding `types` to `["vite/client"]` — so a vitest test that legitimately imports `node:fs` was being type-checked without node types. Six errors, in a pass that has no business reading it.

Test files are now out of that scope: **516 files checked → 432**.

## The gate

This is the whole reason it reached `release` four times:

| script | what it is | where it ran |
|---|---|---|
| `check:wc-parity` | `tsc` over the parity script | `pnpm check` → CI ✅ |
| `check:wc` | `svelte-check` over `tsconfig.wc.json` | release workflow only ❌ |

Similar names, different checks. A PR could be entirely green and still fail the release. `check:wc` now runs inside `check`, which CI and pre-commit already invoke.

## Controls

**Negative** — remove one wrapper's annotation and the gate fails, showing the gap directly:

```
COMPLETED 866 FILES 0 ERRORS   ← tsconfig.json — what PR CI already ran
COMPLETED 432 FILES 1 ERRORS   ← tsconfig.wc.json — the one that was missing
Property 'text' is missing ... but required in type 'MandatoryPillProperties'
```

**Runtime** — the five specs that mount these custom elements, run before any edit and after:

```
BEFORE: 40 passed
AFTER:  40 passed
```

**Visual** — 93 passed, **zero baselines moved**, which is what a types-only change should do.

## Gate

```
lint               exit 0
check              exit 0   866 files 0 errors  +  432 files 0 errors
test:unit          828 passed
test:integration   497 passed
test:visual         93 passed (0 baselines changed)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded validation checks to include web component type checking.
  * Improved type safety and editor guidance across web component properties without changing runtime behavior.
  * Updated menu trigger handling to forward trigger properties correctly.
  * Excluded test files from web component TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->