### PR TITLE
fix(typewriter): honour prefers-reduced-motion, matching ChatController

### DIFF
--- a/docs/Chat.md
+++ b/docs/Chat.md
@@ -73,6 +73,10 @@ Markdown is bundled: set a message's `markdown` field and it renders in the bubb
 
 `ChatControllerOptions`: `transport` (required `ChatTransport`), `initialMessages?`, `typewriter?` (reveal text char-by-char), `generateId?` (defaults to `crypto.randomUUID()`).
 
+**`typewriter` and the standalone `TypewriterText` component are two ways to do one job — use exactly one.** The controller's reveal drains buffered chunks into `msg.content` itself, so it needs no extra component and is what the example above uses. `TypewriterText` is the standalone alternative, worth reaching for when you want pacing control the option does not expose (`variableDelay`, `resolveDelay`, `renderCharacter`, `onprogress`).
+
+Combining them is the one thing to avoid: with `typewriter: true` **and** a `messageBody` snippet rendering `<TypewriterText text={msg.content} … />`, `msg.content` is already growing character by character, and `TypewriterText` re-types each increment on its own cadence — a compounding double-reveal. Set `typewriter: false` (or leave it unset) whenever a snippet owns the reveal. Both honour `prefers-reduced-motion: reduce` and disclose text without animating it.
+
 `ChatTransport`: `(input: { message, history, sessionId, signal }, handlers: ChatStreamHandlers) => Promise<void>`. Handlers: `onText` (required), `onToolStatus?`, `onAttachment?`, `onError?`, `onDone?`. The controller threads sessions for you: whatever a transport reports via `onDone({ sessionId })` is passed back on the next request's `input.sessionId`.
 
 **Roles.** Messages use the two-party primitive `role` — `sender` / `responder` (see `ChatMessage`). The controller emits those, and `partyOf(role)` resolves any role (including the `user`/`assistant`/`system` extensions) to its party. Map the primitive to your provider's roles inside the transport, where the API-specific terms belong: `history.map((m) => ({ role: partyOf(m.role) === 'sender' ? 'user' : 'assistant', content: m.content }))`.

--- a/docs/TypewriterText.md
+++ b/docs/TypewriterText.md
@@ -2,6 +2,15 @@
 
 Reveals text one character at a time, the way a streaming model answer reads. Built for streaming: while `isStreaming` is `true`, typing follows the growing `text` without restarting; the moment it turns `false`, the remainder appears at once.
 
