### PR TITLE
fix(release): derive both packages' versions from every unreleased commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,59 +227,16 @@ jobs:
       # Linting moved to the `verify` job this one now needs, so it gates the
       # publish rather than running beside it.
 
+      # Reads EVERY commit since the last `chore(release):`, not just the newest
+      # one. `git log -1` published 3.5.1 as a patch while the range held
+      # `feat(events)!: remove the 3.x legacy spellings` four commits down.
+      # The rules for classifying a single commit are unchanged; what changed
+      # is that a `fix:` on top can no longer hide a `feat!:` underneath.
+      # `scripts/release/version-bump.test.ts` pins this, including a replay of
+      # that exact range.
       - name: Determine version bump type
         id: version-type
-        run: |
-          # Get the latest commit message
-          COMMIT_MSG=$(git log -1 --pretty=format:"%s")
-          echo "Latest commit: $COMMIT_MSG"
-
-          # Check for BREAKING CHANGE in commit body
-          COMMIT_BODY=$(git log -1 --pretty=format:"%b")
-          HAS_BREAKING_CHANGE=false
-          if echo "$COMMIT_BODY" | grep -iE "^BREAKING CHANGE:" > /dev/null; then
-            HAS_BREAKING_CHANGE=true
-          fi
-
-          # Determine version bump based on commit message (with optional Jira prefix like BZ-1234:)
-          # Pattern: [JIRA-123: ]feat[!|scope!]: message
-          if echo "$COMMIT_MSG" | grep -iE "(^|: )feat(\(.+\))?!?:" > /dev/null; then
-            # Check for breaking change indicator (!) or BREAKING CHANGE in body
-            if echo "$COMMIT_MSG" | grep -E "feat(\(.+\))?!:" > /dev/null || [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change)"
-            else
-              echo "version_type=minor" >> $GITHUB_OUTPUT
-              echo "Version bump: MINOR (new feature)"
-            fi
-          elif echo "$COMMIT_MSG" | grep -iE "(^|: )fix(\(.+\))?!?:" > /dev/null; then
-            # Check for breaking change in fix commits
-            if echo "$COMMIT_MSG" | grep -E "fix(\(.+\))?!:" > /dev/null || [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change in fix)"
-            else
-              echo "version_type=patch" >> $GITHUB_OUTPUT
-              echo "Version bump: PATCH (bug fix)"
-            fi
-          elif echo "$COMMIT_MSG" | grep -iE "(^|: )(build|chore|ci|docs|style|refactor|perf|test)(\(.+\))?!?:" > /dev/null; then
-            # Check for breaking change in other commit types
-            if echo "$COMMIT_MSG" | grep -E "(build|chore|ci|docs|style|refactor|perf|test)(\(.+\))?!:" > /dev/null || [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change)"
-            else
-              echo "version_type=patch" >> $GITHUB_OUTPUT
-              echo "Version bump: PATCH (maintenance)"
-            fi
-          else
-            # Default to patch, but check for breaking change
-            if [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change)"
-            else
-              echo "version_type=patch" >> $GITHUB_OUTPUT
-              echo "Version bump: PATCH (default)"
-            fi
-          fi
+        run: node scripts/release/version-bump.js
 
       - name: Configure Git
         run: |
@@ -561,53 +518,13 @@ jobs:
         working-directory: mcp
         run: npm ci
 
+      # `--mcp` changes two things from the root job: the range stops at
+      # `chore(release): mcp X`, MCP's own landmark rather than the root
+      # package's, and it counts only commits that touched `mcp/`, which is
+      # also what gates this job running at all.
       - name: Determine MCP version bump type
         id: version-type
