### PR TITLE
fix(release): stop a truncated history window inflating the version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,16 @@ on:
 # leaves a version on the registry with no tag behind it.
 #
 # This serialises the runs. It does NOT make the second one correct, and the
-# rest of the race is deliberately left visible rather than half-fixed: the
-# version is chosen by `git log -1` in "Determine version bump type", which
-# reads only the tip commit of that run's own checkout. Two merges each with a
-# `feat:` tip therefore both compute the same next version from the same base,
-# and the queued run will now fail loudly at `npm publish` on a version that
-# already exists rather than racing the first one. Making it pick the right
-# version means reading the branch tip instead of the pushed SHA, which changes
-# what a release builds and belongs in its own change.
+# rest of the race is deliberately left visible rather than half-fixed.
+# "Determine version bump type" now reads every commit since the last
+# `chore(release):` — see scripts/release/version-bump.js — but it reads them
+# from that run's OWN checkout, which is pinned to the SHA that triggered it.
+# Two merges in quick succession therefore each see a range ending at their own
+# commit, and both can compute the same next version from the same base. The
+# queued run then fails loudly at `npm publish` on a version that already
+# exists rather than racing the first one. Making it pick the right version
+# means reading the branch tip instead of the pushed SHA, which changes what a
+# release builds and belongs in its own change.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false

--- a/scripts/release/version-bump.js
+++ b/scripts/release/version-bump.js
@@ -16,7 +16,7 @@
 // that is already on the registry, while the release commit cannot.
 
 import { execFileSync } from 'node:child_process';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, realpathSync } from 'node:fs';
 
 // These mirror the shell the workflow used, deliberately, so a single commit
 // classifies exactly as it always did and only the range is new. Note the