+Typing is an animation, so it honours `prefers-reduced-motion: reduce`: when the reader has asked for less motion, text is disclosed as it arrives instead of being typed, and `speed` / `variableDelay` / `resolveDelay` are not consulted. `onprogress` still fires, once per disclosure rather than once per character.
+
+> **Already using `ChatController` with `typewriter: true`? Do not also wrap `msg.content` in this component.**
+>
+> Both reveal text progressively, and they compose badly: the controller is already growing `msg.content` character by character, so a `messageBody` snippet that renders `<TypewriterText text={msg.content} isStreaming={msg.streaming} />` re-types every increment on its own cadence — a compounding double-reveal, not merely duplicated work. Pick one:
+>
+> - **Reveal handled by the controller** — set `typewriter: true` and render `msg.content` as plain text. Simplest, and what `Chat`'s own examples use.
+> - **Reveal handled here** — leave `typewriter` unset (or `false`) on the controller and wrap `msg.content` in `TypewriterText`. Reach for this when you want per-character control the controller does not expose: `variableDelay`, `resolveDelay`, `renderCharacter`, or `onprogress`.
+
 ## Usage
 
 ```svelte

--- a/src/lib/Chat/controller.svelte.ts
+++ b/src/lib/Chat/controller.svelte.ts
@@ -1,4 +1,5 @@
 import { partyOf } from './roles';
+import { prefersReducedMotion } from '../utils';
 import type {
   ChatControllerOptions,
   ChatMessageData,
@@ -8,14 +9,6 @@ import type {
 
 const REVEAL_CHARS_PER_TICK = 2;
 const REVEAL_INTERVAL_MS = 22;
-
-function prefersReducedMotion(): boolean {
-  return (
-    typeof window !== 'undefined' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  );
-}
 
 let idCounter = 0;
 

--- a/src/lib/TypewriterText/TypewriterText.svelte
+++ b/src/lib/TypewriterText/TypewriterText.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy, untrack } from 'svelte';
+  import { prefersReducedMotion } from '../utils';
   import type { TypewriterTextProperties, TypewriterCharacterDelayRange } from './properties';
 
   let {
@@ -75,7 +76,34 @@
     return speed;
   };
 
+  // Disclose everything still pending at once. The whitespace count has to be rebuilt
+  // from the text itself because the per-character path that normally maintains it is
+  // skipped entirely, and a later continuation would otherwise resume from a count that
+  // never saw the revealed suffix.
+  const revealRemainingText = (): void => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    const hadRemainingText = currentIndex < text.length;
+    displayedText = text;
+    currentIndex = text.length;
+    revealedWordCount = countWhitespace(text);
+    if (hadRemainingText) {
+      onprogress?.({ index: currentIndex, total: text.length, displayedText });
+    }
+  };
+
   const typeNextCharacter = (): void => {
+    // Typing IS the animation here, so a reduced-motion request has to suppress the
+    // reveal itself rather than a transition around it: disclose the text instead.
+    // `ChatController` already bypasses its own drain loop on this setting, and the two
+    // reveal implementations have to answer it identically — a consumer composing this
+    // component through `Chat`'s `messageBody` snippet is running both at once.
+    if (prefersReducedMotion()) {
+      revealRemainingText();
+      return;
+    }
     if (currentIndex < text.length) {
       const revealedCharacter = text[currentIndex];
       const revealedCharacterIndex = currentIndex;
@@ -122,6 +150,7 @@
         if (currentIndex >= previousTextLength) {
           if (timeoutId !== null) {
             clearTimeout(timeoutId);
+            timeoutId = null;
           }
           typeNextCharacter();
         }
@@ -133,16 +162,7 @@
   // eslint-disable-next-line no-restricted-syntax
   $effect(() => {
     if (!isStreaming && text.length > 0) {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-      const hadRemainingText = currentIndex < text.length;
-      displayedText = text;
-      currentIndex = text.length;
-      revealedWordCount = countWhitespace(text);
-      if (hadRemainingText) {
-        onprogress?.({ index: currentIndex, total: text.length, displayedText });
-      }
+      revealRemainingText();
     }
   });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -315,6 +315,23 @@ export function clampInt(v: string, min: number, max: number): number {
 
 // ── Misc ────────────────────────────────────────────────────────
 
+/**
+ * Whether the user has asked the OS to minimise animation.
+ *
+ * Shared rather than per-component: two independent character-reveal
+ * implementations ship in this library — `ChatController`'s buffered drain and
+ * `TypewriterText`'s typing loop — and a reveal that honours this setting in one
+ * but not the other means the same OS preference silences an animation in a chat
+ * bubble and leaves it running in the message body rendered inside it.
+ */
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
 export function createDebouncer(delay: number) {
   let lastCallTime = 0;
   return function <T extends unknown[]>(callback: (...args: T) => void, ...args: T) {

--- a/tests/typewriter-text-reduced-motion.test.ts
+++ b/tests/typewriter-text-reduced-motion.test.ts
@@ -1,0 +1,159 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// `ChatController` bypasses its character-by-character reveal entirely when the user
+// asks for reduced motion (`prefersReducedMotion()`, consulted by `feed()`), but
+// `TypewriterText` — which exists to do the same job, and whose own tagline is "reveals
+// text one character at a time, the way a streaming model answer reads" — had no such
+// handling. The same OS setting therefore silenced one reveal implementation and not the
+// other, so a consumer composing `TypewriterText` through `Chat`'s `messageBody` snippet
+// kept the animation the setting exists to suppress. See #465.
+//
+// Emulation is applied with `page.emulateMedia()` rather than the more idiomatic
+// `test.use({ reducedMotion: 'reduce' })`. That is deliberate and load-bearing: under
+// this config `test.use` does NOT reach the page — `matchMedia('(prefers-reduced-motion:
+// reduce)').matches` stays `false`, so the "reduce" test would render an un-emulated page
+// and fail for a reason that has nothing to do with the component. Verified both ways
+// before writing this. Do not "simplify" it back to `test.use`.
+//
+// Timing is measured from the FIRST text mutation to the LAST via a MutationObserver
+// installed before navigation, never from an expect() poll — matching the pattern the
+// component's existing pacing tests already establish.
+
+const BASELINE_TEXT = 'Baseline pacing check text stays fast.';
+const BASELINE_TEST_ID = 'typewriter-default-pacing';
+
+// Longer and slower (74 characters at speed=20) than the baseline fixture, which leaves room
+// to flip the preference while typing is genuinely still in flight.
+const PROGRESS_TEXT = 'Progress reporting keeps a scroll container pinned to the newest character.';
+const PROGRESS_TEST_ID = 'typewriter-progress-demo';
+
+type RevealTiming = { firstAt: number | null; lastAt: number | null; mutations: number };
+
+const installRevealObserver = async (
+  page: Page,
+  testId: string,
+  windowKey: string
+): Promise<void> => {
+  await page.addInitScript(
+    ({ testId, windowKey }: { testId: string; windowKey: string }) => {
+      const timing: RevealTiming = { firstAt: null, lastAt: null, mutations: 0 };
+      (window as unknown as Record<string, RevealTiming>)[windowKey] = timing;
+      const attach = () => {
+        const element = document.querySelector(`[data-pw="${testId}"]`);
+        if (!element) {
+          requestAnimationFrame(attach);
+          return;
+        }
+        new MutationObserver(() => {
+          if ((element.textContent || '').length === 0) {
+            return;
+          }
+          if (timing.firstAt === null) {
+            timing.firstAt = performance.now();
+          }
+          timing.lastAt = performance.now();
+          timing.mutations += 1;
+        }).observe(element, { childList: true, subtree: true, characterData: true });
+      };
+      requestAnimationFrame(attach);
+    },
+    { testId, windowKey }
+  );
+};
+
+const readTiming = async (
+  page: Page,
+  windowKey: string
+): Promise<{ mutations: number; elapsedMs: number }> => {
+  return page.evaluate((key: string) => {
+    const timing = (window as unknown as Record<string, RevealTiming>)[key];
+    const elapsedMs =
+      timing && timing.firstAt !== null && timing.lastAt !== null
+        ? Math.round(timing.lastAt - timing.firstAt)
+        : -1;
+    return { mutations: timing ? timing.mutations : -1, elapsedMs };
+  }, windowKey);
+};
+
+test('reduced motion reveals the whole string at once instead of typing it', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await installRevealObserver(page, BASELINE_TEST_ID, '__reducedMotionTiming');
+  await page.goto('/components/typewriter-text');
+
+  // The emulation is the premise of the assertion below, so prove it landed rather than
+  // trusting it — an un-emulated page would type, and the failure would look like a
+  // component bug.
+  const emulationActive = await page.evaluate(
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+  expect(emulationActive).toBe(true);
+
+  await expect(page.locator(`[data-pw="${BASELINE_TEST_ID}"]`)).toHaveText(BASELINE_TEXT);
+
+  const { mutations, elapsedMs } = await readTiming(page, '__reducedMotionTiming');
+
+  // One mutation carrying the entire string — not one per character. The length is what
+  // makes this meaningful: typing this text at the default 15ms cadence takes well over
+  // half a second and mutates the node 38 times.
+  expect(mutations).toBe(1);
+  expect(elapsedMs).toBeLessThan(50);
+});
+
+// Raised in review as a possible defect: because `prefersReducedMotion()` is a one-shot
+// call rather than a subscription, does a reveal already in flight keep typing until the
+// text changes or completes?
+//
+// It does not, and this is the proof rather than an argument. `typeNextCharacter()` re-enters
+// through its own `setTimeout` chain and re-reads the preference at the top of every call, so
+// the switch is picked up on the very next character — within one `speed` interval, 20ms on
+// this fixture. A subscription would buy nothing here and would add a listener to unregister.
+test('a mid-stream switch to reduced motion stops the typing immediately', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await installRevealObserver(page, PROGRESS_TEST_ID, '__midStreamTiming');
+  await page.goto('/components/typewriter-text');
+
+  const typewriter = page.locator(`[data-pw="${PROGRESS_TEST_ID}"]`);
+
+  // Catch it as early as possible: the default poll cadence lets ~57 of the 74 characters
+  // type before it first reports, which leaves too little to distinguish the two behaviours.
+  await expect
+    .poll(async () => ((await typewriter.textContent()) ?? '').length, { intervals: [10] })
+    .toBeGreaterThan(0);
+
+  const revealedAtToggle = ((await typewriter.textContent()) ?? '').length;
+  const remaining = PROGRESS_TEXT.length - revealedAtToggle;
+
+  // The toggle has to land with more left to type than the bound below, or the assertion
+  // would pass for the wrong reason. Fail loudly here instead of silently proving nothing.
+  expect(remaining).toBeGreaterThan(12);
+
+  const mutationsAtToggle = (await readTiming(page, '__midStreamTiming')).mutations;
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await expect(typewriter).toHaveText(PROGRESS_TEXT);
+
+  const mutationsAfterToggle =
+    (await readTiming(page, '__midStreamTiming')).mutations - mutationsAtToggle;
+
+  // The bound is absolute rather than scaled, because the two behaviours differ in kind:
+  // disclosing is ONE mutation plus however many characters type during the CDP round-trip
+  // while the emulation lands — a small constant, independent of how much text was left —
+  // whereas continuing to type is one mutation per remaining character.
+  expect(mutationsAfterToggle).toBeLessThanOrEqual(6);
+});
+
+// The control. Without it, `mutations === 1` would also pass if the reveal were broken
+// outright or the observer never attached — this proves the measurement distinguishes the
+// two states rather than always reporting "instant".
+test('with motion allowed it still types character by character', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await installRevealObserver(page, BASELINE_TEST_ID, '__fullMotionTiming');
+  await page.goto('/components/typewriter-text');
+
+  await expect(page.locator(`[data-pw="${BASELINE_TEST_ID}"]`)).toHaveText(BASELINE_TEXT);
+
+  const { mutations, elapsedMs } = await readTiming(page, '__fullMotionTiming');
+
+  expect(mutations).toBeGreaterThan(BASELINE_TEXT.length / 2);
+  expect(elapsedMs).toBeGreaterThan(200);
+});


