### PR TITLE
docs(release)!: record that the 3.x removal shipped in 3.5.1, and cut it as 4.0.0

### DIFF
--- a/DESIGN_PRINCIPLES.md
+++ b/DESIGN_PRINCIPLES.md
@@ -67,9 +67,10 @@ enough that the codebase itself carried hybrids like `onleftImageClick` that wer
 neither convention. A single rule needs no such knowledge, and it matches the spelling
 consumers of the forked library already write.
 
-The earlier spellings all remain accepted as `@deprecated` aliases: passing `onRowClick`
-still works and warns once, in dev, naming its replacement. 4.0.0 removes them; `npx
-sui-codemod ./src` rewrites a consumer's call sites (see `docs/EVENT_CASING_MIGRATION.md`).
+The earlier spellings were accepted as `@deprecated` aliases through 3.5.0: passing
+`onRowClick` worked and warned once, in dev, naming its replacement. 3.5.1 removed them,
+under a patch bump it should not have had; `npx sui-codemod ./src` rewrites a consumer's
+call sites (see `docs/EVENT_CASING_MIGRATION.md`).
 
 `scripts/check-event-casing.js` enforces the rule going forward (`npm run
 lint:event-casing`, wired into `npm run lint`). There is no grandfathering list: an

--- a/README.md
+++ b/README.md
@@ -38,15 +38,25 @@ This library takes a different approach: **components are unstyled by default** 
 
 ---
 
-## Coming in 4.0.0: one breaking change
+## Breaking changes, and the release they actually shipped in
 
-Advance notice, not a change in this release. **Nothing below has happened yet** —
-the current 3.x line still accepts everything it always did.
+**Both changes below shipped in 3.5.1, which went out as a patch by mistake.**
+The release workflow picks the version from the newest commit alone, and the
+commit that made the build green was a `fix:` — so the breaking commit beneath
+it was never seen. 4.0.0 is that same content under the version number it
+should have carried. A `^3.5.0` range already resolves to it; **3.5.0 is the
+last release without these changes.**
 
-In 4.0.0, `children` stops being a declared property on `sui-chat-bubble`,
-`sui-draggable` and `sui-resizable`. Assigning it will set an inert expando and
-the content will silently disappear. Pass the content as light-DOM children
-instead, which those wrappers will forward through their default slot:
+**Every deprecated event-prop spelling is gone.** The 190 camelCase and
+mixed-case event props that 3.x accepted as aliases are now unknown props,
+which Svelte drops without an error — the handler simply stops running.
+`npx sui-codemod ./src` rewrites them, and
+[`docs/MIGRATION_4.0.md`](docs/MIGRATION_4.0.md) lists every pair.
+
+**`children` is no longer a declared property** on `sui-chat-bubble`,
+`sui-draggable` and `sui-resizable`. Assigning it sets an inert expando and the
+content silently disappears. Pass the content as light-DOM children instead,
+which those wrappers forward through their default slot:
 
 ```js
 el.children = mySnippet; // before — no longer works
@@ -58,13 +68,12 @@ el.children = mySnippet; // before — no longer works
 ```
 
 **Reading `element.children` is what the change fixes.** Declaring the property
-replaces the inherited accessor, so on those three elements `element.children`
-returns `undefined` rather than an `HTMLCollection` today and
-`el.children.length` throws. That is why the declaration has to go, and why it
-cannot go before a major.
+replaced the inherited accessor, so up to 3.5.0 `element.children` returned
+`undefined` on those three elements rather than an `HTMLCollection`, and
+`el.children.length` threw. Removing the declaration gives the collection back.
 
