### PR TITLE
docs(pill): document the dark-theme recipe, and stop the demo silently killing tone

### DIFF
--- a/docs/Pill.md
+++ b/docs/Pill.md
@@ -84,6 +84,75 @@ once per theme, then pass `tone` at each call site:
 directly, or via `classes`) always wins over the tone default, so a one-off recolor doesn't
 need to fork the tone.
 
+### Dark Theme
+
+Every fallback baked into Pill is a light value (`--pill-background` falls back to `#e0e0e0`,
+`--pill-color` to `#333333`, and each `tone` to a pastel pair), so a pill dropped onto a dark
+page keeps its light chip until you override the variables.
+
+Theme the **tone** variables at the theme root. These are always safe to set globally — each one
+only reaches the pills carrying that tone:
+
+```css
+/* app.css */
+[data-theme='dark'] {
+  --pill-tone-accent-background: #11262e;
+  --pill-tone-accent-color: #7dd3fc;
+  --pill-tone-ok-background: #10281a;
+  --pill-tone-ok-color: #6ee7a8;
+  --pill-tone-warn-background: #2e2410;
+  --pill-tone-warn-color: #fcd34d;
+  --pill-tone-danger-background: #2d1416;
+  --pill-tone-danger-color: #fca5a5;
+  --pill-tone-muted-background: #252535;
+  --pill-tone-muted-color: #9ca3af;
+}
+```
+
+Those pairs all clear WCAG AA for normal text (5.9:1 at the lowest, `muted`; the rest sit
+between 9:1 and 10.6:1). Reusing the light defaults on a dark ground is what fails — `#155724`
+on `#252535` is 1.74:1, well under the 4.5:1 floor.
+
+For pills that carry **no** tone, set the base pair — but scope it to the containers those pills
+live in, rather than the theme root:
+
+```css
+/* app.css — the filter bar and tag row hold untoned pills */
+[data-theme='dark'] .filter-bar,
+[data-theme='dark'] .tag-row {
+  --pill-background: #252535;
+  --pill-color: #d1d5db;
+  --pill-hover-background: #2f2f45;
+  --pill-hover-color: #e5e7eb;
+  --pill-dismiss-color: #9ca3af;
+  --pill-dismiss-hover-color: #e5e7eb;
+}
+```
+
+**The scoping is the whole point, and skipping it is easy to do: a global `--pill-background` /
+`--pill-color` silently disables `tone`.** Pill resolves colour as
+`var(--pill-background, var(--_pill-tone-background, …))`, so an explicit value wins and the tone
+layer is never consulted — every `tone="ok"` and `tone="danger"` chip renders in the same neutral
+grey as an untoned one, with no error and no visual hint that the prop stopped working. Measured
+on a real `tone="ok"` pill:
+
+| | background | color |
+| --- | --- | --- |
+| tone alone | `#d4edda` | `#155724` |
+| tone + a global `--pill-background`/`--pill-color` | `#252535` | `#d1d5db` |
+
+This library's own demo site had exactly that bug: all five tones rendered byte-identical in dark
+mode. If you have no convenient container to scope to, exclude the tone classes instead —
+`[data-theme='dark'] .pill:not(.tone-accent, .tone-ok, .tone-warn, .tone-danger, .tone-muted)` —
+though that couples your stylesheet to Pill's internal class names, so prefer your own containers
+where you have them.
+
+The `pill-success` / `pill-warning` / `pill-error` / `pill-info` class recipes in **Theming with
+Classes** above are light-only by design: they are example CSS you own once you paste them into
+your app, not something Pill ships. If you use them and support a dark theme, give them dark
+counterparts the same way — or prefer `tone`, which exists precisely so the colour pair lives in
+one themeable place instead of being repeated per call site.
+
 ### Attribute Passthrough
 
 `attrs` spreads arbitrary `data-*`/`aria-*` attributes onto the pill root — for a consumer

--- a/src/routes/components/demo.css
+++ b/src/routes/components/demo.css
@@ -164,11 +164,21 @@
   --attachment-chip-row-file-glyph-color: #9ca3af;
   --attachment-chip-row-file-glyph-fold-color: #1e1e2e;
 
