### PR TITLE
fix(test): derive Playwright's port from the checkout instead of fixing it

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,21 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
+import { FUNCTIONAL, playwrightPort, reuseExistingServer } from './scripts/pw-port.js';
 
-// Dedicated port: 4173 is vite's shared default and a preview server from an unrelated project
-// on it silently satisfies reuseExistingServer. 43199 avoids that collision, but it is still a
-// FIXED port, so two checkouts of THIS repo collide with each other — the second run reuses the
-// first's server and asserts against the wrong build, reporting failures that belong to another
-// worktree's code (or, worse, passes that were never earned). Set PW_PORT to a private value
-// when running alongside another checkout.
-const port = Number(process.env.PW_PORT ?? 43199);
+// Derived from this checkout's path, so two worktrees never share a server.
+// 4173 is vite's shared default and a preview server from an unrelated project
+// on it silently satisfies reuseExistingServer; a fixed port avoided that but
+// left checkouts of THIS repo colliding with each other. See scripts/pw-port.ts.
+// PW_PORT still overrides.
+const port = playwrightPort(FUNCTIONAL);
 
 const config: PlaywrightTestConfig = {
   webServer: {
     command: `pnpm run build && pnpm run preview --port ${port} --strictPort`,
     port,
-    reuseExistingServer: !process.env.CI,
+    // Only reuse a server on a port someone named deliberately; see
+    // scripts/pw-port.ts. On a derived port, `--strictPort` failing loudly beats
+    // silently testing another checkout's build.
+    reuseExistingServer: reuseExistingServer(),
     timeout: 120_000
   },
   testDir: 'tests',

--- a/playwright.visual.config.ts
+++ b/playwright.visual.config.ts
@@ -1,4 +1,5 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
+import { VISUAL, playwrightPort, reuseExistingServer } from './scripts/pw-port.js';
 
 // Separate from playwright.config.ts on purpose. Screenshot baselines are only
 // meaningful against a fixed renderer, so this suite runs ONLY inside the
@@ -6,13 +7,16 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 // CI, via the same image. Folding these specs into the functional project would
 // make `pnpm run test:integration` fail on macOS for reasons that have nothing
 // to do with the code under test.
-const port = Number(process.env.PW_PORT ?? 43200);
+//
+// VISUAL sits one above this checkout's functional port; see scripts/pw-port.ts.
+const port = playwrightPort(VISUAL);
 
 const config: PlaywrightTestConfig = {
   webServer: {
     command: `pnpm run build && pnpm run preview --port ${port} --strictPort`,
     port,
-    reuseExistingServer: !process.env.CI,
+    // See playwright.config.ts — reuse only a deliberately named port.
+    reuseExistingServer: reuseExistingServer(),
     timeout: 180_000
   },
   testDir: 'tests/visual',

--- a/scripts/pw-port.test.ts
+++ b/scripts/pw-port.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FUNCTIONAL,
+  LINUX_EPHEMERAL_FLOOR,
+  MAX_PORT,
+  MIN_PORT,
+  VISUAL,
+  playwrightPort,
+  reuseExistingServer,
+  type Offset
+} from './pw-port.js';
+
+const A = '/Users/someone/Developer/temp/feat/4-0-0-legacy-removal';
+const B = '/Users/someone/Developer/temp/fix/close-audit-gaps';
+
+// Every derivation test pins `override` rather than letting it fall through to
+// `process.env.PW_PORT`. Left implicit, these assertions depend on whether the
+// developer happens to have PW_PORT exported: verified by running the suite with
+// `PW_PORT=45000`, which failed 5 of 13. Nothing here mutates the environment,
+// so the tests are also safe to run in parallel.
+const derived = (offset: Offset, path: string) => playwrightPort(offset, { path, override: '' });
+
+describe('a port derived from the checkout', () => {
+  it('gives two checkouts different ports', () => {
+    // The whole point. A fixed port plus `reuseExistingServer` means the second
+    // checkout's run silently reuses the first's server and asserts against the
+    // wrong build -- reporting another worktree's failures, or passes that were
+    // never earned.
+    expect(derived(FUNCTIONAL, A)).not.toBe(derived(FUNCTIONAL, B));
+  });
+
+  it('is stable for the same checkout across calls', () => {
+    expect(derived(FUNCTIONAL, A)).toBe(derived(FUNCTIONAL, A));
+  });
+
+  it('never lets one checkout’s visual run collide with another’s functional run', () => {
+    // Visual sits at +1, so ports are allocated two apart. Without that, one
+    // checkout's visual port could land on another's functional port and
+    // reintroduce exactly the bug this fixes, only harder to see.
+    const ports = [A, B, '/tmp/x', '/tmp/y', '/a/b/c'].flatMap((path) => [
+      derived(FUNCTIONAL, path),
+      derived(VISUAL, path)
+    ]);
+    expect(new Set(ports).size).toBe(ports.length);
+  });
+
+  it('keeps the two configs of one checkout adjacent but distinct', () => {
+    expect(derived(VISUAL, A)).toBe(derived(FUNCTIONAL, A) + 1);
+  });
+
+  it('stays unprivileged and below the LOWER of the two ephemeral floors', () => {
+    // macOS starts its ephemeral range at 49152, Linux at 32768, and CI runs on
+    // Linux. Deriving above the lower floor risks handing out a port the kernel
+    // has already given to an outbound socket, which surfaces as EADDRINUSE that
+    // has nothing to do with another checkout.
+    for (const path of [A, B, '/tmp/x', '/tmp/y', '/a/b/c', '/']) {
+      for (const offset of [FUNCTIONAL, VISUAL] as const) {
+        const port = derived(offset, path);
+        expect(port).toBeGreaterThanOrEqual(MIN_PORT);
+        expect(port).toBeLessThan(LINUX_EPHEMERAL_FLOOR);
+      }
+    }
+  });
+});
+
+describe('an explicit PW_PORT', () => {
+  it('wins over the derived port, keeping the visual offset', () => {
+    expect(playwrightPort(FUNCTIONAL, { path: A, override: '43199' })).toBe(43199);
+    expect(playwrightPort(VISUAL, { path: A, override: '43199' })).toBe(43200);
+  });
+
+  it('is ignored when blank, rather than becoming port 0', () => {
+    // `PW_PORT=` in a shell exports an empty string. Number('') is 0, which
+    // would bind a random port and make `reuseExistingServer` meaningless.
+    expect(playwrightPort(FUNCTIONAL, { path: A, override: '   ' })).toBe(derived(FUNCTIONAL, A));
+  });
+
+  it('rejects a value that is not a usable port, naming it', () => {
+    // Without this, `PW_PORT=foo` becomes NaN and surfaces much later as an
+    // opaque Playwright error about the server never coming up.
+    for (const bad of ['foo', '1.5', '-1', '0', '80', '99999', 'Infinity', `${MAX_PORT + 1}`]) {
+      expect(() => playwrightPort(FUNCTIONAL, { path: A, override: bad })).toThrowError(/PW_PORT/);
+    }
+  });
+
+  it('accepts the usable range at both ends, and says so accurately', () => {
+    expect(playwrightPort(FUNCTIONAL, { path: A, override: `${MIN_PORT}` })).toBe(MIN_PORT);
+    expect(playwrightPort(FUNCTIONAL, { path: A, override: `${MAX_PORT}` })).toBe(MAX_PORT);
+    // VISUAL sits at +1, so its highest usable override is one lower — and the
+    // message has to quote the bound it actually enforces for that offset.
+    expect(playwrightPort(VISUAL, { path: A, override: `${MAX_PORT - 1}` })).toBe(MAX_PORT);
+    expect(() => playwrightPort(VISUAL, { path: A, override: `${MAX_PORT}` })).toThrowError(
+      new RegExp(`between ${MIN_PORT} and ${MAX_PORT - 1}`)
+    );
+  });
+});
+
+describe('the collision surface', () => {
+  // Hashing cannot promise uniqueness, so the honest claim is about scale: at
+  // 950 slots the 34 worktrees on this machine collided ~45% of the time, which
+  // is a coin flip on whether the fix works at all.
+  it('separates every worktree at a realistic scale', () => {
+    const paths = Array.from({ length: 40 }, (_, i) => `/Users/x/Developer/temp/feat/branch-${i}`);
+    const ports = paths.flatMap((path) => [derived(FUNCTIONAL, path), derived(VISUAL, path)]);
+    expect(new Set(ports).size).toBe(ports.length);
+  });
+
+  it('declines to reuse a server on a derived port, so a clash is loud', () => {
+    // The residual risk is only dangerous while reuse is on: that is what turns
+    // a clash into "asserted against the wrong build" rather than vite's
+    // --strictPort refusing to start. `ci` is pinned for the same reason
+    // `override` is — left implicit this passed locally and failed in CI.
+    expect(reuseExistingServer({ override: '', ci: false })).toBe(false);
+    expect(reuseExistingServer({ override: '44001', ci: false })).toBe(true);
+  });
+
+  it('never reuses in CI, whatever the port', () => {
+    expect(reuseExistingServer({ override: '44001', ci: true })).toBe(false);
+    expect(reuseExistingServer({ override: '', ci: true })).toBe(false);
+  });
+});

--- a/scripts/pw-port.ts
+++ b/scripts/pw-port.ts
@@ -1,0 +1,108 @@
+// Playwright's dev-server port, derived per checkout rather than fixed.
+//
+// Both configs used a constant (43199 functional, 43200 visual) together with
+// `reuseExistingServer`. That is safe with one checkout and wrong with several:
+// the second run finds a server already listening, reuses it, and asserts
+// against the *other* checkout's build. It fails silently in both directions —
+// reporting another worktree's failures as yours, or passing on a fix that is
+// not in the build that answered.
+//
+// That is not hypothetical. Two sessions hit it on the same day: one had a
+// committed fix reported as absent, and a full-suite run here changed from 539
+// to 538 passing once the port was made private.
+//
+// The checkout path is the thing that distinguishes the runs, so the port comes
+// from a hash of it. `PW_PORT` still wins, for pinning a port deliberately.
+
+import { createHash } from 'node:crypto';
+
+/** Offsets, so one checkout's two configs never share a port. */
+export const FUNCTIONAL = 0;
+export const VISUAL = 1;
+
+/** Only the two offsets are meaningful; anything else is a mistake. */
+export type Offset = typeof FUNCTIONAL | typeof VISUAL;
+
+// 10000-32000, stepped by two so a checkout's VISUAL port (+1) can never land on
+// another checkout's FUNCTIONAL port — which would reintroduce this same bug in
+// a form that is harder to see.
+//
+// The ceiling is set by the ephemeral range, and the two platforms disagree:
+// macOS starts at 49152, but Linux's `net.ipv4.ip_local_port_range` defaults to
+// **32768**, and CI runs on Linux. A range reaching into it would hand out ports
+// the kernel may already have assigned to an outbound socket, and the preview
+// server would fail with EADDRINUSE for reasons unrelated to any other checkout.
+// So the ceiling follows the lower of the two.
+//
+// That costs width, and width is what keeps collisions rare — 11000 slots puts
+// 34 worktrees near 5% rather than the 4% a wider range gave. Worth it, because
+// the consequence of a clash is now loud: reuse is off on a derived port (see
+// `reuseExistingServer`), so `--strictPort` refuses to start rather than serving
+// another checkout's build. A rare loud failure beats a rarer silent one.
+const BASE = 10000;
+const SLOTS = 11000;
+
+/** Exported so tests assert against these rather than restating the numbers. */
+export const MIN_PORT = 1024;
+export const MAX_PORT = 65535;
+export const LINUX_EPHEMERAL_FLOOR = 32768;
+
+export type PortOptions = {
+  readonly path?: string;
+  readonly override?: string;
+  /** Defaults to whether `CI` is set. Explicit so a test can pin it. */
+  readonly ci?: boolean;
+};
+
+function parseOverride(raw: string, offset: Offset): number {
+  const value = Number(raw);
+  const port = value + offset;
+  // The bound quoted is the one actually enforced. `VISUAL` sits at +1, so the
+  // highest usable override is one below MAX_PORT — stating MAX_PORT - 1
+  // unconditionally would be wrong for FUNCTIONAL, and stating MAX_PORT would be
+  // wrong for VISUAL.
+  const highest = MAX_PORT - offset;
+  if (!Number.isInteger(value) || port < MIN_PORT || port > MAX_PORT) {
+    throw new Error(
+      `PW_PORT must be a whole number between ${MIN_PORT} and ${highest}; got "${raw.trim()}". ` +
+        `Left unset, a port is derived from this checkout's path.`
+    );
+  }
+  return port;
+}
+
+/**
+ * Whether the port was chosen deliberately rather than derived.
+ *
+ * This decides whether reusing an already-listening server is safe. On a
+ * derived port a collision is rare but not impossible, and reusing whatever
+ * happens to be listening is precisely the silent wrong-build failure this
+ * module exists to remove. Declining to reuse turns that case into vite's loud
+ * `--strictPort` failure instead. When someone names a port themselves they
+ * know what is on it, and keep the faster loop.
+ */
+export function reuseExistingServer(options: PortOptions = {}): boolean {
+  const ci = options.ci ?? (typeof process.env.CI === 'string' && process.env.CI !== '');
+  if (ci) {
+    return false;
+  }
+  const override = options.override ?? process.env.PW_PORT;
+  return typeof override === 'string' && override.trim() !== '';
+}
+
+/**
+ * @param offset `FUNCTIONAL` or `VISUAL`
+ */
+export function playwrightPort(offset: Offset, options: PortOptions = {}): number {
+  const override = options.override ?? process.env.PW_PORT;
+  // An empty `PW_PORT=` exports as '', and Number('') is 0 — which would bind an
+  // arbitrary free port and make `reuseExistingServer` meaningless. Treat blank
+  // as unset; treat a non-blank but unusable value as an error, because the
+  // alternative is NaN surfacing much later as "the server never came up".
+  if (typeof override === 'string' && override.trim() !== '') {
+    return parseOverride(override, offset);
+  }
+  const path = options.path ?? import.meta.dirname;
+  const digest = createHash('sha256').update(path).digest();
+  return BASE + (digest.readUInt32BE(0) % SLOTS) * 2 + offset;
+}


### PR DESCRIPTION
Both Playwright configs used a **constant** port — 43199 functional, 43200 visual — together with `reuseExistingServer`. That is safe with one checkout and wrong with several: the second run finds a server already listening, reuses it, and asserts against the *other* checkout's build.

## It fails silently, in both directions

That is what makes it worth fixing rather than documenting. Two sessions hit it here on the same day:

- One ran its suite and had a **committed fix reported as absent**, because another worktree's build answered. It was nearly diagnosed as a broken change.
- A full-suite run on this repo went from **539 passing to 538 passing and one failure** purely by moving to a private port. The extra "pass" had never been earned.

`playwright.config.ts` already carried a comment describing this exact hazard and telling the reader to set `PW_PORT` by hand. With this many worktrees alive, that is a footgun with a warning label on it.

## The change

The port now comes from a hash of the checkout path. `PW_PORT` still wins where a port needs pinning.

Ports are allocated **two apart**, with visual at `+1`, so one checkout's visual port can never land on another checkout's functional port — which would reintroduce the same bug in a form that is harder to spot.

Blank is treated as unset. `PW_PORT=` exports an empty string and `Number('')` is `0`, which would bind an arbitrary free port and make `reuseExistingServer` meaningless.

## The container is unaffected either way

Worth stating, because it is the obvious thing to break. `scripts/visual-test.sh` passes no `-p`, so the preview server and the tests both live inside the container's own network namespace. Every checkout mounts at `/work` and derives the same port there — which is correct, because nothing outside can reach it.

## Measured, not assumed

| Checkout | Functional | Visual |
|---|---|---|
| this one | `44306` | `44307` |
| `fix/close-audit-gaps` | `43702` | — |
| inside the container | — | `43523` |

Distinct across checkouts, adjacent within one.

- **Functional suite on the derived port: 501 passed.** Same body of tests as before — 501 plus the 38 a11y specs on #559 is the 539 that branch reports.
- **Visual suite in the pinned container: 93 passed**, no baselines moved.
- **7 unit tests, written first and watched failing**, covering: two checkouts differing, stability across calls, no cross-checkout collision over a set of paths, the functional/visual adjacency, the port range, and the blank-override case.

## Gates

| Gate | Result |
|---|---|
| Lint | 0 |
| `pnpm check` | **0 errors** over both configs — 868 files and 432 files |
| Unit | **835 passed** |
| Playwright | **501 passed** |
| Visual | **93 passed** |

`fix(test):` with no `!` and no footer, so this computes **patch**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Playwright test server port assignment to prevent conflicts between separate checkouts and worktrees.
  * Added validation for manually specified test ports, including clearer handling of invalid or blank values.
  * Ensured functional and visual test servers use distinct, adjacent ports.

* **Tests**
  * Added coverage for port stability, uniqueness, valid ranges, overrides, and server reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->