-You can find affected call sites now, well before the major — this reports and
-writes nothing:
+You can find affected call sites with a dry run — this reports and writes
+nothing:
 
 ```sh
 npx sui-codemod --dry-run ./src

--- a/docs/EVENT_CASING_MIGRATION.md
+++ b/docs/EVENT_CASING_MIGRATION.md
@@ -1,4 +1,4 @@
-# Event-casing migration (to lowercase, completing in 4.0.0)
+# Event-casing migration (to lowercase, completed in 3.5.1)
 
 `DESIGN_PRINCIPLES.md` §3 states the rule: **every event prop is `on` followed
 by the event name in lowercase** — `onclick`, `oninput`, `onrowclick`,
@@ -21,10 +21,12 @@ forked library already write, which makes this library a drop-in for them.
 
 ## What a consumer does
 
-Through 3.x, nothing immediately: every spelling the library had ever accepted
-still worked, and passing a deprecated one warned once in dev, naming its
-replacement. 4.0.0 removed them, so an old spelling is now an unknown prop —
-inert, and silent unless you are on TypeScript, where the compiler catches it.
+Through **3.5.0**, nothing immediately: every spelling the library had ever
+accepted still worked, and passing a deprecated one warned once in dev, naming
+its replacement. **3.5.1 removed them** — as a patch, which it should not have
+been; see `docs/MIGRATION_4.0.md`. 4.0.0 is the same content under a correct
+version number. From 3.5.1 on, an old spelling is an unknown prop — inert, and
+silent unless you are on TypeScript, where the compiler catches it.
 
 Run the codemod from the project root, before or as part of the upgrade:
 

--- a/docs/MIGRATION_4.0.md
+++ b/docs/MIGRATION_4.0.md
@@ -7,6 +7,28 @@ that 3.x could only half-apply while the old names still had to work.
 Nothing else about your components changes. If you already ran the codemod on
 3.x, you are done; this release deletes names you have stopped using.
 
+## Check your installed version first
+
+**This removal shipped in 3.5.1, not in 4.0.0.** The release workflow derives
+the version bump from the newest commit alone, and the commit that finally made
+the build green was a `fix:` — so the removal two commits below it went out
+under a patch number. 4.0.0 is that same library content under the version it
+should have carried.
+
+That means a `^3.5.0` or `~3.5.0` range already resolves to it. If handlers
+stopped firing after an install you did not think was a major upgrade, this is
+why:
+
+```sh
+npm ls @juspay/svelte-ui-components
+```
+
+**3.5.0 is the last release that accepts the old spellings.** 3.5.1 and 4.0.0
+accept exactly the same props as each other. Prefer migrating with the codemod
+below over pinning to 3.5.0 — pinning holds you behind `TypewriterText`,
+`ChatMessage`'s `marker`, and the fix that made `MenuTriggerProps` reachable
+through `<sui-menu>`.
+
 ## Do this
 
 ```sh
@@ -51,8 +73,8 @@ with the props it described.
 
 The same rename applies to `<sui-*>` elements, whose declarations followed the
 components. `element.onClick = fn` set an accessor that reached the component
-in 3.x; in 4.0.0 that property is no longer declared, so the assignment lands
-on a plain expando and never arrives. Use the lowercase name.
+in 3.5.0; from 3.5.1 that property is no longer declared, so the assignment
+lands on a plain expando and never arrives. Use the lowercase name.
 
 `addEventListener` is unaffected. It always went through the DOM rather than
 through a declared prop, and still does.
@@ -67,7 +89,7 @@ rather than declaring a function inline, and the lint gate only recognised
 inline function types as events, so the backwards tag was never flagged. The
 gate now understands that shape.
 
-4.0.0 resolves it the way the rule says: **`onscrollstate` is the prop, and
+This release resolves it the way the rule says: **`onscrollstate` is the prop, and
 `onScrollState` is removed.** If you followed Chat's 3.x notice and moved to
 `onScrollState`, move back — you are the one consumer group this release asks
 to change in the opposite direction, and the codemod does not cover it because
@@ -113,8 +135,8 @@ before, because each declaration now pins the attribute it already observed.
 What moved is the JavaScript property name, which is the collision itself:
 
 ```js
-element.title = 'Sales'; // 3.x: set the component prop. 4.0.0: the tooltip.
-element.cardTitle = 'Sales'; // 4.0.0: the component prop.
+element.title = 'Sales'; // 3.5.0: the component prop. 3.5.1+: the tooltip.
+element.cardTitle = 'Sales'; // 3.5.1+: the component prop.
 ```
 
 The new name is the component name followed by the old one —


