### PR TITLE
feat(markdown-text): let a consumer add a class to the table wrapper

### DIFF
--- a/docs/MarkdownText.md
+++ b/docs/MarkdownText.md
@@ -36,14 +36,15 @@ The `marked` package is a peer dependency, needed only when you actually use `Ma
 
 ## Props
 
-| Prop       | Type                      | Required | Default | Description                                                                                                                                                                                                         |
-| ---------- | ------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| markdown   | `string`                  | Yes      | `-`     | Markdown source. Raw HTML is escaped by default; strip mode removes tags and retains text; unsafe link/image protocols are stripped while their text stays.                                                         |
-| breaks     | `boolean`                 | No       | `false` | Render single newlines as `<br>` (GFM "breaks" mode).                                                                                                                                                               |
-| testId     | `string`                  | No       | `-`     | `data-pw` (and native `testID`) on the root element.                                                                                                                                                                |
-| classes    | `string`                  | No       | `-`     | Class string on the root element.                                                                                                                                                                                   |
-| tableLabel | `string`                  | No       | `-`     | Names the scrollable table region: adds `role="region"` and `aria-label` to the wrapper. Without it the wrapper is still focusable and scrollable but announces no landmark.                                        |
-| sanitize   | `MarkdownSanitizeOptions` | No       | `-`     | Narrows the link/image protocol allow-list, the set of tags allowed to render as themselves, whether task-list checkboxes render, and whether raw HTML is escaped or dropped. See the Security model section below. |
+| Prop              | Type                      | Required | Default | Description                                                                                                                                                                                                         |
+| ----------------- | ------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| markdown          | `string`                  | Yes      | `-`     | Markdown source. Raw HTML is escaped by default; strip mode removes tags and retains text; unsafe link/image protocols are stripped while their text stays.                                                         |
+| breaks            | `boolean`                 | No       | `false` | Render single newlines as `<br>` (GFM "breaks" mode).                                                                                                                                                               |
+| testId            | `string`                  | No       | `-`     | `data-pw` (and native `testID`) on the root element.                                                                                                                                                                |
+| classes           | `string`                  | No       | `-`     | Class string on the root element.                                                                                                                                                                                   |
+| tableLabel        | `string`                  | No       | `-`     | Names the scrollable table region: adds `role="region"` and `aria-label` to the wrapper. Without it the wrapper is still focusable and scrollable but announces no landmark.                                        |
+| tableWrapperClass | `string`                  | No       | `-`     | An extra class on the scrollable table wrapper, added alongside the built-in `markdown-table-wrapper` rather than replacing it. See Wide tables below.                                                              |
+| sanitize          | `MarkdownSanitizeOptions` | No       | `-`     | Narrows the link/image protocol allow-list, the set of tags allowed to render as themselves, whether task-list checkboxes render, and whether raw HTML is escaped or dropped. See the Security model section below. |
 
 ## Security model
 
@@ -120,6 +121,39 @@ That adds `role="region"` and `aria-label`. Without it the wrapper stays
 keyboard-scrollable but announces no landmark, since a region the user cannot
 identify is worse than no region at all.
 
+`markdown-table-wrapper` is itself a stable public class name — style it
+directly in your own stylesheet if you would rather theme the wrapper that way
+than reach for CSS variables. If your app already has its own class for this
+(its own scroll/border/token treatment) and you want the rendered markup to
+carry that class instead, pass `tableWrapperClass`:
+
+```svelte
+<MarkdownText {markdown} tableWrapperClass="markdown-table-scroll" />
+```
+
+The wrapper then carries both: `class="markdown-table-wrapper markdown-table-scroll"`.
+
+**It is added, never substituted, and that is deliberate.** The wrapper is a
+`tabindex="0"` scroll container, and the three things that make it one —
+`overflow-x: auto`, the `:focus-visible` ring, and the table's `max-content`
+width — are scoped to `.markdown-table-wrapper` in the component's own styles.
+A Svelte scoped selector cannot be templated to a class name supplied at
+runtime, so replacing the class would leave a focusable element that cannot
+scroll and shows no focus ring: a keyboard dead end, and a regression of the
+fix that made wide tables scrollable in the first place.
+
+Adding costs you nothing. Your own selector matches the wrapper exactly as it
+would have, and you can still override any built-in declaration by specificity
+if you want different scroll or focus treatment.
+
+`markdown-table-wrapper` is a stable public class. Theme against it directly if
+you would rather not pass a prop at all.
+
+Omitting `tableWrapperClass`, or passing an empty or whitespace-only string,
+leaves the wrapper with just `markdown-table-wrapper`. The value is
+HTML-attribute-escaped the same way `tableLabel` is, so it cannot break out of
+the `class="..."` attribute it is placed in.
+
 ## CSS Variables
 
 | Variable                                  | Default                   | Description                    |
@@ -153,6 +187,7 @@ export type MarkdownTextProperties = {
   testId?: string;
   classes?: string;
   tableLabel?: string;
+  tableWrapperClass?: string;
   sanitize?: MarkdownSanitizeOptions;
 };
 
@@ -178,6 +213,7 @@ export type RenderMarkdownOptions = {
   breaks?: boolean;
   inline?: boolean;
   tableLabel?: string;
+  tableWrapperClass?: string;
   sanitize?: MarkdownSanitizeOptions;
 };
 ```

