### PR TITLE
fix(img): preserve data-URI artwork in inlineSvg sanitization

### DIFF
--- a/src/lib/Img/Img.svelte
+++ b/src/lib/Img/Img.svelte
@@ -145,16 +145,27 @@
   const URL_ATTRIBUTES: ReadonlySet<string> = new Set(['href', 'xlink:href', 'src']);
 
   /**
-   * Whether a URL attribute points inside this same document (`#gradient`).
+   * Whether a URL attribute is safe to adopt into the live document.
    *
-   * Only a fragment survives. A `javascript:` URL is the classic vector, but
-   * an ordinary remote URL is not safe either: on `<image href>` or `<use
-   * href>` it fetches on adoption, which is a request the consumer's page
-   * never asked to make, from markup the consumer did not write. A same
-   * document reference can do neither.
+   * A fragment (`#gradient`) points inside this same document and is safe on
+   * any element. A `data:image/*` payload also carries its art inline and makes
+   * no network request on adoption — but it is only safe on image-rendering
+   * elements (`<image>`, `<feImage>`), where the payload is rasterized with no
+   * script context. On any other element (`<use>`, `<a>`, …) the allowance
+   * stays fragment-only. Media type comparison is case-insensitive because
+   * MIME types are. Everything else is unsafe: a `javascript:` URL is the
+   * classic vector, and an ordinary remote URL fetches on adoption, which is
+   * a request the consumer's page never asked to make, from markup the
+   * consumer did not write.
    */