### PR DESCRIPTION
Closes #465.

Two components in this library reveal text progressively, and only one of them answered the reader's motion preference.

`ChatController` bypasses its drain loop entirely when `prefers-reduced-motion: reduce` is set. `TypewriterText` — which exists to do the same job, and whose own tagline is *"reveals text one character at a time, the way a streaming model answer reads"* — had **no such handling at all**. The same OS setting silenced the reveal in a chat bubble and left it running in a message body rendered inside that very bubble, which is a supported composition: `Chat`'s `messageBody` snippet.

## What changed

Typing *is* the animation here, so honouring the setting means suppressing the reveal itself rather than a transition around it. Under `reduce`, text is now disclosed as it arrives; `speed`, `variableDelay` and `resolveDelay` are not consulted. `onprogress` still fires, once per disclosure instead of once per character — the same contract the existing `isStreaming: false` bulk path already had.

The predicate moves to `src/lib/utils.ts` and **both** implementations import it, rather than a second hand-written copy. That is the point: a duplicated reduced-motion check is exactly how the two reveals drifted apart in the first place. `lockBodyScroll` set the precedent for a shared browser-level concern. It is not exported from the public index — this is a fix, not new API.

`revealRemainingText()` is extracted from the `isStreaming: false` effect, which already did precisely this, so the reduced-motion path and the end-of-stream path are now one implementation rather than two that must be kept in agreement.

