### PR TITLE
feat(modal): forward aria-label and role to sui-modal's content panel

### DIFF
--- a/docs/Modal.md
+++ b/docs/Modal.md
@@ -37,6 +37,11 @@ A dialog overlay component that renders on top of the page with configurable siz
 | ariaLabel                | `string`                                                                                                                                                  | No       | `-`             | Accessible name for the modal, rendered as `aria-label` on the content panel (the element carrying `role`/`aria-modal` when `role` is set). Without it a screen reader announces an unnamed dialog.                                                                                                                                                                                             |
 | role                     | `ModalRole = 'dialog' \| 'alertdialog'`                                                                                                                   | No       | `-` (unset)     | ARIA role for the content panel. Unset by default — the panel renders no `role` and no `aria-modal`, matching behavior before this prop existed, so an existing consumer who never touches `role` sees no DOM/ARIA change. Set explicitly to opt in: the panel then also carries `aria-modal="true"`. Use `'alertdialog'` for a dialog that interrupts to demand an immediate response (e.g. a destructive confirmation).                                                                                                                                                                                             |
 
+`<sui-modal>` adds two props that do not exist on the Svelte component: `modalRole` and
+`modalAriaLabel` (attributes `modal-role` / `modal-aria-label`). They are forwarding aliases
+for the `role` and `ariaLabel` rows above, and exist only because `role` and `aria-label` are
+reserved accessors on every custom element. See the Web Component section below.
+
 ## Snippets
 
 Svelte 5 Snippet props — pass content blocks to the component.