-  /* Pill — chat suggestion chips and composer attachment pills */
-  --pill-background: #252535;
-  --pill-color: #d1d5db;
-  --pill-hover-background: #2f2f45;
-  --pill-hover-color: #e5e7eb;
+  /* Pill — dark counterparts for the semantic tones. Without these a status chip
+     falls back to Pill's built-in light pastels, which are unreadable on this
+     ground: the `ok` text #155724 on the neutral chip below is 1.74:1. Every pair
+     here clears WCAG AA (5.93:1 at the lowest, `muted`). The neutral chip itself
+     is scoped separately, below this block — see the note there. */
+  --pill-tone-accent-background: #11262e;
+  --pill-tone-accent-color: #7dd3fc;
+  --pill-tone-ok-background: #10281a;
+  --pill-tone-ok-color: #6ee7a8;
+  --pill-tone-warn-background: #2e2410;
+  --pill-tone-warn-color: #fcd34d;
+  --pill-tone-danger-background: #2d1416;
+  --pill-tone-danger-color: #fca5a5;
+  --pill-tone-muted-background: #252535;
+  --pill-tone-muted-color: #9ca3af;
 
   /* ThinkingTrace */
   --thinking-indicator-trace-connector-color: #2a2a3c;
@@ -220,6 +230,25 @@
   --task-list-retry-background: #2a1416;
   --task-list-retry-color: #f87171;
   --task-list-retry-hover-background: #3b1a1c;
