### PR TITLE
fix(release): abort a release whose build is already stale, and clear the MCP advisories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,14 +366,53 @@ jobs:
       # the registry stays clean. The reverse failure (pushed, then publish fails)
       # leaves a version commit for an unpublished version, which the existing
       # `npm view ... && exit 0` guard below makes safe to resolve by re-running.
+      # The artifacts were built from this run's checkout, which is pinned to the
+      # SHA that triggered it, but the push below rebases the release commit onto
+      # whatever has landed since. A commit arriving in that window ends up UNDER
+      # a landmark for a version built without it: the repository records it as
+      # released, the tarball does not contain it, and because the landmark has
+      # moved past it its `feat` or `fix` can never reach a later bump.
+      #
+      # 4.10.4 is that, already shipped. Five commits merged in under two minutes;
+      # the run triggered by the first built after four of them had landed, then
+      # rebased its release commit above all five and published. The tarball has
+      # `overlayAriaLabel` from the fourth commit and not `modalAriaLabel` from
+      # the fifth, while `chore(release): 4.10.4` sits on top of both -- so a
+      # `feat(modal)` is recorded as released, is absent from the registry, and
+      # will ship inside whatever patch comes next.
+      #
+      # The check lives inside the push step, between its fetch and its rebase,
+      # rather than in a step of its own. A separate step would have to do its
+      # own fetch, and this one would then fetch again -- so a commit landing in
+      # between would pass the guard and still be rebased over, which is the bug
+      # with extra ceremony. Adjacent to the fetch it depends on, the window is
+      # the two lines below.
+      #
+      # `mcp/` and `.github/` are excluded for the same reason detect-changes
+      # excludes them: neither is part of this package's build, so neither makes
+      # these artifacts stale, and a CI-only release must not block on its own
+      # commit.
       - name: Push changes (without tags)
         run: |
           # Pull latest changes to avoid conflicts
           git fetch origin release
 
-          # Check if we're behind
+          STALE_AGAINST=". :(exclude)mcp/ :(exclude).github/"
+          LANDED="$(git rev-list HEAD..origin/release -- $STALE_AGAINST)"
+          if [ -n "$LANDED" ]; then
+            echo "::error::Commits landed on release while this run was building:"
+            git log --oneline HEAD..origin/release -- $STALE_AGAINST
+            echo "They are not in the artifacts this run built, and rebasing onto them"
+            echo "would put the release commit above code it does not contain."
+            echo "Aborting before anything is written, so the next run publishes a"
+            echo "version that contains them and derives its bump from them."
+            exit 1
+          fi
+
+          # Only refs this build is unaffected by can be below us here, so the
+          # rebase can no longer move the release commit over unbuilt code.
           if [ $(git rev-list --count HEAD..origin/release) -gt 0 ]; then
-            echo "Local branch is behind remote. Attempting to rebase..."
+            echo "Local branch is behind remote on excluded paths only; rebasing..."
             git rebase origin/release
           fi
 
@@ -658,8 +697,24 @@ jobs:
           fi
           git tag -a "$TAG_NAME" -m "Release @juspay/svelte-ui-components-mcp $NEW_VERSION"
 
-          # Rebase on any concurrent changes, then push commit + tag
+          # Same check as the pre-publish one, repeated here because this fetch is
+          # a second look at the branch: an MCP commit landing between the two
+          # would otherwise be rebased under a landmark for a version published
+          # without it. Failing here is the recoverable outcome -- the version is
+          # on the registry with no landmark, and the `npm view ... && exit 0`
+          # guard above lets a re-run write the landmark instead of republishing.
           git fetch origin release
