### PR TITLE
fix(mcp): declare the repository so provenance can be verified

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@juspay/svelte-ui-components-mcp",
   "version": "4.0.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juspay/svelte-ui-components",
+    "directory": "mcp"
+  },
   "description": "MCP server for @juspay/svelte-ui-components - provides structured access to component props, CSS variables, and usage patterns",
   "type": "module",
   "main": "build/index.js",


### PR DESCRIPTION
The last blocker between the branch and a published MCP release.

## What changed since the last attempt

Configuring trusted publishing for `@juspay/svelte-ui-components-mcp` cleared the `ENEEDAUTH` that had failed every run this package has ever had. The next run got one step further and failed differently:

```
npm error code E422
422 Unprocessable Entity - PUT https://registry.npmjs.org/@juspay%2fsvelte-ui-components-mcp
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/juspay/svelte-ui-components" from provenance
```

That is progress: authentication now works, and the failure moved to the payload.

## The cause

`npm publish --provenance` signs an attestation naming the repository the build came from, and the registry rejects the upload unless the manifest agrees with it. `mcp/package.json` has **no `repository` field at all**, so the comparison runs against an empty string and can never match.

The root `package.json` has always declared one, which is why only this package is affected:

| package | `repository.url` |
|---|---|
| `@juspay/svelte-ui-components` | `https://github.com/juspay/svelte-ui-components` |
| `@juspay/svelte-ui-components-mcp` | *(absent)* |

## The fix

Five lines of metadata, mirroring the root's url and naming the subdirectory — the convention for a package inside a monorepo:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/juspay/svelte-ui-components",
  "directory": "mcp"
}
```

## What is waiting on this

`mcp/package.json` is at **4.0.3**; the registry still serves **4.0.2**. Sitting in that gap:

- the `body-parser` CVE fix merged in #419 and never shipped
- the `hono`, `ip-address` and `qs` advisories cleared in #577 — 2 high, 3 moderate

## Verification

`npm run build` in `mcp/` succeeds and the manifest parses. Five lines of metadata in one file; no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository metadata linking the package to its source repository and subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->