+}
+
+/* Pill — the neutral dark chip for chat suggestion chips and composer attachment
+   pills, which carry no tone.
+
+   Deliberately NOT set alongside the other tokens in the block above. Pill resolves
+   colour as `var(--pill-background, var(--_pill-tone-background, …))`, so a bare
+   --pill-background on the theme root wins over the tone layer by design (see
+   docs/Pill.md). Set there, it silently flattened every tone="…" chip to this same
+   grey — all five tones rendered byte-identical in dark mode, so the Pill demo
+   showed five indistinguishable chips labelled Accent/Ok/Warn/Danger/Muted.
+
+   Excluding the tone classes keeps the neutral chip for the untoned pills that
+   wanted it, and lets the tone variables above reach the ones that carry a tone. */
+[data-theme='dark'] .pill:not(.tone-accent, .tone-ok, .tone-warn, .tone-danger, .tone-muted) {
+  --pill-background: #252535;
+  --pill-color: #d1d5db;
+  --pill-hover-background: #2f2f45;
+  --pill-hover-color: #e5e7eb;
 }
 
 .page-header {

--- a/tests/pill-dark-theme-tones.test.ts
+++ b/tests/pill-dark-theme-tones.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+// #464. The demo shell used to set `--pill-background` / `--pill-color` on
+// `[data-theme='dark']` itself, for the untoned chat suggestion chips and composer
+// attachment pills. But Pill resolves colour as
+// `var(--pill-background, var(--_pill-tone-background, …))`, so a bare value on the theme
+// root wins over the tone layer by design — which silently flattened every `tone="…"` chip
+// to that same grey. All five tones rendered byte-identical, so the Pill demo showed five
+// indistinguishable chips labelled Accent/Ok/Warn/Danger/Muted in dark mode.
+//
+// This guards both halves of the fix: tones stay distinct, and the untoned pills keep the
+// neutral chip the override existed to give them.
+
+const TONES = ['accent', 'ok', 'warn', 'danger', 'muted'] as const;
+
+const NEUTRAL_DARK_BACKGROUND = 'rgb(37, 37, 53)';
+const NEUTRAL_DARK_COLOR = 'rgb(209, 213, 219)';
+
+const paintOf = (page: import('@playwright/test').Page, testId: string) =>
+  page.locator(`[data-pw="${testId}"]`).evaluate((el) => {
+    const s = getComputedStyle(el);
+    return `${s.backgroundColor} / ${s.color}`;
+  });
+
+// `paintOf` is a one-shot read, so the dark theme has to have actually landed before any of
+// them run. Rather than poll a custom property by string — `getPropertyValue` returns values
+// verbatim, leading whitespace included, so an equality check there is its own flake — this
+// waits on a web-first assertion, which retries until the style resolves. Nothing transitions
+// in the demo shell today, so this is future-proofing rather than a live fix.
+test.beforeEach(async ({ page }) => {
+  await page.goto('/components/pill');
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+  await expect(page.locator('[data-pw="attrs-none-pill"]')).toHaveCSS(
+    'background-color',
+    NEUTRAL_DARK_BACKGROUND
+  );
+});
+
+test('every tone stays visually distinct in the dark theme', async ({ page }) => {
+  const paints = await Promise.all(TONES.map((tone) => paintOf(page, `pill-tone-${tone}`)));
+
+  expect(new Set(paints).size).toBe(TONES.length);
+
+  // ...and none of them has collapsed to the neutral chip, which is what the regression
+  // looked like. `muted` deliberately shares the neutral background but not its text
+  // colour, so compare the pair rather than the background alone.
+  for (const paint of paints) {
+    expect(paint).not.toBe(`${NEUTRAL_DARK_BACKGROUND} / ${NEUTRAL_DARK_COLOR}`);
+  }
+});
+
+test('an untoned pill still gets the neutral dark chip', async ({ page }) => {
+  expect(await paintOf(page, 'attrs-none-pill')).toBe(
+    `${NEUTRAL_DARK_BACKGROUND} / ${NEUTRAL_DARK_COLOR}`
+  );
+});


### PR DESCRIPTION
Closes #464.

Every fallback baked into Pill is a light literal — `--pill-background` to `#e0e0e0`, `--pill-color` to `#333333`, and each of the five tones to a pastel pair — and `docs/Pill.md` had no dark section at all. The only dark recipe in the repo was an incidental four-variable block in `src/routes/components/demo.css`, which exists because Pill is reused inside the chat surfaces, not because Pill's own dark story was ever written down.

Writing that section turned up a real bug in the demo, so this fixes it too.

## A global `--pill-background` silently disables `tone`

Pill resolves colour as `var(--pill-background, var(--_pill-tone-background, …))`, so an explicit base value wins and the tone layer is never consulted. There is no error and no visual hint that the prop stopped working.

`demo.css` set exactly that pair on `[data-theme='dark']` itself. Measured on the real elements on `/components/pill`, before the fix:

| tone | light | dark (before) |
| --- | --- | --- |
| accent | `rgb(209,236,241)` | `rgb(37,37,53)` |
| ok | `rgb(212,237,218)` | `rgb(37,37,53)` |
| warn | `rgb(255,243,205)` | `rgb(37,37,53)` |
| danger | `rgb(248,215,218)` | `rgb(37,37,53)` |
| muted | `rgb(241,241,241)` | `rgb(37,37,53)` |

All five byte-identical. In dark mode the Pill demo rendered five indistinguishable grey chips labelled Accent / Ok / Warn / Danger / Muted, on this library's own documentation site.

After:

```
accent rgb(17,38,46)  ok rgb(16,40,26)  warn rgb(46,36,16)
danger rgb(45,20,22)  muted rgb(37,37,53)
```

## Why the fix is scoped by tone, not by container

The override is not dropped — the untoned chat suggestion chips and composer attachment pills genuinely need it. It moves to a rule that excludes the five tone classes, so untoned pills keep the neutral chip and toned ones reach the tone layer.

Scoping by tone rather than by container matters: **six** components use Pill — `ChatSuggestions`, `ChatComposer`, `ThinkingIndicator`, `ToolCallLog`, `Combobox` and `Table`'s `BuiltinCell` — and a container-scoped rule would have missed some of them.

## Contrast was computed, not eyeballed

Every dark pair clears WCAG AA for normal text — **5.93:1** at the lowest (`muted`), the rest between **9.05:1** and **10.58:1**.

The failure mode is quantified too: the light `ok` text `#155724` on the neutral dark chip `#252535` is **1.74:1**, well under the 4.5:1 floor, which is why the light defaults cannot simply carry over.

## On the question the issue raised

Whether the `pill-success` / `warning` / `error` / `info` class recipes should get dark counterparts or be declared theme-invariant: **neither, as written.** They are example CSS a consumer owns once pasted, not something Pill ships. The docs say to give them dark counterparts if you use them, and point at `tone` as the reason not to need them.

## Verification

| check | result |
| --- | --- |
| `pnpm lint` | 0 |
| `pnpm check` | 0 |
| `pnpm build` | 0 |
| unit (vitest) | 919 passed |
| Playwright — new dark-theme tone tests | 2 passed |
| visual regression (pinned container) | 93 passed, 1 skipped |

Red-green confirmed by restoring the unscoped selector and watching the distinct-tone count drop from **5 to 1** while the untoned assertion held — so the test discriminates rather than failing everything.

No component file is touched.
