### PR TITLE
test(wc): record the 91 wrapper props that shadow native event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,33 @@ import '@juspay/svelte-ui-components/wc';
 Theming works identically to the Svelte components — the same `--{component}-{element}-{property}`
 CSS custom properties apply across the shadow DOM boundary.
 
+### Event handlers: use `addEventListener`, not `element.onclick`
+
+Handlers are passed as **props**, and 91 of those props are named after event-handler
+accessors that already exist on `HTMLElement` — `onclick`, `onchange`, `oninput`,
+`onkeydown` and 21 others. On a custom element the component's prop wins, so assigning
+the property does not register a DOM handler the way it would anywhere else:
+
+```js
+const checkbox = document.querySelector('sui-checkbox');
+
+// Sets the component's prop. On sui-checkbox and sui-toggle that prop is called
+// with a boolean, so `event` here is `true` / `false`, not a MouseEvent.
+checkbox.onclick = (event) => console.log(event.clientX); // undefined
+
+// Always does what you expect.
+checkbox.addEventListener('click', (event) => console.log(event.clientX));
+```
+
+Two things are **not** affected: the inline HTML attribute (`<sui-button onclick="...">`)
+never used this accessor, and `addEventListener` is untouched. Only the JavaScript
+property assignment differs.
+
+Renaming these is a breaking change to every element's JavaScript API, so the whole set
+has to move at once at a major — the same way the `aria*` collisions were renamed in
+4.0.0. Until then the existing declarations are recorded in
+`scripts/wc-parity/prop-parity.test.ts`, which fails the build on a new one.
+
 ---
 
 ## Theming

