### PR TITLE
feat(card,pill): warn in dev when an attrs entry is discarded

### DIFF
--- a/docs/Card.md
+++ b/docs/Card.md
@@ -224,6 +224,8 @@ into per object:
 </script>
 ```
 
+Types only reach consumers who have them. In **dev builds**, Card also logs a `console.warn` naming any managed key it found in `attrs` and what owns it, so a plain-JS caller — or anyone driving `<sui-card>` as a web component, where there are no types at all — sees the discard too. It fires once per mounted instance and is compiled out of production builds.
+
 `CardStrictAttrs` also types native attributes properly — `onfocus` is a function, not a
 string — and rejects managed keys reached through a predeclared variable, not just an
 inline literal. It intentionally differs from `PillStrictAttrs`: Card writes no `aria-*`

--- a/docs/Pill.md
+++ b/docs/Pill.md
@@ -241,6 +241,8 @@ into per object:
 </script>
 ```
 
+Types only reach consumers who have them. In **dev builds**, Pill also logs a `console.warn` naming any managed key it found in `attrs` and what owns it, so a plain-JS caller — or anyone driving `<sui-pill>` as a web component, where there are no types at all — sees the discard too. It fires once per mounted instance and is compiled out of production builds.
+
 It intentionally differs from `CardStrictAttrs`: Pill writes no `style`, so `style` is
 usable on Pill and rejected on Card, while Card writes no `aria-*` state. Forbidding a key
 a component never touches would be a fake restriction.

--- a/src/lib/Card/Card.svelte
+++ b/src/lib/Card/Card.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CardProperties } from './properties';
+  import { CARD_MANAGED_ATTRS, discardedAttrWarnings } from '../attrs-discard';
 
   let {
     children,
@@ -21,6 +22,27 @@
     attrs,
     as
   }: CardProperties = $props();
+
+  /*
+   * The runtime half of the `attrs` deprecation (#576). The `@deprecated`
+   * markers on the managed keys only reach someone reading TypeScript; a
+   * plain-JS caller, or anyone driving this as a web component, has no types
+   * and would otherwise still get silence.
+   *
+   * Dev builds only: this is an authoring aid, and warning on every production
+   * render would be noise nobody asked for. `import.meta.env` is absent under
+   * bundlers that do not define it, so the guard reads it defensively and stays
+   * quiet there rather than throwing.
+   *
+   * Deliberately at init rather than in an `$effect`, which this repo bans:
+   * once per mounted instance is what a consumer needs to act on, and it costs
+   * nothing on subsequent updates.
+   */
+  if (import.meta.env?.DEV === true) {
+    for (const message of discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, attrs)) {
+      console.warn(message);
+    }
+  }
 
   // `as`, when given, picks the rendered tag outright. Omitted, the root keeps
   // its existing rule: an `<a>` exactly when `href` is set, a `<div>`

--- a/src/lib/Pill/Pill.svelte
+++ b/src/lib/Pill/Pill.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PillProperties } from './properties';
+  import { PILL_MANAGED_ATTRS, discardedAttrWarnings } from '../attrs-discard';
   import Button from '../Button/Button.svelte';
   import closeSvg from '$lib/assets/close.svg?raw';
   import { pillToneClass } from './pillTone';
@@ -22,6 +23,27 @@
     classes,
     attrs
   }: PillProperties = $props();
+
+  /*
+   * The runtime half of the `attrs` deprecation (#576). The `@deprecated`
+   * markers on the managed keys only reach someone reading TypeScript; a
+   * plain-JS caller, or anyone driving this as a web component, has no types
+   * and would otherwise still get silence.
+   *
+   * Dev builds only: this is an authoring aid, and warning on every production
+   * render would be noise nobody asked for. `import.meta.env` is absent under
+   * bundlers that do not define it, so the guard reads it defensively and stays
+   * quiet there rather than throwing.
+   *
+   * Deliberately at init rather than in an `$effect`, which this repo bans:
+   * once per mounted instance is what a consumer needs to act on, and it costs
+   * nothing on subsequent updates.
+   */
+  if (import.meta.env?.DEV === true) {
+    for (const message of discardedAttrWarnings('Pill', PILL_MANAGED_ATTRS, attrs)) {
+      console.warn(message);
+    }
+  }
 
   let interactive = $derived(typeof onclick === 'function');
 

