### PR TITLE
fix(tests): wait for hydration before driving demo pages

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
   import { base } from '$app/paths';
   import { componentNav } from './components/_nav';
   import ThemeSwitcher from '$lib/ThemeSwitcher/ThemeSwitcher.svelte';
-  import type { Snippet } from 'svelte';
+  import { onMount, type Snippet } from 'svelte';
   import './components/demo.css';
 
   let { children }: { children: Snippet } = $props();
@@ -20,6 +20,24 @@
       }))
       .filter((group) => group.items.length > 0)
   );
+
+  /*
+   * Marks the document once the app is interactive, for the Playwright suite.
+   *
+   * Every demo page is server-rendered, so a control exists and passes all of
+   * Playwright's actionability checks -- visible, stable, enabled, receiving
+   * events -- while the page is still inert. Playwright has no way to check
+   * that a listener is attached, so a click that arrives before hydration is
+   * delivered to dead markup and silently does nothing; the assertion that
+   * follows then fails as a timeout with no clue as to why. Under load, with
+   * `video`/`trace` recording on every test, that window is wide enough to hit.
+   *
+   * A parent's onMount runs after its children have mounted, so the root layout
+   * setting this is the app as a whole reporting that it is ready.
+   */
+  onMount(() => {
+    document.documentElement.dataset.hydrated = 'true';
+  });
 
   function handleThemeChange(_value: string, resolved: string): void {
     document.documentElement.dataset.theme = resolved;

--- a/tests/a11y-accordion.spec.ts
+++ b/tests/a11y-accordion.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The accordion trigger (WAI-ARIA disclosure pattern) already had aria-controls/aria-expanded
 // wiring exercised via .click() elsewhere, but nothing drove it from the keyboard — the actual
@@ -7,7 +8,7 @@ test.describe('Accordion keyboard interaction (WAI-ARIA disclosure pattern)', ()
   test('Tab reaches the trigger, which is focusable with a visible focus target', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const trigger = page.getByRole('button', { name: /Shipping details/ });
     await trigger.focus();
@@ -16,7 +17,7 @@ test.describe('Accordion keyboard interaction (WAI-ARIA disclosure pattern)', ()
   });
 
   test('Enter and Space both toggle aria-expanded and the panel', async ({ page }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const trigger = page.getByRole('button', { name: /Shipping details/ });
     const panel = page.getByTestId('accordion-linked');
@@ -35,7 +36,7 @@ test.describe('Accordion keyboard interaction (WAI-ARIA disclosure pattern)', ()
   });
 
   test('the accessible name comes from the rendered trigger content', async ({ page }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     // getByRole with a name only resolves if accessible-name computation reaches the
     // trigger's snippet content — a regression here would make every getByRole lookup
@@ -44,7 +45,7 @@ test.describe('Accordion keyboard interaction (WAI-ARIA disclosure pattern)', ()
   });
 
   test('a disabled trigger leaves the tab order and ignores Enter/Space', async ({ page }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const trigger = page.locator('.accordion-trigger', {
       has: page.getByTestId('accordion-disabled-trigger-label')

--- a/tests/a11y-choicebox.spec.ts
+++ b/tests/a11y-choicebox.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Choicebox keyboard interaction', () => {
   test('Tab reaches an enabled Choicebox and Enter/Space toggle it (checkbox mode)', async ({
     page
   }) => {
-    await page.goto('/components/choicebox');
+    await gotoHydrated(page, '/components/choicebox');
 
     const checkA = page.getByTestId('choicebox-check-a');
     await checkA.focus();
@@ -22,7 +23,7 @@ test.describe('Choicebox keyboard interaction', () => {
   test('Space selects a Choicebox in radio mode, and re-pressing an already-selected one is a no-op', async ({
     page
   }) => {
-    await page.goto('/components/choicebox');
+    await gotoHydrated(page, '/components/choicebox');
 
     // Scoped to the group rather than reached by test id alone. Resolving the
     // radios directly would leave the test passing if `role="radiogroup"` or
@@ -51,7 +52,7 @@ test.describe('Choicebox keyboard interaction', () => {
   test('a disabled Choicebox leaves the tab order and ignores keyboard activation', async ({
     page
   }) => {
-    await page.goto('/components/choicebox');
+    await gotoHydrated(page, '/components/choicebox');
 
     const overnight = page.getByTestId('choicebox-radio-overnight');
     await expect(overnight).toHaveAttribute('tabindex', '-1');
@@ -78,7 +79,7 @@ test.describe('Choicebox keyboard interaction', () => {
   test.fixme('sibling radio-mode Choiceboxes form a single-tab-stop group with arrow-key roving selection', async ({
     page
   }) => {
-    await page.goto('/components/choicebox');
+    await gotoHydrated(page, '/components/choicebox');
 
     const standard = page.getByTestId('choicebox-radio-standard');
     const express = page.getByTestId('choicebox-radio-express');

--- a/tests/a11y-command-menu.spec.ts
+++ b/tests/a11y-command-menu.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // WAI-ARIA combobox-with-listbox-popup pattern. Three real gaps were fixed alongside this
 // spec: Tab escaped the dialog entirely despite aria-modal="true" (now trapped on the
@@ -10,7 +11,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   test('opening focuses the input, and Tab/Shift+Tab stay trapped inside the dialog', async ({
     page
   }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
 
     await page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' }).click();
     const input = page.getByTestId('command-menu-demo-input');
@@ -25,7 +26,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   test('Escape closes the menu and returns focus to the button that opened it', async ({
     page
   }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
 
     const openButton = page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' });
     await openButton.click();
@@ -39,7 +40,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   test('ArrowDown/ArrowUp move the highlight without wrapping past either end', async ({
     page
   }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
     await page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' }).click();
 
     const newFile = page.getByTestId('command-menu-demo-item-new-file');
@@ -72,7 +73,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   test('Enter selects the highlighted item, closes the menu, and returns focus to the opener', async ({
     page
   }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
 
     const openButton = page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' });
     await openButton.click();
@@ -93,7 +94,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   test('the input carries the combobox contract, wired to a real listbox and a real active option', async ({
     page
   }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
     await page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' }).click();
 
     const input = page.getByTestId('command-menu-demo-input');
@@ -114,7 +115,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   });
 
   test('typing filters the list and resets the highlight to the first match', async ({ page }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
     await page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' }).click();
 
     const input = page.getByTestId('command-menu-demo-input');
@@ -130,7 +131,7 @@ test.describe('CommandMenu keyboard interaction (WAI-ARIA combobox pattern)', ()
   });
 
   test('the overlay exposes a modal dialog with an accessible name', async ({ page }) => {
-    await page.goto('/components/command-menu');
+    await gotoHydrated(page, '/components/command-menu');
     await page.getByRole('button', { name: 'Open Command Menu (Ctrl+K)' }).click();
 
     const dialog = page.getByRole('dialog', { name: 'Command menu' });

--- a/tests/a11y-context-menu.spec.ts
+++ b/tests/a11y-context-menu.spec.ts
@@ -1,18 +1,19 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // WAI-ARIA APG menu pattern. ContextMenu previously never returned focus to whatever
 // opened it (see the openerElement fix alongside this spec) — every one of these tests
 // after the first exercises a real keyboard-only round trip through the menu.
 test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => {
   test('right-clicking the target opens the menu and focuses the first item', async ({ page }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     await page.getByTestId('context-menu-target').click({ button: 'right' });
     await expect(page.getByRole('menuitem', { name: 'Cut' })).toBeFocused();
   });
 
   test('ArrowDown/ArrowUp move focus between items and wrap at the ends', async ({ page }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
     await page.getByTestId('context-menu-target').click({ button: 'right' });
 
     const cut = page.getByRole('menuitem', { name: 'Cut' });
@@ -35,7 +36,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   });
 
   test('Home and End jump to the first and last item', async ({ page }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
     await page.getByTestId('context-menu-target').click({ button: 'right' });
 
     await page.keyboard.press('End');
@@ -48,7 +49,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   test('Escape closes the menu and returns focus to the element that opened it', async ({
     page
   }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     const target = page.getByTestId('context-menu-target');
     await target.focus();
@@ -62,7 +63,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   });
 
   test('Tab closes the menu instead of trapping focus inside it', async ({ page }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     await page.getByTestId('context-menu-target').click({ button: 'right' });
     await expect(page.getByRole('menuitem', { name: 'Cut' })).toBeFocused();
@@ -74,7 +75,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   test('Enter selects the focused item, closes the menu, and returns focus to the opener', async ({
     page
   }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     const target = page.getByTestId('context-menu-target');
     await target.focus();
@@ -98,7 +99,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   test('closing by clicking a focusable element outside leaves focus there, not on the opener', async ({
     page
   }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     const target = page.getByTestId('context-menu-target');
     const outside = page.getByTestId('context-menu-outside-button');
@@ -118,7 +119,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   test('right-clicking a focusable target while focus is elsewhere returns focus to the target', async ({
     page
   }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     const target = page.getByTestId('context-menu-target');
     const outside = page.getByTestId('context-menu-outside-button');
@@ -142,7 +143,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   });
 
   test('closing with Escape still returns focus to the opener', async ({ page }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     const target = page.getByTestId('context-menu-target');
     await target.focus();
@@ -164,7 +165,7 @@ test.describe('ContextMenu keyboard interaction (WAI-ARIA menu pattern)', () => 
   test('the application role is scoped to while the menu is open, and the menu carries menu/menuitem roles', async ({
     page
   }) => {
-    await page.goto('/components/context-menu');
+    await gotoHydrated(page, '/components/context-menu');
 
     // role="application" makes a screen reader pass every keystroke through.
     // That is right while a menu owns the keyboard and wrong the rest of the

--- a/tests/a11y-pagination.spec.ts
+++ b/tests/a11y-pagination.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Pagination renders plain native <button> elements, so Tab order, Enter/Space
 // activation and disabled exclusion are the browser's job. These tests pin the
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 // wiring the `disabled` prop is supposed to produce.
 test.describe('Pagination keyboard interaction', () => {
   test('Tab reaches a page control and Enter/Space activates it', async ({ page }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
 
     const basic = page.getByTestId('pagination-basic');
     const page2 = basic.getByRole('button', { name: 'Page 2', exact: true });
@@ -28,7 +29,7 @@ test.describe('Pagination keyboard interaction', () => {
   test('aria-current marks only the active page, and prev/next carry their own names', async ({
     page
   }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
 
     const basic = page.getByTestId('pagination-basic');
     await expect(basic.getByRole('button', { name: 'Page 1', exact: true })).toHaveAttribute(
@@ -42,14 +43,14 @@ test.describe('Pagination keyboard interaction', () => {
   test('the previous button is natively disabled (and unreachable by Tab) on the first page', async ({
     page
   }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
 
     const basic = page.getByTestId('pagination-basic');
     await expect(basic.getByRole('button', { name: 'Previous page' })).toBeDisabled();
   });
 
   test('the disabled prop natively disables every button in the group', async ({ page }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
 
     // This instance carries no testId, so scope by the only nav whose buttons are
     // all disabled.
@@ -62,7 +63,7 @@ test.describe('Pagination keyboard interaction', () => {
   test('cursor mode: the load-more control is keyboard-activatable and gets its own name', async ({
     page
   }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
 
     const cursor = page.getByTestId('pagination-cursor');
     await cursor.getByRole('button', { name: 'Page 3', exact: true }).click();

--- a/tests/a11y-radio.spec.ts
+++ b/tests/a11y-radio.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // <input type="radio"> gets grouping, single-tab-stop, and arrow-key roving selection
 // entirely from the browser once radios share a name — Radio.svelte adds no custom
@@ -8,7 +9,7 @@ test.describe('Radio keyboard interaction (native radio group)', () => {
   test('the checked radio is the only member reachable by Tab (single-tab-stop group)', async ({
     page
   }) => {
-    await page.goto('/components/radio');
+    await gotoHydrated(page, '/components/radio');
 
     const upi = page.getByRole('radio', { name: 'UPI' });
     const card = page.getByRole('radio', { name: 'Card' });
@@ -28,7 +29,7 @@ test.describe('Radio keyboard interaction (native radio group)', () => {
   });
 
   test('ArrowDown/ArrowUp move focus and selection together across the group', async ({ page }) => {
-    await page.goto('/components/radio');
+    await gotoHydrated(page, '/components/radio');
 
     const upi = page.getByRole('radio', { name: 'UPI' });
     const card = page.getByRole('radio', { name: 'Card' });
@@ -52,7 +53,7 @@ test.describe('Radio keyboard interaction (native radio group)', () => {
   test('each radio carries its accessible name from the associated label text', async ({
     page
   }) => {
-    await page.goto('/components/radio');
+    await gotoHydrated(page, '/components/radio');
 
     // The native input is visually replaced by a custom .radio-indicator sibling
     // (width/height 0, opacity 0 — a standard accessible custom-control pattern, not
@@ -66,7 +67,7 @@ test.describe('Radio keyboard interaction (native radio group)', () => {
   });
 
   test('selecting via the keyboard is reflected in the page state', async ({ page }) => {
-    await page.goto('/components/radio');
+    await gotoHydrated(page, '/components/radio');
 
     await page.getByRole('radio', { name: 'UPI' }).focus();
     await page.keyboard.press('ArrowDown');

--- a/tests/a11y-slider-wc-label.spec.ts
+++ b/tests/a11y-slider-wc-label.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `sui-slider` renders the native range input inside an open shadow root, and
 // ARIA IDREF attributes do not cross a shadow boundary: an `aria-labelledby` on
@@ -13,7 +14,7 @@ import { expect, test } from '@playwright/test';
 // text. These tests pin both halves: the resolved name, and the fact that a
 // plain `aria-label` still wins where both are absent.
 const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-slider') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/a11y-slider.spec.ts
+++ b/tests/a11y-slider.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // <input type="range"> already gets its arrow-key/Home/End behaviour and role="slider"
 // entirely free from the browser — Slider.svelte adds no custom keydown handling. What
@@ -11,7 +12,7 @@ test.describe('Slider keyboard interaction (native range input)', () => {
   test('Tab reaches the slider, which exposes an accessible name via aria-label', async ({
     page
   }) => {
-    await page.goto('/components/slider');
+    await gotoHydrated(page, '/components/slider');
 
     const slider = page.getByRole('slider', { name: 'Volume' });
     await expect(slider).toBeVisible();
@@ -38,7 +39,7 @@ test.describe('Slider keyboard interaction (native range input)', () => {
   test('Arrow keys nudge the value by one step in each direction, reflected in the displayed value', async ({
     page
   }) => {
-    await page.goto('/components/slider');
+    await gotoHydrated(page, '/components/slider');
 
     const slider = page.getByRole('slider', { name: 'Volume' });
     const display = page.locator('.slider-value');
@@ -64,7 +65,7 @@ test.describe('Slider keyboard interaction (native range input)', () => {
   });
 
   test('Home and End jump to the minimum and maximum', async ({ page }) => {
-    await page.goto('/components/slider');
+    await gotoHydrated(page, '/components/slider');
 
     const slider = page.getByRole('slider', { name: 'Volume' });
     await slider.focus();
@@ -77,7 +78,7 @@ test.describe('Slider keyboard interaction (native range input)', () => {
   });
 
   test('the min/max contract is exposed as real DOM attributes', async ({ page }) => {
-    await page.goto('/components/slider');
+    await gotoHydrated(page, '/components/slider');
 
     const slider = page.getByRole('slider', { name: 'Volume' });
     await expect(slider).toHaveAttribute('min', '0');

--- a/tests/a11y-stepper.spec.ts
+++ b/tests/a11y-stepper.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Each Step is an independent role="button" tab stop (not a roving-tabindex composite)
 // — a deliberate choice for this "clickable breadcrumb" shape, not an APG tablist or
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // genuinely removes a step from the tab order.
 test.describe('Stepper and Step keyboard interaction', () => {
   test('each step is independently reachable by Tab', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     const cartStep = container.getByRole('button', { name: 'Cart' });
@@ -21,7 +22,7 @@ test.describe('Stepper and Step keyboard interaction', () => {
   });
 
   test('Enter and Space both activate a step, moving aria-current to it', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     const shippingStep = container.getByRole('button', { name: 'Shipping' });
@@ -43,14 +44,14 @@ test.describe('Stepper and Step keyboard interaction', () => {
   });
 
   test('the accessible name comes from the step label, via aria-labelledby', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     await expect(container.getByRole('button', { name: 'Confirm' })).toBeVisible();
   });
 
   test('suppressRoleAndTabindex removes a step from the tab order entirely', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-informational');
     const cartStep = container.locator('.step').filter({ hasText: 'Cart' });

--- a/tests/accordion-aria-controls.test.ts
+++ b/tests/accordion-aria-controls.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Accordion — the trigger is linked to the panel it controls', () => {
   // The trigger and the collapsible panel are siblings, not ancestor/descendant, so
@@ -9,7 +10,7 @@ test.describe('Accordion — the trigger is linked to the panel it controls', ()
   test('aria-controls points at the panel element, which really carries that id', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const panel = page.getByTestId('accordion-linked');
     const trigger = page.locator('.accordion-trigger').first();
@@ -22,7 +23,7 @@ test.describe('Accordion — the trigger is linked to the panel it controls', ()
   });
 
   test('aria-expanded tracks the real open state on the linked panel', async ({ page }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const trigger = page.locator('.accordion-trigger').first();
     const panel = page.getByTestId('accordion-linked');
@@ -39,7 +40,7 @@ test.describe('Accordion — the trigger is linked to the panel it controls', ()
   test('each instance generates its own panel id, so two accordions never collide', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const triggers = page.locator('.accordion-trigger');
     const first = await triggers.nth(0).getAttribute('aria-controls');
@@ -53,7 +54,7 @@ test.describe('Accordion — the trigger is linked to the panel it controls', ()
   test('the panel is a region named by its trigger, so the link runs both ways', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const trigger = page.locator('.accordion-trigger').first();
     const panel = page.getByTestId('accordion-linked');
@@ -69,7 +70,7 @@ test.describe('Accordion — the trigger is linked to the panel it controls', ()
   test('an explicit panelId is used verbatim for both the panel and the reference', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const panel = page.getByTestId('accordion-custom-panel');
     await expect(panel).toHaveAttribute('id', 'returns-policy-panel');
@@ -81,7 +82,7 @@ test.describe('Accordion — the trigger is linked to the panel it controls', ()
   test('the trigger id is stable: assigning panelId later moves the panel id, not the trigger', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const panel = page.getByTestId('accordion-late-id');
     const trigger = page.locator('.accordion-trigger', {

--- a/tests/accordion-grid-collapse.spec.ts
+++ b/tests/accordion-grid-collapse.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Locator } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Waits for an element's box to stop changing, rather than for a fixed
 // duration. A `transitionend` listener is the obvious alternative but races:
@@ -53,7 +54,7 @@ test.describe('Accordion inside a grid container (#550)', () => {
   test('the expanded panel sizes from its own content, not from whatever height the grid parent happens to have', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const panel = page.getByTestId('accordion-grid-nested');
     const toggle = page.getByTestId('accordion-grid-toggle');
@@ -104,7 +105,7 @@ test.describe('Accordion inside a grid container (#550)', () => {
   test('the grid parent itself is unaffected — its own box stays the same collapsed or expanded', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const parent = page.getByTestId('accordion-grid-parent');
     const toggle = page.getByTestId('accordion-grid-toggle');

--- a/tests/brand-loader-css-var-namespacing.spec.ts
+++ b/tests/brand-loader-css-var-namespacing.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // BrandLoader's .loader element used to read --loader-width/--loader-height
 // directly. Loader.svelte independently reads the exact same two variable
@@ -13,7 +14,7 @@ test.describe('BrandLoader CSS variable namespacing', () => {
   test('the legacy --loader-width/--loader-height names still size the loader (backward compatibility)', async ({
     page
   }) => {
-    await page.goto('/components/brand-loader');
+    await gotoHydrated(page, '/components/brand-loader');
 
     const loaderBox = page.getByTestId('brand-loader-legacy-demo').locator('.loader');
     const box = await loaderBox.boundingBox();
@@ -25,7 +26,7 @@ test.describe('BrandLoader CSS variable namespacing', () => {
   test('the namespaced --brand-loader-width/--brand-loader-height names size the loader', async ({
     page
   }) => {
-    await page.goto('/components/brand-loader');
+    await gotoHydrated(page, '/components/brand-loader');
 
     const loaderBox = page.getByTestId('brand-loader-namespaced-demo').locator('.loader');
     const box = await loaderBox.boundingBox();
@@ -37,7 +38,7 @@ test.describe('BrandLoader CSS variable namespacing', () => {
   test('the namespaced variable wins when both the legacy and namespaced names are set', async ({
     page
   }) => {
-    await page.goto('/components/brand-loader');
+    await gotoHydrated(page, '/components/brand-loader');
 
     const loaderBox = page.getByTestId('brand-loader-precedence-demo').locator('.loader');
     const box = await loaderBox.boundingBox();

--- a/tests/button-title-busy.test.ts
+++ b/tests/button-title-busy.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // A menu/filter trigger needs a hover tooltip and a "contents still loading" signal while
 // staying clickable. Button previously derived aria-busy solely from `loading`, which also
 // disables the control, so that state was unreachable; `title` had no prop at all.
 test.describe('Button — title and ariaBusy', () => {
   test('renders both attributes on the button element', async ({ page }) => {
-    await page.goto('/components/button');
+    await gotoHydrated(page, '/components/button');
 
     const button = page.getByTestId('button-title-busy');
     await expect(button).toHaveAttribute('title', 'Filters');
@@ -20,7 +21,7 @@ test.describe('Button — title and ariaBusy', () => {
   test('ariaHaspopup round-trips from Menu onto a Button trigger, and tracks expansion', async ({
     page
   }) => {
-    await page.goto('/components/button');
+    await gotoHydrated(page, '/components/button');
 
     const trigger = page.getByTestId('button-haspopup');
     await expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
@@ -33,13 +34,13 @@ test.describe('Button — title and ariaBusy', () => {
   });
 
   test('ariaBusy leaves the button enabled — unlike loading', async ({ page }) => {
-    await page.goto('/components/button');
+    await gotoHydrated(page, '/components/button');
 
     await expect(page.getByTestId('button-title-busy')).toBeEnabled();
   });
 
   test('consumers that pass neither prop are unchanged', async ({ page }) => {
-    await page.goto('/components/button');
+    await gotoHydrated(page, '/components/button');
 
     // Regression guard: both props default to undefined and must render as
     // "attribute absent", not as an empty string.

--- a/tests/card-anchor-div-layout-parity.spec.ts
+++ b/tests/card-anchor-div-layout-parity.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The anchor-rendering PR swaps Card's root between <div> and <a> via
 // svelte:element, but .card had no explicit `display`, so its layout
@@ -17,7 +18,7 @@ test.describe('Card anchor/div layout parity', () => {
   test('an anchor-rendered card has the same bounding box as an identical div-rendered card', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
     const divBox = await page.getByTestId('parity-div-card').boundingBox();
     const anchorBox = await page.getByTestId('parity-anchor-card').boundingBox();
 
@@ -30,7 +31,7 @@ test.describe('Card anchor/div layout parity', () => {
   test('the anchor-rendered card computes display:block, not the browser default inline', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
     const display = await page
       .getByTestId('parity-anchor-card')
       .evaluate((el) => getComputedStyle(el).display);
@@ -38,7 +39,7 @@ test.describe('Card anchor/div layout parity', () => {
   });
 
   test('the anchor-rendered card has no underline (text-decoration reset)', async ({ page }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
     const textDecorationLine = await page
       .getByTestId('parity-anchor-card')
       .evaluate((el) => getComputedStyle(el).textDecorationLine);

--- a/tests/card-attrs-and-as.test.ts
+++ b/tests/card-attrs-and-as.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Card had no way to (a) put an arbitrary data-*/aria-* attribute on its root
 // or (b) render a tag other than <div>/<a> — the two things
@@ -14,7 +15,7 @@ import { expect, test } from '@playwright/test';
 // changes the rendered tag away from its href-derived default.
 test.describe('Card attrs and as', () => {
   test('attrs spreads arbitrary data-* attributes onto the root', async ({ page }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('attrs-data-state-card');
     await expect(card).toHaveAttribute('data-state', 'waiting');
@@ -24,7 +25,7 @@ test.describe('Card attrs and as', () => {
   });
 
   test('as="figure" renders the root as a real <figure>, not a <div>', async ({ page }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('as-figure-card');
     await expect(card).toHaveCount(1);
@@ -37,7 +38,7 @@ test.describe('Card attrs and as', () => {
   test('as overrides the href-derived default: a figure with href renders no href attribute', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('as-figure-with-href-card');
     const tagName = await card.evaluate((el) => el.tagName.toLowerCase());
@@ -48,7 +49,7 @@ test.describe('Card attrs and as', () => {
   test('attrs cannot override the attributes Card already manages (data-pw, class, role)', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     // This card passes attrs = { 'data-pw': 'hijacked', class: 'attrs-injected-class',
     // role: 'not-a-button' } alongside testId="attrs-collision-card" and
@@ -70,7 +71,7 @@ test.describe('Card attrs and as', () => {
   test('omitting attrs/as leaves the default div root unaffected (no regression)', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     // Regression guard for every existing consumer: a card given neither prop
     // still renders a plain <div> with no attributes it didn't have before.
@@ -88,7 +89,7 @@ test.describe('Card attrs and as', () => {
   // Enter/Space-activatable. `isAnchor` now also requires `href` to be set,
   // so this case keeps the shim instead.
   test('as="a" without href still gets the interactive-div keyboard shim', async ({ page }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('as-a-no-href-card');
     const tagName = await card.evaluate((el) => el.tagName.toLowerCase());

--- a/tests/card-title-description-snippets.test.ts
+++ b/tests/card-title-description-snippets.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers Card's `titleSnippet` / `descriptionSnippet`. The reason they exist:
 // `title` and `description` are plain strings, so a consumer whose heading
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // containers, so the header keeps its normal typography.
 test.describe('Card title/description snippets', () => {
   test('titleSnippet renders the header even when no title string is passed', async ({ page }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('card-snippet-header');
     await expect(card).toBeVisible();
@@ -21,7 +22,7 @@ test.describe('Card title/description snippets', () => {
   test('snippet content renders inside the card-title / card-description containers', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('card-snippet-header');
 
@@ -40,7 +41,7 @@ test.describe('Card title/description snippets', () => {
   test('string title/description still render unchanged when no snippet is given', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     // Regression guard for every existing consumer: the string path is untouched.
     const stringCard = page.locator('.card', { hasText: 'Order Summary' }).first();

--- a/tests/carousel.test.ts
+++ b/tests/carousel.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Carousel', () => {
   test('spreads each slide view.properties onto its component, not nested under a properties prop', async ({
     page
   }) => {
-    await page.goto('/components/carousel');
+    await gotoHydrated(page, '/components/carousel');
 
     const carousel = page.getByTestId('carousel-manual-demo');
     // Regression test: view.component previously received a single `properties` prop
@@ -17,7 +18,7 @@ test.describe('Carousel', () => {
   test('clicking a dot navigates to that slide, rendering its own spread properties', async ({
     page
   }) => {
-    await page.goto('/components/carousel');
+    await gotoHydrated(page, '/components/carousel');
 
     const carousel = page.getByTestId('carousel-manual-demo');
     const dot1 = page.getByTestId('carousel-manual-dot-1');
@@ -46,7 +47,7 @@ test.describe('Carousel', () => {
   });
 
   test('the active dot is exposed as aria-current, and only that one', async ({ page }) => {
-    await page.goto('/components/carousel');
+    await gotoHydrated(page, '/components/carousel');
     const dot1 = page.getByTestId('carousel-manual-dot-1');
     const dot2 = page.getByTestId('carousel-manual-dot-2');
 
@@ -65,7 +66,7 @@ test.describe('Carousel', () => {
   });
 
   test('pressing Enter on a focused dot navigates to that slide', async ({ page }) => {
-    await page.goto('/components/carousel');
+    await gotoHydrated(page, '/components/carousel');
 
     const carousel = page.getByTestId('carousel-manual-demo');
     const dot1 = page.getByTestId('carousel-manual-dot-1');
@@ -88,7 +89,7 @@ test.describe('Carousel', () => {
 
 test.describe('Carousel backward compatibility and announcements', () => {
   test('a wrapper that declares `properties` still receives the bag', async ({ page }) => {
-    await page.goto('/components/carousel');
+    await gotoHydrated(page, '/components/carousel');
     const legacy = page.getByTestId('carousel-legacy-demo');
     await expect(legacy).toBeVisible();
     // Spreading the bag was the fix, but the pre-existing wrapper shape has to
@@ -99,7 +100,7 @@ test.describe('Carousel backward compatibility and announcements', () => {
   });
 
   test('the active slide position is announced to assistive technology', async ({ page }) => {
-    await page.goto('/components/carousel');
+    await gotoHydrated(page, '/components/carousel');
     const carousel = page.getByTestId('carousel-manual-demo');
     const live = carousel.locator('[aria-live="polite"]');
     await expect(live).toHaveText('Slide 1 of 3');

--- a/tests/chart-behaviors.spec.ts
+++ b/tests/chart-behaviors.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('interactive legend', () => {
   test('clicking a legend item hides that series and rescales', async ({ page }) => {
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     const chart = page.getByTestId('bar-legend-toggle-chart');
     await expect(chart.getByTestId(/^bar-\d+$/)).toHaveCount(12); // 3 series × 4 categories
     const firstToggle = chart.getByTestId('legend-toggle-0');
@@ -16,7 +17,7 @@ test.describe('interactive legend', () => {
 
 test.describe('bar value labels', () => {
   test('bars at the axis max flip their label inside', async ({ page }) => {
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     const chart = page.getByTestId('bar-inside-flip-chart');
     // Bars at the axis max flip their label inside
     await expect
@@ -43,7 +44,7 @@ test.describe('bar value labels', () => {
 
 test.describe('tooltip clamping', () => {
   test('anchored tooltip never overflows the chart box', async ({ page }) => {
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     const chart = page.getByTestId('bar-inside-flip-chart');
     await chart
       .getByTestId(/^bar-\d+$/)
@@ -63,7 +64,7 @@ test.describe('tooltip clamping', () => {
 test.describe('axis crowding', () => {
   test('crowded category labels rotate and thin instead of overlapping', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 720 });
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     // The docs layout has no mobile breakpoint: wide <pre> blocks pin the
     // content column near 800px, so the chart never actually narrows. Collapse
     // the chrome (same override as the visual mobile project) so the chart
@@ -91,7 +92,7 @@ test.describe('bar value label override', () => {
   test('a data point with valueLabel renders that exact text; others keep the default valueFormat', async ({
     page
   }) => {
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     const chart = page.getByTestId('bar-value-label-chart');
     // valueLabel is set: rendered verbatim instead of the formatted value.
     await expect(chart.getByTestId('bar-value-0')).toHaveText('5,000 visits');
@@ -101,7 +102,7 @@ test.describe('bar value label override', () => {
   });
 
   test('an empty valueLabel is treated as absent, not as a blank label', async ({ page }) => {
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     const chart = page.getByTestId('bar-value-label-chart');
     // Pins the non-empty-only contract: `valueLabel: ''` falls back to the
     // formatter rather than rendering an empty value label. If that contract is
@@ -112,7 +113,7 @@ test.describe('bar value label override', () => {
 
 test.describe('line hover', () => {
   test('hover shows a halo and a shared tooltip listing all series', async ({ page }) => {
-    await page.goto('/components/line-chart');
+    await gotoHydrated(page, '/components/line-chart');
     const chart = page.getByTestId('line-shared-tooltip-chart');
     await chart.getByTestId('hover-overlay').hover({ position: { x: 200, y: 100 } });
     await expect(chart.getByTestId(/^dot-halo-\d+$/)).toHaveCount(3);
@@ -124,7 +125,7 @@ test.describe('line hover', () => {
 
 test.describe('keyboard', () => {
   test('Enter on a focused category fires onbarclick', async ({ page }) => {
-    await page.goto('/components/dual-axis-bar-chart');
+    await gotoHydrated(page, '/components/dual-axis-bar-chart');
     const chart = page.getByTestId('demo-custom-tooltip');
     const target = chart.getByTestId('hover-target-0');
     await target.focus();
@@ -139,7 +140,7 @@ test.describe('touch', () => {
   test.use({ hasTouch: true });
 
   test('tapping a funnel stage shows the tooltip; tapping outside dismisses', async ({ page }) => {
-    await page.goto('/components/funnel-chart');
+    await gotoHydrated(page, '/components/funnel-chart');
     const chart = page.getByTestId('funnel-many-stages-chart');
     await chart.getByTestId('funnel-bar-0').tap();
     await expect(chart.getByTestId('chart-tooltip')).toBeVisible();
@@ -148,7 +149,7 @@ test.describe('touch', () => {
   });
 
   test('keyboard focus on a bar shows its tooltip', async ({ page }) => {
-    await page.goto('/components/bar-chart');
+    await gotoHydrated(page, '/components/bar-chart');
     const chart = page.getByTestId('bar-inside-flip-chart');
     await chart
       .getByTestId(/^bar-\d+$/)

--- a/tests/chat-composer-async-submit.test.ts
+++ b/tests/chat-composer-async-submit.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('ChatComposer — async onsubmit and independent per-control disable', () => {
   // #526: an onsubmit resolving to `false` must leave the draft (value +
@@ -9,7 +10,7 @@ test.describe('ChatComposer — async onsubmit and independent per-control disab
   test('a failed async send keeps the typed draft; a successful one clears it', async ({
     page
   }) => {
-    await page.goto('/components/chat-composer');
+    await gotoHydrated(page, '/components/chat-composer');
 
     const input = page.getByTestId('async-submit-input');
     const send = page.getByTestId('async-submit-send');
@@ -43,7 +44,7 @@ test.describe('ChatComposer — async onsubmit and independent per-control disab
   test('a rejected async send keeps the typed draft, same as a resolved false', async ({
     page
   }) => {
-    await page.goto('/components/chat-composer');
+    await gotoHydrated(page, '/components/chat-composer');
 
     const input = page.getByTestId('async-submit-input');
     const send = page.getByTestId('async-submit-send');
@@ -63,7 +64,7 @@ test.describe('ChatComposer — async onsubmit and independent per-control disab
   // other control stay interactive. Proven here by typing into the input
   // while a send is in flight (sendDisabled is bound to the pending flag).
   test('sendDisabled bound to a pending flag blocks only the send button', async ({ page }) => {
-    await page.goto('/components/chat-composer');
+    await gotoHydrated(page, '/components/chat-composer');
 
     const input = page.getByTestId('async-submit-input');
     const send = page.getByTestId('async-submit-send');
@@ -81,7 +82,7 @@ test.describe('ChatComposer — async onsubmit and independent per-control disab
   // with the other control (and the shared `disabled` prop, left `false`
   // throughout this demo) left untouched.
   test('textDisabled and voiceDisabled each gate only their own control', async ({ page }) => {
-    await page.goto('/components/chat-composer');
+    await gotoHydrated(page, '/components/chat-composer');
 
     const input = page.getByTestId('per-control-disable-input');
     const voice = page.getByTestId('per-control-disable-voice');

--- a/tests/chat-message-clamp.test.ts
+++ b/tests/chat-message-clamp.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `clampLines` collapses the rendered body and makes the bubble its own control. The
 // behaviour was being rebuilt by consumers around the `body` snippet, which meant each
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // height and the exposed state rather than about the class names that produce them.
 test.describe('ChatMessage — clampLines', () => {
   test('collapses a long message and expands it by click and by keyboard', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const bubble = page.locator('[data-pw="clamp-demo"] .bubble');
     await expect(bubble).toBeVisible();
@@ -37,7 +38,7 @@ test.describe('ChatMessage — clampLines', () => {
   });
 
   test('clampLines drives the clamp, so a different value clamps differently', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const twoBody = page.locator('[data-pw="clamp-demo"] .body');
     const fourBody = page.locator('[data-pw="clamp-demo-four"] .body');
@@ -57,7 +58,7 @@ test.describe('ChatMessage — clampLines', () => {
   });
 
   test('withdrawing clampLines re-clamps the message when it is restored', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const bubble = page.locator('[data-pw="clamp-demo-toggle"] .bubble');
     const toggle = page.locator('[data-pw="clamp-toggle"]');
@@ -77,7 +78,7 @@ test.describe('ChatMessage — clampLines', () => {
   });
 
   test('the clamped bubble is named by what it does and reports its state', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     // The disclosure control is a real button with its own name and state. The bubble
     // must NOT be one: a button flattens the semantics of everything inside it, and a
@@ -105,7 +106,7 @@ test.describe('ChatMessage — clampLines', () => {
   test('a consumer stylesheet outranks the prop, which is what the docs promise', async ({
     page
   }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     const fourBody = page.locator('[data-pw="clamp-demo-four"] .body');
     await expect(fourBody).toHaveCSS('-webkit-line-clamp', '4');
 
@@ -116,7 +117,7 @@ test.describe('ChatMessage — clampLines', () => {
   });
 
   test('activating a link inside a clamped message does not also toggle it', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const bubble = page.locator('[data-pw="clamp-demo-link"] .bubble');
     const link = page.locator('[data-pw="clamp-inner-link"]');
@@ -136,7 +137,7 @@ test.describe('ChatMessage — clampLines', () => {
   });
 
   test('a message without clampLines gets no interactive role', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     const plain = page.locator('.chat-message .bubble').first();
     await expect(plain).not.toHaveAttribute('role', 'button');
   });

--- a/tests/chat-message-list-pin-release.test.ts
+++ b/tests/chat-message-list-pin-release.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // pin-sender-turn reserves headroom on the inner wrapper so the newest sender message can reach
 // the top of the viewport, then scrolls it there. Two things used to conspire to lose that pin on
@@ -16,7 +17,7 @@ test.describe('ChatMessageList — pin-sender-turn without pinHold', () => {
   test('a reply shorter than the frame still leaves the sender message pinned to the top', async ({
     page
   }) => {
-    await page.goto('/components/chat-message-list');
+    await gotoHydrated(page, '/components/chat-message-list');
 
     const list = page.locator('[data-pw="pin-nohold-list"]');
     await expect(list).toBeVisible();
@@ -45,7 +46,7 @@ test.describe('ChatMessageList — pin-sender-turn without pinHold', () => {
   });
 
   test('a second turn re-pins, so the reservation tracks the newest question', async ({ page }) => {
-    await page.goto('/components/chat-message-list');
+    await gotoHydrated(page, '/components/chat-message-list');
     const list = page.locator('[data-pw="pin-nohold-list"]');
     await expect(list).toBeVisible();
 

--- a/tests/chat-message-marker.test.ts
+++ b/tests/chat-message-marker.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The marker is a decorative accent bar. The two things that can silently go wrong are
 // that it is not painted at all (a token resolving to nothing, a dropped class) and that
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // bubble's own styling rather than trusting a single absolute value.
 test.describe('ChatMessage — marker', () => {
   test('paints an accent bar only on the message that asks for one', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const withMarker = page.locator('[data-pw="marker-demo"] .marker');
     const withoutMarker = page.locator('[data-pw="marker-demo-off"] .marker');
@@ -33,7 +34,7 @@ test.describe('ChatMessage — marker', () => {
   });
 
   test('is hidden from assistive technology', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     const marker = page.locator('[data-pw="marker-demo"] .marker');
     await expect(marker).toHaveAttribute('aria-hidden', 'true');
     // It must not contribute text either — a bar that reads out is worse than no bar.
@@ -41,7 +42,7 @@ test.describe('ChatMessage — marker', () => {
   });
 
   test('the offset token moves it into the gutter, outside the bubble', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const inside = await page.locator('[data-pw="marker-demo"] .marker').boundingBox();
     const insideBubble = await page.locator('[data-pw="marker-demo"] .bubble').boundingBox();
@@ -61,7 +62,7 @@ test.describe('ChatMessage — marker', () => {
   // it would swallow those clicks silently — the link still looks and reads fine, it just
   // stops working in a strip a few pixels wide.
   test('does not intercept clicks meant for content underneath it', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const marker = page.locator('[data-pw="marker-demo-link"] .marker');
     await expect(marker).toHaveCount(1);

--- a/tests/chat-message-typewriter.test.ts
+++ b/tests/chat-message-typewriter.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `typewriter` renders the message through TypewriterText instead of painting it at once.
 // The risk in wiring two components together is that the reveal silently stops being a
@@ -8,7 +9,7 @@ test.describe('ChatMessage — typewriter', () => {
   test('reveals a streamed message progressively and completes when streaming stops', async ({
     page
   }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     // Deliberately the slow demo (200ms/char), not the human-paced one. At the demo's
     // own 30ms a 51-character reveal closes in ~1.5s, which a stalled runner can step
@@ -37,7 +38,7 @@ test.describe('ChatMessage — typewriter', () => {
   });
 
   test('types markdown through the markdown pipeline, not as raw syntax', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     await page.locator('[data-pw="typewriter-start"]').click();
     await page.locator('[data-pw="typewriter-finish"]').click();
 
@@ -48,7 +49,7 @@ test.describe('ChatMessage — typewriter', () => {
   });
 
   test('the revealing body is silenced for the surrounding live region', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     // The demo starts with no text, so nothing renders until a stream begins.
     await page.locator('[data-pw="typewriter-start"]').click();
 
@@ -94,7 +95,7 @@ test.describe('ChatMessage — typewriter', () => {
     // The markdown renderer loads asynchronously, so a message whose markdown is already
     // set when the component mounts races it. What must hold is that the settled message
     // is rendered markdown, never the source string.
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const body = page.locator('[data-pw="typewriter-at-load"] .body');
     await expect(body.locator('strong')).toHaveText('bold');
@@ -102,13 +103,13 @@ test.describe('ChatMessage — typewriter', () => {
   });
 
   test('a non-streaming typewriter message is shown in full', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     const body = page.locator('[data-pw="typewriter-static"] .body');
     await expect(body).toHaveText('A message that is not streaming shows in full immediately.');
   });
 
   test('without the prop the message is painted at once, with no typewriter', async ({ page }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
     const plain = page.locator('[data-pw="chat-message-settled-bubble"]');
     await expect(plain.locator('.typewriter-text')).toHaveCount(0);
   });
@@ -119,7 +120,7 @@ test.describe('ChatMessage — typewriter', () => {
 // just all at once, which looks correct in a screenshot and is only visible over time.
 test.describe('ChatMessageList — forwards the per-message typewriter', () => {
   test('reveals only the message that carries the flag', async ({ page }) => {
-    await page.goto('/components/chat-message-list');
+    await gotoHydrated(page, '/components/chat-message-list');
 
     const list = page.locator('[data-pw="reveal-list"]');
     const responder = list.locator('.chat-message').nth(1).locator('.body');

--- a/tests/chat-scroll-policy-passthrough.test.ts
+++ b/tests/chat-scroll-policy-passthrough.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Chat scroll policy passthrough', () => {
   test('forwards scroll policy, pin hold, jump controls, and scroll state to its message list', async ({
     page
   }) => {
-    await page.goto('/components/chat');
+    await gotoHydrated(page, '/components/chat');
 
     const pinChat = page.getByTestId('chat-scroll-policy-pin');
     const pinList = pinChat.locator('.chat-message-list');

--- a/tests/chat-tool-status-backcompat.test.ts
+++ b/tests/chat-tool-status-backcompat.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Chat tool-status backward compatibility', () => {
   test('overriding the old --chat-tool-status-* variables still themes the internal chip', async ({
     page
   }) => {
-    await page.goto('/components/chat');
+    await gotoHydrated(page, '/components/chat');
 
     const chip = page.getByTestId('chat-backcompat-demo').locator('.thinking-indicator-chip');
     await chip.scrollIntoViewIfNeeded();

--- a/tests/check-list-item-disabled.test.ts
+++ b/tests/check-list-item-disabled.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('CheckListItem — disabled control styling', () => {
   test('keeps supplied label content opaque while dimming and disabling the checkbox control', async ({
     page
   }) => {
-    await page.goto('/components/check-list-item');
+    await gotoHydrated(page, '/components/check-list-item');
 
     const disabledItem = page.getByTestId('check-list-item-disabled');
     const labelContent = page.getByTestId('check-list-item-disabled-content');

--- a/tests/checkbox-accessible-name.test.ts
+++ b/tests/checkbox-accessible-name.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Checkbox names its role="checkbox" box, and the box is the node assistive technology
 // reads. The visible text is a sibling <span>, and the wrapping <label> does not name the
@@ -7,14 +8,14 @@ import { expect, test } from '@playwright/test';
 // and in any test that reads the label text rather than the computed name.
 test.describe('Checkbox — accessible name', () => {
   test('the visible text names the box', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const box = page.getByTestId('checkbox-named-by-text-box');
     await expect(box).toHaveAccessibleName('Named by its visible text');
   });
 
   test('the visible text wins over an explicit ariaLabel, per WCAG 2.5.3', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     // Label in Name: the accessible name has to carry the text on screen, so an
     // explicit `ariaLabel` cannot replace it. Letting it win would give a
@@ -26,14 +27,14 @@ test.describe('Checkbox — accessible name', () => {
   });
 
   test('ariaLabel still names a checkbox that shows no text', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const box = page.getByTestId('checkbox-named-without-text-box');
     await expect(box).toHaveAccessibleName('Named with no visible text');
   });
 
   test('every checkbox on the page has a name', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     // The sweep that found this reported `control-has-no-accessible-name` against the box
     // on five routes, every one of which passed a visible `text`. Asserting one instance

--- a/tests/checkbox-controlled.test.ts
+++ b/tests/checkbox-controlled.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Checkbox — controlled mode and box attributes', () => {
   test('a controlled checkbox whose parent adopts the click behaves like an uncontrolled one', async ({
     page
   }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const checkbox = page.getByTestId('checkbox-controlled-adopts');
     const box = checkbox.getByRole('checkbox');
@@ -21,7 +22,7 @@ test.describe('Checkbox — controlled mode and box attributes', () => {
   });
 
   test('a controlled checkbox whose parent declines the click does not flip', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const checkbox = page.getByTestId('checkbox-controlled-declines');
     const box = checkbox.getByRole('checkbox');
@@ -44,7 +45,7 @@ test.describe('Checkbox — controlled mode and box attributes', () => {
   test('attributes land on the checkbox element and win over the component test id', async ({
     page
   }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const box = page.locator('#checkbox-attributes-demo');
     await expect(box).toHaveAttribute('role', 'checkbox');

--- a/tests/checkbox-native-input-sync.test.ts
+++ b/tests/checkbox-native-input-sync.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Checkbox — native input stays in sync with the rendered state', () => {
   // Regression guard: clicking the label used to fire handleClick (flipping the
@@ -10,7 +11,7 @@ test.describe('Checkbox — native input stays in sync with the rendered state',
   test('clicking the label toggles the box, aria-checked, and the native input together', async ({
     page
   }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const checkbox = page.getByTestId('checkbox-default');
     await expect(checkbox).toBeVisible();
@@ -31,7 +32,7 @@ test.describe('Checkbox — native input stays in sync with the rendered state',
   });
 
   test('keyboard toggling via the box keeps the native input in sync', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const checkbox = page.getByTestId('checkbox-default');
     const nativeInput = checkbox.getByTestId('checkbox-default-native-input');

--- a/tests/chipinput-testids-and-editing.test.ts
+++ b/tests/chipinput-testids-and-editing.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers GAP L20: per-chip test ids (so a migrated app's specs keep a working locator per chip,
 // per delete control, and for the add/draft field) and opt-in in-place editing (activate a chip,
@@ -14,7 +15,7 @@ import { expect, test } from '@playwright/test';
 //   - the draft/add field:  `${testId}-add`                   (exact match)
 test.describe('ChipInput — per-chip test ids', () => {
   test('every chip, its delete control, and the add field carry a derived id', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     // "Product tags" demo: values = ['sale', 'featured'], editable not set.
     const chipZero = page.getByTestId('chip-input-tags-item-0');
@@ -31,7 +32,7 @@ test.describe('ChipInput — per-chip test ids', () => {
   });
 
   test('deleting a chip by its derived id removes only that value', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     await page.getByTestId('chip-input-tags-item-0-dismiss').click();
 
@@ -45,7 +46,7 @@ test.describe('ChipInput — per-chip test ids', () => {
 
 test.describe('ChipInput — editable (opt-in in-place editing)', () => {
   test('default: clicking a chip does nothing when `editable` is not set', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const chip = page.getByTestId('chip-input-tags-item-0');
     await expect(chip).toContainText('sale');
@@ -59,7 +60,7 @@ test.describe('ChipInput — editable (opt-in in-place editing)', () => {
   });
 
   test('Enter commits an edit back into values and fires onedit', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const chip = page.getByTestId('chip-input-editable-item-0');
     await expect(chip).toContainText('sale');
@@ -81,7 +82,7 @@ test.describe('ChipInput — editable (opt-in in-place editing)', () => {
   });
 
   test('blurring the edit field also commits', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const chip = page.getByTestId('chip-input-editable-item-1');
     await expect(chip).toContainText('featured');
@@ -99,7 +100,7 @@ test.describe('ChipInput — editable (opt-in in-place editing)', () => {
   });
 
   test('Escape cancels and restores the original value without firing onedit', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const chip = page.getByTestId('chip-input-editable-item-2');
     await expect(chip).toContainText('clearance');
@@ -118,7 +119,7 @@ test.describe('ChipInput — editable (opt-in in-place editing)', () => {
   test('the delete control still works while `editable` is on, on a chip not being edited', async ({
     page
   }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     // Demo state is `sale, featured, clearance` (see +page.svelte); index 2 is the LAST chip, so
     // dismissing it collapses the list to two entries rather than shifting another value into

--- a/tests/chipinput-token-passthrough.spec.ts
+++ b/tests/chipinput-token-passthrough.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // ChipInput re-declares --pill-* on the pill element to expose its own --chip-input-pill-* API.
 // Because a declaration on the element beats an inherited one, that mapping used to swallow any
@@ -17,7 +18,7 @@ import { expect, test } from '@playwright/test';
 // index 0, before these run.
 test.describe('ChipInput token passthrough', () => {
   test('falls back to the library default when nothing is themed', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const pill = page.getByTestId('chip-input-tags-item-0');
     await expect(pill).toBeVisible();
@@ -27,7 +28,7 @@ test.describe('ChipInput token passthrough', () => {
   });
 
   test('an explicit --chip-input-pill-* override still wins', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const pill = page.getByTestId('chip-input-accent-item-0');
     await expect(pill).toBeVisible();
@@ -38,7 +39,7 @@ test.describe('ChipInput token passthrough', () => {
   });
 
   test("inherits the app's own Pill theme when no component override is set", async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const pill = page.getByTestId('chip-input-inherited-item-0');
     await expect(pill).toBeVisible();
@@ -53,7 +54,7 @@ test.describe('ChipInput token passthrough', () => {
   // so an app whose Pill is a larger, squarer chip still got a 13px 999px-radius one. These assert
   // the passthrough covers appearance as a whole rather than the subset that happened to be noticed.
   test("inherits the app's Pill size and shape, not just its colours", async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const pill = page.getByTestId('chip-input-inherited-item-0');
     await expect(pill).toBeVisible();
@@ -68,7 +69,7 @@ test.describe('ChipInput token passthrough', () => {
   test('keeps the draft field structural tokens regardless of the app Input theme', async ({
     page
   }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     const draft = page.getByTestId('chip-input-inherited-add');
     await expect(draft).toBeVisible();

--- a/tests/choicebox-selected-hover.spec.ts
+++ b/tests/choicebox-selected-hover.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The library's own `.choicebox:hover` rule (specificity 0,3,0) outranked
 // `.choicebox.selected` (0,2,0), so hovering a selected card repainted it with
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // #9e9e9e (rgb(158,158,158)). The demo's first radio card is selected on load.
 test.describe('Choicebox selected + hover', () => {
   test('a selected card keeps its selected border while hovered', async ({ page }) => {
-    await page.goto('/components/choicebox');
+    await gotoHydrated(page, '/components/choicebox');
 
     const selected = page.locator('.choicebox.selected').first();
     await expect(selected).toBeVisible();

--- a/tests/choicebox-wc-show-indicator.spec.ts
+++ b/tests/choicebox-wc-show-indicator.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The Svelte component gained `showIndicator`, but the web-component wrapper
 // never declared it in customElement.props. An undeclared prop gets no
@@ -9,7 +10,7 @@ import { expect, test } from '@playwright/test';
 // it is injected into a same-origin page instead of being navigated to.
 // `pnpm run build` (the webServer command) runs build:wc, so the file exists.
 const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(
     () => typeof customElements.get('sui-choicebox') !== 'undefined',

--- a/tests/combobox-input-ref.test.ts
+++ b/tests/combobox-input-ref.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Combobox — accessing the underlying input element', () => {
   // Regression guard for a docs defect: docs/Combobox.md documented a `bind:inputElement` prop
@@ -8,7 +9,7 @@ test.describe('Combobox — accessing the underlying input element', () => {
   // the component instance plus the exported `getInputRef()` method, the same pattern Input
   // itself documents. This test proves the corrected docs' example is real, not just plausible.
   test('getInputRef() returns the real DOM node, usable for focus management', async ({ page }) => {
-    await page.goto('/components/combobox');
+    await gotoHydrated(page, '/components/combobox');
 
     const combobox = page.getByTestId('combobox-input-ref-demo');
     const input = combobox.locator('input');

--- a/tests/date-range-picker-checkmark.test.ts
+++ b/tests/date-range-picker-checkmark.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — active-preset checkmark', () => {
   // With presetCheckmark enabled, the active preset shows a trailing checkmark;
   // inactive presets show none, and no checkmark renders before a preset is picked.
   test('shows a checkmark only on the active preset', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-preset-checkmark-demo');
     await expect(picker).toBeVisible();

--- a/tests/date-range-picker-date-time.test.ts
+++ b/tests/date-range-picker-date-time.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — built-in date inputs + time selection', () => {
   // showDateInputs renders read-only start/end date boxes; showTimeSelection adds a
@@ -6,7 +7,7 @@ test.describe('DateRangePicker — built-in date inputs + time selection', () =>
   test('shows date boxes, toggles time inputs, and gates Apply on time validity', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-datetime-demo');
     await expect(picker).toBeVisible();
@@ -38,7 +39,7 @@ test.describe('DateRangePicker — built-in date inputs + time selection', () =>
   });
 
   test('blocks Apply when start time is after end time on the same day', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-datetime-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -64,7 +65,7 @@ test.describe('DateRangePicker — built-in date inputs + time selection', () =>
   test('inline layout: time inputs sit beside the dates with no toggle, and still gate Apply', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-datetime-inline-demo');
     await expect(picker).toBeVisible();

--- a/tests/date-range-picker-preset-toggle.test.ts
+++ b/tests/date-range-picker-preset-toggle.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — preset toggle-off', () => {
   // With presetToggle, re-clicking the currently-active preset deselects it and
   // reverts the highlight to the committed selection (seeded via initialPresetLabel),
   // so a toggle-style preset can be switched back off without picking a calendar date.
   test('re-clicking the active preset reverts to the committed preset', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-preset-toggle-demo');
     await expect(picker).toBeVisible();

--- a/tests/date-range-picker-reopen.test.ts
+++ b/tests/date-range-picker-reopen.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — committed preset persists across the open cycle', () => {
   // Regression guard: after applying a preset, re-opening the picker must
@@ -8,7 +9,7 @@ test.describe('DateRangePicker — committed preset persists across the open cyc
   test('re-opening after applying a same-day preset highlights only the applied preset', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-same-day-presets-demo');
     await expect(picker).toBeVisible();
@@ -33,7 +34,7 @@ test.describe('DateRangePicker — committed preset persists across the open cyc
   // Before the fix the open panel date-matched and could highlight more than the
   // seeded preset; now exactly the seeded preset is active on first open.
   test('initialPresetLabel highlights only the seeded preset on first open', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-initial-preset-demo');
     await expect(picker).toBeVisible();

--- a/tests/date-range-picker-toggle.test.ts
+++ b/tests/date-range-picker-toggle.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — trigger toggles the panel', () => {
   // Regression guard: the trigger used to only open the panel, so a second click
@@ -7,7 +8,7 @@ test.describe('DateRangePicker — trigger toggles the panel', () => {
   test('clicking the trigger while open closes the picker, and re-opens on the next click', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-range-demo');
     await expect(picker).toBeVisible();

--- a/tests/date-range-picker-typed-date-input.test.ts
+++ b/tests/date-range-picker-typed-date-input.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () => {
   // The start/end date boxes are real <input> elements now, not read-only display text:
@@ -6,7 +7,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   // preset was active (a typed date is a custom selection, same as a calendar click),
   // and leaves Apply enabled since both boundaries are still set.
   test('typing a valid date commits it on Enter and clears the active preset', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -37,7 +38,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   });
 
   test('committing a typed date also works via blur, not just Enter', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -70,7 +71,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   test('unparseable text is rejected and reverts to the last committed value on blur', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -85,7 +86,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   });
 
   test('a date past maxDate is rejected and reverts, leaving Apply enabled', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -106,7 +107,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   });
 
   test('a date before minDate is rejected and reverts', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -128,7 +129,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   test('typing a start date after the committed end date is rejected (boundary crossing)', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -171,7 +172,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   test('a boundary-crossing date is flagged invalid while typing, before any commit', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-dates-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();
@@ -214,7 +215,7 @@ test.describe('DateRangePicker — typeable date inputs (showDateInputs)', () =>
   test('retyping a boundary cannot stretch a completed range past maxRangeDays', async ({
     page
   }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-typeable-maxrange-demo');
     await picker.getByRole('button', { name: 'Open date picker' }).click();

--- a/tests/date-range-picker.test.ts
+++ b/tests/date-range-picker.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('DateRangePicker — preset highlight', () => {
   // Regression guard: when several presets fall on the same calendar day,
@@ -6,7 +7,7 @@ test.describe('DateRangePicker — preset highlight', () => {
   // previously matched by same-day instead of the chosen preset's label, so
   // "Today", "Today morning" and "Today evening" all highlighted at once.
   test('selecting one same-day preset highlights only that preset', async ({ page }) => {
-    await page.goto('/components/date-range-picker');
+    await gotoHydrated(page, '/components/date-range-picker');
 
     const picker = page.getByTestId('drp-same-day-presets-demo');
     await expect(picker).toBeVisible();

--- a/tests/docs-accuracy-batch1.test.ts
+++ b/tests/docs-accuracy-batch1.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression coverage for documentation fixes in this batch: props/CSS vars that existed
 // in code but were undocumented are only worth documenting if they're real -- these tests
@@ -9,7 +10,7 @@ test.describe('Accordion — disabled trigger (previously undocumented)', () => 
   test('a disabled trigger cannot be toggled by click, leaves the tab order, and is marked aria-disabled', async ({
     page
   }) => {
-    await page.goto('/components/accordion');
+    await gotoHydrated(page, '/components/accordion');
 
     const content = page.getByTestId('accordion-disabled');
     // The page has several built-in triggers; pick the one wrapping this demo's label rather

--- a/tests/docs-accuracy-batch2.test.ts
+++ b/tests/docs-accuracy-batch2.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Docs accuracy — Card, Checkbox, ChatSuggestions, ChatComposer, ChatMessage', () => {
   // Regression guard: docs/Card.md and docs/Checkbox.md claimed --card-border-radius
@@ -9,7 +10,7 @@ test.describe('Docs accuracy — Card, Checkbox, ChatSuggestions, ChatComposer, 
   test('Card: --card-border-radius truly defaults to 4px, and --radius is a real fallback', async ({
     page
   }) => {
-    await page.goto('/components/card');
+    await gotoHydrated(page, '/components/card');
 
     const card = page.getByTestId('two-zone-card');
     await expect(card).toHaveCSS('border-radius', '4px');
@@ -23,7 +24,7 @@ test.describe('Docs accuracy — Card, Checkbox, ChatSuggestions, ChatComposer, 
   test('Checkbox: --checkbox-border-radius truly defaults to 4px, and --radius is a real fallback', async ({
     page
   }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const box = page.getByTestId('checkbox-default').locator('.box');
     await expect(box).toHaveCSS('border-radius', '4px');
@@ -35,7 +36,7 @@ test.describe('Docs accuracy — Card, Checkbox, ChatSuggestions, ChatComposer, 
   });
 
   test('ChatSuggestions: chipClasses reaches every chip wrapper', async ({ page }) => {
-    await page.goto('/components/chat-suggestions');
+    await gotoHydrated(page, '/components/chat-suggestions');
 
     const group = page.getByTestId('chat-suggestions-chip-classes');
     const hooked = group.locator('.demo-chip-hook');
@@ -45,7 +46,7 @@ test.describe('Docs accuracy — Card, Checkbox, ChatSuggestions, ChatComposer, 
   test('ChatComposer: --chat-composer-attachments-padding is consumed by the rich attachment row', async ({
     page
   }) => {
-    await page.goto('/components/chat-composer');
+    await gotoHydrated(page, '/components/chat-composer');
 
     const richRow = page.locator('.attachments-rich').first();
     await expect(richRow).toBeVisible();
@@ -63,7 +64,7 @@ test.describe('Docs accuracy — Card, Checkbox, ChatSuggestions, ChatComposer, 
   test('ChatMessage: --chat-message-list-margin/-padding are consumed by rendered markdown lists', async ({
     page
   }) => {
-    await page.goto('/components/chat-message');
+    await gotoHydrated(page, '/components/chat-message');
 
     const list = page.getByTestId('chat-message-markdown').locator('ul');
     await expect(list).toBeVisible();

--- a/tests/docs-accuracy-batch3.test.ts
+++ b/tests/docs-accuracy-batch3.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression coverage for the documentation-accuracy pass on this batch of components.
 // Each test proves that a CSS variable this batch newly added/corrected in the docs
@@ -8,7 +9,7 @@ test.describe('Choicebox — indicator CSS variables actually theme the indicato
   test('--choicebox-indicator-selected-background/-border/-size reach the indicator span', async ({
     page
   }) => {
-    await page.goto('/components/choicebox');
+    await gotoHydrated(page, '/components/choicebox');
 
     const card = page.getByTestId('choicebox-themed-indicator');
     await expect(card).toBeVisible();
@@ -24,7 +25,7 @@ test.describe('Gallery — CSS variables actually theme the grid layout', () => 
   test('--gallery-columns, --gallery-gap, and --gallery-item-border-radius reach the grid', async ({
     page
   }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-themed-demo');
     await expect(gallery).toBeVisible();

--- a/tests/docs-accuracy-batch4.test.ts
+++ b/tests/docs-accuracy-batch4.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression coverage for docs/*.md accuracy fixes in this batch (Gauge, GridItem, HITL, Icon,
 // IconStack, Input, InputButton, LineChart). Each assertion proves the prop/behavior the
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Input — newly-documented readonly/spellcheck', () => {
   test('readonly keeps the field focusable and selectable but not editable', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
     const field = page.getByTestId('input-readonly');
     await expect(field).toHaveAttribute('readonly', '');
     await field.click();
@@ -17,14 +18,14 @@ test.describe('Input — newly-documented readonly/spellcheck', () => {
   });
 
   test('spellcheck={false} renders the native attribute as false', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
     await expect(page.getByTestId('input-spellcheck-off')).toHaveAttribute('spellcheck', 'false');
   });
 });
 
 test.describe('InputButton — newly-documented testId', () => {
   test('testId reaches the root container as data-pw', async ({ page }) => {
-    await page.goto('/components/input-button');
+    await gotoHydrated(page, '/components/input-button');
     const demo = page.getByTestId('input-button-messages-demo');
     await expect(demo).toBeVisible();
     await expect(demo).toHaveAttribute('data-pw', 'input-button-messages-demo');
@@ -33,7 +34,7 @@ test.describe('InputButton — newly-documented testId', () => {
 
 test.describe('HITL — newly-documented test-id override props', () => {
   test('confirm/cancel/completion default test ids derive from testId', async ({ page }) => {
-    await page.goto('/components/hitl');
+    await gotoHydrated(page, '/components/hitl');
     const card = page.getByTestId('demo-confirmation');
     await expect(card).toBeVisible();
     await expect(page.getByTestId('demo-confirmation-confirm')).toBeVisible();
@@ -45,7 +46,7 @@ test.describe('HITL — newly-documented test-id override props', () => {
 
 test.describe('Gauge — newly-documented ariaLabel', () => {
   test('ariaLabel sets the accessible name on the progressbar element', async ({ page }) => {
-    await page.goto('/components/gauge');
+    await gotoHydrated(page, '/components/gauge');
     const gauge = page.getByTestId('gauge-with-arialabel');
     await expect(gauge).toHaveAttribute('role', 'progressbar');
     await expect(gauge).toHaveAttribute('aria-label', 'Storage used, 25 percent');
@@ -54,24 +55,24 @@ test.describe('Gauge — newly-documented ariaLabel', () => {
 
 test.describe('GridItem / Icon / IconStack — newly-documented testId', () => {
   test('GridItem testId reaches the root as data-pw', async ({ page }) => {
-    await page.goto('/components/grid-item');
+    await gotoHydrated(page, '/components/grid-item');
     await expect(page.getByTestId('grid-item-photos')).toBeVisible();
   });
 
   test('Icon testId reaches the root as data-pw', async ({ page }) => {
-    await page.goto('/components/icon');
+    await gotoHydrated(page, '/components/icon');
     await expect(page.getByTestId('icon-home')).toBeVisible();
   });
 
   test('IconStack testId reaches the root as data-pw', async ({ page }) => {
-    await page.goto('/components/icon-stack');
+    await gotoHydrated(page, '/components/icon-stack');
     await expect(page.getByTestId('icon-stack-demo')).toBeVisible();
   });
 });
 
 test.describe('LineChart — newly-documented minHeight/maxHeight', () => {
   test('a wide aspect ratio is still clamped to the exact min/max height', async ({ page }) => {
-    await page.goto('/components/line-chart');
+    await gotoHydrated(page, '/components/line-chart');
     const chart = page.getByTestId('line-height-bounds-chart');
     await expect(chart).toBeVisible();
     const box = await chart.boundingBox();

--- a/tests/docs-accuracy-batch5.test.ts
+++ b/tests/docs-accuracy-batch5.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression coverage for docs/*.md accuracy fixes: proves each newly-documented (or
 // previously-undocumented-but-real) prop/CSS variable actually does what its doc entry
@@ -7,14 +8,14 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Loader — testId prop (was undocumented)', () => {
   test('testId renders as data-pw on the root element', async ({ page }) => {
-    await page.goto('/components/loader');
+    await gotoHydrated(page, '/components/loader');
     await expect(page.getByTestId('loader-demo')).toBeVisible();
   });
 });
 
 test.describe('MediaUpload — CSS Variables table (was prose-only)', () => {
   test('themed instance reflects every overridden variable', async ({ page }) => {
-    await page.goto('/components/media-upload');
+    await gotoHydrated(page, '/components/media-upload');
 
     const label = page.getByTestId('media-upload-themed-demo').locator('.label');
     await expect(label).toHaveCSS('color', 'rgb(20, 90, 200)');
@@ -29,7 +30,7 @@ test.describe('MediaUpload — CSS Variables table (was prose-only)', () => {
 
 test.describe('Menu — --menu-item-selected-* (was undocumented)', () => {
   test('the selected item uses the themed selected colors', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     await page.getByTestId('menu-selected-demo').locator('button').click();
     // .menu-item:hover (specificity 0,2,0) beats .menu-item-selected (0,1,0), so if the
@@ -54,7 +55,7 @@ test.describe('Modal — disabled footer button CSS variables (was undocumented)
   test('disabled primary/secondary buttons reflect their themed disabled variables', async ({
     page
   }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByTestId('open-disabled-footer-modal').click();
     const primary = page.getByTestId('disabled-footer-primary');
@@ -71,7 +72,7 @@ test.describe('Modal — disabled footer button CSS variables (was undocumented)
 
 test.describe('PieChart — --chart-legend-* and --chart-empty-* (was undocumented)', () => {
   test('legend rows reflect the themed legend variables', async ({ page }) => {
-    await page.goto('/components/pie-chart');
+    await gotoHydrated(page, '/components/pie-chart');
 
     const legendLabel = page.getByTestId('pie-legend-themed').locator('.legend-label').first();
     await expect(legendLabel).toBeVisible();
@@ -80,7 +81,7 @@ test.describe('PieChart — --chart-legend-* and --chart-empty-* (was undocument
   });
 
   test('the empty state reflects the themed empty-state variables', async ({ page }) => {
-    await page.goto('/components/pie-chart');
+    await gotoHydrated(page, '/components/pie-chart');
 
     const empty = page.getByTestId('pie-all-zero').locator('.chart-empty');
     await expect(empty).toBeVisible();
@@ -91,7 +92,7 @@ test.describe('PieChart — --chart-legend-* and --chart-empty-* (was undocument
 
 test.describe('Pill — --pill-text-white-space (was undocumented)', () => {
   test('the wrap-themed pill allows its text to wrap', async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     const pill = page.getByTestId('pill-wrap-demo');
     await expect(pill).toBeVisible();

--- a/tests/docs-accuracy-batch6.test.ts
+++ b/tests/docs-accuracy-batch6.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression guards for docs/*.md accuracy fixes to ProportionBar through SpeechToText
 // (batch 6 of the library-wide documentation audit). Each test proves a prop the docs
@@ -9,7 +10,7 @@ test.describe('SankeyChart — radius and maxHeight (previously undocumented pro
   test('radius sets node corner rounding and maxHeight caps the rendered height', async ({
     page
   }) => {
-    await page.goto('/components/sankey-chart');
+    await gotoHydrated(page, '/components/sankey-chart');
 
     const chart = page.getByTestId('sankey-radius-demo');
     await expect(chart).toBeVisible();
@@ -31,7 +32,7 @@ test.describe('Select — showSelectAll and usePortal (previously undocumented p
   test('showSelectAll toggles every listed option and shows an indeterminate state for a partial selection', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-all-demo');
     await select.locator('.select-trigger').click();
@@ -58,7 +59,7 @@ test.describe('Select — showSelectAll and usePortal (previously undocumented p
   test('usePortal renders the dropdown panel as a child of document.body, not the select container', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-portal-demo');
     await select.locator('.select-trigger').click();
@@ -75,7 +76,7 @@ test.describe('Sheet — dismissOnOutsideClick (previously undocumented prop)', 
   test('dismissOnOutsideClick={true} with showOverlay={false} still closes on an outside click', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByRole('button', { name: 'Open account menu' }).click();
     const panel = page.getByTestId('sheet-anchored-panel');
@@ -89,7 +90,7 @@ test.describe('Sheet — dismissOnOutsideClick (previously undocumented prop)', 
   test('dismissOnOutsideClick={false} with showOverlay={true} ignores an outside click but still closes on Escape', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByRole('button', { name: 'Open blocking sheet' }).click();
     const panel = page.getByTestId('sheet-blocking-panel');

--- a/tests/docs-accuracy-batch7.test.ts
+++ b/tests/docs-accuracy-batch7.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Proves the behaviors newly documented in this pass are real, not just described.
 // Table.md and Tabs.md previously omitted a substantial slice of their own real, working
@@ -9,7 +10,7 @@ test.describe('Table — newly-documented props are real', () => {
   test('usePortal escapes an in-cell select dropdown from an overflow:hidden ancestor', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const clipper = page.getByTestId('table-portal-clipper');
     const table = page.getByTestId('table-portal-cells');
@@ -41,7 +42,7 @@ test.describe('Table — newly-documented props are real', () => {
   });
 
   test('rowNumberColumn prepends a 1-based sequence column', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const table = page.getByTestId('table-paginated');
     await expect(table).toBeVisible();
@@ -58,7 +59,7 @@ test.describe('Table — newly-documented props are real', () => {
   test('toolbarSlot renders a bulk-action bar only while checkbox selection is non-empty', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const table = page.getByTestId('table-controlled-selection');
     await expect(table).toBeVisible();
@@ -81,7 +82,7 @@ test.describe('Tabs — TabItem[] mode (icon/status/sectionLabel/orientation) is
   test('vertical orientation with TabItem[] renders icons, status dots, a section label, and activeKey/onkeychange work by key', async ({
     page
   }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const tabs = page.getByTestId('tabs-vertical-demo');
     await expect(tabs).toBeVisible();

--- a/tests/draggable.test.ts
+++ b/tests/draggable.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Draggable', () => {
   test('dragging the handle moves the element', async ({ page }) => {
-    await page.goto('/components/draggable');
+    await gotoHydrated(page, '/components/draggable');
 
     const box = page.getByTestId('draggable-demo');
     const before = await box.boundingBox();
@@ -36,7 +37,7 @@ test.describe('Draggable', () => {
   });
 
   test('clicking body content outside the handle does not start a drag', async ({ page }) => {
-    await page.goto('/components/draggable');
+    await gotoHydrated(page, '/components/draggable');
 
     const box = page.getByTestId('draggable-demo');
     const before = await box.boundingBox();
@@ -64,7 +65,7 @@ test.describe('Draggable', () => {
   });
 
   test('arrow keys move the element by step once focused', async ({ page }) => {
-    await page.goto('/components/draggable');
+    await gotoHydrated(page, '/components/draggable');
 
     const box = page.getByTestId('draggable-demo');
     await box.focus();
@@ -86,7 +87,7 @@ test.describe('Draggable', () => {
   });
 
   test('bounds="viewport" keeps the element from being dragged off-screen', async ({ page }) => {
-    await page.goto('/components/draggable');
+    await gotoHydrated(page, '/components/draggable');
 
     const box = page.getByTestId('draggable-demo');
     const handle = page.locator('.drag-handle');

--- a/tests/empty-state-density-align.test.ts
+++ b/tests/empty-state-density-align.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #523. EmptyState hardcoded `align-items: center` with no CSS variable
 // to reach it, and had no page-vs-panel density concept at all — consumers
@@ -10,7 +11,7 @@ test.describe('EmptyState density and align-items (#523)', () => {
   test("default (no density prop) keeps today's padding, gap and centered alignment", async ({
     page
   }) => {
-    await page.goto('/components/empty-state');
+    await gotoHydrated(page, '/components/empty-state');
 
     const root = page.getByTestId('empty-state-density-default');
     await expect(root).toHaveCSS('padding', '32px 16px');
@@ -20,7 +21,7 @@ test.describe('EmptyState density and align-items (#523)', () => {
   });
 
   test('density="page" applies its own padding/gap defaults', async ({ page }) => {
-    await page.goto('/components/empty-state');
+    await gotoHydrated(page, '/components/empty-state');
 
     const root = page.getByTestId('empty-state-density-page');
     await expect(root).toHaveAttribute('data-density', 'page');
@@ -29,7 +30,7 @@ test.describe('EmptyState density and align-items (#523)', () => {
   });
 
   test('density="panel" applies its own, tighter padding/gap defaults', async ({ page }) => {
-    await page.goto('/components/empty-state');
+    await gotoHydrated(page, '/components/empty-state');
 
     const root = page.getByTestId('empty-state-density-panel');
     await expect(root).toHaveAttribute('data-density', 'panel');
@@ -40,7 +41,7 @@ test.describe('EmptyState density and align-items (#523)', () => {
   test('--empty-state-align-items overrides the hardcoded center, no wrapper class needed', async ({
     page
   }) => {
-    await page.goto('/components/empty-state');
+    await gotoHydrated(page, '/components/empty-state');
 
     const root = page.getByTestId('empty-state-align-override');
     await expect(root).toHaveCSS('align-items', 'flex-start');

--- a/tests/empty-state-pill-attributes.test.ts
+++ b/tests/empty-state-pill-attributes.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('EmptyState and Pill native attributes', () => {
   test('EmptyState exposes stable title and description locators for text and snippets', async ({
     page
   }) => {
-    await page.goto('/components/empty-state');
+    await gotoHydrated(page, '/components/empty-state');
 
     await expect(page.getByTestId('empty-state-attributes-title')).toHaveText('Fallback title');
     await expect(page.getByTestId('empty-state-attributes-description')).toHaveText(
@@ -21,7 +22,7 @@ test.describe('EmptyState and Pill native attributes', () => {
   test('EmptyState does not render a description locator when no description is rendered', async ({
     page
   }) => {
-    await page.goto('/components/empty-state');
+    await gotoHydrated(page, '/components/empty-state');
 
     await expect(page.getByTestId('empty-state-without-description-title')).toHaveText(
       'Title only'
@@ -30,7 +31,7 @@ test.describe('EmptyState and Pill native attributes', () => {
   });
 
   test('Pill exposes an optional native title only when supplied', async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     await expect(page.getByTestId('pill-title')).toHaveAttribute('title', 'Pill tooltip');
     await expect(page.getByTestId('pill-without-title')).not.toHaveAttribute('title', /.*/);

--- a/tests/event-casing-alias.spec.ts
+++ b/tests/event-casing-alias.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 /**
  * Every event prop is lowercase (DESIGN_PRINCIPLES §3), and the earlier
@@ -9,7 +10,7 @@ import { expect, test } from '@playwright/test';
  * `wc-event-casing-parity.spec.ts` and `Toggle.svelte.test.ts`.
  */
 test('a component fires its handler through the lowercase prop spelling', async ({ page }) => {
-  await page.goto('/components/toggle');
+  await gotoHydrated(page, '/components/toggle');
 
   const state = page.locator('[data-pw="toggle-alias-state"]');
   await expect(state).toHaveText('OFF');
@@ -22,7 +23,7 @@ test('a component fires its handler through the lowercase prop spelling', async 
 });
 
 test('the first demo row fires through the same spelling', async ({ page }) => {
-  await page.goto('/components/toggle');
+  await gotoHydrated(page, '/components/toggle');
 
   const state = page.locator('.demo-row').first().locator('.state-display');
   await expect(state).toHaveText('OFF');

--- a/tests/gallery.test.ts
+++ b/tests/gallery.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Gallery', () => {
   test('renders one item per image, with edit/delete actions since both handlers are set', async ({
     page
   }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-demo');
     await expect(gallery.locator('.gallery-item')).toHaveCount(3);
@@ -12,7 +13,7 @@ test.describe('Gallery', () => {
   });
 
   test('clicking an item opens the lightbox on that image', async ({ page }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-demo');
     await gallery.locator('.gallery-item-content').nth(1).click();
@@ -25,7 +26,7 @@ test.describe('Gallery', () => {
   test('next/previous controls navigate, disabled at the ends when not looping', async ({
     page
   }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-demo');
     await gallery.locator('.gallery-item-content').first().click();
@@ -44,7 +45,7 @@ test.describe('Gallery', () => {
   });
 
   test('arrow keys navigate and Escape closes the lightbox', async ({ page }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-demo');
     await gallery.locator('.gallery-item-content').first().click();
@@ -60,7 +61,7 @@ test.describe('Gallery', () => {
   });
 
   test('Tab from the last control wraps to the close button (focus trap)', async ({ page }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-demo');
     // Open on the middle image so both previous and next controls render -
@@ -83,7 +84,7 @@ test.describe('Gallery', () => {
   });
 
   test('closing the lightbox returns focus to the item that opened it', async ({ page }) => {
-    await page.goto('/components/gallery');
+    await gotoHydrated(page, '/components/gallery');
 
     const gallery = page.getByTestId('gallery-demo');
     const secondItem = gallery.locator('.gallery-item-content').nth(1);

--- a/tests/hitl-extra-actions.test.ts
+++ b/tests/hitl-extra-actions.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #528: HITL supported exactly one decision (confirm/cancel), so a
 // third disposition (e.g. "deny with instructions") or any free-text/
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // only while the card is pending. Both are additive and off by default.
 test.describe('HITL — extra actions and children (#528)', () => {
   test('an extra action never settles the card and calls its own onSelect', async ({ page }) => {
-    await page.goto('/components/hitl');
+    await gotoHydrated(page, '/components/hitl');
 
     const card = page.getByTestId('demo-extra');
     await expect(card).toBeVisible();
@@ -31,7 +32,7 @@ test.describe('HITL — extra actions and children (#528)', () => {
   });
 
   test('confirm still settles the card normally with an extra action present', async ({ page }) => {
-    await page.goto('/components/hitl');
+    await gotoHydrated(page, '/components/hitl');
 
     await page.getByTestId('demo-extra-confirm').click();
 
@@ -44,7 +45,7 @@ test.describe('HITL — extra actions and children (#528)', () => {
   test('default HITL usage (no actions, no children) renders unchanged: exactly two buttons', async ({
     page
   }) => {
-    await page.goto('/components/hitl');
+    await gotoHydrated(page, '/components/hitl');
 
     const card = page.getByTestId('demo-confirmation');
     await expect(card).toBeVisible();

--- a/tests/hydration-race.spec.ts
+++ b/tests/hydration-race.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
+
+/**
+ * Regression coverage for the suite's own intermittent failures.
+ *
+ * Specs navigated and interacted immediately. Every demo page is
+ * server-rendered, so a trigger is present, visible and clickable before its
+ * handler exists, and Playwright has no actionability check for "a listener is
+ * attached" -- so a click arriving before hydration was delivered to inert
+ * markup and silently lost. The assertion after it then failed as a timeout
+ * naming the missing element rather than the real cause. It surfaced only under
+ * load: a full run at the default worker count failed 8 of 713, a run of the
+ * same commit at `--workers=2` failed 0, and the failures moved between tests
+ * from run to run.
+ *
+ * Delaying the module scripts turns that window into a certainty, so these two
+ * cases pin the race deterministically instead of waiting for a bad day.
+ */
+
+const delayScripts = async (page: Parameters<typeof gotoHydrated>[0]): Promise<void> => {
+  await page.route('**/*.js', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await route.continue();
+  });
+};
+
+test.describe('demo pages are only driven once they are interactive', () => {
+  test('a click before hydration is lost, which is what made the suite flaky', async ({ page }) => {
+    await delayScripts(page);
+    await page.goto('/components/menu', { waitUntil: 'commit' });
+
+    const menu = page.locator('[data-pw="menu-default-demo"]');
+    const trigger = menu.locator('.menu-trigger');
+
+    // Passes every actionability check Playwright makes, while inert.
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    await expect(menu.locator('.menu-dropdown')).toHaveCount(0);
+  });
+
+  test('the same click through gotoHydrated opens the menu', async ({ page }) => {
+    await delayScripts(page);
+    await gotoHydrated(page, '/components/menu');
+
+    const menu = page.locator('[data-pw="menu-default-demo"]');
+    await menu.locator('.menu-trigger').click();
+
+    await expect(menu.locator('.menu-dropdown')).toBeVisible();
+  });
+});

--- a/tests/icon-slot-color-token.spec.ts
+++ b/tests/icon-slot-color-token.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // 2.120.3 made six icon slots inline their SVG, so a `currentColor` asset finally resolves
 // against the host document instead of painting UA black. That was necessary but not
@@ -16,7 +17,7 @@ import { expect, test } from '@playwright/test';
 // wrapped in an `<img>`.
 test.describe('per-icon colour token', () => {
   test('defaults to inherit — the icon still takes the trigger text colour', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const icon = page.getByTestId('select-left-icon');
     await expect(icon).toBeVisible();
@@ -29,7 +30,7 @@ test.describe('per-icon colour token', () => {
   test('an explicit --select-left-icon-color decouples the icon from the label', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const icon = page.getByTestId('select-tinted-left-icon');
     await expect(icon).toBeVisible();
@@ -45,7 +46,7 @@ test.describe('per-icon colour token', () => {
   });
 
   test('the inlined SVG paints from the token, not merely a wrapper', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     // The asset is drawn with stroke="currentColor". A wrapper carrying the right `color`
     // proves nothing on its own — what matters is that the SVG's own resolved `stroke` picks

--- a/tests/img-inline-svg-attr-allowlist.spec.ts
+++ b/tests/img-inline-svg-attr-allowlist.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Img's inlineSvg path fetches remote markup and copies the fetched root's
 // attributes onto the live <svg> host — an element in the host document. The
@@ -35,7 +36,7 @@ test.describe('Img — inlineSvg copies only safe root attributes from fetched m
       ' id="evil-root" style="outline: 6px solid red" data-pw="hijacked" tabindex="0">' +
       '<circle cx="12" cy="12" r="8" fill="currentColor" /></svg>';
     await serveSvg(page, INLINE_DEMO_URL, hostile);
-    await page.goto('/components/img');
+    await gotoHydrated(page, '/components/img');
 
     // Located through the wrapper row, not data-pw on the host itself — a
     // successful data-pw clobber must fail an assertion, not hide the element.
@@ -76,7 +77,7 @@ test.describe('Img — inlineSvg copies only safe root attributes from fetched m
       ' role="img" aria-label="Fetched success" focusable="false">' +
       '<path d="M15 24.5l6.5 6.5L33 19.5" /></svg>';
     await serveSvg(page, INLINE_DEMO_URL, benign);
-    await page.goto('/components/img');
+    await gotoHydrated(page, '/components/img');
 
     const host = page.getByTestId('img-inline-svg-row').locator('svg');
 
@@ -103,7 +104,7 @@ test.describe('Img — inlineSvg copies only safe root attributes from fetched m
       " onload=\"document.documentElement.setAttribute('data-svg-transform-onload-ran', '1')\">" +
       '<rect width="64" height="64" fill="currentColor" /></svg>';
     await serveSvg(page, TRANSFORM_DEMO_URL, hostile);
-    await page.goto('/components/img');
+    await gotoHydrated(page, '/components/img');
 
     const host = page.getByTestId('img-inline-svg-transform-row').locator('svg');
 
@@ -137,7 +138,7 @@ test.describe('Img — inlineSvg strips executable content from fetched descenda
       '<script>document.documentElement.setAttribute("data-child-script-ran", "1")</script>' +
       '</svg>';
     await serveSvg(page, INLINE_DEMO_URL, hostile);
-    await page.goto('/components/img');
+    await gotoHydrated(page, '/components/img');
 
     const host = page.getByTestId('img-inline-svg-row').locator('svg');
     // Anchor: the intercepted payload really was inlined.
@@ -165,7 +166,7 @@ test.describe('Img — inlineSvg strips executable content from fetched descenda
       '<path d="M4 12l6 6 10-14" stroke="currentColor" stroke-width="2" fill="none" transform="translate(1,1)" />' +
       '</svg>';
     await serveSvg(page, INLINE_DEMO_URL, legitimate);
-    await page.goto('/components/img');
+    await gotoHydrated(page, '/components/img');
 
     const path = page.getByTestId('img-inline-svg-row').locator('svg path');
     await expect(path).toHaveAttribute('d', 'M4 12l6 6 10-14');

--- a/tests/img-inline-svg-data-uri-artwork.spec.ts
+++ b/tests/img-inline-svg-data-uri-artwork.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Img's inlineSvg sanitizer strips every descendant URL attribute whose value
 // does not point inside this document. Brand marks do not encode their art as
@@ -43,7 +44,7 @@ test.describe('Img — inlineSvg preserves data-URI artwork in pattern fills', (
       '</defs>' +
       '</svg>';
     await serveSvg(page, INLINE_DEMO_URL, brandMark);
-    await page.goto('/components/img');
+    await gotoHydrated(page, '/components/img');
 
     const host = page.getByTestId('img-inline-svg-row').locator('svg');
     // Anchor: the intercepted payload really was inlined (the on-disk asset

--- a/tests/img-inline-svg-src-change.spec.ts
+++ b/tests/img-inline-svg-src-change.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Img's inlineSvg path copies the fetched root's allowlisted attributes onto
 // the live <svg> host. Before this test existed, a `src` change cleared the
@@ -32,7 +33,7 @@ test('a src change removes the root attributes the previous file supplied', asyn
   await page.route(SECOND_URL, (route) =>
     route.fulfill({ status: 200, contentType: 'image/svg+xml', body: SECOND })
   );
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-img') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/img-review-findings.spec.ts
+++ b/tests/img-review-findings.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { join } from 'node:path';
+import { gotoHydrated } from './support/hydrated';
 
 /**
  * The two findings the review raised against `Img`'s inline-SVG path, each
@@ -12,7 +13,7 @@ import { join } from 'node:path';
 const BUNDLE = join(process.cwd(), 'dist-wc/index.js');
 
 async function loadBundle(page: import('@playwright/test').Page): Promise<void> {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: BUNDLE, type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-img') === 'function');
 }

--- a/tests/input-autoresize-css-ceiling.test.ts
+++ b/tests/input-autoresize-css-ceiling.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // autoResize derived its ceiling from maxRows alone. With the ceiling coming from
 // --input-max-height instead, the computed limit stayed Infinity: the inline height grew
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 // size but its overflow became unreachable rather than scrollable.
 test.describe('Input — autoResize honours a CSS max-height', () => {
   test('becomes scrollable at the ceiling instead of clipping', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-autoresize-capped');
     await field.fill(Array.from({ length: 20 }, (_, index) => `line ${index}`).join('\n'));
@@ -23,7 +24,7 @@ test.describe('Input — autoResize honours a CSS max-height', () => {
   });
 
   test('still hides overflow while the content fits', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-autoresize-capped');
     await field.fill('one line');

--- a/tests/input-capability-gaps.test.ts
+++ b/tests/input-capability-gaps.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Four capabilities Input could not express, each blocking a real consumer that was
 // forced to hand-roll a native element instead. The last test in this file is the
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 // do not opt in.
 test.describe('Input — dataType passthrough, spellcheck, readonly, paste', () => {
   test('dataType renders a native time input', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // Input renders <input type={dataType}>, so widening the union was the only
     // thing needed — the rendering already supported it.
@@ -16,13 +17,13 @@ test.describe('Input — dataType passthrough, spellcheck, readonly, paste', () 
   });
 
   test('spellcheck={false} reaches the textarea', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     await expect(page.getByTestId('input-spellcheck-off')).toHaveAttribute('spellcheck', 'false');
   });
 
   test('readonly keeps the field focusable and selectable but not editable', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-readonly');
     await expect(field).toHaveAttribute('readonly', '');
@@ -38,7 +39,7 @@ test.describe('Input — dataType passthrough, spellcheck, readonly, paste', () 
   });
 
   test('onPaste fires on a non-tel field', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-paste-textarea');
     await field.focus();
@@ -55,7 +56,7 @@ test.describe('Input — dataType passthrough, spellcheck, readonly, paste', () 
   });
 
   test('fields that do not opt in are unchanged', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // Regression guard for every existing consumer: no spellcheck attribute is
     // emitted when the prop is not passed, and no readonly attribute either.

--- a/tests/input-error-announcement.test.ts
+++ b/tests/input-error-announcement.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Input — validation messages reach the accessibility tree', () => {
   // Regression guard: the error text was rendered as a plain <div class="error-message"> with
@@ -6,7 +7,7 @@ test.describe('Input — validation messages reach the accessibility tree', () =
   // absent from the accessibility tree — a screen-reader user submitted, heard nothing, and was
   // left on a form that had not moved. Nothing visual catches this: the message looks correct.
   test('an invalid field is marked invalid and points at its message', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-announced-error');
     await expect(field).toBeVisible();
@@ -23,7 +24,7 @@ test.describe('Input — validation messages reach the accessibility tree', () =
   });
 
   test('the message is a live region so it is spoken when it appears', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-announced-error');
     const describedBy = await field.getAttribute('aria-describedby');
@@ -33,7 +34,7 @@ test.describe('Input — validation messages reach the accessibility tree', () =
   });
 
   test('helper text is associated with the field even when it is valid', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // infoMessage is guidance a screen-reader user needs BEFORE they trip an error, so it must
     // be referenced whether or not the field is currently invalid.
@@ -47,7 +48,7 @@ test.describe('Input — validation messages reach the accessibility tree', () =
   });
 
   test('error and helper text are both referenced, error first', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-announced-error');
     const describedBy = (await field.getAttribute('aria-describedby')) ?? '';
@@ -65,7 +66,7 @@ test.describe('Input — validation messages reach the accessibility tree', () =
   test('an actionInput field in error state is not marked invalid, matching its hidden styling', async ({
     page
   }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
     // actionInput hides the error border, the message and the label. If aria-invalid stayed on,
     // a screen reader would announce an error the field gives no other sign of.
     const field = page.getByTestId('input-action-error');
@@ -77,7 +78,7 @@ test.describe('Input — validation messages reach the accessibility tree', () =
   test('a valid field with no helper text is not marked invalid and describes nothing', async ({
     page
   }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // Negative side of the contract: the attributes must be ABSENT when there is no error,
     // otherwise every field on every form announces itself as invalid.
@@ -95,7 +96,7 @@ test.describe('ChipInput — the draft field can be named', () => {
   // way for a caller to name it: the caption beside it read on screen and the control reached
   // the accessibility tree unnamed.
   test('ariaLabel names the draft field', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     await expect(page.getByTestId('chip-input-tags-add')).toHaveAttribute(
       'aria-label',
@@ -105,7 +106,7 @@ test.describe('ChipInput — the draft field can be named', () => {
   });
 
   test('an unnamed ChipInput emits no empty aria-label', async ({ page }) => {
-    await page.goto('/components/chip-input');
+    await gotoHydrated(page, '/components/chip-input');
 
     // An empty aria-label is worse than none — it names the control the empty string, which
     // suppresses every other naming path an assistive technology would have fallen back to.

--- a/tests/input-height-bounds.test.ts
+++ b/tests/input-height-bounds.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // A textarea that grows with content needs a ceiling before it scrolls, and one used as a
 // paste target needs a floor. Neither was reachable through the --input-* surface.
 test.describe('Input — min-height / max-height', () => {
   test('both custom properties reach the textarea', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-bounded-height');
     await expect(field).toHaveCSS('min-height', '80px');
@@ -12,7 +13,7 @@ test.describe('Input — min-height / max-height', () => {
   });
 
   test('fields that set neither keep the CSS initial values', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // Regression guard: the declarations must fall back to the CSS initial values, not to a
     // library-chosen height that would resize every existing consumer.

--- a/tests/input-helper-error-colors.test.ts
+++ b/tests/input-helper-error-colors.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Input / InputButton — error text and helper text are no longer the same color', () => {
   // Regression guard for both defects filed in #481: .info-message defaulted to the exact
@@ -9,7 +10,7 @@ test.describe('Input / InputButton — error text and helper text are no longer 
   test('Input: error and helper text render in different, AA-compliant colors', async ({
     page
   }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const errorMessage = page.getByTestId('input-announced-error-error-message');
     const infoMessage = page.getByTestId('input-announced-error-info-message');
@@ -35,7 +36,7 @@ test.describe('Input / InputButton — error text and helper text are no longer 
   test("InputButton: external error and helper text share Input's color tokens, not the same value", async ({
     page
   }) => {
-    await page.goto('/components/input-button');
+    await gotoHydrated(page, '/components/input-button');
 
     const demo = page.getByTestId('input-button-messages-demo');
     const externalError = demo.locator('.external-error-message');

--- a/tests/input-label-association.test.ts
+++ b/tests/input-label-association.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Input — the <label> actually names the field', () => {
   // Regression guard: the label was emitted as <label for={name}> while the
@@ -10,7 +11,7 @@ test.describe('Input — the <label> actually names the field', () => {
   // Note on locators: testId lands on the <input>/<textarea> itself (data-pw),
   // not on a wrapper — so getByTestId here IS the field.
   test('a field with label + name is reachable by its visible label text', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-datatype-time');
     await expect(field).toBeVisible();
@@ -31,7 +32,7 @@ test.describe('Input — the <label> actually names the field', () => {
   });
 
   test('clicking the label focuses the field it names', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-datatype-time');
     const id = await field.getAttribute('id');

--- a/tests/input-left-icon-color.test.ts
+++ b/tests/input-left-icon-color.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Input — leading icon colour', () => {
   test('the leading override does not recolour the trailing icon', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const leftIcon = page.getByTestId('input-independent-left-icon');
     const rightIcon = page.getByTestId('input-independent-right-icon');
@@ -17,7 +18,7 @@ test.describe('Input — leading icon colour', () => {
   test('the generic token continues to colour both icons when no leading override exists', async ({
     page
   }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     await expect(page.getByTestId('input-generic-left-icon')).toHaveCSS(
       'color',

--- a/tests/input-line-height.test.ts
+++ b/tests/input-line-height.test.ts
@@ -1,16 +1,17 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // A textarea/input takes `line-height: normal` from the UA stylesheet, which beats any
 // value inherited from its container — so this was unreachable for consumers.
 test.describe('Input — line-height', () => {
   test('the custom property reaches the field', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     await expect(page.getByTestId('input-line-height')).toHaveCSS('line-height', '32px');
   });
 
   test('fields that set nothing still compute normal', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // Regression guard: the default must be the UA value these fields already had,
     // not a library-chosen number that would reflow every existing textarea.

--- a/tests/input-maxlength-null.test.ts
+++ b/tests/input-maxlength-null.test.ts
@@ -1,16 +1,17 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // maxLength defaults to 1000 and was rendered unconditionally, so migrating an unbounded
 // native textarea onto Input silently capped it at 1000 characters.
 test.describe('Input — maxLength={null}', () => {
   test('omits the native maxlength attribute entirely', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     await expect(page.getByTestId('input-unbounded')).not.toHaveAttribute('maxlength', /.*/);
   });
 
   test('accepts input past the former 1000-character default', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     const field = page.getByTestId('input-unbounded');
     await field.fill('x'.repeat(1200));
@@ -18,7 +19,7 @@ test.describe('Input — maxLength={null}', () => {
   });
 
   test('fields that leave maxLength alone still cap at 1000', async ({ page }) => {
-    await page.goto('/components/input');
+    await gotoHydrated(page, '/components/input');
 
     // Regression guard: null must be opt-in, never the new default.
     await expect(page.getByTestId('input-paste-textarea')).toHaveAttribute('maxlength', '1000');

--- a/tests/keyboardinput-literal.spec.ts
+++ b/tests/keyboardinput-literal.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers #527: KeyboardInput's KEY_SYMBOLS table substitutes 'space' -> ␣
 // and 'tab' -> ⇥ unconditionally, with no way to render the word itself.
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // renders exactly as given and the KEY_SYMBOLS lookup is bypassed entirely.
 test.describe('KeyboardInput literal opt-out', () => {
   test('default behaviour substitutes recognised key names with their glyph', async ({ page }) => {
-    await page.goto('/components/keyboard-input');
+    await gotoHydrated(page, '/components/keyboard-input');
 
     // Regression guard: today's substituting behaviour is unchanged when
     // `literal` is not passed at all.
@@ -18,7 +19,7 @@ test.describe('KeyboardInput literal opt-out', () => {
   });
 
   test('literal renders the word itself instead of the substituted glyph', async ({ page }) => {
-    await page.goto('/components/keyboard-input');
+    await gotoHydrated(page, '/components/keyboard-input');
 
     const literalSpace = page.getByTestId('keyboard-input-literal-space');
     await expect(literalSpace.locator('.key')).toHaveText('Space');

--- a/tests/list-item-menu-svg-role.test.ts
+++ b/tests/list-item-menu-svg-role.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('ListItem and Menu — SVG transforms and ListItem semantics', () => {
   test('ListItem transforms and inlines both image SVGs', async ({ page }) => {
-    await page.goto('/components/list-item');
+    await gotoHydrated(page, '/components/list-item');
 
     const leftIcon = page.getByTestId('list-item-transform-left').locator('svg');
     const rightIcon = page.getByTestId('list-item-transform-right').locator('svg');
@@ -14,7 +15,7 @@ test.describe('ListItem and Menu — SVG transforms and ListItem semantics', () 
   });
 
   test('Menu transforms and inlines its item SVG icon', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     await page.locator('[data-pw="menu-transform-svg"] .menu-trigger').click();
 
@@ -28,7 +29,7 @@ test.describe('ListItem and Menu — SVG transforms and ListItem semantics', () 
   test('ListItem suppression removes synthetic roles and tab stops but keeps clicks', async ({
     page
   }) => {
-    await page.goto('/components/list-item');
+    await gotoHydrated(page, '/components/list-item');
 
     const item = page.getByTestId('list-item-suppressed');
     const topSection = page.getByTestId('list-item-suppressed-top');
@@ -52,7 +53,7 @@ test.describe('ListItem and Menu — SVG transforms and ListItem semantics', () 
   });
 
   test('ListItem defaults retain synthetic button semantics', async ({ page }) => {
-    await page.goto('/components/list-item');
+    await gotoHydrated(page, '/components/list-item');
 
     const item = page.locator('.item').filter({ hasText: 'John Doe' });
     await expect(item).toHaveAttribute('role', 'button');

--- a/tests/list-item-suppressed-aria-selected.test.ts
+++ b/tests/list-item-suppressed-aria-selected.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // suppressRoleAndTabindex hands the interactive semantics to a consumer-owned element. Once the
 // item has no role, an aria-selected left on the generic div is state on nothing: assistive
 // technology ignores it at best and reports a contradiction at worst.
 test.describe('ListItem — suppressRoleAndTabindex also drops aria-selected', () => {
   test('the suppressed item carries neither a role nor a selected state', async ({ page }) => {
-    await page.goto('/components/list-item');
+    await gotoHydrated(page, '/components/list-item');
     const item = page.getByTestId('list-item-suppressed');
     await expect(item).toBeVisible();
     await expect(item).not.toHaveAttribute('role', /.*/);

--- a/tests/loading-dots-pulse-scale.test.ts
+++ b/tests/loading-dots-pulse-scale.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('LoadingDots — pulse min-scale token', () => {
   // The pulse variant previously animated opacity only; consumers replacing
@@ -6,7 +7,7 @@ test.describe('LoadingDots — pulse min-scale token', () => {
   // the size component. --loading-dots-pulse-min-scale drives the keyframe's
   // resting scale; the default of 1 keeps existing consumers pixel-identical.
   test('the min-scale token reaches the dots and defaults to 1', async ({ page }) => {
-    await page.goto('/components/loading-dots');
+    await gotoHydrated(page, '/components/loading-dots');
 
     const breathing = page.getByTestId('loading-dots-breathing');
     await expect(breathing).toBeVisible();

--- a/tests/markdown-raw-html-strip.spec.ts
+++ b/tests/markdown-raw-html-strip.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression coverage for #573, in a real browser rather than over the pure
 // string transform: `renderMarkdown` unit tests can only prove what HTML is
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // assertions below read the rendered text content rather than the HTML.
 test.describe('MarkdownText — raw HTML disposal (sanitize.rawHtml)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/markdown-text');
+    await gotoHydrated(page, '/components/markdown-text');
     // Reading offscreen text passes assertions but records the wrong section.
     await page.getByTestId('markdown-text-raw-escape').scrollIntoViewIfNeeded();
   });

--- a/tests/markdown-text-table-scroll.test.ts
+++ b/tests/markdown-text-table-scroll.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('MarkdownText — a wide table scrolls, stays a table, and can be reached', () => {
   // The scroll container is a wrapper rather than the table itself. `display: block`
@@ -6,7 +7,7 @@ test.describe('MarkdownText — a wide table scrolls, stays a table, and can be 
   // also strips the table's semantics for assistive technology — so the box that
   // scrolls and the box that is a table have to be different elements.
   test('the wrapper overflows horizontally while the table stays a table', async ({ page }) => {
-    await page.goto('/components/markdown-text');
+    await gotoHydrated(page, '/components/markdown-text');
 
     const scope = page.getByTestId('markdown-text-wide-table');
     const wrapper = scope.locator('.markdown-table-wrapper');
@@ -31,7 +32,7 @@ test.describe('MarkdownText — a wide table scrolls, stays a table, and can be 
   // A box with overflow-x: auto cannot be scrolled with arrow keys unless it can
   // hold focus, so without a tabindex the scrolling above is mouse-only.
   test('the scroll container is keyboard reachable and really scrolls', async ({ page }) => {
-    await page.goto('/components/markdown-text');
+    await gotoHydrated(page, '/components/markdown-text');
 
     const wrapper = page.getByTestId('markdown-text-wide-table').locator('.markdown-table-wrapper');
     await expect(wrapper).toHaveAttribute('tabindex', '0');
@@ -49,7 +50,7 @@ test.describe('MarkdownText — a wide table scrolls, stays a table, and can be 
   // A tab stop with no visible focus ring is a keyboard user's dead end: they can
   // reach the box and scroll it with no sign of where they are.
   test('the focused wrapper shows a visible focus ring', async ({ page }) => {
-    await page.goto('/components/markdown-text');
+    await gotoHydrated(page, '/components/markdown-text');
 
     const wrapper = page.getByTestId('markdown-text-wide-table').locator('.markdown-table-wrapper');
     await wrapper.focus();
@@ -67,7 +68,7 @@ test.describe('MarkdownText — a wide table scrolls, stays a table, and can be 
   // The width that makes it scroll must not buy that at the cost of the column
   // model — and every row has to hold, not just the first one.
   test('header and body columns stay aligned on every row', async ({ page }) => {
-    await page.goto('/components/markdown-text');
+    await gotoHydrated(page, '/components/markdown-text');
 
     const scope = page.getByTestId('markdown-text-wide-table');
     const edges = await scope.evaluate((root) => ({
@@ -89,7 +90,7 @@ test.describe('MarkdownText — a wide table scrolls, stays a table, and can be 
   // An unnamed region announces a landmark the user cannot identify, so the role
   // is present only when a name is supplied.
   test('the region is named only when the caller supplies a label', async ({ page }) => {
-    await page.goto('/components/markdown-text');
+    await gotoHydrated(page, '/components/markdown-text');
 
     const labelled = page
       .getByTestId('markdown-text-labelled-table')

--- a/tests/media-player.test.ts
+++ b/tests/media-player.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('MediaPlayer', () => {
   test('image type renders through Img, no video controls', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const imagePlayer = page.getByTestId('media-player-image-demo');
     await expect(imagePlayer.locator('img')).toBeVisible();
@@ -10,7 +11,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('video type renders a video element with an accessible toggle role', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const videoPlayer = page.getByTestId('media-player-video-demo');
     const video = videoPlayer.locator('video');
@@ -20,7 +21,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('clicking the video toggles its aria-label between play and pause', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const video = page.getByTestId('media-player-video-demo').locator('video');
     await video.evaluate((el: HTMLVideoElement) => {
@@ -36,7 +37,7 @@ test.describe('MediaPlayer', () => {
   test('hovering reveals the overlay controls, which are real Button instances', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const videoPlayer = page.getByTestId('media-player-video-demo');
     await videoPlayer.hover();
@@ -47,7 +48,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('the mute control toggles aria-label between Mute and Unmute', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const videoPlayer = page.getByTestId('media-player-video-demo');
     await videoPlayer.hover();
@@ -60,7 +61,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('keyboard focus (not just mouse hover) reveals the overlay controls', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const videoPlayer = page.getByTestId('media-player-video-demo');
     const playButton = videoPlayer.locator('.center-control button');
@@ -75,7 +76,7 @@ test.describe('MediaPlayer', () => {
   test('native controls mode omits the custom button role/tabindex from the video', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const video = page.getByTestId('media-player-native-controls-demo').locator('video');
     await expect(video).toBeVisible();
@@ -87,7 +88,7 @@ test.describe('MediaPlayer', () => {
   test('playing bindable, pause direction: an external host setting it false actually pauses', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const video = page.getByTestId('media-player-external-pause-demo').locator('video');
     const button = page.getByTestId('external-pause-toggle');
@@ -104,7 +105,7 @@ test.describe('MediaPlayer', () => {
   test('playing bindable, play direction: an external host setting it true actually plays', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const video = page.getByTestId('media-player-external-play-demo').locator('video');
     const button = page.getByTestId('external-play-toggle');
@@ -117,7 +118,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('no captionsSrc renders no track element at all', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const video = page.getByTestId('media-player-video-demo').locator('video');
     await expect(video.locator('track')).toHaveCount(0);
@@ -128,7 +129,7 @@ test.describe('MediaPlayer', () => {
   test('the three transport controls are opt-in: a default player renders none of them', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const plain = page.getByTestId('media-player-video-demo');
     await plain.hover();
@@ -143,7 +144,7 @@ test.describe('MediaPlayer', () => {
   test('a transport player renders the seek bar, the time and the fullscreen button', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     await player.hover();
@@ -158,7 +159,7 @@ test.describe('MediaPlayer', () => {
   test('duration binds out once metadata loads, and the time display reads m:ss', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     const video = player.locator('video');
@@ -177,7 +178,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('seeking moves the media and reports the position through onseek', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     const video = player.locator('video');
@@ -209,7 +210,7 @@ test.describe('MediaPlayer', () => {
   test('currentTime bindable, inward direction: an external host write actually seeks', async ({
     page
   }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     const video = player.locator('video');
@@ -229,7 +230,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('an external write is not echoed back as a deliberate seek', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     await expect(page.getByTestId('transport-readout')).not.toContainText('duration=0.0');
@@ -247,7 +248,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('the seek bar carries an accessible name', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     await player.hover();
@@ -259,7 +260,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('the transport controls are reachable by keyboard, not hover only', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     const seek = player.getByTestId('media-player-transport-demo-seek').locator('input');
@@ -289,7 +290,7 @@ test.describe('MediaPlayer', () => {
         return Promise.resolve();
       };
     });
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const player = page.getByTestId('media-player-transport-demo');
     await player.hover();
@@ -305,7 +306,7 @@ test.describe('MediaPlayer', () => {
   });
 
   test('a supplied captionsSrc renders a real track element', async ({ page }) => {
-    await page.goto('/components/media-player');
+    await gotoHydrated(page, '/components/media-player');
 
     const track = page.getByTestId('media-player-captions-demo').locator('track');
     await expect(track).toHaveAttribute('kind', 'captions');

--- a/tests/media-upload.test.ts
+++ b/tests/media-upload.test.ts
@@ -1,13 +1,14 @@
 import { expect, test } from '@playwright/test';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { gotoHydrated } from './support/hydrated';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixtures = path.join(__dirname, 'fixtures');
 
 test.describe('MediaUpload', () => {
   test('selecting a file adds a card and updates the counter', async ({ page }) => {
-    await page.goto('/components/media-upload');
+    await gotoHydrated(page, '/components/media-upload');
 
     const upload = page.getByTestId('media-upload-demo');
     await expect(upload.locator('.counter')).toHaveText('0 / 3');
@@ -20,7 +21,7 @@ test.describe('MediaUpload', () => {
   });
 
   test('an image card renders a thumbnail via Img', async ({ page }) => {
-    await page.goto('/components/media-upload');
+    await gotoHydrated(page, '/components/media-upload');
 
     const upload = page.getByTestId('media-upload-demo');
     await upload.locator('input[type="file"]').setInputFiles(path.join(fixtures, 'tiny.png'));
@@ -31,7 +32,7 @@ test.describe('MediaUpload', () => {
   test('a file over maxFileSize is rejected with a visible alert, no card added', async ({
     page
   }) => {
-    await page.goto('/components/media-upload');
+    await gotoHydrated(page, '/components/media-upload');
 
     const upload = page.getByTestId('media-upload-demo');
     await upload.locator('input[type="file"]').setInputFiles(path.join(fixtures, 'too-large.png'));
@@ -42,7 +43,7 @@ test.describe('MediaUpload', () => {
   });
 
   test('removing a card via its remove button updates the counter', async ({ page }) => {
-    await page.goto('/components/media-upload');
+    await gotoHydrated(page, '/components/media-upload');
 
     const upload = page.getByTestId('media-upload-demo');
     await upload.locator('input[type="file"]').setInputFiles(path.join(fixtures, 'tiny.png'));
@@ -55,7 +56,7 @@ test.describe('MediaUpload', () => {
   });
 
   test('the drop tile disappears once maxLength is reached', async ({ page }) => {
-    await page.goto('/components/media-upload');
+    await gotoHydrated(page, '/components/media-upload');
 
     const upload = page.getByTestId('media-upload-demo');
     await upload

--- a/tests/menu-interactive-trigger.test.ts
+++ b/tests/menu-interactive-trigger.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Menu wraps its trigger snippet in a role="button" tabindex="0" div. That is right for
 // inert trigger content and wrong when the snippet renders a real control: the result is
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 // interactive content nested inside interactive content.
 test.describe('Menu — interactiveTrigger', () => {
   test('the wrapper stops being a second interactive element', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const wrapper = page.locator('[data-pw="menu-interactive-trigger"] .menu-trigger');
     await expect(wrapper).not.toHaveAttribute('role', /.*/);
@@ -19,7 +20,7 @@ test.describe('Menu — interactiveTrigger', () => {
   });
 
   test('the trigger still opens the menu, and reports expansion', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const button = page.getByTestId('menu-interactive-trigger-button');
     await button.click();
@@ -31,7 +32,7 @@ test.describe('Menu — interactiveTrigger', () => {
   test('Enter opens the menu exactly once, rather than toggling it shut again', async ({
     page
   }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     // The regression this guards: a native <button> synthesises a click from Enter, and that
     // click is already wired to toggle. If Menu also handled Enter in the keydown it hands the
@@ -45,7 +46,7 @@ test.describe('Menu — interactiveTrigger', () => {
   });
 
   test('Space opens the menu exactly once too', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const button = page.getByTestId('menu-interactive-trigger-button');
     await button.focus();
@@ -58,7 +59,7 @@ test.describe('Menu — interactiveTrigger', () => {
   test('ArrowDown still opens the menu — the key a native button does not implement', async ({
     page
   }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const button = page.getByTestId('menu-interactive-trigger-button');
     await button.focus();
@@ -69,7 +70,7 @@ test.describe('Menu — interactiveTrigger', () => {
   });
 
   test('closing returns focus to the control, not the wrapper', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     // The wrapper carries no tabindex under interactiveTrigger, so focusing it is a no-op
     // and focus would fall to <body> — leaving a keyboard user stranded after Escape.
@@ -85,7 +86,7 @@ test.describe('Menu — interactiveTrigger', () => {
   });
 
   test('selecting an item also returns focus to the control', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const button = page.getByTestId('menu-interactive-trigger-button');
     await button.click();
@@ -98,7 +99,7 @@ test.describe('Menu — interactiveTrigger', () => {
   test('default menus are unchanged — the wrapper stays the interactive element', async ({
     page
   }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     // Regression guard for every existing consumer: without the flag, Menu keeps
     // driving the trigger from its own wrapper exactly as before.

--- a/tests/menu-placement.test.ts
+++ b/tests/menu-placement.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the `placement` prop: the default stays left/below-anchored (backwards
 // compatible), 'bottom-right' anchors the panel's right edge to the trigger, and
 // 'auto' measures on open and flips corners so the panel stays inside the viewport.
 test.describe('Menu — placement', () => {
   test('default placement keeps the panel left-aligned below the trigger', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const menu = page.locator('[data-pw="menu-default-demo"]');
     await menu.locator('.menu-trigger').click();
@@ -23,7 +24,7 @@ test.describe('Menu — placement', () => {
   });
 
   test('bottom-right anchors the panel right edge to the trigger right edge', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const menu = page.locator('[data-pw="menu-bottom-right-demo"]');
     await menu.locator('.menu-trigger').click();
@@ -46,7 +47,7 @@ test.describe('Menu — placement', () => {
   test('auto placement flips to top-right for a trigger pinned at the viewport corner', async ({
     page
   }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const menu = page.locator('[data-pw="menu-auto-corner-demo"]');
     await menu.scrollIntoViewIfNeeded();
@@ -69,7 +70,7 @@ test.describe('Menu — placement', () => {
   });
 
   test('auto placement stays at the default corner when there is room', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     // This demo sits in the normal content flow near the top-left, so every
     // direction has room and resolveAutoPlacement must keep the default corner.
@@ -88,7 +89,7 @@ test.describe('Menu — placement', () => {
   test('omitted placement never gains a corner class (existing-consumer guard)', async ({
     page
   }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const menu = page.locator('[data-pw="menu-default-demo"]');
     await menu.locator('.menu-trigger').click();

--- a/tests/menu-portal-overflow.test.ts
+++ b/tests/menu-portal-overflow.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Menu — usePortal escapes clipping containers', () => {
   // The demo wraps two Menus in 90px-tall overflow:hidden boxes. The default
@@ -7,7 +8,7 @@ test.describe('Menu — usePortal escapes clipping containers', () => {
   test('portals the dropdown to <body> so an overflow:hidden ancestor cannot clip it', async ({
     page
   }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const portalMenu = page.locator('[data-pw="menu-portal-demo"]');
     await expect(portalMenu).toBeVisible();
@@ -35,7 +36,7 @@ test.describe('Menu — usePortal escapes clipping containers', () => {
   });
 
   test('the default (in-flow) dropdown stays inside the .menu-container', async ({ page }) => {
-    await page.goto('/components/menu');
+    await gotoHydrated(page, '/components/menu');
 
     const inflowMenu = page.locator('[data-pw="menu-inflow-demo"]');
     await inflowMenu.locator('.menu-trigger').click();

--- a/tests/modal-left-image-interactivity.spec.ts
+++ b/tests/modal-left-image-interactivity.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Modal used to wrap ANY non-empty header.leftImage in role="button" + tabindex="0" with click and
 // keydown handlers, whether or not onheaderLeftImageClick was supplied. Consumers pass a decorative
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // now interactive only when a handler is actually supplied.
 test.describe('Modal left image interactivity', () => {
   test('a decorative left image with no click handler is not a control', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
     await page.getByText('Open modal with decorative left image').click();
 
     const modal = page.getByTestId('decorative-left-image-modal');
@@ -28,7 +29,7 @@ test.describe('Modal left image interactivity', () => {
   test('a left image with a click handler stays a fully keyboard-operable button', async ({
     page
   }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
     await page.getByText('Open modal with back button').click();
 
     const modal = page.getByTestId('back-button-modal');

--- a/tests/modal-lock-scroll-and-auto-dismiss.test.ts
+++ b/tests/modal-lock-scroll-and-auto-dismiss.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Modal lockScroll', () => {
   test('lockScroll=false leaves document.body scrollable', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByTestId('open-no-scroll-lock-modal').click();
     await expect(page.getByTestId('no-scroll-lock-modal')).toBeVisible();
@@ -12,7 +13,7 @@ test.describe('Modal lockScroll', () => {
   });
 
   test('the default (lockScroll unset) still locks scroll, unchanged', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByText('Open Modal', { exact: true }).click();
     const overflow = await page.evaluate(() => document.body.style.overflow);
@@ -22,7 +23,7 @@ test.describe('Modal lockScroll', () => {
 
 test.describe('Modal autoDismissAfter', () => {
   test('the modal closes itself after the given delay, firing onclose', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByTestId('open-auto-dismiss-modal').click();
     await expect(page.getByTestId('auto-dismiss-modal')).toBeVisible();
@@ -32,7 +33,7 @@ test.describe('Modal autoDismissAfter', () => {
   });
 
   test('scroll unlocks once an auto-dismissed modal unmounts', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByTestId('open-auto-dismiss-modal').click();
     await expect(page.getByTestId('auto-dismiss-modal')).toHaveCount(0, { timeout: 2000 });

--- a/tests/modal-nested-scroll-lock.test.ts
+++ b/tests/modal-nested-scroll-lock.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Body scroll lock — reference counted across surfaces', () => {
   test('closing a nested Modal leaves the outer Modal’s lock in place', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     const overflow = () => page.evaluate(() => document.body.style.overflow);
     const outer = page.locator('[data-pw="nested-lock-outer-modal"]');
@@ -42,7 +43,7 @@ test.describe('Body scroll lock — reference counted across surfaces', () => {
   test('the last release hands back the inline overflow the host had set, not an empty string', async ({
     page
   }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
     const overflow = () => page.evaluate(() => document.body.style.overflow);
     const outer = page.locator('[data-pw="nested-lock-outer-modal"]');
 

--- a/tests/modal-viewport-containment.spec.ts
+++ b/tests/modal-viewport-containment.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Only .fit-content used to carry a max-height, so a size class whose height
 // var was overridden to fit-content (the common app-level sizing) grew past
@@ -12,7 +13,7 @@ test.describe('Modal viewport containment', () => {
   test('a tall fit-content modal stays inside a short viewport with its footer visible', async ({
     page
   }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByText('Open tall modal (viewport containment)').click();
     const modal = page.getByTestId('tall-modal');
@@ -45,7 +46,7 @@ test.describe('Modal viewport containment', () => {
   });
 
   test('default medium modal keeps its 50vh height (defaults unchanged)', async ({ page }) => {
-    await page.goto('/components/modal');
+    await gotoHydrated(page, '/components/modal');
 
     await page.getByText('Open Modal', { exact: true }).click();
     const content = page.locator('.modal-content.medium');

--- a/tests/modal-wc-aria-forwarding.spec.ts
+++ b/tests/modal-wc-aria-forwarding.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `role`/`aria-label` set directly on `<sui-modal>` land on the host element --
 // the ARIAMixin accessors every custom element already has -- not on
@@ -11,7 +12,7 @@ import { expect, test } from '@playwright/test';
 // panel instead -- same prefixed-alias pattern as `<sui-toggle>`'s
 // `inputAriaLabel`, proven by tests/toggle-labelling.spec.ts.
 const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-modal') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/native-test-id.test.ts
+++ b/tests/native-test-id.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 /**
  * Every component that accepts `testId` must emit the id for BOTH runners:
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
  */
 test.describe('testId emits both web and native test attributes', () => {
   test('Checkbox exposes data-pw and the native testid from one testId prop', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     const target = page.locator('[data-pw="checkbox-default"]').first();
     await expect(target).toBeVisible();
@@ -19,7 +20,7 @@ test.describe('testId emits both web and native test attributes', () => {
   });
 
   test('the native attribute is omitted when no testId is supplied', async ({ page }) => {
-    await page.goto('/components/checkbox');
+    await gotoHydrated(page, '/components/checkbox');
 
     // A bare `testid` must never render as the literal string "undefined"/"null";
     // absent ids emit no attribute at all.

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Pagination — cursor / load-more mode', () => {
   test('basic pagination still renders prev/next (backward compatible)', async ({ page }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
     const basic = page.getByTestId('pagination-basic');
     await expect(basic).toBeVisible();
     await expect(basic.getByRole('button', { name: 'Previous page' })).toBeVisible();
@@ -12,7 +13,7 @@ test.describe('Pagination — cursor / load-more mode', () => {
   test('cursor mode swaps the next-button for a load-more CTA on the last page', async ({
     page
   }) => {
-    await page.goto('/components/pagination');
+    await gotoHydrated(page, '/components/pagination');
     const cursor = page.getByTestId('pagination-cursor');
     await expect(cursor).toBeVisible();
     // On page 1 of 3 there is no load-more CTA yet — normal next-button is shown.

--- a/tests/pie-chart-wc.spec.ts
+++ b/tests/pie-chart-wc.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `docs/PieChart.md` described `<sui-pie-chart>` for several releases while no
 // wrapper existed, so the element never upgraded and the documented snippets
@@ -10,7 +11,7 @@ import { expect, test, type Page } from '@playwright/test';
 // it is injected into a same-origin page instead of being navigated to.
 // `pnpm run build` (the webServer command) runs build:wc, so the file exists.
 const loadBundle = async (page: Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(
     () => typeof customElements.get('sui-pie-chart') !== 'undefined',

--- a/tests/pie-label-engine.spec.ts
+++ b/tests/pie-label-engine.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The crowded demo (24 sources, long labels, sliver slices) is the shape that
 // used to render every label unconditionally at its mid-angle — stacked
@@ -9,7 +10,7 @@ test.describe('PieChart label engine', () => {
   test('crowded pie renders zero overlapping labels, all inside the chart box', async ({
     page
   }) => {
-    await page.goto('/components/pie-chart');
+    await gotoHydrated(page, '/components/pie-chart');
 
     const chart = page.getByTestId('pie-crowded-chart');
     await expect(chart.locator('.slice').first()).toBeVisible();
@@ -48,7 +49,7 @@ test.describe('PieChart label engine', () => {
   });
 
   test('all-zero data renders the empty state with no NaN geometry', async ({ page }) => {
-    await page.goto('/components/pie-chart');
+    await gotoHydrated(page, '/components/pie-chart');
 
     const chart = page.getByTestId('pie-all-zero');
     await expect(chart.locator('.chart-empty')).toBeVisible();
@@ -60,7 +61,7 @@ test.describe('PieChart label engine', () => {
   });
 
   test('sparse pie keeps every label (defaults unchanged)', async ({ page }) => {
-    await page.goto('/components/pie-chart');
+    await gotoHydrated(page, '/components/pie-chart');
 
     // The 5-slice expenses demo has ample room — the engine must not drop or
     // truncate anything there.

--- a/tests/piechart-legend-right.spec.ts
+++ b/tests/piechart-legend-right.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #417: PieChart had `legendShowValues` (a below-chart list) but no
 // right-position layout, no item cap and no expander, so Lighthouse's
@@ -9,7 +10,7 @@ import { expect, test } from '@playwright/test';
 // legend renders exactly where and how it did.
 test.describe('PieChart — right-side value legend (#417)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/pie-chart');
+    await gotoHydrated(page, '/components/pie-chart');
   });
 
   test('the default value legend is still below the chart', async ({ page }) => {

--- a/tests/pill-attrs.spec.ts
+++ b/tests/pill-attrs.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Pill had no way to put an arbitrary data-*/aria-* attribute on its root --
 // the gap juspay/svelte-ui-components#545 asks for. A consumer hit this by
@@ -12,7 +13,7 @@ import { expect, test } from '@playwright/test';
 // never reaches the DOM.
 test.describe('Pill attrs', () => {
   test('attrs spreads arbitrary data-* attributes onto the root', async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     const pill = page.getByTestId('attrs-data-state-pill');
     await expect(pill).toHaveAttribute('data-state', 'waiting');
@@ -24,7 +25,7 @@ test.describe('Pill attrs', () => {
   test('attrs cannot override the attributes Pill already manages (data-pw, class, role, tabindex)', async ({
     page
   }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     // This pill passes attrs = { 'data-pw': 'hijacked', class: 'attrs-injected-class',
     // role: 'not-a-button', tabindex: '5' } alongside testId="attrs-collision-pill",
@@ -47,7 +48,7 @@ test.describe('Pill attrs', () => {
   });
 
   test('omitting attrs leaves the pill root unaffected (no regression)', async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     const pill = page.getByTestId('attrs-none-pill');
     await expect(pill).not.toHaveAttribute('data-state', /.*/);

--- a/tests/pill-dark-theme-tones.test.ts
+++ b/tests/pill-dark-theme-tones.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // #464. The demo shell used to set `--pill-background` / `--pill-color` on
 // `[data-theme='dark']` itself, for the untoned chat suggestion chips and composer
@@ -28,7 +29,7 @@ const paintOf = (page: import('@playwright/test').Page, testId: string) =>
 // waits on a web-first assertion, which retries until the style resolves. Nothing transitions
 // in the demo shell today, so this is future-proofing rather than a live fix.
 test.beforeEach(async ({ page }) => {
-  await page.goto('/components/pill');
+  await gotoHydrated(page, '/components/pill');
   await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
   await expect(page.locator('[data-pw="attrs-none-pill"]')).toHaveCSS(
     'background-color',

--- a/tests/pill-dismiss-colour.spec.ts
+++ b/tests/pill-dismiss-colour.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 const expectBareDismiss = async (
   dismiss: import('@playwright/test').Locator,
@@ -12,7 +13,7 @@ const expectBareDismiss = async (
 
 test.describe('Pill dismiss glyph colour', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
     await page.mouse.move(0, 0);
   });
 
@@ -106,7 +107,7 @@ test.describe('Pill dismiss glyph colour', () => {
 test('interactive Pill does not intercept keyboard activation of its dismiss button', async ({
   page
 }) => {
-  await page.goto('/components/pill');
+  await gotoHydrated(page, '/components/pill');
   const dismiss = page.getByTestId('pill-interactive-dismiss');
   await dismiss.press('Space');
   await expect(page.getByTestId('pill-dismiss-count')).toHaveText('1');
@@ -121,7 +122,7 @@ test('interactive Pill does not intercept keyboard activation of its dismiss but
 test('sui-pill supplies a visible default dismiss glyph and honours a slotted glyph', async ({
   page
 }) => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => Boolean(customElements.get('sui-pill')));
   await page.evaluate(() => {

--- a/tests/pill-interactive-root.test.ts
+++ b/tests/pill-interactive-root.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // #469: Pill's root is a non-interactive <div>, with a synthetic
 // role="button"/tabindex/keydown shim bolted on when `onclick` is supplied. Anything
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // deliberate deviation). `as="button"` renders a real <button type="button"> instead.
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/components/pill');
+  await gotoHydrated(page, '/components/pill');
 });
 
 test('as="button" renders a real button element, not a div with role=button', async ({ page }) => {

--- a/tests/pill-line-height.spec.ts
+++ b/tests/pill-line-height.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Regression test: --pill-line-height is documented and implemented in Pill.svelte (it shipped in
 // 5b7dc9d, before this spec). This spec guards against the hook being removed or falling out of
 // sync with the default (line-height: 1 at --pill-font-size: 13px).
 test.describe('Pill line-height hook', () => {
   test('defaults to line-height: 1 when --pill-line-height is unset', async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     const pill = page.getByTestId('pill-line-height-default');
     await expect(pill).toBeVisible();
@@ -15,7 +16,7 @@ test.describe('Pill line-height hook', () => {
   });
 
   test('an explicit --pill-line-height override applies', async ({ page }) => {
-    await page.goto('/components/pill');
+    await gotoHydrated(page, '/components/pill');
 
     const pill = page.getByTestId('pill-line-height-custom');
     await expect(pill).toBeVisible();

--- a/tests/progress-aria.spec.ts
+++ b/tests/progress-aria.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Progress previously rendered with no ARIA at all -- a screen reader had no
 // way to know the .container div was a progress indicator, let alone its
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // the same regardless of what value/max the consumer actually passed).
 test.describe('Progress ARIA', () => {
   test('determinate progress bar exposes role, value, and label attributes', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-determinate-demo');
     await expect(bar).toHaveAttribute('role', 'progressbar');
@@ -21,7 +22,7 @@ test.describe('Progress ARIA', () => {
   });
 
   test('aria-valuenow tracks the visible label for whole-number percentages', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-determinate-demo');
     await page.getByRole('button', { name: '+10' }).click();
@@ -43,7 +44,7 @@ test.describe('Progress ARIA', () => {
   test('aria-valuenow uses 2-decimal precision to stay in step with the bar width', async ({
     page
   }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     // value=1, max=3 -> a repeating-decimal 33.333...% bar width. Whole-number
     // rounding (the old behavior) would report aria-valuenow="33", a full
@@ -60,7 +61,7 @@ test.describe('Progress ARIA', () => {
   test('indeterminate progress bar omits aria-valuenow and announces busy state', async ({
     page
   }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-indeterminate-demo');
     await expect(bar).toHaveAttribute('role', 'progressbar');
@@ -77,7 +78,7 @@ test.describe('Progress ARIA', () => {
   });
 
   test('all demo instances are discoverable via the progressbar role', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     await expect(page.getByRole('progressbar')).toHaveCount(8);
   });
@@ -91,7 +92,7 @@ test.describe('Progress ARIA', () => {
 // reaches the DOM, and the bar renders exactly as an empty progress bar would.
 test.describe('Progress invalid range fallback', () => {
   test('value=0, max=0 renders a 0% bar instead of NaN', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-zero-range-demo');
     await expect(bar).toHaveAttribute('role', 'progressbar');
@@ -103,7 +104,7 @@ test.describe('Progress invalid range fallback', () => {
   });
 
   test('a negative max is an invalid range and also falls back to 0%', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-negative-max-demo');
     await expect(bar).toHaveAttribute('aria-valuenow', '0');
@@ -111,7 +112,7 @@ test.describe('Progress invalid range fallback', () => {
   });
 
   test('a non-finite max is an invalid range and also falls back to 0%', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-nan-max-demo');
     await expect(bar).toHaveAttribute('aria-valuenow', '0');
@@ -119,7 +120,7 @@ test.describe('Progress invalid range fallback', () => {
   });
 
   test('a non-finite value is an invalid range, not indeterminate', async ({ page }) => {
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     // NaN < 0 is false, so a NaN value doesn't trip the isIndeterminate check
     // on its own -- it must be caught by the same finite-range guard as an
@@ -135,7 +136,7 @@ test.describe('Progress invalid range fallback', () => {
     // scoped to `percentage`/`aria-valuenow` and must not suppress the
     // pre-existing negative-value indeterminate behavior, since indeterminate
     // mode never reads `percentage` in the markup anyway.
-    await page.goto('/components/progress');
+    await gotoHydrated(page, '/components/progress');
 
     const bar = page.getByTestId('progress-negative-value-invalid-max-demo');
     await expect(bar).toHaveAttribute('aria-busy', 'true');

--- a/tests/proportion-bar.test.ts
+++ b/tests/proportion-bar.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the ProportionBar: one rect + one legend item per segment, widths that
 // sum to the full track, the accessible SVG summary when the legend is hidden,
 // and sanitization of negative / non-finite segment values.
 test.describe('ProportionBar', () => {
   test('renders one rect and one legend item per segment', async ({ page }) => {
-    await page.goto('/components/proportion-bar');
+    await gotoHydrated(page, '/components/proportion-bar');
 
     const bar = page.getByTestId('payment-methods-bar');
     await expect(bar).toBeVisible();
@@ -20,7 +21,7 @@ test.describe('ProportionBar', () => {
   });
 
   test('segment widths fill the whole track (~100%)', async ({ page }) => {
-    await page.goto('/components/proportion-bar');
+    await gotoHydrated(page, '/components/proportion-bar');
 
     const bar = page.getByTestId('payment-methods-bar');
     const widths = await bar.getByTestId('payment-methods-bar-svg').evaluate((svg) => {
@@ -32,7 +33,7 @@ test.describe('ProportionBar', () => {
   });
 
   test('exposes an accessible SVG summary when the legend is hidden', async ({ page }) => {
-    await page.goto('/components/proportion-bar');
+    await gotoHydrated(page, '/components/proportion-bar');
 
     const bar = page.getByTestId('no-legend-bar');
     await expect(bar.getByTestId('no-legend-bar-legend')).toHaveCount(0);
@@ -43,7 +44,7 @@ test.describe('ProportionBar', () => {
   });
 
   test('ignores negative and non-finite values (widths stay within 0–100)', async ({ page }) => {
-    await page.goto('/components/proportion-bar');
+    await gotoHydrated(page, '/components/proportion-bar');
 
     const bar = page.getByTestId('robust-bar');
     const rectCount = await bar

--- a/tests/sankey-label-engine.spec.ts
+++ b/tests/sankey-label-engine.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The crowded-funnel demo reproduces the two historical label failures:
 // uppercase-heavy middle-column labels sliding under the next column's bars
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // node bar — dropped labels stay reachable via the node's hover <title>.
 test.describe('SankeyChart label engine', () => {
   test('crowded funnel renders zero label/label and label/node overlaps', async ({ page }) => {
-    await page.goto('/components/sankey-chart');
+    await gotoHydrated(page, '/components/sankey-chart');
 
     const chart = page.getByTestId('sankey-crowded-chart');
     await expect(chart.locator('.sankey-node').first()).toBeVisible();
@@ -56,7 +57,7 @@ test.describe('SankeyChart label engine', () => {
   });
 
   test('labels stay inside the chart box on both edges', async ({ page }) => {
-    await page.goto('/components/sankey-chart');
+    await gotoHydrated(page, '/components/sankey-chart');
 
     const chart = page.getByTestId('sankey-crowded-chart');
     await expect(chart.locator('.sankey-label').first()).toBeVisible();
@@ -79,7 +80,7 @@ test.describe('SankeyChart label engine', () => {
   // the sink gutter, must now give them full room. A clipped label still fits
   // inside the chart box, so the edge test above cannot catch this.
   test('first-column source labels render their full text (not clipped)', async ({ page }) => {
-    await page.goto('/components/sankey-chart');
+    await gotoHydrated(page, '/components/sankey-chart');
 
     const chart = page.getByTestId('sankey-crowded-chart');
     await expect(chart.locator('.sankey-label').first()).toBeVisible();

--- a/tests/select-error-clear-pressed.test.ts
+++ b/tests/select-error-clear-pressed.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #414 items 2-4. The Breeze DS dropdown sheet specs an error state
 // (red border + hint), a trigger clear button that resets the selection
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // documented class recipe, since the variables were already themeable.
 test.describe('Select — error state (#414 item 2)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
   });
 
   test('renders the error border on the trigger', async ({ page }) => {
@@ -63,7 +64,7 @@ test.describe('Select — error state (#414 item 2)', () => {
 
 test.describe('Select — trigger clear button (#414 item 3)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
   });
 
   test('clears the selection', async ({ page }) => {
@@ -150,7 +151,7 @@ test.describe('Select — pressed state (#414 item 4)', () => {
   // is how it wasted time once already. hover() scrolls into view first, so
   // these stay correct no matter where the fixture sits on the page.
   test('the trigger tints while the pointer is down', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
     const trigger = page.getByTestId('select-clearable').locator('.select-trigger');
 
     await trigger.hover();
@@ -162,7 +163,7 @@ test.describe('Select — pressed state (#414 item 4)', () => {
   });
 
   test('the trigger returns to its normal background on release', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
     const trigger = page.getByTestId('select-clearable').locator('.select-trigger');
 
     await trigger.hover();
@@ -173,7 +174,7 @@ test.describe('Select — pressed state (#414 item 4)', () => {
   });
 
   test('an option tints while the pointer is down', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
     const select = page.getByTestId('select-clearable');
 
     await select.locator('.select-trigger').click();

--- a/tests/select-in-menu-search.test.ts
+++ b/tests/select-in-menu-search.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #415. The DS dropdown sheet's keyboard-accessibility guidelines put
 // the search box INSIDE the open menu, reached by Tab after opening, while
@@ -8,7 +9,7 @@ import { expect, test } from '@playwright/test';
 // a keyboard user who wanted to arrow through the options had to type first.
 test.describe('Select — in-menu search (#415)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
   });
 
   const openMenu = async (page: import('@playwright/test').Page) => {

--- a/tests/select-lefticon-inline-svg.test.ts
+++ b/tests/select-lefticon-inline-svg.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Select — leftIcon inlines SVG so currentColor themes it', () => {
   // An <img> renders its source as an isolated document: currentColor inside it
@@ -12,7 +13,7 @@ test.describe('Select — leftIcon inlines SVG so currentColor themes it', () =>
   test('renders the leading icon as an inline <svg> that inherits the trigger colour', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const icon = page.getByTestId('select-left-icon');
     await expect(icon).toBeVisible();

--- a/tests/select-multi-indicator.test.ts
+++ b/tests/select-multi-indicator.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Select — multi-select checkbox indicator', () => {
   // The default multi-select option indicator is a design-system checkbox box:
@@ -7,7 +8,7 @@ test.describe('Select — multi-select checkbox indicator', () => {
   test('renders a checkbox box that fills with a checkmark when an option is selected', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-multi-demo');
     await expect(select).toBeVisible();

--- a/tests/select-portal-overflow.test.ts
+++ b/tests/select-portal-overflow.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Select — usePortal escapes clipping containers', () => {
   // The demo wraps two Selects in 90px-tall overflow:hidden boxes. The default
@@ -7,7 +8,7 @@ test.describe('Select — usePortal escapes clipping containers', () => {
   test('portals the dropdown to <body> so an overflow:hidden ancestor cannot clip it', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const portalSelect = page.locator('[data-pw="select-portal-demo"]');
     await expect(portalSelect).toBeVisible();
@@ -35,7 +36,7 @@ test.describe('Select — usePortal escapes clipping containers', () => {
   });
 
   test('the default (in-flow) dropdown stays inside the .select container', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const inflowSelect = page.locator('[data-pw="select-inflow-demo"]');
     await inflowSelect.getByRole('combobox').click();

--- a/tests/select-select-all.test.ts
+++ b/tests/select-select-all.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the `showSelectAll` multi-select feature: the synthetic "select all" row,
 // toggle-all / deselect-all, the indeterminate (dash) state + its accessible label,
 // keyboard reachability, and search-scoped selection.
 test.describe('Select — select all (multi-select)', () => {
   test('renders a select-all row that selects and deselects every option', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-all-demo');
     await expect(select).toBeVisible();
@@ -56,7 +57,7 @@ test.describe('Select — select all (multi-select)', () => {
   test('shows an indeterminate dash and accessible state when only some are selected', async ({
     page
   }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-all-demo');
     await select.getByRole('combobox').click();
@@ -74,7 +75,7 @@ test.describe('Select — select all (multi-select)', () => {
   });
 
   test('keyboard navigation reaches the select-all row', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-all-demo');
     await select.getByRole('combobox').focus();
@@ -93,7 +94,7 @@ test.describe('Select — select all (multi-select)', () => {
   });
 
   test('searchable: select-all toggles only the filtered options', async ({ page }) => {
-    await page.goto('/components/select');
+    await gotoHydrated(page, '/components/select');
 
     const select = page.getByTestId('select-all-search-demo');
     await expect(select).toBeVisible();

--- a/tests/sheet-anchor-and-overlay.test.ts
+++ b/tests/sheet-anchor-and-overlay.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the three Sheet gaps: anchor-position tokens (turning an edge-to-edge
 // slide-in into a floating anchored panel), an invisible-but-dismissible overlay
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // while the other is still open).
 test.describe('Sheet anchor position tokens', () => {
   test('an unconfigured sheet stays edge-to-edge (defaults unchanged)', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open right', { exact: true }).click();
     const panel = page.getByTestId('sheet-right-panel');
@@ -27,7 +28,7 @@ test.describe('Sheet anchor position tokens', () => {
   });
 
   test('anchor tokens turn the panel into a floating, content-sized box', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open account menu').click();
     const panel = page.getByTestId('sheet-anchored-panel');
@@ -56,7 +57,7 @@ test.describe('Sheet anchor position tokens', () => {
 
 test.describe('Sheet dismissOnOutsideClick', () => {
   test('an invisible overlay is still click-dismissible when requested', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open account menu').click();
     const overlay = page.getByTestId('sheet-anchored');
@@ -76,7 +77,7 @@ test.describe('Sheet dismissOnOutsideClick', () => {
   test('a visible, non-dismissible overlay blocks the page but does not close on click', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open blocking sheet').click();
     const overlay = page.getByTestId('sheet-blocking');
@@ -106,7 +107,7 @@ test.describe('Sheet reference-counted scroll lock', () => {
   test('closing one of two open sheets keeps the page scroll-locked for the other', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open right', { exact: true }).click();
     await expect(page.getByTestId('sheet-right-panel')).toBeVisible();

--- a/tests/sheet-band-width.test.ts
+++ b/tests/sheet-band-width.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #572: Sheet's top/bottom sides had no width-capping mechanism. left
 // and right expose --sheet-width; top and bottom were always full-viewport-
@@ -48,7 +49,7 @@ const viewportOf = (page: import('@playwright/test').Page) => {
 
 test.describe('Sheet — width-capped top/bottom (#572)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
   });
 
   test('an unconfigured bottom sheet is still edge-to-edge', async ({ page }) => {

--- a/tests/sheet-centered-variant.test.ts
+++ b/tests/sheet-centered-variant.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Closes #525: Sheet had no centered/floating dialog variant (edge-anchored
 // left/right/top/bottom only) and always rendered its title through a plain
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // using this component at all.
 test.describe('Sheet side="center"', () => {
   test('is a fixed-size dialog centered in the viewport, not edge-anchored', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open centered dialog').click();
     const panel = page.getByTestId('sheet-centered-panel');
@@ -49,7 +50,7 @@ test.describe('Sheet side="center"', () => {
   test('an unconfigured left/right/top/bottom sheet is unaffected (still edge-to-edge)', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open right', { exact: true }).click();
     const panel = page.getByTestId('sheet-right-panel');
@@ -73,7 +74,7 @@ test.describe('Sheet side="center"', () => {
 
 test.describe('Sheet headingLevel', () => {
   test('renders the title through a real heading element when set', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open with headingLevel').click();
     const panel = page.getByTestId('sheet-heading-panel');
@@ -87,7 +88,7 @@ test.describe('Sheet headingLevel', () => {
   test('title stays a <span> when headingLevel is not set (default unchanged)', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByText('Open right', { exact: true }).click();
     const panel = page.getByTestId('sheet-right-panel');

--- a/tests/sheet-overlay-a11y.test.ts
+++ b/tests/sheet-overlay-a11y.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Two pre-existing a11y defects on Sheet, shipped on every side since 4.0.0:
 //
@@ -16,7 +17,7 @@ test.describe('Sheet overlay accessible name', () => {
   test('a dismissible overlay (side="right", default dismissOnOutsideClick) is a named button', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-right-trigger').click();
     const overlay = page.getByTestId('sheet-right');
@@ -29,7 +30,7 @@ test.describe('Sheet overlay accessible name', () => {
   test('a non-dismissible overlay (dismissOnOutsideClick=false) carries no role at all', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-blocking-trigger').click();
     const overlay = page.getByTestId('sheet-blocking');
@@ -42,7 +43,7 @@ test.describe('Sheet overlay accessible name', () => {
   });
 
   test('overlayAriaLabel overrides the default name (side="left")', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-custom-overlay-label-trigger').click();
     const overlay = page.getByTestId('sheet-custom-overlay-label');
@@ -55,7 +56,7 @@ test.describe('Sheet overlay accessible name', () => {
   test('an invisible-but-dismissible overlay (showOverlay=false) is still a named button', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-anchored-trigger').click();
     const overlay = page.getByTestId('sheet-anchored');
@@ -70,7 +71,7 @@ test.describe('Sheet panel focus indicator', () => {
   test('a keyboard-opened sheet (side="right") shows a visible focus ring on the panel', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     // .press() dispatches a real key event, which is what puts the browser in
     // keyboard input modality -- the precondition :focus-visible checks before
@@ -94,7 +95,7 @@ test.describe('Sheet panel focus indicator', () => {
   test('a keyboard-opened sheet (side="bottom") shows a visible focus ring on the panel', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-bottom-trigger').press('Enter');
     const panel = page.getByTestId('sheet-bottom-panel');
@@ -113,7 +114,7 @@ test.describe('Sheet panel focus indicator', () => {
   test('a mouse-opened sheet (side="right") keeps the panel default outline unchanged', async ({
     page
   }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-right-trigger').click();
     const panel = page.getByTestId('sheet-right-panel');
@@ -134,7 +135,7 @@ test.describe('Sheet panel focus indicator', () => {
 
 test.describe('Sheet overlay keyboard activation', () => {
   test('a dismissible overlay closes on Enter, as its role="button" promises', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-right-trigger').click();
     const overlay = page.getByTestId('sheet-right');
@@ -149,7 +150,7 @@ test.describe('Sheet overlay keyboard activation', () => {
   });
 
   test('a non-dismissible overlay ignores Enter', async ({ page }) => {
-    await page.goto('/components/sheet');
+    await gotoHydrated(page, '/components/sheet');
 
     await page.getByTestId('sheet-blocking-trigger').click();
     const overlay = page.getByTestId('sheet-blocking');

--- a/tests/snippet-copy-options.test.ts
+++ b/tests/snippet-copy-options.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers Snippet's `copiedLabel` and `copyResetMs` (#530). Before this change the
 // copied-feedback text and its 2000ms reset were hardcoded, so a consumer wanting
@@ -12,7 +13,7 @@ test.describe('Snippet copiedLabel / copyResetMs', () => {
     context
   }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/components/snippet');
+    await gotoHydrated(page, '/components/snippet');
 
     const snippet = page.getByTestId('snippet-default');
     await snippet.getByRole('button', { name: 'Copy to clipboard' }).click();
@@ -30,7 +31,7 @@ test.describe('Snippet copiedLabel / copyResetMs', () => {
     context
   }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/components/snippet');
+    await gotoHydrated(page, '/components/snippet');
 
     const snippet = page.getByTestId('snippet-copy-options');
     await snippet.getByRole('button', { name: 'Copy to clipboard' }).click();

--- a/tests/snippet-copy-state.spec.ts
+++ b/tests/snippet-copy-state.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Coverage for #574: the copy affordance was only reachable by also taking
 // Snippet's `<code>` box and `$` prompt, so consumers who wanted a bare copy
@@ -11,7 +12,7 @@ import { expect, test } from '@playwright/test';
 test.describe('createCopyState — copy affordance without the presentation', () => {
   test.beforeEach(async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/components/snippet');
+    await gotoHydrated(page, '/components/snippet');
   });
 
   test('copies the value to the real clipboard', async ({ page }) => {

--- a/tests/split-button-trigger-name.test.ts
+++ b/tests/split-button-trigger-name.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // SplitButton's second control renders a chevron and nothing else, inside Menu's
 // inert-trigger branch. That branch is the right one here — the snippet holds no real
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // a weak name, none, since there is no text to fall back on either.
 test.describe('SplitButton — the dropdown trigger has a name', () => {
   test('it defaults to a name derived from the primary text', async ({ page }) => {
-    await page.goto('/components/split-button');
+    await gotoHydrated(page, '/components/split-button');
 
     const trigger = page.locator('[data-pw="split-button-default"] .menu-trigger');
     await expect(trigger).toHaveAttribute('role', 'button');
@@ -15,14 +16,14 @@ test.describe('SplitButton — the dropdown trigger has a name', () => {
   });
 
   test('triggerAriaLabel overrides the default', async ({ page }) => {
-    await page.goto('/components/split-button');
+    await gotoHydrated(page, '/components/split-button');
 
     const trigger = page.locator('[data-pw="split-button-named"] .menu-trigger');
     await expect(trigger).toHaveAccessibleName('Choose an export format');
   });
 
   test('the primary button keeps its own name, distinct from the trigger', async ({ page }) => {
-    await page.goto('/components/split-button');
+    await gotoHydrated(page, '/components/split-button');
 
     // The two controls sit side by side and must not announce identically, which is the
     // reason the default derives from the text rather than being a bare "More options".
@@ -32,7 +33,7 @@ test.describe('SplitButton — the dropdown trigger has a name', () => {
   });
 
   test('naming the trigger does not stop it opening the menu', async ({ page }) => {
-    await page.goto('/components/split-button');
+    await gotoHydrated(page, '/components/split-button');
 
     const trigger = page.locator('[data-pw="split-button-named"] .menu-trigger');
     await trigger.click();

--- a/tests/split-input-autocomplete-inputmode.test.ts
+++ b/tests/split-input-autocomplete-inputmode.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('SplitInput — autoComplete / inputMode field passthrough', () => {
   // OTP consumers need `autocomplete="one-time-code"` (WebOTP / SMS autofill
@@ -6,7 +7,7 @@ test.describe('SplitInput — autoComplete / inputMode field passthrough', () =>
   // FieldConfig previously had no way to express either, forcing hand-rolled
   // segmented inputs for exactly the use case SplitInput exists for.
   test('per-field autoComplete and inputMode render on the native inputs', async ({ page }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     const group = page.getByTestId('split-input-sms-otp');
     await expect(group).toBeVisible();
@@ -22,7 +23,7 @@ test.describe('SplitInput — autoComplete / inputMode field passthrough', () =>
   });
 
   test('fields without the new config keep the previous defaults', async ({ page }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     // The plain OTP demo (length-based default fields) is unchanged: default
     // autocomplete stays 'on' and no inputmode attribute is rendered.

--- a/tests/splitinput-autofill-distribute.spec.ts
+++ b/tests/splitinput-autofill-distribute.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // WebOTP / Android-SMS autofill drops the WHOLE code into the first field as a
 // single input event (no keyboard, no clipboard paste). With the default
@@ -18,7 +19,7 @@ test.describe('SplitInput autofill/multi-char distribution', () => {
   };
 
   test('whole code injected into field 0 distributes across all fields', async ({ page }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     const group = page.getByTestId('split-input-default');
     const inputs = group.locator('input');
@@ -36,7 +37,7 @@ test.describe('SplitInput autofill/multi-char distribution', () => {
   });
 
   test('injected code with separators is digit-sanitized before distribution', async ({ page }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     const inputs = page.getByTestId('split-input-sms-otp').locator('input');
 
@@ -49,7 +50,7 @@ test.describe('SplitInput autofill/multi-char distribution', () => {
   });
 
   test('single-character typing still auto-advances field by field', async ({ page }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     const inputs = page.getByTestId('split-input-default').locator('input');
 
@@ -66,7 +67,7 @@ test.describe('SplitInput autofill/multi-char distribution', () => {
   test('typing into an already-filled middle field keeps the newest digit and advances', async ({
     page
   }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     const inputs = page.getByTestId('split-input-default').locator('input');
 

--- a/tests/splitinput-overtype-caret.spec.ts
+++ b/tests/splitinput-overtype-caret.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The existing overtype test passed on macOS and failed on Linux CI, because it
 // relied on where Chromium happens to put the caret when you click a filled
@@ -30,7 +31,7 @@ async function typeAtCaret(
 test.describe('SplitInput — overtyping is independent of caret position', () => {
   for (const caret of [0, 1]) {
     test(`the newly typed digit wins when the caret sits at offset ${caret}`, async ({ page }) => {
-      await page.goto('/components/split-input');
+      await gotoHydrated(page, '/components/split-input');
 
       const inputs = page.getByTestId('split-input-default').locator('input');
       await inputs.nth(0).evaluate(inject, '1234');
@@ -52,7 +53,7 @@ test.describe('SplitInput — overtyping is independent of caret position', () =
   test('overtyping a digit with the same digit still clears the extra character', async ({
     page
   }) => {
-    await page.goto('/components/split-input');
+    await gotoHydrated(page, '/components/split-input');
 
     const inputs = page.getByTestId('split-input-default').locator('input');
     await inputs.nth(0).evaluate(inject, '1234');

--- a/tests/stat-card.test.ts
+++ b/tests/stat-card.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the extended StatCard: backward-compatible single value, multi-row layout
 // with dividers + per-row deltas, the breakdown grid, a header that renders without
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 // interaction from firing an interactive card's click action.
 test.describe('StatCard', () => {
   test('renders a basic single value (backward compatible)', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('basic-positive');
     await expect(card).toBeVisible();
@@ -14,7 +15,7 @@ test.describe('StatCard', () => {
   });
 
   test('multi-row card renders a row and a divider per metric', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('multi-row');
     await expect(card.getByTestId(/^checkout-row-\d+$/)).toHaveCount(3);
@@ -23,7 +24,7 @@ test.describe('StatCard', () => {
   });
 
   test('horizontal rows lay the sections side by side', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const rowsContainer = page.getByTestId('horizontal-rows-rows');
     await expect(rowsContainer).toHaveClass(/statcard-rows-horizontal/);
@@ -39,14 +40,14 @@ test.describe('StatCard', () => {
   });
 
   test('breakdown grid renders one item per breakdown entry', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('with-breakdown');
     await expect(card.getByTestId(/^with-breakdown-breakdown-item-\d+-\d+$/)).toHaveCount(3);
   });
 
   test('renders the header even when no title is set', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('headerless-card');
     await expect(card.getByTestId('headerless-card-header')).toHaveCount(1);
@@ -55,7 +56,7 @@ test.describe('StatCard', () => {
   });
 
   test('checkbox toggle fires onCheckboxChange', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('with-checkbox');
     await expect(card.getByTestId('with-checkbox-value')).toHaveText('₹10.9Cr');
@@ -64,7 +65,7 @@ test.describe('StatCard', () => {
   });
 
   test('toggling the checkbox does not trigger the card action', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('clickable-checkbox-card');
     const clickCount = page.getByTestId('card-click-count');
@@ -81,7 +82,7 @@ test.describe('StatCard', () => {
   });
 
   test('renders the subtitle below metric rows', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     // Regression: the subtitle block previously lived inside the no-rows {:else}
     // branch, so a card given both `rows` and `subtitle` silently dropped the
@@ -92,7 +93,7 @@ test.describe('StatCard', () => {
   });
 
   test('still renders the subtitle for a single-value card', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('with-subtitle');
     await expect(card.getByTestId(/^checkout-row-\d+$/)).toHaveCount(0);
@@ -102,7 +103,7 @@ test.describe('StatCard', () => {
   test('multi-row card renders a per-row subtitle independent of the card-level subtitle', async ({
     page
   }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('per-row-subtitle');
     await expect(card.getByTestId('per-row-subtitle-subtitle-0')).toHaveText('Today vs Yesterday');
@@ -112,7 +113,7 @@ test.describe('StatCard', () => {
   });
 
   test('additionalContent stays inline by default, alongside the value', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     // Regression: a real consumer (identity page) pairs `value: '--'` with a short
     // unit suffix like additionalContent: '%' and expects it beside the value, not
@@ -135,7 +136,7 @@ test.describe('StatCard', () => {
   });
 
   test('additionalContentBreak forces additionalContent onto its own line', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('wide-additional');
     const value = card.getByTestId('wide-additional-value-0');
@@ -156,7 +157,7 @@ test.describe('StatCard', () => {
   });
 
   test('valueVariant tints a row value for success and warning states', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('value-tint');
     const successValue = card.getByTestId('value-tint-value-0');
@@ -169,7 +170,7 @@ test.describe('StatCard', () => {
   test('row-level value typography override applies to that row and not its sibling', async ({
     page
   }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('value-typography');
     const primaryValue = card.getByTestId('value-typography-value-0');
@@ -193,7 +194,7 @@ test.describe('StatCard', () => {
   test('row-level heading typography override applies independently of the value override', async ({
     page
   }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('value-typography');
     const primaryHeading = card.locator(
@@ -212,7 +213,7 @@ test.describe('StatCard', () => {
   test('a single-value (non-rows) card is unaffected by the row-scoped value variables', async ({
     page
   }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     // Regression guard: --statcard-row-value-font-size/-font-weight are scoped to
     // .statcard-row-value-line so they must never reach the plain value/delta row.
@@ -224,7 +225,7 @@ test.describe('StatCard', () => {
   });
 
   test('row order overrides rearrange one row to title -> subtitle -> value', async ({ page }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('row-order');
     const headingWrap = card.locator(
@@ -254,7 +255,7 @@ test.describe('StatCard', () => {
   test('omitting the row order overrides preserves the default heading -> value -> subtitle order', async ({
     page
   }) => {
-    await page.goto('/components/stat-card');
+    await gotoHydrated(page, '/components/stat-card');
 
     const card = page.getByTestId('row-order');
     const headingWrap = card.locator(

--- a/tests/status-children-slot.test.ts
+++ b/tests/status-children-slot.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the Status `children` snippet: an action area rendered BELOW the
 // description, outside `.status-description`.
@@ -11,7 +12,7 @@ import { expect, test } from '@playwright/test';
 // in the wrong parent, so the containment check is the assertion that matters.
 test.describe('Status children slot', () => {
   test('children renders outside the description box', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-children');
     await expect(host).toBeVisible();
@@ -28,7 +29,7 @@ test.describe('Status children slot', () => {
   });
 
   test('omitting children renders nothing extra', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-default-icon');
     await expect(host.getByTestId('status-children-content')).toHaveCount(0);

--- a/tests/status-default-icon.spec.ts
+++ b/tests/status-default-icon.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 /**
  * `statusIcon` defaults to `icons/order-success-icon.svg` — a relative URL
@@ -15,7 +16,7 @@ import { expect, test } from '@playwright/test';
 test('the default icon falls back to the built-in one when the file is absent', async ({
   page
 }) => {
-  await page.goto('/components/status');
+  await gotoHydrated(page, '/components/status');
 
   const icon = page.locator(
     '[data-pw="status-inline"] .status-image img, [data-pw="status-inline"] .status-image svg'
@@ -39,7 +40,7 @@ test('the fallback does not replace an icon the caller supplied', async ({ page 
   // built-in icon then replaced it -- both render as an <svg>.
   await page.route('**/status-success.svg', (route) => route.abort());
 
-  await page.goto('/components/status');
+  await gotoHydrated(page, '/components/status');
 
   const icon = page.locator('[data-pw="status-default-icon"] .status-image');
   // The built-in fallback is inlined into an <svg>; its absence is what proves
@@ -55,7 +56,7 @@ test('the icon takes its accessible name from statusIconAlt, not from its own ma
   // its own would outrank the alt-derived label on every screen that uses it.
   // The fallback is inlined into an <svg> host, where the name lives on
   // `aria-label` rather than on `alt`.
-  await page.goto('/components/status');
+  await gotoHydrated(page, '/components/status');
 
   const icon = page.locator('[data-pw="status-inline"] .status-image svg');
   await expect(icon).toHaveAttribute('aria-label', 'status');
@@ -64,7 +65,7 @@ test('the icon takes its accessible name from statusIconAlt, not from its own ma
 test('statusIconAlt is forwarded, not just defaulted', async ({ page }) => {
   // Asserting only the default would pass even if the prop stopped being
   // forwarded at all.
-  await page.goto('/components/status');
+  await gotoHydrated(page, '/components/status');
 
   await expect(page.locator('[data-pw="status-alt-named"] .status-image svg')).toHaveAttribute(
     'aria-label',
@@ -73,7 +74,7 @@ test('statusIconAlt is forwarded, not just defaulted', async ({ page }) => {
 });
 
 test('an empty statusIconAlt marks the icon decorative', async ({ page }) => {
-  await page.goto('/components/status');
+  await gotoHydrated(page, '/components/status');
 
   const icon = page.locator('[data-pw="status-alt-decorative"] .status-image svg');
   await expect(icon).toHaveAttribute('aria-hidden', 'true');

--- a/tests/status-description-snippet.test.ts
+++ b/tests/status-description-snippet.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the Status `descriptionSnippet`: a consumer can render a description it
 // does not control as escaped text, instead of the {@html} interpolation that the
@@ -10,7 +11,7 @@ import { expect, test } from '@playwright/test';
 // escape is real). Either test alone would pass against a broken implementation.
 test.describe('Status descriptionSnippet', () => {
   test('statusDescription still interpolates markup as markup', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-description-html');
     await expect(host).toBeVisible();
@@ -20,7 +21,7 @@ test.describe('Status descriptionSnippet', () => {
   });
 
   test('descriptionSnippet renders the same string as escaped text', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-description-snippet');
     await expect(host).toBeVisible();
@@ -31,7 +32,7 @@ test.describe('Status descriptionSnippet', () => {
   });
 
   test('omitting the snippet leaves the default description path unchanged', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     await expect(page.getByTestId('status-default-icon')).toContainText(
       'Your order has been confirmed'

--- a/tests/status-icon-slot.test.ts
+++ b/tests/status-icon-slot.test.ts
@@ -1,18 +1,19 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the Status `icon` snippet: a consumer can render custom media (e.g. a
 // LottiePlayer) instead of the default statusIcon <Img>, and the default path
 // stays unchanged when `icon` isn't provided.
 test.describe('Status icon slot', () => {
   test('default statusIcon renders an <img> when no icon snippet is given', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const defaultStatus = page.getByTestId('status-default-icon');
     await expect(defaultStatus.getByRole('img')).toBeVisible();
   });
 
   test('icon snippet replaces the default image with custom content', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const slotHost = page.getByTestId('status-icon-slot');
     await expect(slotHost).toBeVisible();

--- a/tests/status-panel-variables.test.ts
+++ b/tests/status-panel-variables.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the Status panel CSS variables. Status is styled as a standalone
 // full-screen result page: 100vh tall, with a translucent white backdrop-filter
@@ -10,7 +11,7 @@ import { expect, test } from '@playwright/test';
 // values, so an existing consumer sees no change.
 test.describe('Status panel variables', () => {
   test('defaults keep the full-screen panel exactly as it was', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const panel = page.getByTestId('status-default-icon').locator('.order-status');
     await expect(panel).toHaveCSS('background-color', 'rgba(255, 255, 255, 0.6)');
@@ -23,7 +24,7 @@ test.describe('Status panel variables', () => {
   });
 
   test('the variables neutralise the panel for inline embedding', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-inline');
     await expect(host).toBeVisible();

--- a/tests/status-text-tag.test.ts
+++ b/tests/status-text-tag.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the Status `statusTextTag` prop: statusText can render as a real
 // heading (h1..h6) instead of the default div, so an app whose design system
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // keeps rendering a plain div, unchanged.
 test.describe('Status statusTextTag', () => {
   test('defaults to a div when statusTextTag is not provided', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-default-icon');
     const statusText = host.locator('.status-text');
@@ -18,7 +19,7 @@ test.describe('Status statusTextTag', () => {
   });
 
   test('renders as the requested heading tag when statusTextTag is set', async ({ page }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     const host = page.getByTestId('status-heading-tag');
     const statusText = host.locator('.status-text');
@@ -32,7 +33,7 @@ test.describe('Status statusTextTag', () => {
   test('a heading tag is left to the application typography; only the div takes the defaults', async ({
     page
   }) => {
-    await page.goto('/components/status');
+    await gotoHydrated(page, '/components/status');
 
     // The component's weight/colour defaults live on .status-text-default, which only the plain
     // div receives. A heading must not carry them, or the app's h2 rules could never win.

--- a/tests/status-wc-icon-alt.spec.ts
+++ b/tests/status-wc-icon-alt.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `statusIconAlt` was added to the Svelte component without being declared in
 // `Status.wc.svelte`'s customElement.props. An undeclared prop gets no accessor
@@ -14,7 +15,7 @@ import { expect, test } from '@playwright/test';
 // it is injected into a same-origin page instead of being navigated to.
 // `pnpm run build` (the webServer command) runs build:wc, so the file exists.
 const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-status') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/stepper.test.ts
+++ b/tests/stepper.test.ts
@@ -1,8 +1,9 @@
 import { expect, test, type Page } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Stepper and Step — suppressRoleAndTabindex', () => {
   test('suppressed steps have no role or tabindex and are not tab-reachable', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-informational');
     const cartStep = container.locator('.step').filter({ hasText: 'Cart' });
@@ -23,7 +24,7 @@ test.describe('Stepper and Step — suppressRoleAndTabindex', () => {
   test('default (unsuppressed) steps keep synthetic button semantics and stay clickable', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     const shippingStep = container.locator('.step').filter({ hasText: 'Shipping' });
@@ -40,7 +41,7 @@ test.describe('Stepper and Step — testId', () => {
   test('an explicit per-step testId renders as data-pw on that step, matching a real migration consumer', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     await expect(page.getByTestId('abandoned-checkouts-recovery-strip-step-1')).toHaveText(/Cart/);
     await expect(page.getByTestId('abandoned-checkouts-recovery-strip-step-2')).toHaveText(
@@ -54,7 +55,7 @@ test.describe('Stepper and Step — testId', () => {
   test('an omitted per-step testId derives "<stepperTestId>-step-<n>" (1-based) from the Stepper testId', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     await expect(container.getByTestId('stepper-horizontal-step-1')).toHaveText(/Cart/);
@@ -66,7 +67,7 @@ test.describe('Stepper and Step — testId', () => {
   test('a step with no testId anywhere in scope renders no data-pw attribute at all', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.locator('#no-testid-demo');
     const cartStep = container.locator('.step').filter({ hasText: 'Cart' });
@@ -78,7 +79,7 @@ test.describe('Stepper — wrapping (--container-flex-wrap / --step-container-fl
   test('off (default): the row stays nowrap and steps keep their content-fit flex-basis', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-wrap-off');
     const flexWrap = await container.evaluate((element) => getComputedStyle(element).flexWrap);
@@ -100,7 +101,7 @@ test.describe('Stepper — wrapping (--container-flex-wrap / --step-container-fl
   test('on: the row wraps and each step claims a full-width flex-basis, stacking one per line', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-wrap-on');
     const flexWrap = await container.evaluate((element) => getComputedStyle(element).flexWrap);
@@ -124,7 +125,7 @@ test.describe('Stepper — separator growth (--step-flex-grow / --stepper-separa
   test('off (default): the separator keeps its fixed --stepper-separator-width', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-separator-growth-off');
     const separator = container.locator('.separator').first();
@@ -137,7 +138,7 @@ test.describe('Stepper — separator growth (--step-flex-grow / --stepper-separa
   });
 
   test('on: the separator grows to absorb the card leftover width', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-separator-growth-on');
     const separator = container.locator('.separator').first();
@@ -152,7 +153,7 @@ test.describe('Stepper — separator growth (--step-flex-grow / --stepper-separa
 
 test.describe('Step — circle border hook (--step-index-container-*-border)', () => {
   test('default: no status sets a border, matching current behaviour exactly', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     const cartCircle = container
@@ -169,7 +170,7 @@ test.describe('Step — circle border hook (--step-index-container-*-border)', (
   test('themed: completed/active/failure each render their own distinct, non-default border', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-themed-border');
     const readBorder = async (label: string) => {
@@ -210,7 +211,7 @@ test.describe('Step — label font-weight hook (--step-text-font-weight)', () =>
   test('default: the label renders at the normal browser-default weight, matching current behaviour exactly', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-horizontal');
     const cartLabel = container.locator('.step').filter({ hasText: 'Cart' }).locator('.step-text');
@@ -222,7 +223,7 @@ test.describe('Step — label font-weight hook (--step-text-font-weight)', () =>
   test('semibold: an ancestor override reaches .step-text through the new hook', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-semibold-label');
     const cartLabel = container.locator('.step').filter({ hasText: 'Cart' }).locator('.step-text');
@@ -236,7 +237,7 @@ test.describe('Stepper — status "muted" (smaller, subtly-tinted marker)', () =
   test('muted renders a smaller circle than the default-sized pending sibling', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-muted');
     const pendingCircle = container
@@ -259,7 +260,7 @@ test.describe('Stepper — status "muted" (smaller, subtly-tinted marker)', () =
   });
 
   test('muted uses its own tint, distinct from the pending default grey', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-muted');
     const pendingCircle = container
@@ -282,7 +283,7 @@ test.describe('Stepper — status "muted" (smaller, subtly-tinted marker)', () =
   test('existing statuses in the same Stepper are unaffected by a sibling muted step', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     const container = page.getByTestId('stepper-muted');
     const completedCircle = container
@@ -304,7 +305,7 @@ test.describe('Stepper — suppressContainerTestId', () => {
   test('off (default): the container still claims testId, colliding with an ancestor that carries the same data-pw', async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     // The demo's wrapping element and the Stepper's own container both render
     // data-pw="checkout-rail-default" — exactly the collision the opt-out exists for.
@@ -314,7 +315,7 @@ test.describe('Stepper — suppressContainerTestId', () => {
   test("on: the container no longer claims testId, leaving only the ancestor's data-pw, while per-step ids are unaffected", async ({
     page
   }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
 
     await expect(page.locator('[data-pw="checkout-rail-suppressed"]')).toHaveCount(1);
 
@@ -342,7 +343,7 @@ test.describe('Step used on its own, outside a Stepper', () => {
       .evaluate((node) => getComputedStyle(node).backgroundColor);
 
   test('a bare Step renders a different marker colour per status', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
     await expect(page.getByTestId('bare-step-completed')).toBeVisible();
 
     const completed = await circleBackground(page, 'bare-step-completed');
@@ -355,7 +356,7 @@ test.describe('Step used on its own, outside a Stepper', () => {
   });
 
   test('a bare muted Step is smaller than a bare pending Step', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
     await expect(page.getByTestId('bare-step-muted')).toBeVisible();
 
     const muted = await page
@@ -397,7 +398,7 @@ test.describe('muted status legibility', () => {
   };
 
   test('a muted step index reads against its own circle', async ({ page }) => {
-    await page.goto('/components/stepper');
+    await gotoHydrated(page, '/components/stepper');
     const marker = page.locator('[data-pw="bare-step-muted"] .step-index-container').first();
     await expect(marker).toBeVisible();
 

--- a/tests/support/hydrated.ts
+++ b/tests/support/hydrated.ts
@@ -1,0 +1,35 @@
+import type { Page, Response } from '@playwright/test';
+
+/**
+ * Navigates and waits until the app is interactive.
+ *
+ * `page.goto` resolves on the navigation, not on hydration, and every demo page
+ * is server-rendered. A control is therefore present, visible and clickable
+ * while its handler does not yet exist -- and Playwright cannot check for a
+ * listener, so the click is delivered to inert markup and lost. The assertion
+ * that follows fails as an unexplained timeout.
+ *
+ * The marker is set in `src/routes/+layout.svelte`, whose `onMount` runs after
+ * its children have mounted.
+ *
+ * It does NOT mean custom elements are ready, and must not be used that way. A
+ * custom element has a second readiness step -- `customElements.define` runs,
+ * then matching elements upgrade -- and the marker is strictly earlier than it:
+ * measured on `/`, `data-hydrated` was set at ~755ms while
+ * `customElements.get('sui-status')` was still undefined and no element had
+ * upgraded. On top of that, `dist-wc` is a self-contained bundle rather than a
+ * route of the demo site, so a spec injects it with `addScriptTag` after
+ * navigating, and nothing is defined at marker time by construction.
+ *
+ * A spec driving a custom element therefore has to gate on the element itself,
+ * as every one of them already does:
+ *
+ *   await gotoHydrated(page, '/');
+ *   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+ *   await page.waitForFunction(() => Boolean(customElements.get('sui-status')));
+ */
+export const gotoHydrated = async (page: Page, path: string): Promise<Response | null> => {
+  const response = await page.goto(path);
+  await page.waitForFunction(() => document.documentElement.dataset.hydrated === 'true');
+  return response;
+};

--- a/tests/table-builtin-cells.test.ts
+++ b/tests/table-builtin-cells.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table — built-in cell renderers', () => {
   test('tag and tag-array cells render Pills with consumer classes', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     await expect(table).toBeVisible();
     await expect(table.getByTestId('builtin-state-0')).toContainText('Active');
@@ -15,7 +16,7 @@ test.describe('Table — built-in cell renderers', () => {
   });
 
   test('two-line-text cells render primary and secondary lines', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     const bodyRows = table.getByRole('rowgroup').last().getByRole('row');
     const firstPlanCell = bodyRows.first().getByRole('cell').first();
@@ -24,7 +25,7 @@ test.describe('Table — built-in cell renderers', () => {
   });
 
   test('avatar-stack caps at 4 chips and shows the +N overflow', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     const secondRow = table.getByRole('rowgroup').last().getByRole('row').nth(1);
     await expect(secondRow).toContainText('+2');
@@ -33,7 +34,7 @@ test.describe('Table — built-in cell renderers', () => {
   test('compare cells render primary, comparison, and colored trend; scalar rows fall back to text', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     const bodyRows = table.getByRole('rowgroup').last().getByRole('row');
     const firstRevenue = bodyRows.nth(0).getByRole('cell').nth(4);
@@ -49,7 +50,7 @@ test.describe('Table — built-in cell renderers', () => {
   test('toggle cells emit the column onToggle with row index and the NEW post-flip state', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     // Row 0 starts checked: true — flipping off must report the new state (false).
     // Click the switch wrapper, not the checkbox role: the native input is
@@ -65,7 +66,7 @@ test.describe('Table — built-in cell renderers', () => {
   test('link cells render an anchor, copy affordance opt-out, and null fallback', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     const firstLink = table.getByTestId('builtin-docs-link-0');
     await expect(firstLink).toHaveAttribute('href', 'https://example.com/plans/42');
@@ -89,7 +90,7 @@ test.describe('Table — built-in cell renderers', () => {
     context
   }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-builtin-cells');
     await table.getByTestId('builtin-docs-copy-0').click();
     await expect(table.getByTestId('builtin-docs-link-copied')).toContainText('Copied');
@@ -100,7 +101,7 @@ test.describe('Table — built-in cell renderers', () => {
   test('icon-label cells render leading icons with the label, icon-less rows label only', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-media-cells');
     const bodyRows = table.getByRole('rowgroup').last().getByRole('row');
     const firstGateway = bodyRows.first().getByRole('cell').first();
@@ -115,7 +116,7 @@ test.describe('Table — built-in cell renderers', () => {
   test('image-two-line-text cells render a thumbnail or placeholder plus both lines', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-media-cells');
     const bodyRows = table.getByRole('rowgroup').last().getByRole('row');
     const firstProduct = bodyRows.first().getByRole('cell').nth(1);

--- a/tests/table-cell-portal.test.ts
+++ b/tests/table-cell-portal.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table — usePortal escapes clipping containers for in-cell dropdowns', () => {
   // The demo wraps a usePortal table (a type:'select' column) in a 120px-tall
@@ -7,7 +8,7 @@ test.describe('Table — usePortal escapes clipping containers for in-cell dropd
   test('an in-cell select dropdown portals to <body> instead of being clipped', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const table = page.locator('[data-pw="table-portal-cells"]');
     await expect(table).toBeVisible();
@@ -36,7 +37,7 @@ test.describe('Table — usePortal escapes clipping containers for in-cell dropd
   });
 
   test('without usePortal the in-cell select dropdown stays in the table', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     // The interactive demo table (no usePortal) keeps its dropdown in-flow.
     await page

--- a/tests/table-header-meta.test.ts
+++ b/tests/table-header-meta.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table — header metadata + controlled sort', () => {
   test('align: right applies to the header and body cells of that column only', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-header-meta');
     await expect(table.getByTestId('meta-amount')).toHaveCSS('text-align', 'right');
     const amountCell = table
@@ -21,7 +22,7 @@ test.describe('Table — header metadata + controlled sort', () => {
   test('maxWidth caps the column and ellipsizes scalar cells with a title tooltip', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-header-meta');
     const longIdTd = table
       .getByRole('rowgroup')
@@ -36,7 +37,7 @@ test.describe('Table — header metadata + controlled sort', () => {
   });
 
   test('header tooltip renders on hover', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-header-meta');
     const nameHeader = table.getByTestId('meta-name');
     // Hover the tooltip's own trigger label, not the wider <th>: this column
@@ -51,7 +52,7 @@ test.describe('Table — header metadata + controlled sort', () => {
   });
 
   test('filter dropdown filters via the consumer and clears on re-select', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-header-meta');
     await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(3);
 
@@ -70,7 +71,7 @@ test.describe('Table — header metadata + controlled sort', () => {
   test('headers and cells wrap at word boundaries, not mid-word (word-break fix)', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-header-meta');
     const header = table.getByTestId('meta-name');
     await expect(header).toHaveCSS('word-break', 'normal');
@@ -86,7 +87,7 @@ test.describe('Table — header metadata + controlled sort', () => {
   });
 
   test('getSortValue sorts currency numerically, not lexicographically', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-header-meta');
     await table.getByRole('button', { name: 'Sort by Amount' }).click();
     const amounts = await table.getByTestId(/^meta-amount-cell-\d+$/).allInnerTexts();
@@ -100,7 +101,7 @@ test.describe('Table — header metadata + controlled sort', () => {
   test('sortMode server keeps header UI and onSort but lets the consumer reorder', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-server-sort');
     await expect(table.getByTestId('srv-sort-name-cell-0')).toContainText('Gamma');
 

--- a/tests/table-interactive-cells.test.ts
+++ b/tests/table-interactive-cells.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table — interactive cell renderers', () => {
   test('button cell fires the column handler and never the row click', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     await expect(table).toBeVisible();
     await table.getByTestId('demo-renew-0').click();
@@ -13,7 +14,7 @@ test.describe('Table — interactive cell renderers', () => {
   test('clicking a plain text cell still fires the row click (guard is scoped)', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     await table
       .getByRole('rowgroup')
@@ -27,7 +28,7 @@ test.describe('Table — interactive cell renderers', () => {
   });
 
   test('disabled button cell renders disabled', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     await expect(table.getByTestId('demo-renew-1')).toBeDisabled();
   });
@@ -35,7 +36,7 @@ test.describe('Table — interactive cell renderers', () => {
   test('select cell forwards itemTestId — options carry data-pw="{prefix}-{id}"', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     const select = table.getByTestId('demo-tier-0');
     await select.getByRole('combobox').click();
@@ -45,7 +46,7 @@ test.describe('Table — interactive cell renderers', () => {
   });
 
   test('select cell fires onSelect with the chosen option id, no row click', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     const select = table.getByTestId('demo-tier-0');
     await select.getByRole('combobox').click();
@@ -57,7 +58,7 @@ test.describe('Table — interactive cell renderers', () => {
   });
 
   test('input cell fires onInput with the typed value, no row click', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     const input = table.getByTestId('demo-note-1');
     await input.first().fill('hello');
@@ -68,7 +69,7 @@ test.describe('Table — interactive cell renderers', () => {
   test('input cell forwards validationPattern/onErrorMessage — live inline validation', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     const input = table.getByTestId('demo-note-1');
     // demo-note-1 carries validationPattern '^\d+$' + onErrorMessage 'Digits only'.
@@ -81,7 +82,7 @@ test.describe('Table — interactive cell renderers', () => {
   test('action-group primary button and overflow menu both dispatch column handlers', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     await table.getByTestId('demo-edit-0').click();
     await expect(page.getByTestId('interactive-log')).toContainText('primary r0');
@@ -93,7 +94,7 @@ test.describe('Table — interactive cell renderers', () => {
   });
 
   test('action-group without a primary button renders menu only', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     const secondManageCell = table
       .getByRole('rowgroup')
@@ -107,7 +108,7 @@ test.describe('Table — interactive cell renderers', () => {
   });
 
   test('popup-menu cell dispatches onMenuAction, no row click', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-interactive-cells');
     await table.getByTestId('demo-more-popup-trigger-0').click();
     await page.getByText('Archive', { exact: true }).first().click();

--- a/tests/table-keyed-columns.test.ts
+++ b/tests/table-keyed-columns.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table — keyed column model', () => {
   test('keyed table renders identically to its positional twin', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const keyed = page.getByTestId('table-keyed-basic');
     const positional = page.getByTestId('table-positional-twin');
     await expect(keyed).toBeVisible();
@@ -18,7 +19,7 @@ test.describe('Table — keyed column model', () => {
   });
 
   test('sorting behaves identically on keyed and positional twins', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const keyed = page.getByTestId('table-keyed-basic');
     const positional = page.getByTestId('table-positional-twin');
 
@@ -37,7 +38,7 @@ test.describe('Table — keyed column model', () => {
   });
 
   test('per-column sortable: false suppresses that column sort button only', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const features = page.getByTestId('table-keyed-features');
     await expect(features).toBeVisible();
     await expect(features.getByRole('button', { name: 'Sort by Name' })).toBeVisible();
@@ -46,7 +47,7 @@ test.describe('Table — keyed column model', () => {
   });
 
   test('column-scoped custom cell snippet renders per row with the keyed row', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const features = page.getByTestId('table-keyed-features');
     // The Status column renders a Pill per row via the column's cell snippet
     await expect(features.getByTestId('keyed-status-active')).toBeVisible();
@@ -55,7 +56,7 @@ test.describe('Table — keyed column model', () => {
   });
 
   test('missing row keys render as empty cells, not "undefined"', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const features = page.getByTestId('table-keyed-features');
     const thirdRowCells = await features
       .getByRole('rowgroup')
@@ -69,7 +70,7 @@ test.describe('Table — keyed column model', () => {
   });
 
   test('column testId is emitted as data-pw on the header cell', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const features = page.getByTestId('table-keyed-features');
     await expect(features.getByTestId('keyed-header-name')).toHaveCount(1);
     await expect(features.getByTestId('keyed-header-name')).toContainText('Name');
@@ -78,7 +79,7 @@ test.describe('Table — keyed column model', () => {
   test('positional API is untouched: the basic positional table renders as before', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     // The pre-existing Basic demo (positional props, no columns/rows)
     const basicHeaders = page.getByRole('table').first().getByRole('columnheader');
     await expect(basicHeaders).toHaveCount(3);

--- a/tests/table-menu-single-tab-stop.test.ts
+++ b/tests/table-menu-single-tab-stop.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Table's row menus render a real Button in the trigger snippet, so Menu's inert-trigger
 // wrapper was the wrong branch: it added a second focusable role="button" around the named
@@ -9,7 +10,7 @@ test.describe('Table row menus — one named tab stop', () => {
   test('the action-group menu wrapper is inert, and the Button carries the ARIA', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const wrapper = page.locator('[data-pw="demo-manage-menu-0"] .menu-trigger');
     await expect(wrapper).not.toHaveAttribute('role', /.*/);
@@ -22,7 +23,7 @@ test.describe('Table row menus — one named tab stop', () => {
   });
 
   test('the popup menu wrapper is inert, and the Button carries the ARIA', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const wrapper = page.locator('[data-pw="demo-more-popup-0"] .menu-trigger');
     await expect(wrapper).not.toHaveAttribute('role', /.*/);
@@ -34,7 +35,7 @@ test.describe('Table row menus — one named tab stop', () => {
   });
 
   test('a row menu contributes exactly one focusable element', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     // The defect was two focus stops for one conceptual control, one of them nameless.
     // Counting is what distinguishes the fix from a wrapper that merely gained a label.
@@ -51,7 +52,7 @@ test.describe('Table row menus — one named tab stop', () => {
   });
 
   test('the header filter trigger is the Button, not a wrapper around it', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     // Same mechanism, third call site: a column filter renders a real Button in the trigger
     // snippet too, so every filterable column carried the same nameless second tab stop.
@@ -65,7 +66,7 @@ test.describe('Table row menus — one named tab stop', () => {
   });
 
   test('the trigger still opens the menu and reports expansion', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     // interactiveTrigger moves the click wiring off the wrapper and onto the snippet, so
     // the menu stops opening entirely if the snippet does not spread what Menu hands it.
@@ -77,7 +78,7 @@ test.describe('Table row menus — one named tab stop', () => {
   });
 
   test('the row menu still selects an item', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const button = page.getByTestId('demo-manage-menu-trigger-0');
     await button.click();

--- a/tests/table-pagination-followups.test.ts
+++ b/tests/table-pagination-followups.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table follow-up API', () => {
   test('forwards explicit pagination button ids while keeping default generated ids unchanged', async ({
@@ -6,7 +7,7 @@ test.describe('Table follow-up API', () => {
     context
   }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const defaults = page.getByTestId('table-builtin-cells');
     await expect(defaults.getByTestId('builtin-docs-link-0')).toBeVisible();
@@ -26,7 +27,7 @@ test.describe('Table follow-up API', () => {
     context
   }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
 
     const table = page.getByTestId('table-followups');
     await expect(table.getByTestId('followup-name')).toHaveCSS('width', '176px');
@@ -47,7 +48,7 @@ test.describe('Table — pagination.rangeTestId', () => {
   test('an explicit rangeTestId wins over the id derived from the table testId', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     // table-followups carries its own load-bearing testId (built-in cell ids
     // derive from it), so the range span would otherwise be locked to
     // `table-followups-paginator-range`. rangeTestId overrides that.
@@ -57,7 +58,7 @@ test.describe('Table — pagination.rangeTestId', () => {
   });
 
   test('unset rangeTestId keeps deriving from the table testId', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paginated');
     await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('1-5 of 23');
   });
@@ -67,7 +68,7 @@ test.describe('Table — independent pagination control suppression', () => {
   test('hidePageSizeSelector hides only the page-size Select, steppers keep working', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-split-selector-hidden');
     await expect(table.getByTestId('split-selector-hidden-page-size')).toHaveCount(0);
     await expect(table.getByTestId('table-split-selector-hidden-paginator-range')).toContainText(
@@ -88,7 +89,7 @@ test.describe('Table — independent pagination control suppression', () => {
   test('hideSteppers hides only the Pagination steppers, the page-size Select keeps working', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-split-steppers-hidden');
     await expect(table.getByTestId('split-steppers-hidden-pages')).toHaveCount(0);
     await expect(table.getByRole('navigation')).toHaveCount(0);
@@ -110,7 +111,7 @@ test.describe('Table — independent pagination control suppression', () => {
   test('hideControls still hides both, unaffected by the new independent flags', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-count-only-pagination');
     await expect(table.getByTestId('count-only-paged-page-size')).toHaveCount(0);
     await expect(table.getByTestId('count-only-paged-pages')).toHaveCount(0);

--- a/tests/table-pagination-selection.test.ts
+++ b/tests/table-pagination-selection.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Table — built-in pagination + row numbers', () => {
   test('client mode slices rows, shows the range, and pages forward', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paginated');
     await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(5);
     await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('1-5 of 23');
@@ -18,7 +19,7 @@ test.describe('Table — built-in pagination + row numbers', () => {
   });
 
   test('row numbers are pagination-aware', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paginated');
     await expect(
       table.getByRole('rowgroup').last().getByRole('row').first().getByRole('cell').first()
@@ -33,7 +34,7 @@ test.describe('Table — built-in pagination + row numbers', () => {
   test('handlers receive GLOBAL row indices under client pagination, not page-local', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paginated');
     // Page 1: first row is global index 0.
     await expect(table.getByTestId('paged-idx-0')).toHaveCount(1);
@@ -44,7 +45,7 @@ test.describe('Table — built-in pagination + row numbers', () => {
   });
 
   test('page-size change re-slices and snaps back to page 1', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paginated');
     await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 2' }).click();
     await expect(table.getByTestId('table-paginated-paginator-range')).toContainText('6-10 of 23');
@@ -60,7 +61,7 @@ test.describe('Table — built-in pagination + row numbers', () => {
   });
 
   test('search filters across all pages and snaps back to page 1', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paginated');
     await table.getByTestId('paged-pages').getByRole('button', { name: 'Page 2' }).click();
     // The search bar renders above the table wrapper, outside the testId element.
@@ -81,7 +82,7 @@ test.describe('Table — pagination footer on a single page (showFooterOnSingleP
   test('showFooterOnSinglePage keeps the footer (incl. page-size selector) visible', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-single-page-pagination');
     await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(3);
     const footer = table.getByTestId('single-page-paged');
@@ -97,7 +98,7 @@ test.describe('Table — count-only pagination footer (pagination.hideControls)'
   test('hideControls renders the range text with no page-size selector or steppers', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-count-only-pagination');
     const footer = table.getByTestId('count-only-paged');
     await expect(footer).toBeVisible();
@@ -114,7 +115,7 @@ test.describe('Table — server-mode pagination', () => {
   test('server mode renders consumer rows untouched with chrome from page/totalItems', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-server-paginated');
     await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(5);
     await expect(table.getByRole('rowgroup').last().getByRole('row').first()).toContainText(
@@ -130,7 +131,7 @@ test.describe('Table — server-mode pagination', () => {
   test('page change reports to the consumer, which swaps the rows (incl. short last page)', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-server-paginated');
     await table.getByTestId('srv-paged-pages').getByRole('button', { name: 'Page 3' }).click();
     await expect(table.getByRole('rowgroup').last().getByRole('row')).toHaveCount(2);
@@ -143,7 +144,7 @@ test.describe('Table — server-mode pagination', () => {
   });
 
   test('getRowTestId emits row-level data-pw for keyed rows', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-server-paginated');
     await expect(table.getByTestId('srv-row-Record 01')).toHaveCount(1);
   });
@@ -153,7 +154,7 @@ test.describe('Table — page-scoped select-all under client pagination', () => 
   test('header select-all selects ONLY the current page (skipping disabled rows); second click clears it', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paged-select');
     const log = page.getByTestId('paged-select-log');
 
@@ -176,7 +177,7 @@ test.describe('Table — page-scoped select-all under client pagination', () => 
   });
 
   test('header toggle on page 2 leaves page-1 selections intact', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paged-select');
     const log = page.getByTestId('paged-select-log');
 
@@ -196,7 +197,7 @@ test.describe('Table — page-scoped select-all under client pagination', () => 
   test('row checkboxes expose DataGrid-parity aria-labels; header keeps its own label', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-paged-select');
     await expect(table.getByRole('checkbox', { name: 'Select row Member 1' })).toHaveCount(1);
     await expect(
@@ -215,7 +216,7 @@ test.describe('Table — controlled selection + toolbar', () => {
   test('controlled selection renders from the consumer set and reports next sets', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-controlled-selection');
     await expect(page.getByTestId('bulk-count')).toHaveCount(0);
 
@@ -228,7 +229,7 @@ test.describe('Table — controlled selection + toolbar', () => {
   });
 
   test('toolbar action consumes the selection and clearing hides the toolbar', async ({ page }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-controlled-selection');
     await table.getByTestId('table-controlled-selection-row-checkbox-Bob').click();
     await table.getByTestId('table-controlled-selection-row-checkbox-Carol').click();
@@ -243,7 +244,7 @@ test.describe('Table — controlled selection + toolbar', () => {
   test('getRowAttributes spreads onto the row checkboxes (header gets -1 sentinel)', async ({
     page
   }) => {
-    await page.goto('/components/table');
+    await gotoHydrated(page, '/components/table');
     const table = page.getByTestId('table-controlled-selection');
     await expect(
       table.getByTestId('table-controlled-selection-row-checkbox-Alice')

--- a/tests/tabs-active-width-reservation.spec.ts
+++ b/tests/tabs-active-width-reservation.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // .tabs-item.active bumps font-weight from --tabs-item-font-weight (400) to
 // --tabs-active-font-weight (600). Before this fix that weight jump resized
@@ -11,7 +12,7 @@ test.describe('Tabs active-state width reservation', () => {
   test('selecting a different tab does not shift an untouched sibling tab (horizontal)', async ({
     page
   }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
@@ -34,7 +35,7 @@ test.describe('Tabs active-state width reservation', () => {
   });
 
   test("a tab's own width is identical active vs. inactive (horizontal)", async ({ page }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
@@ -54,7 +55,7 @@ test.describe('Tabs active-state width reservation', () => {
   });
 
   test("a vertical nav item's label width is identical active vs. inactive", async ({ page }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const rail = page.getByTestId('tabs-vertical-demo');
     const tabAt = (label: string) => rail.getByRole('tab', { name: label });

--- a/tests/tabs-fade-solid-zone.spec.ts
+++ b/tests/tabs-fade-solid-zone.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The overflow fade used to ramp from transparent at the exact edge, which
 // left the clipped tab label perceptible (~20% opacity) a few px in — reading
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // --tabs-fade-size.
 test.describe('Tabs fade solid zone', () => {
   test('edge fades hold a fully-transparent 8px zone', async ({ page }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     await expect(bar).toHaveClass(/fade-right/);
@@ -22,7 +23,7 @@ test.describe('Tabs fade solid zone', () => {
   });
 
   test('mid-scroll both edges fade through the double-ended mask', async ({ page }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     await bar.evaluate((el) => {

--- a/tests/tabs-keyboard-navigation.spec.ts
+++ b/tests/tabs-keyboard-navigation.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The roving tabindex (active tab 0, everything else -1) used to pair with a
 // keydown handler that only covered Enter/Space — a keyboard user could Tab
@@ -10,7 +11,7 @@ test.describe('Tabs keyboard navigation (APG tablist contract)', () => {
   test('ArrowRight/ArrowLeft move selection and focus with wrap-around (horizontal, string mode)', async ({
     page
   }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
@@ -36,7 +37,7 @@ test.describe('Tabs keyboard navigation (APG tablist contract)', () => {
   test('Home/End jump to the first/last tab, scrolling the offscreen target into view', async ({
     page
   }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });
@@ -56,7 +57,7 @@ test.describe('Tabs keyboard navigation (APG tablist contract)', () => {
   test('vertical orientation uses ArrowDown/ArrowUp and ignores ArrowRight (object mode via activeKey)', async ({
     page
   }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const rail = page.getByTestId('tabs-vertical-demo');
     await expect(rail.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
@@ -79,7 +80,7 @@ test.describe('Tabs keyboard navigation (APG tablist contract)', () => {
   });
 
   test('Enter and Space still activate the focused tab', async ({ page }) => {
-    await page.goto('/components/tabs');
+    await gotoHydrated(page, '/components/tabs');
 
     const bar = page.getByTestId('tabs-overflow-demo').locator('.tabs-bar');
     const tabAt = (label: string) => bar.getByRole('tab', { name: label, exact: true });

--- a/tests/theme-switcher-pressed-state.spec.ts
+++ b/tests/theme-switcher-pressed-state.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The toggle button had a hover rule but no `:active` rule at all, so pressing it
 // looked identical to hovering it and the control gave no confirmation of the press.
@@ -20,7 +21,7 @@ const settlesTo = (locator: Locator, expected: string) =>
 
 test.describe('ThemeSwitcher pressed state', () => {
   test('the toggle button paints three distinct states', async ({ page }) => {
-    await page.goto('/components/theme-switcher');
+    await gotoHydrated(page, '/components/theme-switcher');
 
     const toggle = page.locator('.toggle-button').first();
     await expect(toggle).toBeVisible();
@@ -44,7 +45,7 @@ test.describe('ThemeSwitcher pressed state', () => {
   });
 
   test('the pressed colour is driven by --theme-switcher-bg-pressed', async ({ page }) => {
-    await page.goto('/components/theme-switcher');
+    await gotoHydrated(page, '/components/theme-switcher');
 
     const toggle = page.locator('.toggle-button').first();
     await expect(toggle).toBeVisible();

--- a/tests/thinking-indicator-chip-variant.test.ts
+++ b/tests/thinking-indicator-chip-variant.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('ThinkingIndicator chip variant', () => {
   test('defaults to a static label, no shimmer animation', async ({ page }) => {
-    await page.goto('/components/thinking-indicator');
+    await gotoHydrated(page, '/components/thinking-indicator');
 
     const chip = page.getByTestId('thinking-indicator-chip-static-demo');
     await expect(chip).toBeVisible();
@@ -10,7 +11,7 @@ test.describe('ThinkingIndicator chip variant', () => {
   });
 
   test('busy shimmers the label (no static-label class)', async ({ page }) => {
-    await page.goto('/components/thinking-indicator');
+    await gotoHydrated(page, '/components/thinking-indicator');
 
     const chip = page.getByTestId('thinking-indicator-chip-busy-demo');
     await expect(chip).toBeVisible();
@@ -20,7 +21,7 @@ test.describe('ThinkingIndicator chip variant', () => {
   test('the chip root is a polite live region, so a screen reader announces status changes', async ({
     page
   }) => {
-    await page.goto('/components/thinking-indicator');
+    await gotoHydrated(page, '/components/thinking-indicator');
 
     await expect(page.getByTestId('thinking-indicator-chip-static-demo')).toHaveAttribute(
       'aria-live',

--- a/tests/toggle-labelling.spec.ts
+++ b/tests/toggle-labelling.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The checkbox inside Toggle is visually hidden, so a label association is the only way to
 // name it or to activate it from its text. Before these props existed the visible text was
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // editing" text could not activate its own switch.
 test.describe('Toggle label association', () => {
   test('the built-in text is a real label: clicking it toggles the switch', async ({ page }) => {
-    await page.goto('/components/toggle');
+    await gotoHydrated(page, '/components/toggle');
 
     const container = page.getByTestId('toggle-text-label');
     const input = container.locator('input[type="checkbox"]');
@@ -26,7 +27,7 @@ test.describe('Toggle label association', () => {
   test("a consumer-supplied id lets the consumer's own <label for> activate the switch", async ({
     page
   }) => {
-    await page.goto('/components/toggle');
+    await gotoHydrated(page, '/components/toggle');
 
     const input = page
       .getByTestId('toggle-external-label-switch')
@@ -40,7 +41,7 @@ test.describe('Toggle label association', () => {
   });
 
   test('ariaLabel names a switch that has no visible text', async ({ page }) => {
-    await page.goto('/components/toggle');
+    await gotoHydrated(page, '/components/toggle');
 
     const input = page.getByTestId('toggle-aria-label').locator('input[type="checkbox"]');
     await expect(input).toHaveAttribute('aria-label', 'Silent switch');
@@ -52,7 +53,7 @@ test.describe('Toggle label association', () => {
 test('generated ids are unique and preserve keyboard activation of the hidden input', async ({
   page
 }) => {
-  await page.goto('/components/toggle');
+  await gotoHydrated(page, '/components/toggle');
   const inputs = page.locator('input[type="checkbox"]');
   const ids = await inputs.evaluateAll((elements) => elements.map((element) => element.id));
   expect(ids.every((id) => id.length > 0)).toBe(true);
@@ -65,14 +66,14 @@ test('generated ids are unique and preserve keyboard activation of the hidden in
 });
 
 test('ariaLabelledby names the hidden checkbox', async ({ page }) => {
-  await page.goto('/components/toggle');
+  await gotoHydrated(page, '/components/toggle');
   await expect(page.getByTestId('toggle-labelledby').locator('input')).toHaveAccessibleName(
     'Order notifications'
   );
 });
 
 test('disabled text cannot activate the hidden checkbox', async ({ page }) => {
-  await page.goto('/components/toggle');
+  await gotoHydrated(page, '/components/toggle');
   const container = page.getByTestId('toggle-disabled-label');
   await expect(container.locator('input')).toBeDisabled();
   await expect(container.locator('input')).toHaveAccessibleName('Disabled setting');
@@ -82,7 +83,7 @@ test('disabled text cannot activate the hidden checkbox', async ({ page }) => {
 
 test.describe('sui-toggle shadow-DOM labelling', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await gotoHydrated(page, '/');
     await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
     await page.waitForFunction(() => Boolean(customElements.get('sui-toggle')));
     await page.evaluate(() => {
@@ -212,7 +213,7 @@ test.describe('sui-toggle shadow-DOM labelling', () => {
 
 for (const index of [0, 1]) {
   test(`blank id ${index} still names and activates the checkbox`, async ({ page }) => {
-    await page.goto('/components/toggle');
+    await gotoHydrated(page, '/components/toggle');
     const toggle = page.getByTestId(`toggle-blank-id-${index}`);
     const input = toggle.locator('input');
     await expect(input).toHaveAccessibleName(`Blank id setting ${index}`);

--- a/tests/toolbar-back-href.test.ts
+++ b/tests/toolbar-back-href.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Issue #522: Toolbar's built-in back control was callback-only (onbackclick),
 // with no way to make it a real link. Consumers who needed href-based back navigation had to
@@ -9,7 +10,7 @@ test.describe('Toolbar backHref', () => {
   test('an unconfigured toolbar keeps rendering the back control as a <button>, not a link', async ({
     page
   }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-root').locator('.back');
     expect(await back.evaluate((element) => element.tagName.toLowerCase())).toBe('button');
@@ -19,7 +20,7 @@ test.describe('Toolbar backHref', () => {
   test('backHref renders the back control as a real <a> carrying the given href', async ({
     page
   }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-back-href').locator('.back');
     expect(await back.evaluate((element) => element.tagName.toLowerCase())).toBe('a');
@@ -32,7 +33,7 @@ test.describe('Toolbar backHref', () => {
   test('onbackclick still fires as the anchor click handler when backHref is set', async ({
     page
   }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const clicks = page.getByTestId('toolbar-back-href-clicks');
     await expect(clicks).toHaveText('0');
@@ -43,7 +44,7 @@ test.describe('Toolbar backHref', () => {
   });
 
   test('the anchor activates from the keyboard like the default button did', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-back-href').locator('.back');
     await back.focus();
@@ -55,7 +56,7 @@ test.describe('Toolbar backHref', () => {
   test('Space also activates the anchor, which a native <a> would not do on its own', async ({
     page
   }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-back-href').locator('.back');
     await back.focus();
@@ -67,7 +68,7 @@ test.describe('Toolbar backHref', () => {
   test('leftContent still takes precedence over backHref, same as it does over the default button', async ({
     page
   }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const root = page.getByTestId('toolbar-left-content-precedence');
     await expect(root.getByTestId('toolbar-left-content-marker')).toBeVisible();

--- a/tests/toolbar-content-geometry.test.ts
+++ b/tests/toolbar-content-geometry.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers the Toolbar content-row geometry tokens (--toolbar-content-width/-height/
 // -max-width/-margin): defaults must reproduce the previous rendering exactly, and
 // an instance overriding them must resolve to the overridden values.
 test.describe('Toolbar content-row geometry tokens', () => {
   test('defaults leave an unconfigured toolbar content row unchanged', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const content = page.getByTestId('toolbar-root-content');
     await expect(content).toBeVisible();
@@ -26,7 +27,7 @@ test.describe('Toolbar content-row geometry tokens', () => {
   });
 
   test('an instance can clamp and center its content row via tokens', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const content = page.getByTestId('toolbar-content-tokens-content');
     await expect(content).toBeVisible();

--- a/tests/toolbar-page-header.test.ts
+++ b/tests/toolbar-page-header.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Toolbar gained no props for the page-header shape — only CSS variables. The component's
 // documented position is that presentational structure belongs in a Snippet, so a title with
@@ -6,7 +7,7 @@ import { expect, test } from '@playwright/test';
 // both halves of that contract: the defaults are untouched, and the tokens do the work.
 test.describe('Toolbar page-header shape', () => {
   test('an unconfigured toolbar is untouched by any of this', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const root = page.getByTestId('toolbar-root');
     await expect(root).toBeVisible();
@@ -36,7 +37,7 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('backIcon={null} still renders no icon', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const root = page.getByTestId('toolbar-no-back-icon');
     await expect(root).toBeVisible();
@@ -44,7 +45,7 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('a consumer-supplied backIcon still renders as an image', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-custom-back-icon').locator('.back');
     await expect(back.locator('img')).toHaveCount(1);
@@ -54,14 +55,14 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('an empty backLabel falls back to the default accessible name', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-empty-back-label').locator('.back');
     await expect(back).toHaveAttribute('aria-label', 'Back');
   });
 
   test('the button occupies the same box the div did', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     // 20px content + 14px/20px padding per side, content-box: 48 wide, 60 tall — the div's box.
     const box = await page.getByTestId('toolbar-root').locator('.back').boundingBox();
@@ -71,7 +72,7 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('the back button activates from the keyboard', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const back = page.getByTestId('toolbar-root').locator('.back');
     const activations: string[] = [];
@@ -89,7 +90,7 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('tokens turn the fixed bar into an in-flow page header', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const header = page.getByTestId('toolbar-page-header');
     await expect(header).toBeVisible();
@@ -112,7 +113,7 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('the title block keeps the consumer tags, classes and type scale', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     // Semantic tags the library never sees, because the markup is the consumer's.
     const heading = page.getByTestId('toolbar-page-header-heading');
@@ -130,7 +131,7 @@ test.describe('Toolbar page-header shape', () => {
   });
 
   test('the action region absorbs no shrink while the title ellipsizes', async ({ page }) => {
-    await page.goto('/components/toolbar');
+    await gotoHydrated(page, '/components/toolbar');
 
     const right = page.getByTestId('toolbar-page-header').locator('.right-content');
     await expect(right).toHaveCSS('flex-shrink', '0');

--- a/tests/tooltip-action-clamping.spec.ts
+++ b/tests/tooltip-action-clamping.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The use:tooltip action used to centre its bubble on the trigger with a bare
 // translate(-50%) and no edge handling: a trigger near the viewport edge
@@ -10,7 +11,7 @@ test.describe('tooltip action — viewport clamping', () => {
   test('left-edge trigger keeps its bubble inside the viewport with the arrow on the trigger', async ({
     page
   }) => {
-    await page.goto('/components/tooltip');
+    await gotoHydrated(page, '/components/tooltip');
 
     const trigger = page.getByTestId('tooltip-edge-left');
     // Pin the trigger to the exact viewport edge so the test is independent of
@@ -42,7 +43,7 @@ test.describe('tooltip action — viewport clamping', () => {
   });
 
   test('right-edge trigger keeps its bubble inside the viewport', async ({ page }) => {
-    await page.goto('/components/tooltip');
+    await gotoHydrated(page, '/components/tooltip');
 
     const trigger = page.getByTestId('tooltip-edge-right');
     await trigger.evaluate((el) => {
@@ -71,7 +72,7 @@ test.describe('tooltip action — viewport clamping', () => {
   test('bottom-positioned tooltip flips above a trigger sitting at the viewport bottom', async ({
     page
   }) => {
-    await page.goto('/components/tooltip');
+    await gotoHydrated(page, '/components/tooltip');
 
     const trigger = page.getByTestId('tooltip-edge-left');
     // Scroll so the trigger sits ~30px above the viewport bottom — no room below.

--- a/tests/tooltip.test.ts
+++ b/tests/tooltip.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 test.describe('Tooltip component', () => {
   test('shows bubble on hover and hides on mouse leave', async ({ page }) => {
-    await page.goto('/components/tooltip');
+    await gotoHydrated(page, '/components/tooltip');
 
     const trigger = page.getByTestId('tooltip-container').first();
     await expect(trigger).toBeVisible();
@@ -23,7 +24,7 @@ test.describe('Tooltip component', () => {
 
 test.describe('tooltip action — use:tooltip directive', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/components/tooltip');
+    await gotoHydrated(page, '/components/tooltip');
   });
 
   test('shows bubble with correct text on hover', async ({ page }) => {

--- a/tests/typewriter-text-pacing-progress-render.test.ts
+++ b/tests/typewriter-text-pacing-progress-render.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers three additive TypewriterText capabilities — none change behaviour
 // for a consumer that doesn't opt in:
@@ -36,7 +37,7 @@ test.describe('TypewriterText — variable pacing, progress, per-character rende
       };
       requestAnimationFrame(attach);
     });
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     const baselineText = 'Baseline pacing check text stays fast.';
     const host = page.getByTestId('typewriter-default-pacing');
@@ -103,7 +104,7 @@ test.describe('TypewriterText — variable pacing, progress, per-character rende
       };
       requestAnimationFrame(attach);
     });
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     // "Total: 4 items, $9!" — 2 digits (200ms fixed), 3 spaces (10ms fixed),
     // 2 punctuation (120ms fixed), 12 default chars incl. ':' and '$' (5ms
@@ -140,7 +141,7 @@ test.describe('TypewriterText — variable pacing, progress, per-character rende
   test('onProgress is called once per revealed character and reaches the total', async ({
     page
   }) => {
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     const progressText =
       'Progress reporting keeps a scroll container pinned to the newest character.';
@@ -162,7 +163,7 @@ test.describe('TypewriterText — variable pacing, progress, per-character rende
   });
 
   test('renderCharacter decorates exactly the characters the snippet targets', async ({ page }) => {
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     const host = page.getByTestId('typewriter-render-character');
     await expect(host).toBeVisible();
@@ -186,7 +187,7 @@ test.describe('TypewriterText — variable pacing, progress, per-character rende
     const consoleErrors: string[] = [];
     page.on('pageerror', (error) => consoleErrors.push(error.message));
 
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     // These demos never pass onProgress/renderCharacter/variableDelay.
     await expect(page.getByTestId('typewriter-default-pacing')).toBeVisible();

--- a/tests/typewriter-text-reduced-motion.test.ts
+++ b/tests/typewriter-text-reduced-motion.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // `ChatController` bypasses its character-by-character reveal entirely when the user
 // asks for reduced motion (`prefersReducedMotion()`, consulted by `feed()`), but
@@ -27,7 +28,12 @@ const BASELINE_TEST_ID = 'typewriter-default-pacing';
 const PROGRESS_TEXT = 'Progress reporting keeps a scroll container pinned to the newest character.';
 const PROGRESS_TEST_ID = 'typewriter-progress-demo';
 
-type RevealTiming = { firstAt: number | null; lastAt: number | null; mutations: number };
+type RevealTiming = {
+  firstAt: number | null;
+  lastAt: number | null;
+  mutations: number;
+  mutationsAtReduceFlip: number | null;
+};
 
 const installRevealObserver = async (
   page: Page,
@@ -36,8 +42,27 @@ const installRevealObserver = async (
 ): Promise<void> => {
   await page.addInitScript(
     ({ testId, windowKey }: { testId: string; windowKey: string }) => {
-      const timing: RevealTiming = { firstAt: null, lastAt: null, mutations: 0 };
+      const timing: RevealTiming = {
+        firstAt: null,
+        lastAt: null,
+        mutations: 0,
+        mutationsAtReduceFlip: null
+      };
       (window as unknown as Record<string, RevealTiming>)[windowKey] = timing;
+      /*
+       * Recorded in the page, at the instant the preference actually flips.
+       * Sampling the count from the test process instead would put the
+       * `emulateMedia` CDP round-trip inside the measured window, and every
+       * character that types while that round-trip is in flight would count
+       * against the bound -- which is why this assertion failed under load and
+       * passed in isolation.
+       */
+      const reduceQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+      reduceQuery.addEventListener('change', (event) => {
+        if (event.matches && timing.mutationsAtReduceFlip === null) {
+          timing.mutationsAtReduceFlip = timing.mutations;
+        }
+      });
       const attach = () => {
         const element = document.querySelector(`[data-pw="${testId}"]`);
         if (!element) {
@@ -64,21 +89,25 @@ const installRevealObserver = async (
 const readTiming = async (
   page: Page,
   windowKey: string
-): Promise<{ mutations: number; elapsedMs: number }> => {
+): Promise<{ mutations: number; elapsedMs: number; mutationsAtReduceFlip: number | null }> => {
   return page.evaluate((key: string) => {
     const timing = (window as unknown as Record<string, RevealTiming>)[key];
     const elapsedMs =
       timing && timing.firstAt !== null && timing.lastAt !== null
         ? Math.round(timing.lastAt - timing.firstAt)
         : -1;
-    return { mutations: timing ? timing.mutations : -1, elapsedMs };
+    return {
+      mutations: timing ? timing.mutations : -1,
+      elapsedMs,
+      mutationsAtReduceFlip: timing ? timing.mutationsAtReduceFlip : null
+    };
   }, windowKey);
 };
 
 test('reduced motion reveals the whole string at once instead of typing it', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await installRevealObserver(page, BASELINE_TEST_ID, '__reducedMotionTiming');
-  await page.goto('/components/typewriter-text');
+  await gotoHydrated(page, '/components/typewriter-text');
 
   // The emulation is the premise of the assertion below, so prove it landed rather than
   // trusting it — an un-emulated page would type, and the failure would look like a
@@ -110,36 +139,53 @@ test('reduced motion reveals the whole string at once instead of typing it', asy
 test('a mid-stream switch to reduced motion stops the typing immediately', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'no-preference' });
   await installRevealObserver(page, PROGRESS_TEST_ID, '__midStreamTiming');
-  await page.goto('/components/typewriter-text');
+  await gotoHydrated(page, '/components/typewriter-text');
 
   const typewriter = page.locator(`[data-pw="${PROGRESS_TEST_ID}"]`);
 
-  // Catch it as early as possible: the default poll cadence lets ~57 of the 74 characters
-  // type before it first reports, which leaves too little to distinguish the two behaviours.
-  await expect
-    .poll(async () => ((await typewriter.textContent()) ?? '').length, { intervals: [10] })
-    .toBeGreaterThan(0);
-
-  const revealedAtToggle = ((await typewriter.textContent()) ?? '').length;
-  const remaining = PROGRESS_TEXT.length - revealedAtToggle;
-
-  // The toggle has to land with more left to type than the bound below, or the assertion
-  // would pass for the wrong reason. Fail loudly here instead of silently proving nothing.
-  expect(remaining).toBeGreaterThan(12);
-
-  const mutationsAtToggle = (await readTiming(page, '__midStreamTiming')).mutations;
+  /*
+   * Waiting in the page rather than polling `textContent` from here. The whole
+   * string reveals in roughly 450ms, and every `expect.poll` iteration costs a
+   * round-trip; on a loaded machine those spent most of the window, so the flip
+   * below landed after typing had already finished and the guard on `remaining`
+   * failed. `waitForFunction` evaluates in the page, so the wait ends on the
+   * first revealed character and the only round-trip left in the critical path
+   * is the `emulateMedia` call itself.
+   */
+  await page.waitForFunction(
+    (key: string) => {
+      const timing = (window as unknown as Record<string, RevealTiming>)[key];
+      return Boolean(timing) && timing.mutations > 0;
+    },
+    '__midStreamTiming',
+    { polling: 'raf' }
+  );
 
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await expect(typewriter).toHaveText(PROGRESS_TEXT);
 
-  const mutationsAfterToggle =
-    (await readTiming(page, '__midStreamTiming')).mutations - mutationsAtToggle;
+  const timing = await readTiming(page, '__midStreamTiming');
+  // A missing count would mean the flip was never observed in the page, so the
+  // number below would be measuring the whole reveal and quietly passing for the
+  // wrong reason. Asserting a real number catches that, and also catches the
+  // field being dropped by `readTiming`'s projection -- which is exactly the
+  // mistake this guard was first written too loosely to catch.
+  const flippedAt = timing.mutationsAtReduceFlip;
+  expect(typeof flippedAt).toBe('number');
+
+  // The flip has to land with more left to type than the bound below, or the
+  // assertion would pass for the wrong reason. Taken from the in-page count at
+  // the flip, so it measures where the reveal actually was rather than where a
+  // sample taken a round-trip earlier said it was.
+  expect(PROGRESS_TEXT.length - (flippedAt ?? 0)).toBeGreaterThan(12);
+
+  const mutationsAfterToggle = timing.mutations - (flippedAt ?? 0);
 
   // The bound is absolute rather than scaled, because the two behaviours differ in kind:
-  // disclosing is ONE mutation plus however many characters type during the CDP round-trip
-  // while the emulation lands — a small constant, independent of how much text was left —
-  // whereas continuing to type is one mutation per remaining character.
-  expect(mutationsAfterToggle).toBeLessThanOrEqual(6);
+  // disclosing is ONE mutation, whereas continuing to type is one mutation per remaining
+  // character. Measuring from the in-page flip rather than from before the CDP call keeps
+  // this independent of how loaded the machine is.
+  expect(mutationsAfterToggle).toBeLessThanOrEqual(2);
 });
 
 // The control. Without it, `mutations === 1` would also pass if the reveal were broken
@@ -148,7 +194,7 @@ test('a mid-stream switch to reduced motion stops the typing immediately', async
 test('with motion allowed it still types character by character', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'no-preference' });
   await installRevealObserver(page, BASELINE_TEST_ID, '__fullMotionTiming');
-  await page.goto('/components/typewriter-text');
+  await gotoHydrated(page, '/components/typewriter-text');
 
   await expect(page.locator(`[data-pw="${BASELINE_TEST_ID}"]`)).toHaveText(BASELINE_TEXT);
 

--- a/tests/typewriter-text-resolve-delay.test.ts
+++ b/tests/typewriter-text-resolve-delay.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Covers `resolveDelay`, added to TypewriterText for BZ-5721/F71: a fully custom,
 // per-character pacing function that receives enough state (character index, running
@@ -56,7 +57,7 @@ test.describe('TypewriterText — resolveDelay', () => {
   test('resolveDelay receives character, index and wordCount in the guaranteed order', async ({
     page
   }) => {
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     const host = page.getByTestId('typewriter-resolve-delay-cyclical');
     await expect(host).toBeVisible();
@@ -93,7 +94,7 @@ test.describe('TypewriterText — resolveDelay', () => {
     page
   }) => {
     await installTimingObserver(page, 'typewriter-resolve-delay-cyclical', '__cyclicalTiming');
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     const host = page.getByTestId('typewriter-resolve-delay-cyclical');
     await expect(host).toBeVisible();
@@ -115,7 +116,7 @@ test.describe('TypewriterText — resolveDelay', () => {
 
   test('resolveDelay takes priority over variableDelay when both are set', async ({ page }) => {
     await installTimingObserver(page, 'typewriter-resolve-delay-priority', '__priorityTiming');
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     const host = page.getByTestId('typewriter-resolve-delay-priority');
     await expect(host).toBeVisible();
@@ -135,7 +136,7 @@ test.describe('TypewriterText — resolveDelay', () => {
   test('omitting resolveDelay leaves variableDelay/speed pacing exactly as before', async ({
     page
   }) => {
-    await page.goto('/components/typewriter-text');
+    await gotoHydrated(page, '/components/typewriter-text');
 
     // Neither of these pre-existing demos ever sets resolveDelay — proving that adding
     // the prop, and the new branch it takes in `resolveTypingDelay`, left the

--- a/tests/wc-custom-elements.spec.ts
+++ b/tests/wc-custom-elements.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // The four form custom elements (sui-chip-input, sui-color-picker, sui-combobox,
 // sui-split-input) had no browser-level coverage: the build emitting a tag string is not
@@ -11,7 +12,7 @@ import { expect, test } from '@playwright/test';
 const TAGS = ['sui-chip-input', 'sui-color-picker', 'sui-combobox', 'sui-split-input'] as const;
 
 const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(
     (tags) => tags.every((tag) => typeof customElements.get(tag) !== 'undefined'),

--- a/tests/wc-event-casing-parity.spec.ts
+++ b/tests/wc-event-casing-parity.spec.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, test, type Page } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 import {
   readComponentProps,
   readCustomElementDeclaration,
@@ -25,7 +26,7 @@ import {
 const WC_DIR = join(process.cwd(), 'src/wc/components');
 
 const loadBundle = async (page: Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-status') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/wc-menu-trigger-props.spec.ts
+++ b/tests/wc-menu-trigger-props.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 // Menu hands its `trigger` snippet the interaction wiring (MenuTriggerProps) so a consumer
 // whose trigger is itself an interactive element can spread it and set `interactiveTrigger`.
@@ -7,7 +8,7 @@ import { expect, test } from '@playwright/test';
 // whole feature was unreachable. Nothing failed: the menu still opened, the trigger just
 // never received its wiring.
 const loadBundle = async (page: import('@playwright/test').Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-menu') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/wc-prop-parity.spec.ts
+++ b/tests/wc-prop-parity.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import { readWrapperParity } from '../scripts/wc-parity/prop-parity';
+import { gotoHydrated } from './support/hydrated';
 
 /**
  * The unit guard proves the wrapper *source* declares every prop. This proves
@@ -13,7 +14,7 @@ import { readWrapperParity } from '../scripts/wc-parity/prop-parity';
  * `pnpm run build` (the webServer command) runs build:wc, so the file exists.
  */
 const loadBundle = async (page: Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-status') !== 'undefined', null, {
     timeout: 15_000

--- a/tests/wc-review-findings.spec.ts
+++ b/tests/wc-review-findings.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
 
 /**
  * MEASUREMENT HARNESS for the review findings on PR #506.
@@ -10,7 +11,7 @@ import { expect, test, type Page } from '@playwright/test';
  * a failure names a real defect rather than a disagreement between bots.
  */
 const loadBundle = async (page: Page): Promise<void> => {
-  await page.goto('/');
+  await gotoHydrated(page, '/');
   await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
   await page.waitForFunction(() => typeof customElements.get('sui-status') === 'function', null, {
     timeout: 15_000


### PR DESCRIPTION
The functional suite failed intermittently: a full local run at the default
worker count failed 8 of 713, a run of the same commit at `--workers=2` failed 0
of 713, and the failing tests moved from run to run. CI never showed it because
`retries: process.env.CI ? 2 : 0` re-ran them.

Root cause, confirmed rather than inferred. Every demo page is server-rendered,
so a control is present, visible, stable and enabled — passing every
actionability check Playwright makes — before hydration has attached its
handler. Playwright has no check for "a listener exists", so a click arriving in
that window is delivered to inert markup and silently does nothing; the
assertion after it then fails as a timeout naming the missing element, which
says nothing about the real cause. Recording `video` and `trace` on all 713
tests makes the window wide enough to hit whenever workers compete.

The confirmation was a probe that delays the module scripts, making the race
deterministic: the trigger passes `toBeVisible`, the click lands, and the
dropdown never appears. That probe is kept as
`tests/hydration-race.spec.ts`, alongside its inverse — the same delayed page
driven through the new helper, where the click works. Together they fail if
either half of this regresses.

`src/routes/+layout.svelte` now sets `document.documentElement.dataset.hydrated`
in `onMount`; a parent's `onMount` runs after its children have mounted, so the
root layout is the app as a whole reporting it is ready. `gotoHydrated` in
`tests/support/hydrated.ts` navigates and waits for it, and replaces
`page.goto` at 579 call sites across 149 spec files. The three remaining raw
`goto` calls are deliberate: the race probe needs an unhydrated page, the helper
itself, and the visual suite's templated navigation.

Separately, `typewriter-text-reduced-motion.test.ts` sampled its mutation count
from the test process on either side of an `emulateMedia` CDP round-trip, so
every character typed while that call was in flight counted against a bound of
6. The count is now recorded inside the page, when the media query actually
flips, which takes the round-trip out of the measured window and lets the bound
tighten to 2. Writing that exposed a second defect in my own first attempt:
`readTiming` projects a narrower shape, so the new field never reached the
assertion, and a `not.toBeNull()` guard passed on `undefined` while the test
measured the whole reveal. The guard now asserts a real number, which is what
catches a dropped projection.

Verified on this commit: check 0, lint 0, unit 0, integration 0. The full suite
at the default worker count that was failing 8 now passes 715 of 715.

The same test also sampled `textContent` from the test process to find the
moment typing had started. The whole string reveals in roughly 450ms and every
`expect.poll` iteration costs a round-trip, so on a loaded machine those spent
most of the window and the flip landed after typing had finished -- failing the
test's own `remaining > 12` guard, which exists to prove it caught the reveal
mid-stream. That wait now happens in the page via `waitForFunction`, so it ends
on the first revealed character and the only round-trip left in the critical
path is the `emulateMedia` call. The guard reads the in-page count at the flip
too, rather than a sample taken a round-trip earlier.

Fixing it in the demo app was tried first and abandoned: the site is
prerendered, so a query parameter cannot reach the server-rendered output, and
slowing the shared fixture outright would break the pacing assertions in
`typewriter-text-pacing-progress-render.test.ts` and change the visual baseline.

Verified on this commit: check 0, lint 0, unit 0, integration 0. The full suite
at the default worker count that was failing 8 now passes 715 of 715, and the
reduced-motion file passes 48 of 48 at `--repeat-each=16 --workers=14`, a load
at which it previously failed repeatedly.