## Evidence

A real red-green cycle, not a test written after the fact:

```
guard disabled -> reduce test FAILS (38 mutations, one per character)
                  control test PASSES
guard enabled  -> both PASS
```

The control is deliberate. Without it, `mutations === 1` would also pass if the reveal were broken outright or the observer never attached, so it proves the measurement distinguishes the two states rather than always reporting "instant".

**One trap worth recording, since it cost a wrong diagnosis.** The idiomatic `test.use({ reducedMotion: 'reduce' })` does **not** reach the page under this config — `matchMedia(...).matches` stays `false`, so the test renders an un-emulated page and fails for a reason unrelated to the component. Verified both ways:

```
PROBE test.use      = false
PROBE emulateMedia  = true
```

The test uses `page.emulateMedia()` and asserts the emulation actually landed before asserting anything about the reveal. There is a comment saying not to "simplify" it back.

## Docs

Both pages now warn against the double-reveal that combining `typewriter: true` with a `TypewriterText` `messageBody` produces — the controller is already growing `msg.content` character by character, so `TypewriterText` re-types each increment on its own cadence.

Cross-links use plain backticked names, not relative `.md` links: those resolve to `/components/<name>.md` and **fail the prerender build outright**, which is how I found out.

## Verification

| check | result |
| --- | --- |
| `pnpm lint` | 0 |
| `pnpm check` | 0 |
| unit (vitest) | 919 passed |
| Playwright — typewriter pacing, resolveDelay, reduced motion, ChatMessage typewriter | 18 passed |
| Playwright — full functional suite | 605 passed, 1 skipped |

## Scope

This closes the behavioural divergence and the documented failure mode. The ~114 LOC of independently-written reveal logic that #465 also describes is **not** consolidated here — that needs an API decision (the issue lays out three options, all with regression risk), and this change deliberately does not pre-empt it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved reduced-motion support for text reveal. When enabled, text appears immediately instead of animating, while progress callbacks continue to work appropriately.
  - Normal motion continues to reveal streamed text incrementally.

- **Documentation**
  - Clarified that controller-managed typewriter output and the standalone text-reveal component are alternative approaches.
  - Added configuration guidance to prevent doubled or compounded reveal effects when using custom message rendering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->