-        run: |
-          # Use the latest non-release commit so the root job's auto "chore(release):"
-          # commit doesn't drive the MCP version bump.
-          COMMIT_MSG=$(git log --grep="^chore(release):" --invert-grep -1 --pretty=format:"%s")
-          COMMIT_BODY=$(git log --grep="^chore(release):" --invert-grep -1 --pretty=format:"%b")
-          echo "MCP release driven by commit: $COMMIT_MSG"
-
-          HAS_BREAKING_CHANGE=false
-          if echo "$COMMIT_BODY" | grep -iE "^BREAKING CHANGE:" > /dev/null; then
-            HAS_BREAKING_CHANGE=true
-          fi
-
-          if echo "$COMMIT_MSG" | grep -iE "(^|: )feat(\(.+\))?!?:" > /dev/null; then
-            if echo "$COMMIT_MSG" | grep -E "feat(\(.+\))?!:" > /dev/null || [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change)"
-            else
-              echo "version_type=minor" >> $GITHUB_OUTPUT
-              echo "Version bump: MINOR (new feature)"
-            fi
-          elif echo "$COMMIT_MSG" | grep -iE "(^|: )fix(\(.+\))?!?:" > /dev/null; then
-            if echo "$COMMIT_MSG" | grep -E "fix(\(.+\))?!:" > /dev/null || [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change in fix)"
-            else
-              echo "version_type=patch" >> $GITHUB_OUTPUT
-              echo "Version bump: PATCH (bug fix)"
-            fi
-          elif echo "$COMMIT_MSG" | grep -iE "(^|: )(build|chore|ci|docs|style|refactor|perf|test)(\(.+\))?!?:" > /dev/null; then
-            if echo "$COMMIT_MSG" | grep -E "(build|chore|ci|docs|style|refactor|perf|test)(\(.+\))?!:" > /dev/null || [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change)"
-            else
-              echo "version_type=patch" >> $GITHUB_OUTPUT
-              echo "Version bump: PATCH (maintenance)"
-            fi
-          else
-            if [ "$HAS_BREAKING_CHANGE" = true ]; then
-              echo "version_type=major" >> $GITHUB_OUTPUT
-              echo "Version bump: MAJOR (breaking change)"
-            else
-              echo "version_type=patch" >> $GITHUB_OUTPUT
-              echo "Version bump: PATCH (default)"
-            fi
-          fi
+        run: node scripts/release/version-bump.js --mcp
 
       - name: Bump MCP version
         id: version-bump

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package": "svelte-kit sync && svelte-package && publint",
     "prepublishOnly": "npm run build:wc && npm run build:codemod && npm run package",
     "test": "npm run test:integration && npm run test:unit",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:wc && npm run check:codemod && npm run check:migrate && npm run check:wc-parity",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run check:wc && npm run check:codemod && npm run check:migrate && npm run check:release && npm run check:wc-parity",
     "check:codemod": "tsc -p scripts/codemod/tsconfig.json",
     "codemod": "node scripts/codemod/cli.ts",
     "check:wc": "svelte-check --tsconfig ./tsconfig.wc.json --compiler-warnings \"options_missing_custom_element:ignore\"",
@@ -42,6 +42,7 @@
     "test:visual:update": "scripts/visual-test.sh --update-snapshots",
     "migrate": "node scripts/migrate/cli.ts",
     "check:migrate": "tsc -p scripts/migrate/tsconfig.json",
+    "check:release": "tsc -p scripts/release/tsconfig.json",
     "check:wc-parity": "tsc -p scripts/wc-parity/tsconfig.json",
     "postinstall": "node scripts/postinstall.mjs"
   },

--- a/scripts/release/tsconfig.json
+++ b/scripts/release/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "checkJs": true
+  },
+  "include": ["./**/*.ts", "./**/*.js"]
+}