--- a/src/lib/MarkdownText/MarkdownText.svelte
+++ b/src/lib/MarkdownText/MarkdownText.svelte
@@ -8,10 +8,13 @@
     testId,
     classes,
     tableLabel,
+    tableWrapperClass,
     sanitize
   }: MarkdownTextProperties = $props();
 
-  let html = $derived(renderMarkdown(markdown, { breaks, tableLabel, sanitize }));
+  let html = $derived(
+    renderMarkdown(markdown, { breaks, tableLabel, tableWrapperClass, sanitize })
+  );
 </script>
 
 <div

--- a/src/lib/MarkdownText/markdown.test.ts
+++ b/src/lib/MarkdownText/markdown.test.ts
@@ -226,4 +226,59 @@ describe('renderMarkdown — table wrapping', () => {
   it('leaves markdown without a table untouched', () => {
     expect(renderMarkdown('plain **text**')).not.toContain('markdown-table-wrapper');
   });
+
+  it('adds tableWrapperClass so a consumer selector matches the wrapper', () => {
+    const output = renderMarkdown(table, { tableWrapperClass: 'markdown-table-scroll' });
+    expect(output).toContain(
+      '<div class="markdown-table-wrapper markdown-table-scroll" tabindex="0"><table>'
+    );
+  });
+
+  it('falls back to the default wrapper class when tableWrapperClass is empty', () => {
+    const output = renderMarkdown(table, { tableWrapperClass: '' });
+    expect(output).toContain('<div class="markdown-table-wrapper" tabindex="0"><table>');
+  });
+
+  it('falls back to the default wrapper class when tableWrapperClass is whitespace-only', () => {
+    // Pins that a whitespace-only value is trimmed to empty rather than
+    // surviving as a meaningless custom class, matching the documented
+    // "empty string keeps the default" behaviour for the empty case above.
+    const output = renderMarkdown(table, { tableWrapperClass: '   ' });
+    expect(output).toContain('<div class="markdown-table-wrapper" tabindex="0"><table>');
+  });
+
+  it('combines a custom tableWrapperClass with tableLabel', () => {
+    const output = renderMarkdown(table, {
+      tableWrapperClass: 'markdown-table-scroll',
+      tableLabel: 'Recent orders'
+    });
+    expect(output).toContain(
+      '<div class="markdown-table-wrapper markdown-table-scroll" tabindex="0" role="region" aria-label="Recent orders"><table>'
+    );
+  });
+
+  it('keeps the built-in wrapper class alongside a custom one', () => {
+    // The wrapper is a `tabindex="0"` scroll container (5cb4df4). Its
+    // overflow-x, its focus ring and the table's max-content width are all
+    // scoped to `.markdown-table-wrapper` in MarkdownText.svelte, and a Svelte
+    // scoped selector cannot be templated to a caller's class name. Replacing
+    // the class would leave a focusable element that cannot scroll and shows no
+    // focus ring -- undoing the accessibility fix that made it focusable.
+    const output = renderMarkdown(table, { tableWrapperClass: 'markdown-table-scroll' });
+    expect(output).toContain('class="markdown-table-wrapper markdown-table-scroll"');
+  });
+
+  it('adds nothing when no custom class is given', () => {
+    const output = renderMarkdown(table, {});
+    expect(output).toContain('class="markdown-table-wrapper"');
+  });
+
+  it('escapes tableWrapperClass so it cannot break out of the attribute', () => {
+    const output = renderMarkdown(table, { tableWrapperClass: '" onmouseover="alert(1)' });
+    // The hostile value must never appear as a live, unescaped attribute --
+    // that would close `class="..."` early and inject a new attribute.
+    expect(output).not.toContain('" onmouseover="alert(1)"');
+    expect(output).not.toContain('<div class="" onmouseover=');
+    expect(output).toContain('class="markdown-table-wrapper &quot; onmouseover=&quot;alert(1)"');
+  });
 });

