### PR TITLE
fix(release)!: classify the version from the whole range, not the triggering commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,12 +230,26 @@ jobs:
       - name: Determine version bump type
         id: version-type
         run: |
-          # Get the latest commit message
-          COMMIT_MSG=$(git log -1 --pretty=format:"%s")
-          echo "Latest commit: $COMMIT_MSG"
+          # Classify the WHOLE range since the last released tag, not just the commit that
+          # happened to trigger this run. Reading `git log -1` loses every bump a failed or
+          # skipped run should have carried: 3.5.1 shipped two features and a BREAKING
+          # change as a patch, because the three runs before it failed and the `fix(wc):`
+          # merge that finally succeeded was the only commit it looked at.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*' 2>/dev/null || true)
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="$LAST_TAG..HEAD"
+            echo "Classifying range: $RANGE"
+          else
+            RANGE=""
+            echo "No release tag found; classifying full history"
+          fi
 
-          # Check for BREAKING CHANGE in commit body
-          COMMIT_BODY=$(git log -1 --pretty=format:"%b")
+          # Release commits are this workflow's own bookkeeping, never a reason to bump.
+          COMMIT_MSG=$(git log $RANGE --grep="^chore(release):" --invert-grep --pretty=format:"%s")
+          COMMIT_BODY=$(git log $RANGE --grep="^chore(release):" --invert-grep --pretty=format:"%b")
+          echo "Commits considered:"
+          echo "$COMMIT_MSG" | sed 's/^/  /'
+
           HAS_BREAKING_CHANGE=false
           if echo "$COMMIT_BODY" | grep -iE "^BREAKING CHANGE:" > /dev/null; then
             HAS_BREAKING_CHANGE=true
@@ -566,8 +580,13 @@ jobs:
         run: |
           # Use the latest non-release commit so the root job's auto "chore(release):"
           # commit doesn't drive the MCP version bump.
-          COMMIT_MSG=$(git log --grep="^chore(release):" --invert-grep -1 --pretty=format:"%s")
-          COMMIT_BODY=$(git log --grep="^chore(release):" --invert-grep -1 --pretty=format:"%b")
+          MCP_LAST_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*' 2>/dev/null || true)
+          MCP_RANGE=""
+          if [ -n "$MCP_LAST_TAG" ]; then
+            MCP_RANGE="$MCP_LAST_TAG..HEAD"
+          fi
+          COMMIT_MSG=$(git log $MCP_RANGE --grep="^chore(release):" --invert-grep --pretty=format:"%s")
+          COMMIT_BODY=$(git log $MCP_RANGE --grep="^chore(release):" --invert-grep --pretty=format:"%b")
           echo "MCP release driven by commit: $COMMIT_MSG"
 
           HAS_BREAKING_CHANGE=false


### PR DESCRIPTION
## The defect

`Determine version bump type` read `git log -1`, so a release was versioned by whichever commit happened to trigger it. Any bump belonging to a commit whose own run failed — or that landed in the same push — was silently dropped.

## What it already cost

Three consecutive release runs failed at `Type-check web components`. The `fix(wc):` merge that finally succeeded was the only commit the classifier saw, so **3.5.1, a patch, shipped:**

- `feat(ChatMessage): typewriter`
- `feat(ChatMessage): marker`
- **`feat(events)!: remove the 3.x legacy spellings and host-reserved element props`**

That last one removes 190 event-prop spellings and renames 24 custom-element properties. Every consumer on `^3.x` takes it as a routine patch upgrade.

**Nothing catches it downstream.** Svelte does not error on an unknown prop — the handler just never fires. Measured in one consumer, against the published `.d.ts`:

```
Modal 3.5.1  →  onoverlayclick?: () => void
consumer     →  onoverlayClick={...}          82 files
```

| prop | files |
|---|---|
| `onoverlayClick` | 82 |
| `onToastHide` | 68 |
| `onheaderRightImageClick` | 56 |
| `onprimaryButtonClick` / `onsecondaryButtonClick` | 29 each |
| `onRowClick` | 21 |
| …6 more | 19 |
| **total** | **304** |

All of it type-checks and builds clean. Modal overlays stop closing; toasts stop dismissing; table rows stop responding.

## The fix

Both classifiers (the root job and the MCP job) now read `<last tag>..HEAD` and skip this workflow's own `chore(release):` bookkeeping commits.

## Control

Replaying the exact shell logic against the real `3.5.0..d6066e9` range:

```
OLD (git log -1)     ->  patch      the version that shipped
NEW (whole range)    ->  major      correct; the range contains feat(events)!
```

And for this PR's own range, which is what decides the version it cuts:

```
range 3.5.1..HEAD    ->  major      => 4.0.0
```

## What merging this does

Cuts **4.0.0**, republishing under a major the removals 3.5.1 shipped as a patch. **The code is unchanged from 3.5.1** — only the version now states what it contains.

- consumers on 3.4.x → migrate with `npx sui-codemod ./src`, see `docs/MIGRATION_4.0.md`
- consumers who took 3.5.1 → already on this code; re-pin
- 3.5.1 → to be deprecated on npm with a pointer here

YAML validated with `yaml.safe_load`.