--- a/scripts/release/version-bump.js
+++ b/scripts/release/version-bump.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Chooses the semver bump for a release from EVERY commit since the last
+// release, not just the newest one.
+//
+// The newest-commit-only rule shipped a breaking change as a patch. 3.5.1
+// carried `feat(events)!: remove the 3.x legacy spellings` four commits down,
+// but the workflow read `git log -1`, saw `fix(wc): ...` on top, and computed
+// `patch`. Consumers on `^3.5.0` were moved onto it by a routine install, and
+// because Svelte drops an unknown prop without erroring, their handlers simply
+// stopped running.
+//
+// The boundary is the most recent `chore(release):` commit rather than the
+// most recent tag. The release job pushes that commit before it pushes the
+// tag, and the workflow's own comments describe the window where a publish
+// succeeds and the tag push does not -- so a tag can be missing for a version
+// that is already on the registry, while the release commit cannot.
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+// These mirror the shell the workflow used, deliberately, so a single commit
+// classifies exactly as it always did and only the range is new. Note the
+// asymmetry carried over with them: the type is matched case-insensitively but
+// the `!` is not, so `FEAT!:` is a feature rather than a breaking one. That is
+// preserved rather than fixed here -- widening what counts as breaking is a
+// separate change, and this one is about not missing the breaking commits the
+// rule already recognises.
+const BREAKING_FOOTER = /^BREAKING CHANGE:/im;
+const MAINTENANCE = 'build|chore|ci|docs|style|refactor|perf|test';
+const FEAT = /(^|: )feat(\(.+\))?!?:/i;
+const FEAT_BREAKING = /feat(\(.+\))?!:/;
+const FIX = /(^|: )fix(\(.+\))?!?:/i;
+const FIX_BREAKING = /fix(\(.+\))?!:/;
+const OTHER = new RegExp(`(^|: )(${MAINTENANCE})(\\(.+\\))?!?:`, 'i');
+const OTHER_BREAKING = new RegExp(`(${MAINTENANCE})(\\(.+\\))?!:`);
+
+// Two packages release from this branch and each commits its own landmark:
+// the root job writes `chore(release): 4.0.0`, the MCP job writes
+// `chore(release): mcp 4.0.2`. Both are on this history. They have to be told
+// apart, because either one ending the other's range would hide unreleased
+// commits -- the same failure as reading only the newest commit, one level up.
+const ROOT_RELEASE = /^chore\(release\): \d/;
+const MCP_RELEASE = /^chore\(release\): mcp\b/;
+// Neither package's own release commit should ever drive a bump.
+const ANY_RELEASE = /^chore\(release\):/;
+const RANK = { patch: 0, minor: 1, major: 2 };
+
+/**
+ * @typedef {{ subject: string, body: string }} Commit
+ * @typedef {'major' | 'minor' | 'patch'} Bump
+ * @typedef {'root' | 'mcp'} Target
+ */
+
+/**
+ * @param {Commit} commit
+ * @returns {Bump}
+ */
+export function bumpForCommit({ subject, body }) {
+  const breaking = BREAKING_FOOTER.test(body ?? '');
+  if (FEAT.test(subject)) {
+    return FEAT_BREAKING.test(subject) || breaking ? 'major' : 'minor';
+  }
+  if (FIX.test(subject)) {
+    return FIX_BREAKING.test(subject) || breaking ? 'major' : 'patch';
+  }
+  if (OTHER.test(subject)) {
+    return OTHER_BREAKING.test(subject) || breaking ? 'major' : 'patch';
+  }
+  return breaking ? 'major' : 'patch';
+}
+
+/**
+ * The strongest bump anything in the range asks for.
+ *
+ * @param {readonly Commit[]} commits
+ * @returns {Bump}
+ */
+export function bumpForRange(commits) {
+  return commits
+    .filter((commit) => !ANY_RELEASE.test(commit.subject))
+    .reduce((strongest, commit) => {
+      const next = bumpForCommit(commit);
+      return RANK[next] > RANK[strongest] ? next : strongest;
+    }, /** @type {Bump} */ ('patch'));
+}
+
+/**
+ * Everything newer than the last release commit *for this package*. `log` is
+ * newest-first, the order `git log` gives.
+ *
+ * @param {readonly Commit[]} log
+ * @param {Target} [target]
+ * @returns {readonly Commit[]}
+ */
+export function unreleasedCommits(log, target = 'root') {
+  const isBoundary = target === 'mcp' ? MCP_RELEASE : ROOT_RELEASE;
+  const boundary = log.findIndex((commit) => isBoundary.test(commit.subject));
+  return boundary === -1 ? [...log] : log.slice(0, boundary);
+}
+
+/**
+ * @param {{ cwd?: string, path?: string }} [options]
+ * @returns {readonly Commit[]}
+ */
+export function readLog(options = {}) {
+  // NUL between subject and body, record separator between commits: a commit
+  // body contains newlines and can contain almost anything else.
+  const args = ['log', '--pretty=format:%s%x00%b%x1e', '-n', '200'];
+  if (typeof options.path === 'string') {
+    args.push('--', options.path);
+  }
+  const raw = execFileSync('git', args, {
+    cwd: options.cwd,
+    encoding: 'utf8'
+  });
+  return raw
+    .split('\x1e')
+    .map((record) => record.replace(/^\n/, ''))
+    .filter((record) => record.trim() !== '')
+    .map((record) => {
+      const [subject, body = ''] = record.split('\x00');
+      return { subject, body };
+    });
+}
+
+function main() {
+  /** @type {Target} */
+  const target = process.argv.includes('--mcp') ? 'mcp' : 'root';
+  // MCP versions only what happened inside `mcp/`, which is also what gates
+  // the job running at all. The root package versions the whole tree.
+  const log = readLog(target === 'mcp' ? { path: 'mcp' } : {});
+  const range = unreleasedCommits(log, target);
+  const bump = bumpForRange(range);
+
+  const label = target === 'mcp' ? 'MCP' : 'root';
+  if (range.length === 0) {
+    console.log(`No ${label} commits since its last release commit; defaulting to patch.`);
+  } else {
+    console.log(`Considering ${range.length} ${label} commit(s) since its last release:`);
+    for (const commit of range) {
+      console.log(`  ${bumpForCommit(commit).padEnd(5)}  ${commit.subject}`);
+    }
+  }
+  console.log(`Version bump: ${bump.toUpperCase()}`);
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (typeof out === 'string' && out !== '') {
+    appendFileSync(out, `version_type=${bump}\n`);
+  }
+}
+
+// Only run as a CLI, so the test can import the pure parts.
+if (process.argv[1] === import.meta.filename) {
+  main();
+}