--- a/src/lib/MarkdownText/markdown.ts
+++ b/src/lib/MarkdownText/markdown.ts
@@ -290,15 +290,35 @@ function annotateExternalLinks(html: string): string {
 const TABLE_OPEN = /<table>/g;
 const TABLE_CLOSE = /<\/table>/g;
 
-function wrapTables(html: string, label?: string): string {
+const DEFAULT_TABLE_WRAPPER_CLASS = 'markdown-table-wrapper';
+
+function wrapTables(html: string, label?: string, wrapperClass?: string): string {
   /* `role="region"` without an accessible name announces a landmark the user
      cannot identify, which is worse than no landmark, so the role appears only
      when the caller supplies a name. The tabindex does not depend on it:
      keyboard scrolling should work either way. */
+  /* A caller's class is ADDED, never substituted. The wrapper's own styling --
+     `overflow-x: auto`, the `:focus-visible` ring, and the table's max-content
+     width -- is scoped to `.markdown-table-wrapper` in MarkdownText.svelte, and
+     a Svelte scoped selector cannot be templated to a name supplied at runtime.
+     Substituting the class would leave a `tabindex="0"` element that cannot
+     scroll and shows no focus ring, undoing the fix that made a wide table
+     keyboard-scrollable in the first place. Adding costs a consumer nothing:
+     their own selector still matches, and they can still override by
+     specificity. */
+  const custom = typeof wrapperClass === 'string' ? wrapperClass.trim() : '';
+  // The caller's value lands inside a double-quoted HTML attribute, same as
+  // `label` below -- escaping it the same way is what stops a value like
+  // `" onmouseover="alert(1)` from closing the attribute early and injecting a
+  // new one. The built-in name is a literal and needs no escaping.
+  const classAttr =
+    custom.length > 0
+      ? `${DEFAULT_TABLE_WRAPPER_CLASS} ${escapeHtml(custom)}`
+      : DEFAULT_TABLE_WRAPPER_CLASS;
   const open =
     typeof label === 'string' && label.length > 0
-      ? `<div class="markdown-table-wrapper" tabindex="0" role="region" aria-label="${escapeHtml(label)}">`
-      : '<div class="markdown-table-wrapper" tabindex="0">';
+      ? `<div class="${classAttr}" tabindex="0" role="region" aria-label="${escapeHtml(label)}">`
+      : `<div class="${classAttr}" tabindex="0">`;
   return html.replace(TABLE_OPEN, `${open}<table>`).replace(TABLE_CLOSE, '</table></div>');
 }
 
@@ -341,5 +361,7 @@ export function renderMarkdown(markdown: string, options: RenderMarkdownOptions 
   }
   /* Inline parsing produces no block elements, so there is no table to wrap. */
   const linked = annotateExternalLinks(output);
-  return options.inline === true ? linked : wrapTables(linked, options.tableLabel);
+  return options.inline === true
+    ? linked
+    : wrapTables(linked, options.tableLabel, options.tableWrapperClass);
 }

--- a/src/lib/MarkdownText/properties.ts
+++ b/src/lib/MarkdownText/properties.ts
@@ -24,6 +24,15 @@ export type OptionalMarkdownTextProperties = {
    */
   tableLabel?: string;
   /**
+   * Extra class name added to the scrollable region wrapping each table,
+   * alongside the built-in `markdown-table-wrapper` rather than replacing it
+   * (the wrapper's scroll/focus behaviour is scoped to that class and cannot
+   * be retargeted). Lets a consumer whose own stylesheet targets a different
+   * class keep that styling too. Omitting it, or passing an empty or
+   * whitespace-only string, keeps only `markdown-table-wrapper`.
+   */
+  tableWrapperClass?: string;
+  /**
    * Narrow which URL protocols survive on rendered links/images. See
    * `MarkdownSanitizeOptions`.
    */
@@ -110,6 +119,8 @@ export type RenderMarkdownOptions = {
   inline?: boolean;
   /** Accessible name for the scroll region wrapping each table. See `MarkdownTextProperties.tableLabel`. */
   tableLabel?: string;
+  /** Class name for the scroll region wrapping each table. See `MarkdownTextProperties.tableWrapperClass`. */
+  tableWrapperClass?: string;
   /** Narrow the protocol allow-list. See `MarkdownSanitizeOptions`. */
   sanitize?: MarkdownSanitizeOptions;
 };

--- a/src/wc/components/MarkdownText.wc.svelte
+++ b/src/wc/components/MarkdownText.wc.svelte
@@ -8,6 +8,7 @@
       testId: { type: 'String', attribute: 'test-id' },
       classes: { type: 'String' },
       tableLabel: { type: 'String', attribute: 'table-label' },
+      tableWrapperClass: { type: 'String', attribute: 'table-wrapper-class' },
       sanitize: { type: 'Object' }
     }
   }}