--- a/scripts/wc-parity/prop-parity.test.ts
+++ b/scripts/wc-parity/prop-parity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { HOST_RESERVED_PROPS, readWrapperParity } from './prop-parity.ts';
+import { HOST_EVENT_HANDLER_PROPS, HOST_RESERVED_PROPS, readWrapperParity } from './prop-parity.ts';
 
 /**
  * Adding a prop to a Svelte component and forgetting its custom-element wrapper
@@ -117,5 +117,145 @@ describe('host-reserved names are excluded deliberately, not forgotten', () => {
     // API decision rather than a mechanical fix. Printing them keeps the count
     // honest instead of letting an exclusion list quietly absorb them.
     expect(Array.isArray(wanted)).toBe(true);
+  });
+});
+
+/**
+ * Every wrapper prop whose name is already an event-handler accessor on
+ * `HTMLElement`. Recorded rather than failed on, because renaming a public prop
+ * is a breaking change to each element's JavaScript API and the whole set has to
+ * move at once, at a major — the same reasoning that held the `aria*` names
+ * above until 4.0.0.
+ *
+ * Recording is not nothing: it bounds the debt. A wrapper that declares a
+ * twenty-sixth native handler name fails here instead of shipping, and one that
+ * gets fixed has to be deleted from this list rather than quietly re-added.
+ *
+ * The attributes are unaffected either way — `<sui-button onclick="...">` never
+ * used this accessor, and `addEventListener` is untouched. What is affected is
+ * the JavaScript property: `element.onclick = fn` sets the component prop, and
+ * for `sui-checkbox` / `sui-toggle` that prop is called with a boolean rather
+ * than the `MouseEvent` the platform would have given.
+ */
+const KNOWN_HOST_EVENT_HANDLER_DECLARATIONS: readonly string[] = [
+  'Accordion.wc.svelte:ontoggle',
+  'Avatar.wc.svelte:onclick',
+  'Banner.wc.svelte:onclick',
+  'Button.wc.svelte:onclick',
+  'Button.wc.svelte:onkeydown',
+  'Button.wc.svelte:onkeyup',
+  'Button.wc.svelte:onmousedown',
+  'Button.wc.svelte:onmouseup',
+  'Button.wc.svelte:onmouseleave',
+  'Calendar.wc.svelte:onselect',
+  'Card.wc.svelte:onclick',
+  'Carousel.wc.svelte:onkeydown',
+  'Chat.wc.svelte:onclose',
+  'ChatBubble.wc.svelte:onclose',
+  'ChatBubble.wc.svelte:ontoggle',
+  'ChatComposer.wc.svelte:onsubmit',
+  'ChatComposer.wc.svelte:oninput',
+  'ChatComposer.wc.svelte:onkeydown',
+  'ChatComposer.wc.svelte:onpaste',
+  'ChatHeader.wc.svelte:onclose',
+  'ChatMessage.wc.svelte:oncopy',
+  'ChatSuggestions.wc.svelte:onselect',
+  'CheckListItem.wc.svelte:onclick',
+  'Checkbox.wc.svelte:onclick',
+  'ChipInput.wc.svelte:onchange',
+  'Choicebox.wc.svelte:onclick',
+  'ColorPicker.wc.svelte:onchange',
+  'ColorPicker.wc.svelte:oninput',
+  'Combobox.wc.svelte:onselect',
+  'Combobox.wc.svelte:oninput',
+  'Combobox.wc.svelte:onclose',
+  'Combobox.wc.svelte:onkeydown',
+  'Combobox.wc.svelte:onfocus',
+  'Combobox.wc.svelte:onblur',
+  'Combobox.wc.svelte:onchange',
+  'CommandMenu.wc.svelte:onselect',
+  'CommandMenu.wc.svelte:onclose',
+  'ContextMenu.wc.svelte:onselect',
+  'ContextMenu.wc.svelte:onclose',
+  'DateRangePicker.wc.svelte:oncancel',
+  'FileDropzoneTrigger.wc.svelte:onclick',
+  'FileInput.wc.svelte:onerror',
+  'Gallery.wc.svelte:onkeydown',
+  'Gallery.wc.svelte:onclose',
+  'Gallery.wc.svelte:onchange',
+  'GridItem.wc.svelte:onclick',
+  'GridItem.wc.svelte:onkeydown',
+  'Icon.wc.svelte:onclick',
+  'Icon.wc.svelte:onkeydown',
+  'Img.wc.svelte:onerror',
+  'Input.wc.svelte:onfocus',
+  'Input.wc.svelte:onblur',
+  'Input.wc.svelte:oninput',
+  'Input.wc.svelte:onpaste',
+  'Input.wc.svelte:onclick',
+  'Input.wc.svelte:onkeydown',
+  'KeyboardInput.wc.svelte:onclick',
+  'ListItem.wc.svelte:onkeydown',
+  'LottiePlayer.wc.svelte:onerror',
+  'MediaPlayer.wc.svelte:onplay',
+  'MediaPlayer.wc.svelte:onpause',
+  'MediaPlayer.wc.svelte:onvolumechange',
+  'MediaPlayer.wc.svelte:ontimeupdate',
+  'MediaPlayer.wc.svelte:onfullscreenchange',
+  'MediaUpload.wc.svelte:onchange',
+  'MediaUpload.wc.svelte:onerror',
+  'Menu.wc.svelte:onselect',
+  'Menu.wc.svelte:onclose',
+  'Modal.wc.svelte:onclose',
+  'Modal.wc.svelte:onkeydown',
+  'Pagination.wc.svelte:onchange',
+  'Pill.wc.svelte:onclick',
+  'Radio.wc.svelte:onchange',
+  'Resizable.wc.svelte:onresize',
+  'Select.wc.svelte:onchange',
+  'Select.wc.svelte:onclose',
+  'Sheet.wc.svelte:onclose',
+  'Slider.wc.svelte:oninput',
+  'Slider.wc.svelte:onchange',
+  'Snippet.wc.svelte:oncopy',
+  'SplitButton.wc.svelte:onclick',
+  'SplitButton.wc.svelte:onselect',
+  'SplitInput.wc.svelte:onchange',
+  'SplitInput.wc.svelte:oninput',
+  'StatCard.wc.svelte:onclick',
+  'Tabs.wc.svelte:onchange',
+  'ThemeSwitcher.wc.svelte:onchange',
+  'ThinkingIndicator.wc.svelte:ontoggle',
+  'Toggle.wc.svelte:onclick',
+  'Toolbar.wc.svelte:onkeydown',
+  'TypewriterText.wc.svelte:onprogress'
+];
+
+describe('native event-handler names are recorded, not silently shadowed', () => {
+  const offenders = (): string[] =>
+    parity.flatMap((entry) =>
+      entry.declared
+        .filter((name) => HOST_EVENT_HANDLER_PROPS.has(name))
+        .map((name) => `${entry.wrapper}:${name}`)
+    );
+
+  it('adds no new prop that would replace an HTMLElement event-handler accessor', () => {
+    const added = offenders().filter(
+      (name) => !KNOWN_HOST_EVENT_HANDLER_DECLARATIONS.includes(name)
+    );
+
+    expect(added, `new host event-handler overrides: ${added.join(', ')}`).toEqual([]);
+  });
+
+  it('keeps the recorded set honest, so a fixed one cannot be quietly re-added', () => {
+    const current = offenders();
+    const goneButStillListed = KNOWN_HOST_EVENT_HANDLER_DECLARATIONS.filter(
+      (name) => !current.includes(name)
+    );
+
+    expect(
+      goneButStillListed,
+      `fixed — delete from KNOWN_HOST_EVENT_HANDLER_DECLARATIONS: ${goneButStillListed.join(', ')}`
+    ).toEqual([]);
   });
 });