### PR DESCRIPTION
## 3.5.1 published a breaking change as a patch

`release.yml` derives the version from **`git log -1` alone**. It read `d6066e9` (`fix(wc): …`, no breaking footer) and never saw `190800b` (`feat(events)!: remove the 3.x legacy spellings…`) two commits below. `pnpm version patch` from 3.5.0 gave 3.5.1, and that is what went to npm on **2026-09-06T18:39:40Z**.

Verified against the published tarballs rather than the branch:

| | 3.5.0 | 3.5.1 |
|---|---|---|
| `dist/Toast/properties.d.ts:27` | `onToastHide?: () => void;` | `ontoasthide?: () => void;` |
| camelCase names across all `dist/*/properties.d.ts` | **134** | **14** |

The removal is live, and a `^3.5.0` or `~3.5.0` range resolves to it.

**The failure mode is silence.** Svelte drops an unknown prop without erroring, so a caret upgrade that looks like a patch stops handlers firing with no build failure and no runtime error. Only a TypeScript consumer gets a signal, because the prop is gone from the component's `Properties` type.

## The docs said the opposite

That is what this PR fixes. No library code changes.

- **`README.md`** announced the `children` removal as "Coming in 4.0.0", under the words *"**Nothing below has happened yet** — the current 3.x line still accepts everything it always did."* That sentence tells a reader on 3.5.1 they are safe when they are not.
- **`DESIGN_PRINCIPLES.md`** §3 still had the aliases "remain accepted", present tense.
- **`docs/EVENT_CASING_MIGRATION.md`** was titled "completing in 4.0.0" and told consumers that through 3.x, "nothing immediately".
- **`docs/MIGRATION_4.0.md`** attributed the whole change to 4.0.0, with `element.title` commented `3.x:` / `4.0.0:`.

All four now name the release the change actually landed in. `MIGRATION_4.0.md` leads with how to tell whether you already have it:

```sh
npm ls @juspay/svelte-ui-components
```

…and states that **3.5.0 is the last release accepting the old spellings**. It recommends migrating over pinning to 3.5.0, and says what pinning costs: `TypewriterText`, `ChatMessage`'s `marker`, and the fix that made `MenuTriggerProps` reachable through `<sui-menu>`.

## ⚠️ Merging this publishes 4.0.0

4.0.0 ships the **same components 3.5.1 does**, under the version number the change should have carried. 3.5.1 stays published and undeprecated — a deliberate call, not an oversight.

The `!` in the subject and the `BREAKING CHANGE:` footer are load-bearing for exactly the reason this PR exists. Replayed against the workflow's own block, verbatim, on the real commit:

```
Latest commit: docs(release)!: record that the 3.x removal shipped in 3.5.1, and cut it as 4.0.0
HAS_BREAKING_CHANGE=true
version_type=major (breaking change)
current: 3.5.1  ->  major bump -> 4.0.0
```

They are independently sufficient: the `!` matches the `docs(…)!:` branch, and the footer forces major on every branch. Without either, `git log -1` reads a `docs:` subject and cuts 4.0.1.

**This trap is still armed.** Anything landing on `release` before the publish needs the same treatment, or it takes the release slot and buries the mis-versioned break one release deeper. Fixing the derivation to read the commit range since the last tag is deferred by decision until after 4.0.0 ships.

## Gates

| Gate | Result |
|---|---|
| Lint | 0 — prettier, eslint, **0 event-casing violations** across 94 `properties.ts` files |
| `pnpm check` | **exit 0 over both configs** — 867 files / 0 errors, 432 files / 0 errors |
| Unit | **828 passed** |

The 4 remaining `svelte-check` warnings (Modal, ThemeSwitcher, MediaPlayer caption, `moduleResolution` deprecation) predate this branch and are untouched by a docs change.

Worth recording: the README edit was caught by `rename-doc-usages`'s repository-wide guard, which flagged a legacy spelling I had named in prose. The prose was reworded rather than `EXCLUDED_DOCS` widened — the guard was doing its job.
