### PR TITLE
test(wc): catch a prop declared twice in a customElement props map

### DIFF
--- a/scripts/wc-parity/prop-parity.test.ts
+++ b/scripts/wc-parity/prop-parity.test.ts
@@ -82,6 +82,31 @@ describe('host-reserved names are excluded deliberately, not forgotten', () => {
     ).toEqual([]);
   });
 
+  it('declares no prop twice in one customElement props map', () => {
+    // A duplicated key is last-wins in JavaScript, so the object stays
+    // structurally valid, every other check still sees a complete map, and the
+    // only symptom is that the *earlier* declaration's `attribute` quietly does
+    // not exist at runtime. Nothing here was looking for it.
+    //
+    // Not hypothetical: a git auto-merge of two branches that had each added
+    // `sliderAriaLabel` to Slider.wc.svelte produced exactly this, with two
+    // entries whose `attribute` differed. It was caught by reading the merged
+    // file, which is not a control.
+    const duplicated = parity.flatMap((entry) => {
+      const seen = new Set<string>();
+      const twice = new Set<string>();
+      for (const prop of entry.declared) {
+        if (seen.has(prop)) {
+          twice.add(prop);
+        }
+        seen.add(prop);
+      }
+      return [...twice].map((prop) => `${entry.wrapper}:${prop}`);
+    });
+
+    expect(duplicated, `declared more than once: ${duplicated.join(', ')}`).toEqual([]);
+  });
+
   it('reports which components want a reserved name, so the debt stays visible', () => {
     const wanted = parity
       .filter((entry) => entry.reserved.length > 0)


### PR DESCRIPTION
A duplicated key in a `customElement.props` map is **last-wins in JavaScript**. The object stays structurally valid, every existing parity check still sees a complete map, and the only symptom is that the *earlier* declaration's `attribute` quietly does not exist at runtime.

Nothing was looking for it.

## Not hypothetical

Resolving a rebase where two branches had each added `sliderAriaLabel` to `Slider.wc.svelte`, git's auto-merge kept **both** — two entries for one prop whose `attribute` differed, one `aria-label` and one `aria-labelledby`. It was caught by reading the merged file, which is not a control, and a rebase is exactly where nobody reads the hunks that merged cleanly.

Credit to `componen-reuse-63` for pointing out that the guard could close this cheaply.

## Where the duplicate was disappearing

The check runs over `WrapperParity.declared`, the raw array from the parser. Everything downstream funnels it through `new Set(props)` for lookups — which is precisely where a duplicate stops existing.

## Controls

Planting the real duplicate back into `Slider.wc.svelte`:

```
× declares no prop twice in one customElement props map
  AssertionError: declared more than once: Slider.wc.svelte:sliderAriaLabel

Tests  1 failed | 90 passed (91)
```

**90 of the 91 assertions still passed with the duplicate present.** That is the gap stated as a measurement rather than an argument. Restored, all 91 pass.

| Gate | Result |
|---|---|
| Lint | 0 |
| `check:wc-parity` | clean |
| Unit | **874 passed** (with `CI=true`) |

One file, test-only, no runtime change. `test(wc):` computes patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to detect duplicate property declarations in custom-element wrappers.
  * Test failures identify each wrapper and duplicated property for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->