--- a/scripts/wc-parity/prop-parity.ts
+++ b/scripts/wc-parity/prop-parity.ts
@@ -250,6 +250,152 @@ export const HOST_RESERVED_PROPS: ReadonlySet<string> = new Set([
   'ariaRoleDescription'
 ]);
 
+/**
+ * Event-handler IDL attributes that already exist on `HTMLElement`. Declaring
+ * one as a custom-element prop replaces the host's own accessor, so
+ * `element.onclick = fn` sets this library's prop instead of registering a DOM
+ * handler. On `sui-checkbox` and `sui-toggle` that is not just a shadowed
+ * accessor but a changed signature: their `onclick` is typed
+ * `(checked: boolean) => void`, so the assignment receives a boolean where every
+ * other element in the document hands back a `MouseEvent`.
+ *
+ * Deliberately NOT folded into `HOST_RESERVED_PROPS`. That set is *excluded*
+ * from the parity requirement, so putting these there would stop a wrapper that
+ * simply forgot to declare `onclick` from being reported missing — masking the
+ * exact class of gap this suite exists to catch. These get recorded separately
+ * instead: existing declarations are listed, and a new one fails.
+ *
+ * This is the platform's whole set, not the subset this library happens to use.
+ * The first version listed only the 25 names currently declared somewhere, which
+ * reads as thorough and is not: a guard built from present usage cannot fail on
+ * a name nobody has used yet, so a wrapper adding `oncontextmenu` or `ondblclick`
+ * tomorrow would have walked straight past the check whose entire job is to catch
+ * that. Reviewed and corrected before merge.
+ *
+ * Enumerated in Chromium rather than curated by hand: every `on*` own-property
+ * name reachable by walking `HTMLElement.prototype`'s chain — 110 of them,
+ * through Element, Node and EventTarget. That is the same "ask the browser, do
+ * not reason about it" method the ARIAMixin list above was built with, and it is
+ * why `onselect` is here (a genuine host accessor) while `onopen`, `ondismiss`,
+ * `onretry` and the library's other 80-odd bespoke handler names are not: they
+ * collide with nothing.
+ *
+ * Re-enumerate if a browser adds handlers. A name missing from this list is not
+ * flagged, so the list being complete is what the guard rests on.
+ */
+export const HOST_EVENT_HANDLER_PROPS: ReadonlySet<string> = new Set([
+  'onabort',
+  'onanimationcancel',
+  'onanimationend',
+  'onanimationiteration',
+  'onanimationstart',
+  'onauxclick',
+  'onbeforecopy',
+  'onbeforecut',
+  'onbeforeinput',
+  'onbeforematch',
+  'onbeforepaste',
+  'onbeforetoggle',
+  'onbeforexrselect',
+  'onblur',
+  'oncancel',
+  'oncanplay',
+  'oncanplaythrough',
+  'onchange',
+  'onclick',
+  'onclose',
+  'oncommand',
+  'oncontentvisibilityautostatechange',
+  'oncontextlost',
+  'oncontextmenu',
+  'oncontextrestored',
+  'oncopy',
+  'oncuechange',
+  'oncut',
+  'ondblclick',
+  'ondrag',
+  'ondragend',
+  'ondragenter',
+  'ondragleave',
+  'ondragover',
+  'ondragstart',
+  'ondrop',
+  'ondurationchange',
+  'onemptied',
+  'onended',
+  'onerror',
+  'onfocus',
+  'onformdata',
+  'onfullscreenchange',
+  'onfullscreenerror',
+  'ongotpointercapture',
+  'oninput',
+  'oninvalid',
+  'onkeydown',
+  'onkeypress',
+  'onkeyup',
+  'onload',
+  'onloadeddata',
+  'onloadedmetadata',
+  'onloadstart',
+  'onlostpointercapture',
+  'onmousedown',
+  'onmouseenter',
+  'onmouseleave',
+  'onmousemove',
+  'onmouseout',
+  'onmouseover',
+  'onmouseup',
+  'onmousewheel',
+  'onpaste',
+  'onpause',
+  'onplay',
+  'onplaying',
+  'onpointercancel',
+  'onpointerdown',
+  'onpointerenter',
+  'onpointerleave',
+  'onpointermove',
+  'onpointerout',
+  'onpointerover',
+  'onpointerrawupdate',
+  'onpointerup',
+  'onprogress',
+  'onratechange',
+  'onreset',
+  'onresize',
+  'onscroll',
+  'onscrollend',
+  'onscrollsnapchange',
+  'onscrollsnapchanging',
+  'onsearch',
+  'onsecuritypolicyviolation',
+  'onseeked',
+  'onseeking',
+  'onselect',
+  'onselectionchange',
+  'onselectstart',
+  'onslotchange',
+  'onstalled',
+  'onsubmit',
+  'onsuspend',
+  'ontimeupdate',
+  'ontoggle',
+  'ontransitioncancel',
+  'ontransitionend',
+  'ontransitionrun',
+  'ontransitionstart',
+  'onvolumechange',
+  'onwaiting',
+  'onwebkitanimationend',
+  'onwebkitanimationiteration',
+  'onwebkitanimationstart',
+  'onwebkitfullscreenchange',
+  'onwebkitfullscreenerror',
+  'onwebkittransitionend',
+  'onwheel'
+]);
+
 export type WrapperParity = {
   readonly wrapper: string;
   readonly tag: string | null;


### PR DESCRIPTION
Closes the host-accessor finding raised on #560, where a review flagged `onclick` on `SplitButton.wc.svelte`. Declining it *there* was right — that PR added one line to the file and `onclick` was pre-existing — but the finding was sound, and much larger than the one prop it named.

## What the review was actually pointing at

Chromium says **25** of the `on*` names this library declares as custom-element props are already event-handler accessors on `HTMLElement`:

```
onblur oncancel onchange onclick onclose oncopy onerror onfocus
onfullscreenchange oninput onkeydown onkeyup onmousedown onmouseleave
onmouseup onpaste onpause onplay onprogress onresize onselect onsubmit
ontimeupdate ontoggle onvolumechange
```

Verified with `name in HTMLElement.prototype` — the same check the ARIAMixin list was built with — rather than reasoned about. That distinction earns its keep: `onselect` **is** a real host accessor and is on the list, while `onopen`, `ondismiss`, `onretry` and the other 80-odd bespoke handler names collide with nothing and are not.

Across the 86 wrappers, those 25 names account for **91 declarations**.

## Why it matters, stated precisely

Each declaration replaces the host's own accessor, so `element.onclick = fn` sets the component prop instead of registering a DOM handler. On `sui-checkbox` and `sui-toggle` it is not merely a shadowed accessor but a **changed signature** — their `onclick` is typed `(checked: boolean) => void`:

```js
checkbox.onclick = (event) => console.log(event.clientX); // undefined — it's `true`
checkbox.addEventListener('click', (e) => console.log(e.clientX)); // works
```

Two things are **not** affected, and the README note says so rather than overstating it: the inline attribute never used this accessor, so `<sui-button onclick="...">` is unchanged, and `addEventListener` is untouched.

## What this PR does and does not do

**Does not rename anything.** That is a breaking change to every element's JavaScript API, and the set has to move at once at a major — the same reasoning that held the `aria*` collisions until 4.0.0.

**Does stop the debt growing.** The 91 are recorded; a wrapper declaring a ninety-second fails the build by name; and one that gets fixed has to be deleted from the list rather than quietly re-added.

## The design decision worth reviewing

These are a **separate list**, not an addition to `HOST_RESERVED_PROPS`. That set is *excluded* from the parity requirement, so folding them in would have stopped a wrapper that simply forgot to declare `onclick` from being reported missing — masking the exact class of gap this suite exists to catch.

I confirmed that rather than assuming it. Removing `onclick` from `Avatar.wc.svelte` fails **both**:

```
✘ fixed — delete from KNOWN_HOST_EVENT_HANDLER_DECLARATIONS: Avatar.wc.svelte:onclick
✘ Avatar.wc.svelte is missing: onclick
```

The second is the original parity guard, still firing. Parity is intact.

And adding `onblur` to a wrapper that did not have it fails the new guard by name:

```
✘ new host event-handler overrides: Avatar.wc.svelte:onblur
```

## Verification

lint 0 · `pnpm check` 0 errors over both configs · **915 unit**.

No runtime code is touched — the change is the parity script, its tests, and the README — so I have leaned on CI for the functional and visual suites rather than running them locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling events on Web Components, recommending `addEventListener` instead of assigning to properties such as `onclick`.
  * Documented how event-handler property name collisions can result in unexpected values instead of event objects.

* **Tests**
  * Added validation to detect new collisions between custom-element properties and native event-handler accessors.
  * Added tracking to ensure known event-handler declarations remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->