@@ -248,7 +253,15 @@ Tag: `<sui-modal>`
 </sui-modal>
 ```
 
-`aria-label` and `role` are not props on `<sui-modal>` — they're reserved accessors on every custom element (`ARIAMixin`/`role`), so declaring them as component props would replace the native ones instead of adding to them. Set them as native attributes directly on the host, e.g. `<sui-modal role="alertdialog" aria-label="Delete account">`. `ondismiss` (and `overlayAriaLabel`) are ordinary props and work the same way as on the Svelte component.
+`aria-label` and `role` are not props on `<sui-modal>` — they're reserved accessors on every custom element (`ARIAMixin`/`role`), so declaring them as component props would replace the native ones instead of adding to them. Setting them as native attributes directly on the host (`<sui-modal role="alertdialog" aria-label="Delete account">`) does not name the dialog: it lands on the host element, which the shadow tree wraps around its whole full-screen overlay, not on the `.modal-content` panel that actually carries the accessible name and `aria-modal`. Use `modal-role` / `modal-aria-label` (properties `modalRole` / `modalAriaLabel`) instead — same prefixed-alias pattern as `<sui-toggle>`'s `input-aria-label` — which forward to the panel's `role`/`aria-label`:
+
+```html
+<sui-modal modal-role="alertdialog" modal-aria-label="Delete account">
+  <p>This can't be undone.</p>
+</sui-modal>
+```
+
+The host's own `role`/`aria-label` stay free for whatever the page around the modal wants to do with them. `ondismiss` (and `overlayAriaLabel`) are ordinary props and work the same way as on the Svelte component.
 
 ### Slots
 

--- a/src/wc/components/Modal.wc.svelte
+++ b/src/wc/components/Modal.wc.svelte
@@ -32,24 +32,37 @@
       onprimarybuttonclick: { type: 'Object' },
       onsecondarybuttonclick: { type: 'Object' },
       onoverlayclick: { type: 'Object' },
-      ondismiss: { type: 'Object' }
-      // ariaLabel and role are declared on the Svelte component (#529) but not
-      // here -- both are HOST_RESERVED_PROPS (see scripts/wc-parity), since
-      // declaring them would replace the custom element's own ARIAMixin `role`/
-      // `ariaLabel` accessors. A web-component consumer sets the native
-      // attribute (role="alertdialog") on <sui-modal> directly instead.
+      ondismiss: { type: 'Object' },
+      // ariaLabel and role themselves are HOST_RESERVED_PROPS (see
+      // scripts/wc-parity) -- declaring them here would replace the custom
+      // element's own ARIAMixin `role`/`ariaLabel` accessors, and worse, the
+      // host they'd reflect onto is the shadow root's whole full-screen
+      // wrapper, not the `.modal-content` panel that actually needs the
+      // accessible name (that panel is nested two levels inside the shadow
+      // tree -- see Modal.svelte). `role="alertdialog"` set directly on
+      // `<sui-modal>` looks like it works (the attribute is right there) and
+      // does not: it names the enclosing host, not the dialog panel assistive
+      // tech is looking for. Same fix as Toggle.wc.svelte's `inputAriaLabel` --
+      // a prefixed alias that reaches the inner element the reserved name
+      // cannot.
+      modalAriaLabel: { type: 'String', attribute: 'modal-aria-label' },
+      modalRole: { type: 'String', attribute: 'modal-role' }
     }
   }}
 />
 
 <script lang="ts">
   import Modal from '$lib/Modal/Modal.svelte';
-  let props = $props();
+
+  // Pulled out so they forward to the panel under Modal's own `ariaLabel`/`role`
+  // names instead of the host-reserved ones. Unset by default, so a consumer
+  // who sets neither sees today's unnamed, unroled panel unchanged.
+  let { modalAriaLabel, modalRole, ...props } = $props();
 </script>
 
 <!-- Property-assigned snippets win; the slots are the fallback. The branch stays
      inside the body snippet so `<slot>` keeps its `$$props` scope. -->
-<Modal {...props}>
+<Modal {...props} ariaLabel={modalAriaLabel} role={modalRole}>
   {#snippet content()}
     {#if props.content}{@render props.content()}{:else}<slot></slot>{/if}
   {/snippet}

--- a/tests/modal-wc-aria-forwarding.spec.ts
+++ b/tests/modal-wc-aria-forwarding.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '@playwright/test';
+
+// `role`/`aria-label` set directly on `<sui-modal>` land on the host element --
+// the ARIAMixin accessors every custom element already has -- not on
+// `.modal-content`, the panel two levels inside the shadow tree that actually
+// carries `aria-modal` and the accessible name (see Modal.svelte). The host
+// wraps the whole full-screen overlay, so the attribute looks like it worked
+// (it's right there in the DOM) while assistive tech looking for the dialog
+// finds an unnamed, unroled panel. `modalAriaLabel`/`modalRole` (attributes
+// `modal-aria-label`/`modal-role`) are the forwarding aliases that reach the
+// panel instead -- same prefixed-alias pattern as `<sui-toggle>`'s
+// `inputAriaLabel`, proven by tests/toggle-labelling.spec.ts.
+const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(() => typeof customElements.get('sui-modal') !== 'undefined', null, {
+    timeout: 15_000
+  });
+};
+
+test.describe('sui-modal ARIA forwarding', () => {
+  test('modal-role and modal-aria-label attributes name the content panel, not the host', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    await page.evaluate(() => {
+      const modal = document.createElement('sui-modal');
+      modal.setAttribute('data-pw', 'wc-modal');
+      // Set directly on the host too, so the test also pins that these keep
+      // reflecting their own native ARIAMixin accessors, unreplaced.
+      modal.setAttribute('role', 'note');
+      modal.setAttribute('aria-label', 'Host label');
+      modal.setAttribute('modal-role', 'alertdialog');
+      modal.setAttribute('modal-aria-label', 'Delete account');
+      const body = document.createElement('p');
+      body.textContent = "This can't be undone.";
+      modal.append(body);
+      document.body.append(modal);
+    });
+
+    // The accessibility tree resolves this across the shadow boundary --
+    // proof the panel itself, not just some element in the document, carries
+    // the forwarded role and name.
+    const dialog = page.getByRole('alertdialog', { name: 'Delete account' });
+    await expect(dialog).toBeVisible();
+
+    const host = page.getByTestId('wc-modal');
+    await expect(host).toHaveAttribute('role', 'note');
+    await expect(host).toHaveAttribute('aria-label', 'Host label');
+
+    const panel = host.locator('.modal-content');
+    await expect(panel).toHaveAttribute('role', 'alertdialog');
+    await expect(panel).toHaveAttribute('aria-modal', 'true');
+    await expect(panel).toHaveAttribute('aria-label', 'Delete account');
+  });
+
+  test('modalRole and modalAriaLabel properties do the same as the attributes', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    await page.evaluate(() => {
+      const modal = document.createElement('sui-modal');
+      modal.setAttribute('data-pw', 'wc-modal-props');
+      document.body.append(modal);
+      Reflect.set(modal, 'modalRole', 'dialog');
+      Reflect.set(modal, 'modalAriaLabel', 'Edit profile');
+    });
+
+    await expect(page.getByRole('dialog', { name: 'Edit profile' })).toBeVisible();
+  });
+
+  test('with neither alias set, the panel is unroled and unnamed -- the shipped default', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    await page.evaluate(() => {
+      const modal = document.createElement('sui-modal');
+      modal.setAttribute('data-pw', 'wc-modal-bare');
+      document.body.append(modal);
+    });
+
+    const panel = page.getByTestId('wc-modal-bare').locator('.modal-content');
+    await expect(panel).toBeVisible();
+    await expect(panel).not.toHaveAttribute('role');
+    await expect(panel).not.toHaveAttribute('aria-modal');
+    await expect(panel).not.toHaveAttribute('aria-label');
+  });
+
+  test('role/aria-label set on the host still do not reach the panel -- which is why the aliases exist', async ({
+    page
+  }) => {
+    await loadBundle(page);
+
+    await page.evaluate(() => {
+      const modal = document.createElement('sui-modal');
+      modal.setAttribute('role', 'alertdialog');
+      modal.setAttribute('aria-label', 'Delete account');
+      modal.setAttribute('data-pw', 'wc-modal-host-aria');
+      document.body.append(modal);
+    });
+
+    const host = page.getByTestId('wc-modal-host-aria');
+    const panel = host.locator('.modal-content');
+    await expect(panel).toBeVisible();
+
+    // The attributes are really there on the host -- which is exactly what
+    // makes this a trap. They look applied, and assistive tech looking for the
+    // dialog still finds an unnamed, unroled panel.
+    await expect(host).toHaveAttribute('role', 'alertdialog');
+    await expect(host).toHaveAttribute('aria-label', 'Delete account');
+
+    await expect(panel).not.toHaveAttribute('role');
+    await expect(panel).not.toHaveAttribute('aria-label');
+
+    // This PR is additive: it does not change what host-level attributes do,
+    // it adds a spelling that reaches the panel. A consumer relying on the
+    // host attributes sees exactly what they saw before.
+  });
+});


### PR DESCRIPTION
role and aria-label set on <sui-modal> land on the custom-element host --
the ARIAMixin accessors every element already has -- not on
.modal-content, the panel two levels inside the shadow tree that
actually carries aria-modal and the accessible name. The host wraps the
whole full-screen overlay, so the attribute looks wired and isn't:
assistive tech finds an unnamed, unroled panel.

Add modalAriaLabel/modalRole (attributes modal-aria-label/modal-role),
the same prefixed-alias pattern Toggle.wc.svelte already uses for
inputAriaLabel, forwarded to the inner Modal's ariaLabel/role. Purely
additive: a consumer setting neither alias sees the panel exactly as
before, and the host's own role/aria-label are untouched.

Separate from other work on this branch because it's an unrelated
web-component wrapper fix, not part of the same change.