### PR TITLE
docs(select): document the trigger sizing recipe

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -125,6 +125,57 @@ Svelte 5 Snippet props — pass content blocks to the component.
 | onopen   | `() => void`                | Fires when the dropdown opens.                                                                                                    |
 | onclose  | `() => void`                | Fires when the dropdown closes.                                                                                                   |
 
+## Sizing
+
+There is no `size` prop, and none is needed: the trigger's geometry is already themeable.
+Define a class in your app's CSS that sets the three variables together, then pass it via
+`classes` — the same pattern as **Theming with Classes** on `Pill`:
+
+```css
+/* app.css */
+.select-sm {
+  --select-trigger-min-height: 32px;
+  --select-trigger-padding: 4px 10px;
+  --select-font-size: 13px;
+}
+
+.select-lg {
+  --select-trigger-min-height: 48px;
+  --select-trigger-padding: 12px 14px;
+  --select-font-size: 15px;
+}
+```
+
+```svelte
+<Select {items} classes="select-sm" placeholder="Compact" />
+<Select {items} placeholder="Default" />
+<Select {items} classes="select-lg" placeholder="Roomy" />
+```
+
+Measured against the unmodified component, those recipes give:
+
+|              | `--select-trigger-min-height` | `--select-trigger-padding` | `--select-font-size` | rendered height |
+| ------------ | ----------------------------- | -------------------------- | -------------------- | --------------- |
+| `.select-sm` | 32px                          | 4px 10px                   | 13px                 | 42px            |
+| default      | 40px                          | 8px 12px                   | 14px                 | 58px            |
+| `.select-lg` | 48px                          | 12px 14px                  | 15px                 | 74px            |
+
+Those rendered heights are for a **single-line trigger**; a multi-select whose pills wrap
+onto a second row grows past them.
+
+They are also worth reading carefully, because they are `min-height` **plus** the vertical
+padding and border, not the `min-height` itself — 32 + 8 + 2 = 42, 40 + 16 + 2 = 58,
+48 + 24 + 2 = 74. So raising `--select-trigger-padding` raises the control even when
+`--select-trigger-min-height` is untouched.
+
+That is also why the three move together: setting `min-height` alone leaves the padding and
+label at their default scale, which is what makes a hand-tuned single override look wrong
+and tempts an `!important`. Set all three, or none.
+
+Because these are your classes rather than ours, the scale is yours too: add an `xs`, match
+a host application's density, or drive them from a `[data-density]` attribute. Nothing here
+is version-locked to this library.
+
 ## CSS Variables
 
 Override these custom properties to theme the component.


### PR DESCRIPTION
Addresses **#414 item 1** (sm/md/lg trigger sizes) with documentation instead of API. Replaces #585, which is closed unmerged.

## The gap was discoverability, not capability

Lighthouse hand-rolled a light-theme-only `36px !important` in `shopify.css` rather than resize Select properly — that is the evidence the gap is real.

But `--select-trigger-min-height`, `--select-trigger-padding` and `--select-font-size` have **always** been themeable. Sizing works on the shipped library with no code at all; a consumer just has to know the three move together. That is a docs problem, so it gets a docs fix:

```css
/* app.css */
.select-sm {
  --select-trigger-min-height: 32px;
  --select-trigger-padding: 4px 10px;
  --select-font-size: 13px;
}
```

```svelte
<Select {items} classes="select-sm" placeholder="Compact" />
```

## The values are measured, not intended

Applied to the **unmodified** component and read back from the rendered trigger:

| | min-height | padding | font-size | rendered height |
| --- | --- | --- | --- | --- |
| `.select-sm` | 32px | 4px 10px | 13px | 42px |
| default | 40px | 8px 12px | 14px | 58px |
| `.select-lg` | 48px | 12px 14px | 15px | 74px |

The verification probe was removed after measuring — it needed no library change to pass, which is the whole point.

## Why not the prop

[#585](https://github.com/juspay/svelte-ui-components/pull/585) shipped a typed `size` prop first. It cost a `SelectSize` type, a `selectSize.ts` resolver, a unit-test file, a reflected web-component attribute, a prop-parity entry and an internal `--_select-size-*` CSS layer — to deliver three numbers a consumer can already set, and to version-lock a scale that ought to belong to the application. Closed unmerged.

**The counter-argument, recorded because this repo's own history supports it:** `docs/Pill.md` documents "Theming with Classes", and #520 later promoted exactly that pattern to a `tone` prop, because a hand-rolled class per call site was worse. The distinction taken here is that `tone` is semantic and design-system-governed, while trigger geometry is not — a consumer who wants a 36px trigger should not need us to ship a `size` value for it.

If that distinction turns out to be wrong, the prop is easy to add later; removing one would be a breaking change.

## One thing the docs make explicit

The trap that produced the `!important` in the first place: setting `min-height` alone leaves the padding and label at their default scale, so the control looks wrong and the next move is to fight the computed property. The section says to set all three, or none.

## Scope

No component, demo, test or visual baseline is touched — one file, 43 added lines.

**#414 items 2–4** (error state, trigger clear button, pressed state) and **#415** remain open and unaffected. Those are real behaviour rather than token bundles, and will need actual props.

## Verification

lint 0 · check 0 · build 0 · 919 unit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a sizing guide for the Select component.
  - Documented customizable trigger dimensions and typography.
  - Added small and large size examples, usage instructions, and a comparison table.
  - Clarified that related sizing variables should be configured together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->