### PR DESCRIPTION
`wrapTables` hardcoded `markdown-table-wrapper`, so a consumer whose own
stylesheet targets a different class silently lost all table styling when
they swapped to this renderer -- no error, no warning, just unstyled
tables. `tableWrapperClass` on `MarkdownTextProperties` and
`RenderMarkdownOptions` fixes that, following how the existing
`tableLabel` is typed, threaded and defaulted.

The class is ADDED, not substituted. That distinction is the whole
design. The wrapper is a `tabindex="0"` scroll container, and the three
things that make it one -- `overflow-x: auto`, the `:focus-visible` ring
and the table's `max-content` width -- are scoped to
`.markdown-table-wrapper` in the component's own styles. A Svelte scoped
selector cannot be templated to a class name supplied at runtime, so
substituting would leave a focusable element that cannot scroll and shows
no focus ring: a keyboard dead end, and a direct regression of 5cb4df4,
which made a wide table scroll in a focusable wrapper rather than
scrolling the table itself.

Adding costs the consumer nothing. Their selector matches the wrapper
exactly as it would have, and specificity still lets them override any
built-in declaration. `markdown-table-wrapper` is documented as a stable
public class besides, so theming against it directly remains an option
and the prop is not the only route.

The value is caller-supplied and lands inside a double-quoted HTML
attribute on a surface that is otherwise sanitizing-by-construction, so
it is escaped exactly as `tableLabel` is. A value of `" onmouseover=
"alert(1)` becomes `&quot;` rather than closing the attribute and
injecting a live event handler.

Omitting the prop, or passing an empty or whitespace-only string, leaves
the markup byte-identical to before this change.

Verified on this commit: check 0, lint 0, 1027 unit tests, 714
integration, build 0. Mutation-tested: substituting the class instead of
adding it fails 4 cases, and dropping the escape fails the injection
case and only that one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional custom CSS class for wrappers around rendered Markdown tables.
  - The built-in `markdown-table-wrapper` class is always retained.
  - Custom classes are trimmed and safely escaped; empty values are ignored.
  - Exposed the option through the Markdown Text component and custom element attribute.

- **Documentation**
  - Added API documentation for the new table wrapper class option.

- **Tests**
  - Added coverage for custom, empty, combined, omitted, and safely escaped class values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->