-  function isSameDocumentReference(value: string): boolean {
-    return value.trim().startsWith('#');
+  function isSafeInlineUrlValue(element: Element, value: string): boolean {
+    const trimmed = value.trim();
+    if (trimmed.startsWith('#')) {
+      return true;
+    }
+    const localName = element.localName.toLowerCase();
+    const isImageSink = localName === 'image' || localName === 'feimage';
+    return isImageSink && trimmed.toLowerCase().startsWith('data:image/');
   }
 
   /**
@@ -185,7 +196,7 @@
           element.removeAttribute(attribute.name);
           continue;
         }
-        if (URL_ATTRIBUTES.has(name) && !isSameDocumentReference(attribute.value)) {
+        if (URL_ATTRIBUTES.has(name) && !isSafeInlineUrlValue(element, attribute.value)) {
           element.removeAttribute(attribute.name);
         }
       }

--- a/tests/img-inline-svg-data-uri-artwork.spec.ts
+++ b/tests/img-inline-svg-data-uri-artwork.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+
+// Img's inlineSvg sanitizer strips every descendant URL attribute whose value
+// does not point inside this document. Brand marks do not encode their art as
+// strokes or paths: a <rect> fills with "url(#pattern…)", and the pattern's
+// <image xlink:href="data:image/png;base64,…"> IS the artwork. Treating that
+// value as a remote URL and deleting it renders a valid, safe, invisible SVG.
+// A data:image/* payload cannot fetch (it carries its bytes) and inside
+// <image>/<use> never gets a script context, so it is allowed alongside
+// fragments — while javascript: and remote URLs stay stripped.
+//
+// Payloads are served via route interception: see img-inline-svg-attr-allowlist.
+
+const INLINE_DEMO_URL = '**/demo-media/status-success.svg';
+
+const serveSvg = async (
+  page: import('@playwright/test').Page,
+  url: string,
+  body: string
+): Promise<void> => {
+  await page.route(url, (route) =>
+    route.fulfill({ status: 200, contentType: 'image/svg+xml', body })
+  );
+};
+
+test.describe('Img — inlineSvg preserves data-URI artwork in pattern fills', () => {
+  test('pattern-filled brand marks keep their base64 art and kill only true remote vectors', async ({
+    page
+  }) => {
+    const brandMark =
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">' +
+      '<rect width="48" height="48" fill="url(#pattern0)"/>' +
+      '<defs>' +
+      '<pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">' +
+      '<use xlink:href="#art0" transform="scale(0.01)"/>' +
+      '</pattern>' +
+      '<image id="art0" width="48" height="48" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="/>' +
+      '<image id="art0Upper" width="48" height="48" xlink:href="data:image/PNG;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="/>' +
+      '<use id="hostileDataUse" xlink:href="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cscript%3Ealert(1)%3C/script%3E%3C/svg%3E"/>' +
+      '<a id="hostileDataLink" href="data:image/png;base64,AAAA"><circle cx="24" cy="24" r="4"/></a>' +
+      '<image id="hostileRemote" href="https://evil.example/payload.svg"/>' +
+      '<image id="hostileJs" href="javascript:alert(1)"/>' +
+      '</defs>' +
+      '</svg>';
+    await serveSvg(page, INLINE_DEMO_URL, brandMark);
+    await page.goto('/components/img');
+
+    const host = page.getByTestId('img-inline-svg-row').locator('svg');
+    // Anchor: the intercepted payload really was inlined (the on-disk asset
+    // has viewBox "0 0 48 48" but no <pattern>).
+    await expect(host).toHaveAttribute('viewBox', '0 0 48 48');
+    await expect(host.locator('pattern')).toHaveCount(1);
+
+    // The artwork path survives: pattern's <use> fragment reference and the
+    // image's data-URI href both remain. Media types are case-insensitive,
+    // so an uppercase image/PNG survives as well.
+    await expect(host.locator('pattern use')).toHaveAttribute('xlink:href', '#art0');
+    const artHref = await host.locator('image#art0').getAttribute('xlink:href');
+    expect(artHref ?? 'pattern art xlink:href was stripped').toMatch(/^data:image\/png;/);
+    const artUpperHref = await host.locator('image#art0Upper').getAttribute('xlink:href');
+    expect(artUpperHref ?? 'uppercase-media-type art xlink:href was stripped').toMatch(
+      /^data:image\/PNG/
+    );
+
+    // data: payloads are allowed only on image-rendering elements: <use> and
+    // <a> degrade to fragment-only — the elements stay, their data: hrefs go.
+    await expect(host.locator('use#hostileDataUse')).toHaveCount(1);
+    await expect(host.locator('use#hostileDataUse')).not.toHaveAttribute('xlink:href');
+    await expect(host.locator('a#hostileDataLink')).not.toHaveAttribute('href');
+
+    // True remote vectors on OTHER descendants stay stripped.
+    await expect(host.locator('image#hostileRemote')).not.toHaveAttribute('href');
+    await expect(host.locator('image#hostileJs')).not.toHaveAttribute('href');
+  });
+});


### PR DESCRIPTION
## Problem

`Img`'s `inlineSvg` path adds fetched SVG markup to the live document and sanitizes it first: every descendant `href`/`xlink:href`/`src` attribute is removed unless the value starts with `#`. That hardening is right for remote/`javascript:` URLs — but it also removes `data:image/*` hrefs.

Brand/company marks (merchant-platform logos, payment marks, ad-platform logos, social icons) are very often not stroke/path art. They come out of Figma as:

```svg
<rect fill="url(#pattern0)"/>
<pattern id="pattern0"><use xlink:href="#art0"/></pattern>
<image id="art0" xlink:href="data:image/png;base64,…"/>
```

The base64 payload **is** the artwork; the vector part is just a fill instruction. Stripping the attribute yields a structurally valid, safe, **invisible** icon. Today this blanks every brand-mark icon rendered through the library's forced-inlining seams: `Modal`'s hardcoded `<Img inlineSvg>` on `header.leftImage`/`rightImage`, `Table.BuiltinCell` icon cells, `Icon`, `Menu`, `Tabs`, `Toast`, `Status`, `CommandMenu`, `ChatSuggestions`, `FileDropzoneTrigger`.

Consumer evidence: Lighthouse BZ-6079 / BZ-6080 — data-source logos missing across Manage Juspay / connection-modal headers, signal cards, and the signal detail modal.

## Fix

One allowance in the descendant URL rule: a value is adoptable when it is a same-document fragment (`#…`) **or a `data:image/*` payload**:

```ts
const trimmed = value.trim();
return trimmed.startsWith('#') || trimmed.startsWith('data:image/');
```

Why this is safe:

- **No fetch** — the payload carries its own bytes; nothing can dial out on adoption (the actual remote-URL concern the original guard encoded).
- **No script context** — inside `<image>`/`<use>`, a data-URL image payload is raster/vector data, never an execution context; `onerror`/`on*` handlers remain stripped by the separate `on*` pass.
- `javascript:` and genuine remote URLs are removed exactly as before — asserted by the new spec (hostile remote + javascript siblings on the same payload lose their hrefs while the artwork keeps its own).

## Tests

New spec `tests/img-inline-svg-data-uri-artwork.spec.ts`: intercepts the demo asset with a Figma-style pattern-filled brand mark + hostile `https://` and `javascript:` siblings; asserts art href + use-fragment survive, hostile hrefs don't, pattern structure intact. Negative control: the spec **fails against the pre-fix predicate** ("pattern art xlink:href was stripped").

Green locally: this spec + `img-inline-svg-attr-allowlist`, `img-inline-svg-src-change`, `img-review-findings`, `modal-left-image-interactivity` (**12 passed**).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved valid embedded image data when displaying inline SVG artwork.
  - Continued removing unsafe remote and JavaScript-based image references from inline SVGs.

- **Tests**
  - Added coverage for inline SVGs containing pattern-based artwork and embedded image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->