+          LANDED="$(git rev-list HEAD..origin/release -- mcp/)"
+          if [ -n "$LANDED" ]; then
+            echo "::error::MCP commits landed after this version was published:"
+            git log --oneline HEAD..origin/release -- mcp/
+            echo "The MCP package at $NEW_VERSION is on the registry but does not"
+            echo "contain them. Not rebasing the landmark over them; re-run once they"
+            echo "are released so the landmark lands where the build actually was."
+            exit 1
+          fi
+
+          # Rebase on any concurrent changes, then push commit + tag
           if [ "$(git rev-list --count HEAD..origin/release)" -gt 0 ]; then
             git rebase origin/release
           fi

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juspay/svelte-ui-components-mcp",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juspay/svelte-ui-components-mcp",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -925,9 +925,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1128,9 +1128,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1384,12 +1384,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1592,14 +1593,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1611,13 +1612,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
Two changes in one commit, at the repository owner's direction. They ride together because the MCP half is what exercises the publish path the first half protects.

## 4.10.4 shipped without a commit it claims to contain

The root release job builds from its own checkout — pinned to the SHA that triggered it — and then rebases the release commit onto whatever has landed since, before pushing. A commit arriving in that window ends up **under** a landmark for a version built without it.

That is not hypothetical. Five commits merged in under two minutes today; the run triggered by the first built after four of them had landed, rebased its release commit above all five, and published:

| commit | in the published 4.10.4 tarball |
|---|---|
| `4ba6957` fix(accordion) | ✅ |
| `d4c8a91` feat(pill) · `c6f0382` docs(card) | ✅ |
| `6162f5f` fix(sheet) — `overlayAriaLabel` | ✅ |
| `754694c` **feat(modal)** — `modalAriaLabel` | ❌ |

`chore(release): 4.10.4` sits above all of them. So `feat(modal)` is recorded as released, is absent from the registry, and — because the landmark has moved past it — its `feat` can never reach a later bump. It will ship inside whatever patch comes next.

That is the 3.5.1 failure again, a version understating what is in it, reached by a different route: not the version derivation, which is correct, but the gap between what was built and where the landmark landed.

## The fix

Both jobs now check for commits that landed during the run and abort **before** writing anything — the last point at which stopping is free.

`publish-mcp` got this in #571. The root job has the identical window and I left it alone, which was an omission rather than a decision: I argued its git-writes-first *ordering* was correct — it is — and did not notice that the rebase window is a separate defect present in both.

The root check excludes `mcp/` and `.github/` for the same reason `detect-changes` does: neither is part of this package's build, so neither makes its artifacts stale.

### Verified against the real history, not assumed

```
git rev-list b941104..8df18d4 -- . ':(exclude)mcp/' ':(exclude).github/'   → 6
git rev-list 1811375^..1811375 -- . ':(exclude)mcp/' ':(exclude).github/'  → 0
```

The first is the 4.10.4 range: the guard would have fired. The second is #571's workflow-only merge: a release that only changes CI is not blocked by its own commit.

## The MCP half

`npm audit fix` on the MCP lockfile, clearing **5 advisories — 2 high, 3 moderate** — in `hono`, `ip-address` and `qs`. `npm audit` now reports 0, and `npm run build` passes.

It also resyncs the lockfile's own version, which said `4.0.2` while `mcp/package.json` said `4.0.3`: the failed release run bumped the manifest, committed it, and never updated the lockfile beside it.

## Why this is the run to watch

Trusted publishing was configured for `@juspay/svelte-ui-components-mcp` today. Until now that job had **never** published — 4.0.1 and 4.0.2 were both published by hand, which is what hid the `ENEEDAUTH` failure. This should be the first MCP release that publishes from CI, and it carries out the `body-parser` CVE fix that #419 merged and never shipped.

Touching only `.github/` and `mcp/` means `detect-changes` reports `root_changed=false`, so **no root version is cut by this**.

## Scope

Two files: `.github/workflows/release.yml` and `mcp/package-lock.json`. No runtime, test or source code is touched, so I have leaned on CI for the suites rather than claiming local runs that would prove nothing about this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Release publishing now checks for new root-package changes that arrive during the release process.
  - If relevant changes are detected, the release is stopped before creating or publishing a release commit.
  - Changes limited to MCP-related or workflow configuration areas are excluded from this check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->