### PR TITLE
fix(deps): declare node types so SvelteKit 2.70 can be adopted

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.63.1",
+    "@sveltejs/kit": "^2.70.3",
     "@sveltejs/package": "^2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/svelte": "^5.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 1.60.0
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))
+        version: 7.0.1(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))
+        version: 3.0.10(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))
       '@sveltejs/kit':
-        specifier: ^2.63.1
-        version: 2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))
+        specifier: ^2.70.3
+        version: 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)
@@ -514,8 +514,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.63.1':
-    resolution: {integrity: sha512-bL8ch7WDjJTRMjViXZAN3luH6O8gk3RoCaBB8yacNKCRdzGCHlryGpGk/Hpm/STXN0ls9/NJ+VrrxP3m/S2bIg==}
+  '@sveltejs/kit@2.70.3':
+    resolution: {integrity: sha512-UDvEYuZqAMbfB/oXIoqKvbKcb7YczK5zYrzmsGV1zRJk03jntwp8dXiYoIJotxAndsKvcPFtx9H1GRSKFdSHgg==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -2129,15 +2129,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))
+      '@sveltejs/kit': 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))
+      '@sveltejs/kit': 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))
 
-  '@sveltejs/kit@2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))':
+  '@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@22.20.1)(jiti@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)

--- a/src/tsconfig-node-types.test.ts
+++ b/src/tsconfig-node-types.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `tsconfig.json` must declare `types: ["node"]` itself rather than inherit it.
+ *
+ * It extends `./.svelte-kit/tsconfig.json`, which SvelteKit generates. Kit 2.63
+ * emitted `types: ["node"]` into that file; 2.70 stopped, and the root config
+ * was the one place in the repo relying on the injection. The result was 28
+ * errors of the form `Cannot find name 'node:fs'` across tests and scripts,
+ * with nothing in the diff to point at — the failure arrived on a dependency
+ * bump that touched no source file. It cost one investigation here and a second
+ * on Dependabot's own PR (#584) before the cause was located.
+ *
+ * The line looks redundant beside a generated config that used to supply it,
+ * which is precisely what makes it easy to delete. This test turns that
+ * deletion into a failure that names the cause, instead of a wall of
+ * unresolved-global errors that names nothing.
+ *
+ * The four tsconfigs under `scripts/` already declare `types` explicitly and
+ * were unaffected by the bump; this brings the root config in line with them.
+ */
+
+const ROOT_TSCONFIG = join(import.meta.dirname, '..', 'tsconfig.json');
+
+const declaredTypes = (): readonly unknown[] | null => {
+  const parsed: unknown = JSON.parse(readFileSync(ROOT_TSCONFIG, 'utf8'));
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null;
+  }
+  const compilerOptions = Reflect.get(parsed, 'compilerOptions');
+  if (typeof compilerOptions !== 'object' || compilerOptions === null) {
+    return null;
+  }
+  const types = Reflect.get(compilerOptions, 'types');
+  return Array.isArray(types) ? types : null;
+};
+
+describe('root tsconfig', () => {
+  it('declares node types itself rather than inheriting them from SvelteKit', () => {
+    const types = declaredTypes();
+
+    expect(
+      types,
+      'tsconfig.json must declare compilerOptions.types — SvelteKit no longer injects it'
+    ).not.toBeNull();
+    expect(types).toContain('node');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "strict": true,
     "module": "ES2022",
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "types": ["node"]
   },
   "exclude": ["node_modules", "src/wc"]
 }


### PR DESCRIPTION
Supersedes #584. Adopts SvelteKit 2.70.3 and fixes the type-resolution break that made the bump fail, closing the repo's last open Dependabot advisory.

## The failure

Dependabot's bump fails `check` with 28 errors that name no cause:

```
Cannot find name 'node:fs'.
Cannot find name 'node:path'.
Cannot find name 'process'.
Property 'dirname' does not exist on type 'ImportMeta'.
```

`@types/node` is declared (`^22.20.1`), locked and installed throughout. It simply stops resolving — on a bump that touches no source file.

## The cause is a one-line diff in a file nobody wrote

`tsconfig.json` extends `./.svelte-kit/tsconfig.json`, which SvelteKit **generates**. Diffing that generated file across the two versions:

```diff
  "target": "esnext",
- "types": ["node"]        ← emitted by kit 2.63.1, not by 2.70.3
```

That is the entire difference.

## Why the fix is a convention, not a workaround

The root `tsconfig.json` was the **only** config in the repo relying on that injection:

| Config | `types` | Affected |
| --- | --- | --- |
| `tsconfig.json` | *inherited from generated* | **yes** |
| `tsconfig.wc.json` | `["vite/client"]` | no |
| `scripts/codemod/tsconfig.json` | `["node"]` | no |
| `scripts/migrate/tsconfig.json` | `["node"]` | no |
| `scripts/release/tsconfig.json` | `["node"]` | no |
| `scripts/wc-parity/tsconfig.json` | `["node"]` | no |

Four of six already declare it explicitly. This brings the outlier in line, and makes type resolution here independent of whatever a generated file happens to contain.

## Measured, not inferred

Controlled experiment at kit 2.70.3, single variable:

| `types: ["node"]` | svelte-check |
| --- | --- |
| absent | **28 errors**, exit 1 |
| present | **0 errors**, exit 0 |

## The regression test, and why it earns its place

The line looks redundant beside a generated config that used to supply it — which is exactly what makes it easy to delete, and deleting it costs an investigation. This one cost two: once here when kit was deliberately excluded from #582, and again on Dependabot's own PR.

`src/tsconfig-node-types.test.ts` turns that deletion into a failure that names the cause. Red-green verified rather than assumed:

```
AssertionError: tsconfig.json must declare compilerOptions.types
  — SvelteKit no longer injects it: expected null not to be null
```

Restored, it passes. So the guard fails for the right reason, not because of a typo in the test.

## Scope

2.70.3 rather than Dependabot's 2.70.2 — current patch, same advisory fix.

**Deliberately not included:** `svelte-check` also warns that `moduleResolution: "Node"` (node10) is deprecated and stops working in TypeScript 7. That is pre-existing, is not caused by this bump, and bundling it would blur what this change proves. Worth its own PR.

## Verification

| Gate | Exit |
| --- | --- |
| `lint` | 0 |
| `check` | 0 |
| `test:unit` | 0 |
| `build` | 0 |
| `test:integration` | 0 |

Closes #584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the SvelteKit development dependency to a newer version.

- **Bug Fixes**
  - Ensured Node.js type definitions are explicitly available through the project’s TypeScript configuration.

- **Tests**
  - Added coverage verifying that Node.js types are declared directly in the root TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->