@@ -88,32 +88,64 @@ export function bumpForRange(commits) {
  * Everything newer than the last release commit *for this package*. `log` is
  * newest-first, the order `git log` gives.
  *
+ * The window `log` came from is capped, because an unbounded `git log` on a long
+ * history overruns the subprocess buffer. That makes "no boundary found" two
+ * different situations, and conflating them is how an already-released `feat!`
+ * gets counted a second time:
+ *
+ *   - the whole history was read and holds no release commit — a fresh
+ *     repository, and everything genuinely is unreleased;
+ *   - the window ran out first — the boundary exists but was not read, and the
+ *     honest answer is that we cannot tell.
+ *
+ * The second case throws. A release that stops is recoverable; a release that
+ * silently picks the wrong number is what this whole module exists to prevent.
+ *
  * @param {readonly Commit[]} log
  * @param {Target} [target]
+ * @param {{ truncated?: boolean }} [window]
  * @returns {readonly Commit[]}
  */
-export function unreleasedCommits(log, target = 'root') {
+export function unreleasedCommits(log, target = 'root', window = {}) {
   const isBoundary = target === 'mcp' ? MCP_RELEASE : ROOT_RELEASE;
   const boundary = log.findIndex((commit) => isBoundary.test(commit.subject));
-  return boundary === -1 ? [...log] : log.slice(0, boundary);
+  if (boundary === -1) {
+    if (window.truncated === true) {
+      throw new Error(
+        `Read ${log.length} commits without reaching a ${target} release commit, and the ` +
+          `history window was truncated. The bump cannot be derived safely — raise the limit ` +
+          `in scripts/release/version-bump.js.`
+      );
+    }
+    return [...log];
+  }
+  return log.slice(0, boundary);
 }
+
+// Deliberately far past this repository's whole history (677 commits, 360 KB
+// with bodies) so the cap is a backstop against an unbounded read, not a limit
+// anything normally meets. `unreleasedCommits` refuses to answer if the boundary
+// is still not inside it.
+const HISTORY_LIMIT = 5000;
 
 /**
  * @param {{ cwd?: string, path?: string }} [options]
- * @returns {readonly Commit[]}
+ * @returns {{ commits: readonly Commit[], truncated: boolean }}
  */
 export function readLog(options = {}) {
   // NUL between subject and body, record separator between commits: a commit
   // body contains newlines and can contain almost anything else.
-  const args = ['log', '--pretty=format:%s%x00%b%x1e', '-n', '200'];
+  const args = ['log', '--pretty=format:%s%x00%b%x1e', '-n', String(HISTORY_LIMIT)];
   if (typeof options.path === 'string') {
     args.push('--', options.path);
   }
   const raw = execFileSync('git', args, {
     cwd: options.cwd,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    // The default 1 MB is already only ~3x this repository's full log.
+    maxBuffer: 256 * 1024 * 1024
   });
-  return raw
+  const commits = raw
     .split('\x1e')
     .map((record) => record.replace(/^\n/, ''))
     .filter((record) => record.trim() !== '')
@@ -121,6 +153,7 @@ export function readLog(options = {}) {
       const [subject, body = ''] = record.split('\x00');
       return { subject, body };
     });
+  return { commits, truncated: commits.length >= HISTORY_LIMIT };
 }
 
 function main() {
@@ -128,8 +161,8 @@ function main() {
   const target = process.argv.includes('--mcp') ? 'mcp' : 'root';
   // MCP versions only what happened inside `mcp/`, which is also what gates
   // the job running at all. The root package versions the whole tree.
-  const log = readLog(target === 'mcp' ? { path: 'mcp' } : {});
-  const range = unreleasedCommits(log, target);
+  const { commits, truncated } = readLog(target === 'mcp' ? { path: 'mcp' } : {});
+  const range = unreleasedCommits(commits, target, { truncated });
   const bump = bumpForRange(range);
 
   const label = target === 'mcp' ? 'MCP' : 'root';
@@ -149,7 +182,23 @@ function main() {
   }
 }
 
-// Only run as a CLI, so the test can import the pure parts.
-if (process.argv[1] === import.meta.filename) {
+// Only run as a CLI, so the test can import the pure parts. Compare resolved
+// real paths: `process.argv[1]` is the path as invoked and `import.meta.filename`
+// is the resolved module path, so a symlink or a differently-normalised
+// invocation would make a plain === silently skip main() and emit no version at
+// all.
+function invokedDirectly() {
+  const invoked = process.argv[1];
+  if (typeof invoked !== 'string') {
+    return false;
+  }
+  try {
+    return realpathSync(invoked) === realpathSync(import.meta.filename);
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) {
   main();
 }

--- a/scripts/release/version-bump.test.ts
+++ b/scripts/release/version-bump.test.ts
@@ -132,3 +132,26 @@ describe('choosing the range', () => {
     expect(unreleasedCommits([commit('chore(release): 4.0.0'), commit('feat(a): b')])).toEqual([]);
   });
 });
+
+describe('a history window that did not reach the boundary', () => {
+  // The window has to be capped, or a repository with a long history blows the
+  // subprocess buffer. But "no boundary in the window" has two very different
+  // causes, and silently treating them alike is how a released `feat!` gets
+  // counted a second time and inflates the next bump.
+  it('treats a complete history with no release commit as all-unreleased', () => {
+    const log = [commit('feat(a): b'), commit('fix(c): d')];
+    expect(unreleasedCommits(log, 'root', { truncated: false })).toHaveLength(2);
+  });
+
+  it('refuses to answer when the window was truncated before any boundary', () => {
+    const log = [commit('feat(a): b'), commit('fix(c): d')];
+    expect(() => unreleasedCommits(log, 'root', { truncated: true })).toThrowError(
+      /truncated|boundary/i
+    );
+  });
+
+  it('is unbothered by truncation when the boundary is inside the window', () => {
+    const log = [commit('feat(a): b'), commit('chore(release): 4.0.0'), commit('feat(old): x')];
+    expect(unreleasedCommits(log, 'root', { truncated: true })).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Follow-up to `a9f2e1c` (#558), closing the three review findings raised on it. #558 merged and published **4.1.1** before these were addressed, so they land separately.

All three sit in the version-bump logic the release now depends on.

## MAJOR — a truncated window could inflate the bump

`readLog` capped history at 200 commits. If more than 200 landed since the last release, the boundary was not in the window, `unreleasedCommits` fell back to the whole range, and already-released commits could be counted again. That silently undermines the exact property the module exists to guarantee.

"No boundary found" had two causes being conflated:

| Cause | Correct answer |
|---|---|
| Whole history read, no release commit | fresh repo — everything genuinely is unreleased |
| Window ran out first | the boundary exists but was not read — **cannot answer** |

`readLog` now reports whether it truncated, and the second case **throws**. A release that stops is recoverable; a release that silently picks the wrong number is the failure this module was written to prevent.

The cap moves to 5000 — far past this repository's entire history (677 commits, 360 KB with bodies) — so it is a backstop against an unbounded read rather than a limit anything meets. `maxBuffer` is raised too, because the 1 MB default is already only ~3× the full log.

## MINOR — the CLI guard was symlink-brittle

`process.argv[1] === import.meta.filename` compares the path *as invoked* against the *resolved* module path. Through a symlink or a differently-normalised invocation, `main()` would be skipped and no version emitted — silently, since the step still exits 0. Both sides now go through `realpathSync`.

## MINOR — the concurrency comment described the old mechanism

`release.yml`'s header still explained the race in terms of `git log -1`, which #558 replaced. The race is real and unchanged; its mechanism is not what the comment said. Each run now reads the full unreleased range **from its own checkout**, pinned to the SHA that triggered it — so two quick merges can still compute the same version, and the queued run fails at `npm publish` rather than racing.

## Controls

The truncation case was written first and watched failing:

```
× refuses to answer when the window was truncated before any boundary
  AssertionError: expected [Function] to throw an error
```

Both CLI modes run against the real repository — root reports PATCH with nothing since `chore(release): 4.1.1`, `--mcp` reports PATCH with nothing since `chore(release): mcp 4.0.2`. That the CLI runs at all is the check on the `realpath` guard.

| Gate | Result |
|---|---|
| Lint | 0 |
| `pnpm check` | 0 errors over both configs |
| Unit | **848 passed** |
| `release.yml` | parses |