### PR TITLE
fix(wc): enumerate host event handlers with touch support, catching four it missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,10 +245,11 @@ CSS custom properties apply across the shadow DOM boundary.
 
 ### Event handlers: use `addEventListener`, not `element.onclick`
 
-Handlers are passed as **props**, and 91 of those props are named after event-handler
+Handlers are passed as **props**, and 93 of those props are named after event-handler
 accessors that already exist on `HTMLElement` — `onclick`, `onchange`, `oninput`,
-`onkeydown` and 21 others. On a custom element the component's prop wins, so assigning
-the property does not register a DOM handler the way it would anywhere else:
+`onkeydown`, `ontouchstart` and 22 others. On a custom element the component's prop
+wins, so assigning the property does not register a DOM handler the way it would
+anywhere else:
 
 ```js
 const checkbox = document.querySelector('sui-checkbox');

--- a/scripts/wc-parity/prop-parity.test.ts
+++ b/scripts/wc-parity/prop-parity.test.ts
@@ -147,6 +147,8 @@ const KNOWN_HOST_EVENT_HANDLER_DECLARATIONS: readonly string[] = [
   'Button.wc.svelte:onmousedown',
   'Button.wc.svelte:onmouseup',
   'Button.wc.svelte:onmouseleave',
+  'Button.wc.svelte:ontouchstart',
+  'Button.wc.svelte:ontouchend',
   'Calendar.wc.svelte:onselect',
   'Card.wc.svelte:onclick',
   'Carousel.wc.svelte:onkeydown',

--- a/scripts/wc-parity/prop-parity.ts
+++ b/scripts/wc-parity/prop-parity.ts
@@ -273,12 +273,23 @@ export const HOST_RESERVED_PROPS: ReadonlySet<string> = new Set([
  * that. Reviewed and corrected before merge.
  *
  * Enumerated in Chromium rather than curated by hand: every `on*` own-property
- * name reachable by walking `HTMLElement.prototype`'s chain — 110 of them,
+ * name reachable by walking `HTMLElement.prototype`'s chain — 114 of them,
  * through Element, Node and EventTarget. That is the same "ask the browser, do
  * not reason about it" method the ARIAMixin list above was built with, and it is
  * why `onselect` is here (a genuine host accessor) while `onopen`, `ondismiss`,
  * `onretry` and the library's other 80-odd bespoke handler names are not: they
  * collide with nothing.
+ *
+ * **Enumerate with touch support on.** Four of the 114 — `ontouchstart`,
+ * `ontouchend`, `ontouchmove`, `ontouchcancel` — are only defined when the
+ * browser reports touch, so a plain desktop context reports 110 and quietly
+ * omits them. The first version of this list was built that way and missed all
+ * four, while `Button.wc.svelte` was already declaring two: asking the browser
+ * is only better than reasoning if you ask a browser configured like the ones
+ * consumers use. Playwright's `hasTouch: true` is what makes the difference:
+ *
+ *   without touch -> []
+ *   with touch    -> ontouchstart, ontouchend, ontouchmove, ontouchcancel
  *
  * Re-enumerate if a browser adds handlers. A name missing from this list is not
  * flagged, so the list being complete is what the guard rests on.
@@ -381,6 +392,10 @@ export const HOST_EVENT_HANDLER_PROPS: ReadonlySet<string> = new Set([
   'onsuspend',
   'ontimeupdate',
   'ontoggle',
+  'ontouchcancel',
+  'ontouchend',
+  'ontouchmove',
+  'ontouchstart',
   'ontransitioncancel',
   'ontransitionend',
   'ontransitionrun',


### PR DESCRIPTION
Fixes a hole in the guard #565 added — raised by review on #571, and correct.

## The bug

#565 built `HOST_EVENT_HANDLER_PROPS` by walking `HTMLElement.prototype`'s chain in Chromium and recording every `on*` name it found: **110**. Four are missing from that number, because the touch handlers are only defined when the browser reports touch support, and the context it was enumerated in did not:

```
NO-TOUCH: []
TOUCH:    ["ontouchstart","ontouchend","ontouchmove","ontouchcancel"]
```

So the guard shipped in **4.10.2** with a hole in exactly the shape it was written to close — and the hole was already occupied. `Button.wc.svelte` declares `ontouchstart` and `ontouchend`, both genuine host accessors on every touch-capable browser, and neither was recorded.

Widening the set to **114** surfaces them immediately:

```
✘ new host event-handler overrides: Button.wc.svelte:ontouchstart, Button.wc.svelte:ontouchend
```

They join the recorded list at **93**.

## The lesson, written into the comment

The whole point of enumerating rather than hand-listing was "ask the browser, don't reason about the spec". That only beats reasoning if you ask a browser configured like the ones consumers use, and a headless desktop context is not one. Playwright's `hasTouch: true` is the difference, and the comment now says so explicitly — otherwise the next person to re-enumerate reproduces the same 110 and quietly drops these four again.

## Scope

Nothing is renamed. This remains a recorded debt for a major to clear, and the two touch declarations are recorded rather than fixed for the same reason as the other 91.

## Verification

The red-green is the specific hole, not just a longer list. Adding `ontouchmove` to a wrapper that did not have it now fails by name, where before the widening it passed silently:

```
✘ new host event-handler overrides: Avatar.wc.svelte:ontouchmove
```

Sabotage reverted, tree clean. lint 0 · `pnpm check` 0 errors over both configs · **915 unit**.

No runtime code is touched — the parity script, its test, and the README count.