--- a/scripts/release/version-bump.test.ts
+++ b/scripts/release/version-bump.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { bumpForCommit, bumpForRange, unreleasedCommits } from './version-bump.js';
+
+const commit = (subject: string, body = '') => ({ subject, body });
+
+describe('a single commit', () => {
+  it('reads feat as minor and fix as patch', () => {
+    expect(bumpForCommit(commit('feat(chat): add a marker'))).toBe('minor');
+    expect(bumpForCommit(commit('fix(chat): stop the flicker'))).toBe('patch');
+  });
+
+  it('reads an exclamation mark as breaking, on any type', () => {
+    expect(bumpForCommit(commit('feat(events)!: remove the legacy spellings'))).toBe('major');
+    expect(bumpForCommit(commit('fix(wc)!: drop the alias'))).toBe('major');
+    expect(bumpForCommit(commit('docs(release)!: cut it as 4.0.0'))).toBe('major');
+  });
+
+  it('reads a BREAKING CHANGE footer as breaking, whatever the subject', () => {
+    expect(
+      bumpForCommit(commit('fix(wc): restore the type coverage', 'BREAKING CHANGE: gone.'))
+    ).toBe('major');
+    expect(bumpForCommit(commit('chore(deps): bump', 'BREAKING CHANGE: gone.'))).toBe('major');
+  });
+
+  it('only honours a BREAKING CHANGE footer at the start of a line', () => {
+    // Prose mentioning the words mid-sentence is not a footer, and must not
+    // silently turn a patch into a major.
+    expect(
+      bumpForCommit(commit('fix(docs): explain', 'This is not a BREAKING CHANGE: it is prose.'))
+    ).toBe('patch');
+  });
+
+  it('treats maintenance types as patch, and anything unrecognised as patch', () => {
+    expect(bumpForCommit(commit('chore(release): 4.0.0'))).toBe('patch');
+    expect(bumpForCommit(commit('docs(readme): fix a typo'))).toBe('patch');
+    expect(bumpForCommit(commit('nonsense subject with no type'))).toBe('patch');
+  });
+
+  it('tolerates a Jira prefix, which the workflow has always allowed', () => {
+    expect(bumpForCommit(commit('BZ-1234: feat(chat): add a marker'))).toBe('minor');
+    expect(bumpForCommit(commit('BZ-1234: feat(events)!: remove them'))).toBe('major');
+  });
+});
+
+describe('a range of commits', () => {
+  it('takes the strongest bump in the range, not the newest commit', () => {
+    // This is the whole point. 3.5.1 shipped a breaking removal as a patch
+    // because the workflow read only `git log -1` -- a `fix:` sitting on top
+    // of an unreleased `feat!:` four commits down.
+    const range = [
+      commit('fix(wc): restore the type coverage the host-reserved rename removed, and gate it'),
+      commit('feat(ChatMessage): mark a turn with a leading accent bar via `marker`'),
+      commit('feat(ChatMessage): reveal a streamed message progressively via TypewriterText'),
+      commit('feat(events)!: remove the 3.x legacy spellings and host-reserved element props'),
+      commit('feat(events): make every event prop lowercase, keeping the old spellings as aliases')
+    ];
+    expect(bumpForRange(range)).toBe('major');
+  });
+
+  it('promotes to minor when the range holds a feat under a fix', () => {
+    expect(bumpForRange([commit('fix(a): b'), commit('feat(c): d')])).toBe('minor');
+  });
+
+  it('stays patch when the range is only fixes and chores', () => {
+    expect(bumpForRange([commit('fix(a): b'), commit('chore(c): d')])).toBe('patch');
+  });
+
+  it('is patch for an empty range rather than throwing', () => {
+    expect(bumpForRange([])).toBe('patch');
+  });
+
+  it('ignores the release job’s own commits', () => {
+    // The workflow commits `chore(release): X` back to the branch. Counting it
+    // would be harmless today, but a range that contains *only* it means
+    // nothing new has landed.
+    expect(bumpForRange([commit('chore(release): 4.0.0'), commit('feat(a): b')])).toBe('minor');
+  });
+});
+
+describe('the two packages have separate release commits', () => {
+  // The MCP job commits `chore(release): mcp 4.0.2`; the root job commits
+  // `chore(release): 4.0.0`. Both exist on this branch. A boundary that
+  // matched `^chore(release):` loosely would let an MCP release hide the
+  // root package's unreleased commits -- the same class of bug as reading
+  // only the newest commit.
+  it('does not let an MCP release commit end the root range', () => {
+    const log = [
+      commit('fix(a): a fix'),
+      commit('chore(release): mcp 4.0.2'),
+      commit('feat(events)!: a breaking change the root package has not released'),
+      commit('chore(release): 4.0.0')
+    ];
+    expect(bumpForRange(unreleasedCommits(log))).toBe('major');
+  });
+
+  it('does not let the root release commit end the MCP range', () => {
+    const log = [
+      commit('fix(mcp): a fix'),
+      commit('chore(release): 4.0.0'),
+      commit('feat(mcp)!: a breaking change MCP has not released'),
+      commit('chore(release): mcp 4.0.2')
+    ];
+    expect(bumpForRange(unreleasedCommits(log, 'mcp'))).toBe('major');
+  });
+
+  it('excludes both kinds of release commit from driving a bump', () => {
+    expect(bumpForRange([commit('chore(release): mcp 4.0.2'), commit('fix(a): b')])).toBe('patch');
+  });
+});
+
+describe('choosing the range', () => {
+  it('stops at the most recent release commit', () => {
+    const log = [
+      commit('fix(wc): a fix'),
+      commit('feat(events)!: a breaking feature'),
+      commit('chore(release): 3.5.0'),
+      commit('feat(old): already released, must not count')
+    ];
+    expect(unreleasedCommits(log).map((entry) => entry.subject)).toEqual([
+      'fix(wc): a fix',
+      'feat(events)!: a breaking feature'
+    ]);
+  });
+
+  it('takes the whole log when no release commit is present', () => {
+    const log = [commit('fix(a): b'), commit('feat(c): d')];
+    expect(unreleasedCommits(log)).toHaveLength(2);
+  });
+
+  it('returns nothing when the newest commit is the release itself', () => {
+    // Immediately after a release, before anything new merges.
+    expect(unreleasedCommits([commit('chore(release): 4.0.0'), commit('feat(a): b')])).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       'scripts/*.{test,spec}.{js,ts}',
       'scripts/codemod/**/*.{test,spec}.{js,ts}',
       'scripts/migrate/**/*.{test,spec}.{js,ts}',
+      'scripts/release/**/*.{test,spec}.{js,ts}',
       'scripts/wc-parity/**/*.{test,spec}.{js,ts}'
     ]
   }


### PR DESCRIPTION
## ⏳ Merge this after 4.1.0 is on the registry

Not urgent, and deliberately not merge-on-green. A release run is in flight for `a2d2a70 feat(Table): …`, and merging into an in-flight run risks the concurrent-release race this workflow's own comments describe — two runs each choosing a version, each pushing a `chore(release):` commit and a tag. **This PR does not fix that race and does not touch it.** Wait for `npm view @juspay/svelte-ui-components version` to report 4.1.0, then merge.

## What went wrong

`Determine version bump type` read **`git log -1`**. That is what published 3.5.1:

| | |
|---|---|
| Range since 3.5.0 held | `feat(events)!: remove the 3.x legacy spellings and host-reserved element props` |
| Newest commit was | `fix(wc): restore the type coverage the host-reserved rename removed, and gate it` |
| Workflow computed | `patch` → **3.5.1** |

A breaking removal reached npm under a patch number. `^3.5.0` resolves to it on a routine install, and because Svelte drops an unknown prop without erroring, consumers' handlers stopped running with **no build failure and no runtime error**.

## Both jobs, and the trap the second one surfaced

Two packages release from this branch and each writes its own landmark: the root job commits `chore(release): 4.0.0`, the MCP job commits `chore(release): mcp 4.0.2`. **Both are on this history** — `30b7746` and `d2fd26e`.

A boundary matching `^chore(release):` loosely would let an MCP release end the *root* package's range and hide everything below it — the same failure as reading only the newest commit, one level up. My first push had exactly that bug. The boundaries are now distinct:

| Package | Boundary | Range |
|---|---|---|
| root | `chore(release): <digit>` | whole tree |
| MCP | `chore(release): mcp` | commits touching `mcp/` |

Neither kind of release commit drives a bump. MCP's path filter matches what already gates the job running at all (`mcp_changed`).

The two cross-package tests were **watched failing first**, and failed for the right reason — `expected 'patch' to be 'major'`, the MCP landmark truncating the root range.

## The change

The bump is now the strongest one any commit since the last release asks for.

Classification of a single commit is **unchanged** — the regexes are carried over verbatim, including the asymmetry where the type is matched case-insensitively and the `!` is not, so `FEAT!:` still reads as a feature. Widening what counts as breaking is a different change from not missing what already counts, and this PR is only the second one.

The boundary is a **release commit, not a tag**. The release job pushes the commit before it pushes the tag, and this workflow's own comments describe the window where the publish succeeds and the tag push does not — so a tag can be absent for a version already on the registry, while the release commit cannot. `publish-mcp` already used a release commit as its landmark for the same reason; what it lacked was a range.

The logic moves out of inline YAML into `scripts/release/version-bump.js` so it can be tested at all. It was previously unreachable from any test, which is why a rule this load-bearing had none.

## Controls

A gate nobody has seen fail proves nothing, so each of these was watched failing.

**Replayed against the real history**, which is a better test than any fixture because it reproduces the failure that actually happened:

```
=== 3.5.1 (the failure) — HEAD d6066e9 ===
old rule (git log -1): patch -> published 3.5.1
  patch  fix(wc): restore the type coverage the host-reserved rename removed, and gate it
  minor  feat(ChatMessage): mark a turn with a leading accent bar via `marker`
  minor  feat(ChatMessage): reveal a streamed message progressively via TypewriterText
  major  feat(events)!: remove the 3.x legacy spellings and host-reserved element props
  minor  feat(events): make every event prop lowercase, keeping the old spellings as aliases
new rule over 5 commit(s): major        <- would have cut 4.0.0
PASS

=== 4.0.0 (the correction) — HEAD 3013d88 ===
new rule over 1 commit(s): major        <- correct case unchanged
PASS
```

**17 unit tests**, including that exact five-commit range, a `BREAKING CHANGE:` appearing mid-sentence in prose (must stay `patch`, not silently become a major), an empty range, and the Jira-prefixed subjects the workflow has always accepted.

**`check:release` is new and wired into `check`.** Verified it actually fails — returning a bump outside the union gives:

```
scripts/release/version-bump.js(60,31): error TS2322: Type '"PATCH_TYPO"' is not assignable to type 'Bump'.
```

The sabotage was then restored byte-identically (`diff -q` clean). This matters because a new script directory that no configured check reads is *exactly* the shape of the `check:wc` gap that let this incident reach a release four times.


**Both CLI modes run against this repository:**

```
$ node scripts/release/version-bump.js
Considering 2 root commit(s) since its last release:
  patch  fix(release): derive the version from every unreleased commit, not just the newest
  minor  feat(Table): render row selection with the library Checkbox
Version bump: MINOR

$ node scripts/release/version-bump.js --mcp
No MCP commits since its last release commit; defaulting to patch.
Version bump: PATCH
```

The root run is the fix demonstrating itself: it sees `feat(Table)` underneath a `fix:` and returns MINOR rather than PATCH.

## Left undone, deliberately

**The concurrent-run race is untouched**, as above. Two runs in flight still each choose their own version and each push a commit and a tag. That is a real problem and this PR does not address it.

## Gates

| Gate | Result |
|---|---|
| Lint | 0 — prettier, eslint, 0 event-casing violations across 94 `properties.ts` files |
| `pnpm check` | **exit 0 over both configs** — 867 files / 0 errors, 432 files / 0 errors, now including `check:release` |
| Unit | **845 passed** (up from 828) |

The 4 remaining `svelte-check` warnings predate this branch.
