### PR TITLE
feat(pie-chart): register sui-pie-chart as a web component

### DIFF
--- a/docs/PieChart.md
+++ b/docs/PieChart.md
@@ -294,6 +294,47 @@ Thresholds: ≥ 1 Cr (10 million) → `"1.5Cr"`, ≥ 1 L (100 thousand) → `"2.
 
 ## Web Component
 
-PieChart is currently available through the Svelte entry point only. The web-component bundle does not register `sui-pie-chart`; importing it will not create a functioning chart element. Use `PieChart` from `@juspay/svelte-ui-components` for the APIs documented above.
+`sui-pie-chart` is registered by the web-component bundle:
 
-> **Correction.** Earlier revisions of this page documented `<sui-pie-chart>` with kebab-case attributes and JS-assigned function props. **That wrapper was never built** — there is no `PieChart.wc.svelte` and no `customElements.define('sui-pie-chart', …)`, so the element never upgraded and the markup rendered nothing. If you followed that section and saw an empty space, this is why. Nothing was withdrawn here: the documentation described a component that did not exist, and now says so. Adding a real wrapper is tracked separately.
+```html
+<script type="module" src="@juspay/svelte-ui-components/wc"></script>
+
+<sui-pie-chart show-legend legend-show-values legend-position="right" legend-max-items="5">
+</sui-pie-chart>
+
+<script>
+  document.querySelector('sui-pie-chart').data = [
+    { label: 'UPI', value: 62 },
+    { label: 'Cards', value: 21 },
+    { label: 'Netbanking', value: 9 }
+  ];
+</script>
+```
+
+**Scalar props are kebab-case attributes**, coerced to their declared type: `inner-radius`, `pad-angle`, `show-labels`, `show-values`, `label-position`, `show-legend`, `start-angle`, `aspect-ratio`, `max-height`, `min-height`, `semi-circle`, `legend-show-values`, `legend-position`, `legend-max-items`, `percent-decimals`, `highlighted-index`, `change-percentage`, `change-invert-colors`, `test-id`, `classes`. Booleans are presence-based, so `show-legend` is on and removing the attribute turns it off.
+
+**Everything else is a JS property**, because arrays, objects and functions cannot cross the HTML-attribute boundary:
+
+```js
+const chart = document.querySelector('sui-pie-chart');
+chart.data = slices;
+chart.valueFormat = (value) => `₹${value}`;
+chart.onsliceclick = ({ index, slice }) => console.log(index, slice.label);
+chart.onlegendmore = () => openBreakdownDrawer();
+chart.onchartready = (api) => narrator.attach(api);
+```
+
+**`center` and `empty` are slots**, not properties — a plain-HTML consumer cannot construct a Svelte snippet:
+
+```html
+<sui-pie-chart inner-radius="0.6">
+  <div slot="center"><strong>₹4.2Cr</strong></div>
+  <span slot="empty">No transactions in this period</span>
+</sui-pie-chart>
+```
+
+Leaving a slot empty keeps the component's own default, so an unslotted element still renders the built-in empty state rather than a blank box.
+
+`tooltipSnippet` has no slot equivalent. It is called with `(slice, index)`, and a slot cannot receive those arguments, so it stays available only to Svelte consumers.
+
+> **Correction.** Revisions of this page before `4.12` documented `<sui-pie-chart>` while no wrapper existed — there was no `PieChart.wc.svelte` and no `customElements.define('sui-pie-chart', …)`, so the element never upgraded and the markup rendered nothing. If you followed that section and saw an empty space, this is why. The wrapper described above is the real one.

--- a/src/wc/components/PieChart.wc.svelte
+++ b/src/wc/components/PieChart.wc.svelte
@@ -1,0 +1,102 @@
+<svelte:options
+  customElement={{
+    tag: 'sui-pie-chart',
+    shadow: 'open',
+    props: {
+      // Complex props (arrays / objects / functions / snippets) cannot cross the
+      // HTML-attribute boundary, so they are exposed as JS properties only:
+      //   document.querySelector('sui-pie-chart').data = [{ label: 'UPI', value: 62 }];
+      data: { type: 'Object' },
+      innerRadius: { type: 'Number', attribute: 'inner-radius' },
+      padAngle: { type: 'Number', attribute: 'pad-angle' },
+      showLabels: { type: 'Boolean', attribute: 'show-labels' },
+      showValues: { type: 'Boolean', attribute: 'show-values' },
+      labelPosition: { type: 'String', attribute: 'label-position' },
+      showLegend: { type: 'Boolean', attribute: 'show-legend' },
+      startAngle: { type: 'Number', attribute: 'start-angle' },
+      aspectRatio: { type: 'Number', attribute: 'aspect-ratio' },
+      maxHeight: { type: 'Number', attribute: 'max-height' },
+      minHeight: { type: 'Number', attribute: 'min-height' },
+      semiCircle: { type: 'Boolean', attribute: 'semi-circle' },
+      legendShowValues: { type: 'Boolean', attribute: 'legend-show-values' },
+      legendPosition: { type: 'String', attribute: 'legend-position' },
+      legendMaxItems: { type: 'Number', attribute: 'legend-max-items' },
+      percentDecimals: { type: 'Number', attribute: 'percent-decimals' },
+      highlightedIndex: { type: 'Number', attribute: 'highlighted-index' },
+      changePercentage: { type: 'Number', attribute: 'change-percentage' },
+      changeInvertColors: { type: 'Boolean', attribute: 'change-invert-colors' },
+      testId: { type: 'String', attribute: 'test-id' },
+      classes: { type: 'String' },
+      valueFormat: { type: 'Object' },
+      tooltipSnippet: { type: 'Object' },
+      center: { type: 'Object' },
+      empty: { type: 'Object' },
+      onlegendmore: { type: 'Object' },
+      onchartready: { type: 'Object' },
+      onsliceclick: { type: 'Object' },
+      onslicehover: { type: 'Object' }
+    }
+  }}
+/>
+
+<script lang="ts">
+  import PieChart from '$lib/PieChart/PieChart.svelte';
+
+  let props = $props();
+
+  /*
+   * PieChart gates its own defaults on `typeof snippet === 'function'`, so a
+   * wrapper that defined these unconditionally would replace the built-in empty
+   * state with a blank box and force an empty centre onto every donut. Claim a
+   * snippet only when the consumer actually slotted content into it, which also
+   * leaves a JS-assigned `center`/`empty` property working when they did not.
+   *
+   * `tooltipSnippet` is deliberately absent here: it is called with
+   * `(slice, index)`, and a `<slot>` cannot receive those arguments, so it stays
+   * a JS-property-only prop rather than being wired to markup that would drop
+   * the values it exists to render.
+   *
+   * `$host()` is called inline rather than held in a `const host`: a `$`-prefixed
+   * identifier is Svelte's store-subscription spelling, so a local named `host`
+   * makes `$host` read as that store and svelte-check reports the initializer as
+   * referencing itself.
+   */
+  const hasCenterSlot = $host().querySelector('[slot="center"]') !== null;
+  const hasEmptySlot = $host().querySelector('[slot="empty"]') !== null;
+</script>
+
+<!--
+  Four branches rather than two conditional snippet props, because a `{#snippet}`
+  declared at the top level of the template is hoisted to module scope, while the
+  `<slot>` inside it compiles to `$.slot(node, $$props, …)` — and `$$props` only
+  exists inside the component function. The hoisted version throws
+  `$$props is not defined` the moment the snippet is rendered, which shows up as
+  a silently empty shadow root rather than as a build error. Declaring each
+  snippet inside `<PieChart>` keeps it in component scope, which is what every
+  other wrapper in this directory does; the branching is what makes it
+  conditional without a top-level declaration.
+-->
+{#if hasCenterSlot && hasEmptySlot}
+  <PieChart {...props}>
+    {#snippet center()}
+      <slot name="center"></slot>
+    {/snippet}
+    {#snippet empty()}
+      <slot name="empty"></slot>
+    {/snippet}
+  </PieChart>
+{:else if hasCenterSlot}
+  <PieChart {...props}>
+    {#snippet center()}
+      <slot name="center"></slot>
+    {/snippet}
+  </PieChart>
+{:else if hasEmptySlot}
+  <PieChart {...props}>
+    {#snippet empty()}
+      <slot name="empty"></slot>
+    {/snippet}
+  </PieChart>
+{:else}
+  <PieChart {...props} />
+{/if}

--- a/src/wc/index.ts
+++ b/src/wc/index.ts
@@ -62,6 +62,7 @@ import './components/LottiePlayer.wc.svelte';
 import './components/StatCard.wc.svelte';
 import './components/DeltaIndicator.wc.svelte';
 import './components/ProportionBar.wc.svelte';
+import './components/PieChart.wc.svelte';
 import './components/Resizable.wc.svelte';
 import './components/Draggable.wc.svelte';
 import './components/MediaPlayer.wc.svelte';

--- a/tests/pie-chart-wc.spec.ts
+++ b/tests/pie-chart-wc.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// `docs/PieChart.md` described `<sui-pie-chart>` for several releases while no
+// wrapper existed, so the element never upgraded and the documented snippets
+// rendered nothing at all. These tests are the difference between the docs
+// describing a component and the component existing: each one fails outright
+// against a missing registration.
+//
+// dist-wc is a self-contained bundle rather than a route of the demo site, so
+// it is injected into a same-origin page instead of being navigated to.
+// `pnpm run build` (the webServer command) runs build:wc, so the file exists.
+const loadBundle = async (page: Page): Promise<void> => {
+  await page.goto('/');
+  await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+  await page.waitForFunction(
+    () => typeof customElements.get('sui-pie-chart') !== 'undefined',
+    null,
+    {
+      timeout: 15_000
+    }
+  );
+  // The demo app's own markup is cleared so the element under test is the only
+  // thing on the page. Appending below a full-length demo route leaves it far
+  // outside the viewport, which makes `toBeVisible` meaningless and leaves the
+  // recorded video showing an unrelated page instead of the element it proves.
+  await page.evaluate(() => {
+    document.body.replaceChildren();
+    document.body.style.padding = '24px';
+  });
+};
+
+const SLICES = [
+  { label: 'UPI', value: 62 },
+  { label: 'Cards', value: 21 },
+  { label: 'Netbanking', value: 9 },
+  { label: 'Wallet', value: 5 },
+  { label: 'EMI', value: 2 },
+  { label: 'BNPL', value: 1 }
+];
+
+/** Mounts the element with `data` assigned as a JS property, as documented. */
+const mount = async (page: Page, attributes: Record<string, string> = {}): Promise<void> => {
+  await page.evaluate(
+    ({ slices, attrs }) => {
+      const el = document.createElement('sui-pie-chart');
+      el.id = 'chart';
+      for (const [name, value] of Object.entries(attrs)) {
+        el.setAttribute(name, value);
+      }
+      Object.assign(el, { data: slices });
+      document.body.append(el);
+    },
+    { slices: SLICES, attrs: attributes }
+  );
+};
+
+test.describe('sui-pie-chart', () => {
+  test('registers as a custom element', async ({ page }) => {
+    await loadBundle(page);
+    const upgraded = await page.evaluate(() => {
+      const el = document.createElement('sui-pie-chart');
+      document.body.append(el);
+      return el.shadowRoot !== null;
+    });
+    expect(upgraded).toBe(true);
+  });
+
+  test('renders one arc per slice from a JS-assigned data array', async ({ page }) => {
+    await loadBundle(page);
+    await mount(page);
+    await expect(page.locator('#chart path.slice')).toHaveCount(SLICES.length);
+    await expect(page.locator('#chart svg')).toBeVisible();
+  });
+
+  test('coerces kebab-case number attributes into typed props', async ({ page }) => {
+    await loadBundle(page);
+    await mount(page, {
+      'show-legend': '',
+      'legend-show-values': '',
+      'legend-position': 'right',
+      'legend-max-items': '3'
+    });
+
+    // '3' arrives as the string "3" unless the declared type coerces it; the
+    // component floors a non-integer cap and ignores a non-finite one, so a
+    // string would surface as either every row or none.
+    await expect(page.locator('#chart .pie-legend-row')).toHaveCount(3);
+    await expect(page.locator('#chart .pie-legend-more')).toBeVisible();
+    await expect(page.locator('#chart .pie-legend-more')).toHaveText('+3 more');
+  });
+
+  test('observes a boolean attribute being removed', async ({ page }) => {
+    await loadBundle(page);
+    await mount(page, { 'show-legend': '', 'legend-show-values': '' });
+    await expect(page.locator('#chart .pie-legend-row')).toHaveCount(SLICES.length);
+
+    await page.evaluate(() => document.querySelector('#chart')?.removeAttribute('show-legend'));
+    await expect(page.locator('#chart .pie-legend-row')).toHaveCount(0);
+  });
+
+  test('expands in place when the built-in control is activated', async ({ page }) => {
+    await loadBundle(page);
+    await mount(page, {
+      'show-legend': '',
+      'legend-show-values': '',
+      'legend-max-items': '2'
+    });
+    await page.locator('#chart .pie-legend-more').click();
+    await expect(page.locator('#chart .pie-legend-row')).toHaveCount(SLICES.length);
+  });
+
+  test('keeps the built-in empty state when nothing is slotted into it', async ({ page }) => {
+    // The wrapper declares `empty` as a snippet. Defining it unconditionally
+    // would satisfy PieChart's `typeof empty === 'function'` guard on every
+    // mount and replace the default rendering with a blank slot, so this pins
+    // that an unslotted element still takes the component's own path.
+    await loadBundle(page);
+    await page.evaluate(() => {
+      const el = document.createElement('sui-pie-chart');
+      el.id = 'empty-default';
+      Object.assign(el, { data: [] });
+      document.body.append(el);
+    });
+    // Asserting only the absence of `.chart-empty` would also pass if the
+    // element rendered nothing at all, so the chart itself is asserted present.
+    await expect(page.locator('#empty-default svg')).toHaveCount(1);
+    await expect(page.locator('#empty-default .chart-empty')).toHaveCount(0);
+  });
+
+  test('uses slotted empty content when it is provided', async ({ page }) => {
+    await loadBundle(page);
+    await page.evaluate(() => {
+      const el = document.createElement('sui-pie-chart');
+      el.id = 'empty-slotted';
+      el.innerHTML = '<span slot="empty">Nothing to chart</span>';
+      Object.assign(el, { data: [] });
+      document.body.append(el);
+    });
+    await expect(page.locator('#empty-slotted .chart-empty')).toHaveCount(1);
+    await expect(page.locator('#empty-slotted [slot="empty"]')).toBeVisible();
+    await expect(page.locator('#empty-slotted [slot="empty"]')).toHaveText('Nothing to chart');
+  });
+
+  test('renders slotted center content inside a donut', async ({ page }) => {
+    await loadBundle(page);
+    await page.evaluate(
+      ({ slices }) => {
+        const el = document.createElement('sui-pie-chart');
+        el.id = 'donut';
+        el.setAttribute('inner-radius', '0.6');
+        el.innerHTML = '<strong slot="center">62%</strong>';
+        Object.assign(el, { data: slices });
+        document.body.append(el);
+      },
+      { slices: SLICES }
+    );
+    await expect(page.locator('#donut .pie-center-content')).toHaveCount(1);
+    await expect(page.locator('#donut [slot="center"]')).toBeVisible();
+    await expect(page.locator('#donut [slot="center"]')).toHaveText('62%');
+  });
+
+  test('forwards the slice-click handler assigned as a property', async ({ page }) => {
+    await loadBundle(page);
+    await mount(page);
+    const attached = await page.evaluate(() => {
+      const el = document.querySelector('#chart');
+      if (el === null) {
+        return false;
+      }
+      Object.assign(el, {
+        onsliceclick: (event: { index: number; slice: { label: string } }) => {
+          document.body.dataset.clicked = `${event.index}:${event.slice.label}`;
+        }
+      });
+      return true;
+    });
+    expect(attached).toBe(true);
+
+    await page.locator('#chart path.slice').first().click();
+    await expect(page.locator('body')).toHaveAttribute('data-clicked', '0:UPI');
+  });
+});


### PR DESCRIPTION
Builds the `sui-pie-chart` wrapper that `docs/PieChart.md` has described for several releases without it ever existing. Split out of #592 at review request rather than smuggled into a legend feature.

**Stacked on `feat/piechart-legend-right` (#592), not `release`.** The parity checker requires a wrapper to declare *every* prop its component accepts, and #592 adds four legend props. A wrapper built on `release` would go green today and break `check:wc-parity` the moment #592 lands. Merge #592 first; the base retargets to `release` automatically.

## What was actually wrong

`src/wc/index.ts` is a list of side-effecting imports, one per wrapper file. PieChart had no wrapper file, so it was never imported, so `customElements.define('sui-pie-chart', …)` never ran. `<sui-pie-chart>` in a consumer's page was an unknown element: no upgrade, no props, no render. Anyone following the documented snippet got a blank space and no error.

## What is here

**All 30 props declared.** This is enforced, not asserted — `scripts/wc-parity/prop-parity.test.ts` fails a wrapper that misses one. Verified by removing a declaration:

```
× PieChart.wc.svelte declares every prop
AssertionError: PieChart.wc.svelte is missing: legendMaxItems
```

**Attribute coercion.** Scalars are kebab-case attributes with declared types, so `legend-max-items="3"` arrives as the number `3` rather than the string `"3"` — which matters, since the component floors a non-integer cap and ignores a non-finite one, so a string would surface as either every row or none. Booleans are presence-based and observed, so removing `show-legend` turns the legend off.

**Arrays, functions and snippets stay JS properties**, because they cannot cross the HTML-attribute boundary. `data`, `valueFormat`, `onsliceclick`, `onlegendmore`, `onchartready`, `onslicehover`.

**`center` and `empty` are slots**, since a plain-HTML consumer cannot construct a Svelte snippet — and they are passed *only when content is actually slotted*. PieChart gates its own defaults on `typeof snippet === 'function'`, so a wrapper that defined them unconditionally would replace the built-in empty state with a blank box and force an empty centre onto every donut.

`tooltipSnippet` deliberately gets no slot: it is called with `(slice, index)`, and a slot cannot receive those arguments.

## The bug this shook out

The first version declared the snippets at the top level of the template. That compiles to:

```js
const emptySlot = ($$anchor) => {          // hoisted to MODULE scope
  $.slot(node_1, $$props, 'empty', {}, null);   // $$props lives in the component fn
};
```

A top-level `{#snippet}` is hoisted, and the `<slot>` inside it references `$$props`, which only exists inside the component function. It threw `$$props is not defined` **at render time** — surfacing as a silently empty shadow root, not a build error, and only when the snippet was actually rendered. So it passed with data present and failed only on an empty dataset with slotted content.

Declaring each snippet inside `<PieChart>` keeps it in component scope, which is what every other wrapper in the directory already does. Confirmed by compiling: `hoisted snippets before component fn: 0`.

Worth flagging separately: the same trap catches anyone who writes a top-level slot snippet in a wrapper, and nothing in the repo would have caught it — the failure is silent and only at runtime.

## Verification

- `lint` 0 · `check` 0 · `build` 0 · unit **935 passed**
- `scripts/wc-parity` (source): **162 passed**, red/green verified
- Browser, against the built `dist-wc/index.js`: **19 passed** — the 9 new `sui-pie-chart` cases plus the existing `wc-prop-parity` and `wc-event-casing-parity` suites, whose `every wrapper in the directory is registered by the bundle` case now covers this tag.

The new cases cover registration, per-slice rendering from a JS-assigned array, kebab attribute coercion, boolean-attribute removal, in-place expansion, the empty-state default surviving an unslotted element, slotted `empty`, slotted `center` in a donut, and `onsliceclick` reaching the component.

## Not included: a pixel baseline

`tests/visual/` screenshots demo routes discovered from `src/routes/components/`, and no route in this repo renders a custom element — all 86 wrappers have zero pixel baselines. Adding one route for this one wrapper would invent a convention nothing else follows and add a page to the docs site as a side effect. The rendered output is the same `PieChart` already covered by `pie-chart.png`.

Happy to add a `wc` demo route and baseline as a follow-up if the coverage is wanted — as a deliberate decision for all the wrappers rather than a side effect of this one.

Refs #417
