### PR TITLE
docs(roadmap): add the AI/chat primitives section and correct a duplicate entry

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,7 @@
 | 33  | Modal        | :white_check_mark: | Popup dialog for focused content or confirmations           |
 | 34  | Command Menu | :white_check_mark: | Full-screen action palette triggered by keyboard shortcut   |
 | 35  | Context Menu | :white_check_mark: | Right-click or long-press contextual action list            |
-| 36  | Drawer       | :x:                | Panel that slides in from a screen edge                     |
+| 36  | Drawer       | :white_check_mark: | Panel that slides in from a screen edge (ships as `Sheet`)  |
 | 37  | Menu         | :white_check_mark: | Dropdown action menu with typeahead and keyboard navigation |
 | 38  | Sheet        | :white_check_mark: | Side panel sliding from left or right screen edge           |
 
@@ -121,13 +121,37 @@
 
 ---
 
+## AI / Chat Primitives
+
+The library already ships a full chat surface — `Chat`, `ChatController`, `ChatMessage`,
+`ChatMessageList`, `ChatComposer`, `ChatHeader`, `ChatSuggestions`, `ChatToolStatus`,
+`ChatBubble`, `HITL`, `ThinkingIndicator`, `ToolCallLog`, `TaskList`, `TypewriterText`,
+`AttachmentChipRow`, `MarkdownText`, `SoundKit`. The entries below are the next layer of
+answer-rendering primitives, none of which exist yet.
+
+These are **proposals, not specs.** None is scoped, named definitively, or estimated; each
+needs its own issue before implementation. Listed here so they stop being invisible.
+
+| #   | Component      | Status | Description                                                                                    |
+| --- | -------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| 55  | Sources        | :x:    | Collapsible list of the citations a response drew from, shown with or below a `ChatMessage`    |
+| 56  | InlineCitation | :x:    | Inline numbered reference inside message text that expands to a source — pairs with `Sources`  |
+| 57  | Context        | :x:    | Compact context-window / token-usage indicator for the active conversation                     |
+| 58  | Checkpoint     | :x:    | Marker in the message list denoting a restorable point; composes with `ChatController.retry()` |
+| 59  | Queue          | :x:    | Indicator for a prompt queued while one is still streaming, or for multi-step agent task lists |
+
+Naming note: `Context` is proposed for context-window usage and is unrelated to the existing
+`ContextMenu`, which is a right-click/dropdown menu. If both ever ship, one needs renaming.
+
+---
+
 ## Summary
 
 | Metric                              | Count |
 | ----------------------------------- | ----- |
-| **Total Components (this roadmap)** | 54    |
-| **Available**                       | 44    |
-| **To Build**                        | 10    |
+| **Total Components (this roadmap)** | 59    |
+| **Available**                       | 45    |
+| **To Build**                        | 14    |
 
 ---
 


### PR DESCRIPTION
Closes #466.

Two things the issue asked for, plus a correction to the issue's own premise.

## The AI / Chat primitives section

The library ships a full chat surface — `Chat`, `ChatController`, `ChatMessage`, `ChatMessageList`, `ChatComposer`, `ChatHeader`, `ChatSuggestions`, `ChatToolStatus`, `ChatBubble`, `HITL`, `ThinkingIndicator`, `ToolCallLog`, `TaskList`, `TypewriterText`, `AttachmentChipRow`, `MarkdownText`, `SoundKit` — and the roadmap had **no AI or chat section at all**, so the next layer of answer-rendering primitives was invisible to anyone reading it.

Added as five entries: `Sources`, `InlineCitation`, `Context`, `Checkpoint`, `Queue`. Each is marked explicitly as a **proposal, not a spec**, needing its own issue before implementation, so the table isn't read as a commitment.

Also recorded a naming collision while it's cheap to notice: the proposed `Context` (context-window / token usage) is unrelated to the shipped `ContextMenu` (right-click menu). If both ever ship, one needs renaming.

## A duplicate entry, not just a stale one

Row 36 `Drawer` — *"Panel that slides in from a screen edge"* — was marked not-built, while row 38 `Sheet` — *"Side panel sliding from left or right screen edge"* — sat two rows below it marked shipped.

They are the same component, listed twice. `docs/Sheet.md` opens:

> A panel component that slides in from any edge of the screen (left, right, top, or bottom)

which is row 36's description verbatim. Marked shipped and annotated `(ships as Sheet)` rather than deleted, so the numbering the rest of the file and the Summary depend on stays stable.

## Correcting the issue's premise

#466 lists **Checkbox, Radio, Avatar, Combobox, Pagination, Menu, Sheet, Tabs, Calendar, EmptyState** as wrongly marked `:x:`. **None of those carries an `:x:` today** — they were corrected at some point after the issue was filed.

The ten entries still marked unbuilt are a different set: `Feedback`, `Code Block`, `Description`, `Entity`, `Error`, `Drawer`, `Show More`, `Material`, `Project Banner`, `Context Card`. I checked each against `src/lib/` rather than trusting the list, and of the ten **only `Drawer` is demonstrably already shipped**.

Two others are arguable — `Material` ("elevated surface with shadow and blur") is close to `Card`, and `Project Banner` is close to `Banner` — but neither is the verbatim match Drawer/Sheet is, so I left both alone rather than resolving them on my own reading of a one-line description.

## Counts

Recomputed from the tables themselves rather than adjusted by hand:

```
available (:white_check_mark:)  45
to build  (:x:)                 14
total rows                      59
```

## Verification

lint 0 · build 0 · 919 unit. Documentation only — no component, demo, or test file is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap to mark the Drawer component as available under the name `Sheet`.
  - Added a planned AI and chat primitives section covering Sources, InlineCitation, Context, Checkpoint, and Queue components.
  - Updated roadmap totals to 59 components: 45 available and 14 planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->