--- a/src/lib/attrs-discard-runtime.test.ts
+++ b/src/lib/attrs-discard-runtime.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import Card from './Card/Card.svelte';
+import Pill from './Pill/Pill.svelte';
+
+/**
+ * That `discardedAttrWarnings` returns the right strings proves nothing about
+ * whether a consumer ever sees one. These render the real components and read
+ * `console.warn`, so they fail if the wiring is dropped from either template.
+ *
+ * The rendered DOM is asserted alongside the warning on purpose: the point of
+ * the warning is that the entry was discarded, so a test that checked only the
+ * message could pass while `attrs` had silently started winning instead.
+ */
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+});
+
+const messages = (): string[] =>
+  (warn.mock.calls as readonly (readonly unknown[])[]).map((call) => String(call[0]));
+
+describe('Card warns an untyped caller that a managed attrs entry is discarded', () => {
+  it('warns for class, and the class really is discarded', async () => {
+    const { container } = render(Card, {
+      classes: 'mine',
+      attrs: { class: 'from-attrs' }
+    });
+
+    const root = container.querySelector('.card');
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain('mine');
+    expect(root?.className).not.toContain('from-attrs');
+
+    expect(messages().some((m) => m.includes('Card') && m.includes('"class"'))).toBe(true);
+  });
+
+  it('stays silent for an attribute Card does not manage, which still lands', async () => {
+    const { container } = render(Card, { attrs: { 'data-state': 'waiting' } });
+
+    expect(container.querySelector('.card')?.getAttribute('data-state')).toBe('waiting');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when attrs is omitted entirely', async () => {
+    render(Card, {});
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('Pill warns on its own list, not Card’s', () => {
+  it('warns for aria-pressed, which Pill manages and Card does not', async () => {
+    render(Pill, { text: 'Syncing', attrs: { 'aria-pressed': 'true' } });
+    expect(messages().some((m) => m.includes('Pill') && m.includes('"aria-pressed"'))).toBe(true);
+  });
+
+  it('stays silent for style, which Pill does not manage', async () => {
+    render(Pill, { text: 'Syncing', attrs: { style: 'color: red' } });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/attrs-discard.test.ts
+++ b/src/lib/attrs-discard.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { CARD_MANAGED_ATTRS, PILL_MANAGED_ATTRS, discardedAttrWarnings } from './attrs-discard';
+import type { CardStrictAttrs } from './Card/properties';
+import type { PillStrictAttrs } from './Pill/properties';
+
+/**
+ * #576 again, for the callers types cannot reach.
+ *
+ * `attrs` is spread onto the root before each component writes its own managed
+ * attributes, so an entry for a managed key is accepted and then overwritten.
+ * 4.19.0 made that visible by deprecating those keys, which only helps someone
+ * reading TypeScript in an editor. A plain-JS consumer, or anyone driving
+ * `<sui-card>`/`<sui-pill>` as a web component, gets no types at all and so
+ * still gets silence. These messages are what reaches them.
+ */
+
+describe('discardedAttrWarnings', () => {
+  it('says nothing when attrs is not passed at all', () => {
+    expect(discardedAttrWarnings('Card', CARD_MANAGED_ATTRS)).toEqual([]);
+  });
+
+  it('says nothing for attributes the component does not manage', () => {
+    const attrs = { 'data-state': 'waiting', 'aria-label': 'Order card' };
+    expect(discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, attrs)).toEqual([]);
+  });
+
+  it('names the discarded key, the component, and what owns it', () => {
+    const messages = discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, { class: 'mine' });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('Card');
+    expect(messages[0]).toContain('class');
+    expect(messages[0]).toContain('classes');
+  });
+
+  it('reports every discarded key rather than only the first', () => {
+    const attrs = { class: 'mine', role: 'button', 'data-state': 'waiting' };
+    const messages = discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, attrs);
+    expect(messages).toHaveLength(2);
+    expect(messages.some((m) => m.includes('class'))).toBe(true);
+    expect(messages.some((m) => m.includes('role'))).toBe(true);
+  });
+
+  it('keeps the two components on their own lists', () => {
+    // Card writes no aria state and Pill writes no style, so the same object is
+    // a problem on one and fine on the other. A shared list would invent a
+    // restriction neither component actually applies.
+    const ariaPressed = { 'aria-pressed': 'true' };
+    expect(discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, ariaPressed)).toEqual([]);
+    expect(discardedAttrWarnings('Pill', PILL_MANAGED_ATTRS, ariaPressed)).toHaveLength(1);
+
+    const style = { style: 'color: red' };
+    expect(discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, style)).toHaveLength(1);
+    expect(discardedAttrWarnings('Pill', PILL_MANAGED_ATTRS, style)).toEqual([]);
+  });
+
+  it('ignores an inherited property rather than warning about it', () => {
+    const attrs = Object.create({ class: 'from-the-prototype' }) as Record<string, string>;
+    attrs['data-state'] = 'waiting';
+    expect(discardedAttrWarnings('Card', CARD_MANAGED_ATTRS, attrs)).toEqual([]);
+  });
+});
+
+describe('the runtime lists cannot drift from the types', () => {
+  it('every key Card warns about is a key CardStrictAttrs rejects', () => {
+    // Indexing the strict type by the runtime map's keys is `undefined` only if
+    // all of them are managed; a key that drifted out of the type would widen
+    // this to its real attribute type and fail.
+    expectTypeOf<CardStrictAttrs[keyof typeof CARD_MANAGED_ATTRS]>().toBeUndefined();
+  });
+
+  it('every key Pill warns about is a key PillStrictAttrs rejects', () => {
+    expectTypeOf<PillStrictAttrs[keyof typeof PILL_MANAGED_ATTRS]>().toBeUndefined();
+  });
+
+  it('names a replacement for every managed key on both components', () => {
+    for (const [key, guidance] of Object.entries({
+      ...CARD_MANAGED_ATTRS,
+      ...PILL_MANAGED_ATTRS
+    })) {
+      expect(guidance, `${key} has no guidance`).toMatch(/\S/);
+    }
+  });
+});

--- a/src/lib/attrs-discard.ts
+++ b/src/lib/attrs-discard.ts
@@ -1,0 +1,75 @@
+/**
+ * Runtime counterpart to the `@deprecated` markers on `attrs` (#576).
+ *
+ * Both Card and Pill spread `attrs` onto their root FIRST and write their own
+ * managed attributes after, so an entry for a managed key is accepted, spread,
+ * and then overwritten. 4.19.0 made that visible in the type by deprecating
+ * those keys, which reaches someone reading TypeScript in an editor and nobody
+ * else: a plain-JS consumer, or anyone driving `<sui-card>` / `<sui-pill>` as a
+ * web component, has no types at all and still gets silence.
+ *
+ * These maps carry the same guidance the `@deprecated` tags carry, as data the
+ * components can read at runtime. `attrs-discard.test.ts` pins each list
+ * against its `*StrictAttrs` type so the two cannot drift apart.
+ */
+
+/** What Card writes on its own root, and what a consumer should reach for instead. */
+export const CARD_MANAGED_ATTRS = {
+  class: 'use the `classes` prop',
+  style: 'use the `cssVars` prop',
+  role: 'Card derives it from `onclick`/`href`; there is no prop for it',
+  tabindex: 'Card derives it from `onclick`/`href`; there is no prop for it',
+  href: 'use the `href` prop',
+  target: 'use the `target` prop',
+  rel: 'use the `rel` prop',
+  onclick: 'use the `onclick` prop',
+  onkeydown: 'Card binds its own to activate on Enter/Space; there is no prop for it',
+  'data-pw': 'use the `testId` prop',
+  testID: 'use the `testId` prop'
+} as const;
+
+/** What Pill writes on its own root, and what a consumer should reach for instead. */
+export const PILL_MANAGED_ATTRS = {
+  class: 'use the `classes` prop',
+  type: 'Pill always supplies `type="button"` on a button root; there is no prop for it',
+  role: 'Pill derives it from whether it is interactive; there is no prop for it',
+  tabindex: 'Pill derives it from whether it is interactive; there is no prop for it',
+  title: 'use the `title` prop',
+  onclick: 'use the `onclick` prop',
+  onkeydown: 'Pill binds its own to activate on Enter/Space; there is no prop for it',
+  'data-pw': 'use the `testId` prop',
+  testID: 'use the `testId` prop',
+  'aria-disabled': 'Pill derives it from the `disabled` prop',
+  'aria-expanded': 'Pill derives it from the `ariaExpanded` prop',
+  'aria-pressed': 'Pill derives it from the `ariaPressed` prop'
+} as const;
+
+/**
+ * The messages for every managed key present in `attrs`, in the order the
+ * component's own list declares them. Pure: the caller decides whether the
+ * environment is one that should be told, and does the reporting.
+ *
+ * `attrs` is the optional trailing parameter so an absent one is simply not
+ * passed: the repo bans the `undefined` keyword outright.
+ *
+ * Only own properties count. An object built on a prototype that happens to
+ * carry `class` did not ask for that attribute to be spread, and warning about
+ * it would be noise a consumer cannot act on.
+ */
+export const discardedAttrWarnings = (
+  component: string,
+  managed: Readonly<Record<string, string>>,
+  attrs?: Readonly<Record<string, string>>
+): readonly string[] => {
+  if (!attrs) {
+    return [];
+  }
+
+  return Object.keys(managed)
+    .filter((key) => Object.prototype.hasOwnProperty.call(attrs, key))
+    .map(
+      (key) =>
+        `[svelte-ui-components] ${component}: the "${key}" entry in \`attrs\` is discarded, ` +
+        `because ${component} writes its own "${key}" after spreading \`attrs\` — ${managed[key]}.`
+    );
+};


### PR DESCRIPTION
4.19.0 deprecated the `attrs` keys Card and Pill overwrite, which turns the
silent discard into a strikethrough for anyone reading TypeScript in an editor
— and does nothing at all for anyone else. A plain-JS consumer has no types, and
`<sui-card>`/`<sui-pill>` callers driving the web components have none either.
Those are exactly the callers the spread order was always protecting, so they
were the ones still getting silence.

Dev builds now log, once per mounted instance, which managed key was found in
`attrs` and what owns it:

  [svelte-ui-components] Card: the "class" entry in `attrs` is discarded,
  because Card writes its own "class" after spreading `attrs` — use the
  `classes` prop.

`src/lib/attrs-discard.ts` holds the two key→guidance maps and a pure
`discardedAttrWarnings`; the components decide whether to report. The maps
repeat what the `@deprecated` tags say, so the test pins each one against its
`*StrictAttrs` type — indexing the strict type by the runtime map's keys is
undefined-only exactly when every key is really managed, so a key that drifted
out of the type fails `pnpm check`. Verified by mutation: adding an unmanaged
key to the Card map does fail it.

Three repo rules shaped the implementation rather than the other way round:

- `$effect` is banned, so the check runs once at component init. That is also
  the right frequency: one warning per call site is what a consumer acts on, and
  re-warning on every reactive update would bury it.
- The built-in `Set` is banned in favour of `SvelteSet`. Warning at init removed
  the need to dedupe at all, so neither is used.
- The `undefined` keyword is banned, so `attrs` is the optional trailing
  parameter and an absent one is simply not passed.

Only own properties count: an object built on a prototype that happens to carry
`class` never asked for that attribute to be spread, and warning about it would
be noise a consumer cannot act on.

Guarded on `import.meta.env?.DEV === true`, read defensively because bundlers
that do not define `import.meta.env` should stay quiet rather than throw. It
compiles out of production builds, so nothing ships to end users.

Nothing about the rendered output changes; #576 is still open for the major that
makes `attrs` itself reject these keys.

Verified on this commit: check 0, lint 0, unit 0. 1021 unit tests, of which 14
are new, and 25 Card/Pill integration cases. The render tests assert the DOM
alongside the warning — a test that only checked the message could pass while
`attrs` had started winning instead — and were mutation-checked by stripping the
warning from Card, which fails them.

The full integration suite shows 3 failures locally on this branch and 3 on
`origin/release` with none of this applied, in different tests each run:
pre-existing flakiness in tooltip/menu placement and table cells, masked in CI
by `retries: process.env.CI ? 2 : 0`. Not introduced here, and not touched here.

Refs #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Card and Pill now provide development-time warnings when managed attributes are passed through `attrs` and discarded.
  * Warnings identify the affected attribute and recommended alternative, helping plain JavaScript and web-component users resolve issues.
  * Warnings appear once per component instance and are omitted from production builds.

* **Documentation**
  * Updated Card and Pill documentation to describe the new development warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->