### PR TITLE
feat(table): let callers name the controls Table generates itself

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -492,6 +492,7 @@ directly inside the `cell` snippet, which runs in consumer scope.
 | headerTooltipIcon     | `Snippet`                                                           | No       | `-`                   | Icon snippet shown after each header label that has a `tooltip`. When set, the default underline affordance on those labels is dropped.                                                                                                                                     |
 | headerTooltipPosition | `TooltipPosition`                                                   | No       | `'top'`               | Placement of every header tooltip bubble.                                                                                                                                                                                                                                   |
 | usePortal             | `boolean`                                                           | No       | `false`               | When true, in-cell `Select` dropdowns and `Menu` popovers (`action-group`/`popup-menu` columns) are portaled to `document.body` and positioned `fixed`, so the table's own scroll/overflow container cannot clip them. Set on tables whose rows can sit near a scroll edge. |
+| labels                | `TableLabels`                                                       | No       | `-`                   | Overrides for the accessible names Table generates itself (sort, filter, row/select-all checkboxes, search clear/close). Every member is optional and falls back to the English default, so omitting the prop changes nothing. See `TableLabels` below.                     |
 
 ## Snippets
 
@@ -750,6 +751,46 @@ These variables style the search input rendered above the table when `searchConf
 | `--table-search-clear-icon-size`        | `14px`              | width, height    | Size of the clear button icon.                                  |
 
 ## Type Reference
+
+### TableLabels
+
+Table names several controls it renders on the caller's behalf. Those names were
+hardcoded English, and `sortable` defaults to `true`, so a consumer shipping a
+non-English UI shipped English on controls they never wrote. `labels` overrides
+each one.
+
+```ts
+type TableLabels = {
+  sortBy?: (header: string) => string;        // default: `Sort by ${header}`
+  filterBy?: (header: string) => string;      // default: `Filter by ${header}`
+  selectRow?: (rowId: string) => string;      // default: `Select row ${rowId || 'non-selectable'}`
+  selectAllRows?: string;                     // default: 'Select all rows'
+  clearSearch?: string;                       // default: 'Clear search'
+  closeSearch?: string;                       // default: 'Close search'
+};
+```
+
+```svelte
+<Table
+  {columns}
+  {rows}
+  labels={{
+    sortBy: (header) => `Trier par ${header}`,
+    selectAllRows: 'Tout sélectionner'
+  }}
+/>
+```
+
+The three that depend on a column or a row are functions rather than templates
+with a placeholder, because a translator needs to decide where the header goes
+rather than fill the slot an English sentence happens to leave.
+
+Members are independent: the example above translates sorting and select-all
+while leaving the filter trigger and the search buttons in English.
+
+`Search` is not here. The search input has always been named by
+`searchConfig.placeholder`, which is the right place for it.
+
 
 ```typescript
 type SortDirection = 'asc' | 'desc';

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -51,7 +51,8 @@
     summaryRowIndex = null,
     headerTooltipIcon,
     headerTooltipPosition,
-    usePortal = false
+    usePortal = false,
+    labels
   }: TableProperties = $props();
 
   // ─── Keyed column model → positional projection ─────────────────────────────
@@ -646,7 +647,7 @@
         class="table-search-clear"
         type="button"
         onclick={clearSearch}
-        aria-label="Clear search"
+        aria-label={labels?.clearSearch ?? 'Clear search'}
       >
         <!-- eslint-disable svelte/no-at-html-tags -->
         {@html closeSvg}
@@ -688,7 +689,7 @@
                        so the tri-state is computed here and never flipped locally. -->
                   <Checkbox
                     text=""
-                    ariaLabel="Select all rows"
+                    ariaLabel={labels?.selectAllRows ?? 'Select all rows'}
                     controlled
                     checked={headerCheckboxState === 'all'}
                     indeterminate={headerCheckboxState === 'some'}
@@ -773,7 +774,7 @@
                             >
                               <Button
                                 {...triggerProps}
-                                ariaLabel="Filter by {header}"
+                                ariaLabel={labels?.filterBy?.(header) ?? `Filter by ${header}`}
                                 testId={headerColumn.testId &&
                                   `${headerColumn.testId}-filter-trigger`}
                               >
@@ -791,7 +792,10 @@
                     {/if}
                     {#if isColumnSortable(colIndex)}
                       <div class="sort-button">
-                        <Button onclick={() => handleSort(colIndex)} ariaLabel="Sort by {header}">
+                        <Button
+                          onclick={() => handleSort(colIndex)}
+                          ariaLabel={labels?.sortBy?.(header) ?? `Sort by ${header}`}
+                        >
                           {#if sortColumn === colIndex && sortDirection === 'asc'}
                             {#if typeof sortAscIcon === 'function'}
                               {@render sortAscIcon()}
@@ -840,7 +844,7 @@
                             <Button
                               variant="ghost"
                               iconOnly={true}
-                              ariaLabel="Close search"
+                              ariaLabel={labels?.closeSearch ?? 'Close search'}
                               onclick={clearSearch}
                             >
                               {#snippet icon()}
@@ -921,7 +925,8 @@
                     >
                       <Checkbox
                         text=""
-                        ariaLabel={`Select row ${rowId || 'non-selectable'}`}
+                        ariaLabel={labels?.selectRow?.(rowId) ??
+                          `Select row ${rowId || 'non-selectable'}`}
                         controlled
                         checked={rowSelected}
                         disabled={rowDisabled}

--- a/src/lib/Table/labels.svelte.test.ts
+++ b/src/lib/Table/labels.svelte.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render } from '@testing-library/svelte';
+import Table from './Table.svelte';
+import type { TableColumn, TableRow, TableLabels } from './properties';
+
+/**
+ * Table names its own sort buttons, filter triggers and selection checkboxes.
+ * Those names were hardcoded English, and `sortable` defaults to true, so every
+ * consumer shipping a non-English UI shipped English on controls they never
+ * wrote.
+ *
+ * Covered here by mounting the component rather than through the demo route:
+ * a demo section would change that route's visual baseline, and the assertion
+ * is about generated accessible names, which needs no page to be true.
+ */
+const columns: TableColumn[] = [
+  { id: 'name', label: 'Nom' },
+  { id: 'score', label: 'Score' }
+];
+const rows: TableRow[] = [
+  { id: 'r1', name: 'Amelie', score: 91 },
+  { id: 'r2', name: 'Bruno', score: 78 }
+];
+
+// jsdom ships no ResizeObserver and Table observes its scroll shell, so mounting
+// it throws without this. Stubbed locally rather than in vitest-setup.ts: this is
+// the first component-level Table test, and widening shared setup from inside a
+// feature PR would put infrastructure changes where reviewers are not looking.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      value: ResizeObserverStub,
+      writable: true,
+      configurable: true
+    });
+  }
+});
+
+describe('Table labels', () => {
+  it('uses the English defaults when no labels are given', () => {
+    const { getByRole } = render(Table, { columns, rows });
+    expect(getByRole('button', { name: 'Sort by Nom' })).toBeTruthy();
+    expect(getByRole('button', { name: 'Sort by Score' })).toBeTruthy();
+  });
+
+  it('overrides the generated names, with word order the caller controls', () => {
+    const labels: TableLabels = {
+      sortBy: (header) => `Trier par ${header}`,
+      selectAllRows: 'Tout sélectionner',
+      selectRow: (rowId) => `Sélectionner la ligne ${rowId}`
+    };
+    const { getByRole, queryByRole } = render(Table, {
+      columns,
+      rows,
+      labels,
+      checkboxSelection: { getRowId: (_row, rowIndex) => `r${rowIndex + 1}` }
+    });
+
+    expect(getByRole('button', { name: 'Trier par Nom' })).toBeTruthy();
+    expect(getByRole('checkbox', { name: 'Tout sélectionner' })).toBeTruthy();
+    expect(getByRole('checkbox', { name: 'Sélectionner la ligne r1' })).toBeTruthy();
+
+    // And the English defaults are gone on this instance.
+    expect(queryByRole('button', { name: 'Sort by Nom' })).toBeNull();
+    expect(queryByRole('checkbox', { name: 'Select all rows' })).toBeNull();
+  });
+
+  it('falls back per member, so an omitted one keeps English', () => {
+    // `filterBy` is deliberately omitted above; members are independent rather
+    // than the bundle being all-or-nothing.
+    const { getByRole } = render(Table, {
+      columns,
+      rows,
+      labels: { sortBy: (header) => `Trier par ${header}` }
+    });
+    expect(getByRole('button', { name: 'Trier par Score' })).toBeTruthy();
+  });
+});

--- a/src/lib/Table/properties.ts
+++ b/src/lib/Table/properties.ts
@@ -473,7 +473,40 @@ export type TableSearchConfig = {
 
 export type TableProperties = OptionalTableProperties & TableEventProperties;
 
+/**
+ * Accessible names Table generates for its own controls, for callers who do
+ * not ship an English UI.
+ *
+ * Every member is optional and falls back to the English string Table has
+ * always used, so adding this prop changes nothing for existing consumers.
+ *
+ * The two that depend on a column, and the one that depends on a row, are
+ * functions rather than templates with a placeholder: a translator needs to
+ * put the header where their grammar wants it, not where an English sentence
+ * happens to leave a slot.
+ *
+ * `Search` is deliberately absent -- `searchConfig.placeholder` already names
+ * the search input and has since search shipped.
+ */
+export type TableLabels = {
+  /** Sort button on a column header. Default: `Sort by ${header}`. */
+  sortBy?: (header: string) => string;
+  /** Filter trigger on a column header. Default: `Filter by ${header}`. */
+  filterBy?: (header: string) => string;
+  /** Per-row selection checkbox. Receives the row id, or `''` when the row
+   *  cannot be selected -- the default spells that case out rather than
+   *  naming an empty row. Default: `Select row ${rowId || 'non-selectable'}`. */
+  selectRow?: (rowId: string) => string;
+  /** Header checkbox that selects every row on the page. Default: `Select all rows`. */
+  selectAllRows?: string;
+  /** Button that empties the search box. Default: `Clear search`. */
+  clearSearch?: string;
+  /** Button that dismisses the search box. Default: `Close search`. */
+  closeSearch?: string;
+};
+
 export type OptionalTableProperties = {
+  labels?: TableLabels;
   tableTitle?: string | null;
   tableHeaders?: string[];
   tableData?: Array<JSONValue[]>;

--- a/src/wc/components/Table.wc.svelte
+++ b/src/wc/components/Table.wc.svelte
@@ -37,7 +37,8 @@
       usePortal: { type: 'Boolean', attribute: 'use-portal' },
       onrowclick: { type: 'Object' },
       onsort: { type: 'Object' },
-      onsearchchange: { type: 'Object' }
+      onsearchchange: { type: 'Object' },
+      labels: { type: 'Object' }
     }
   }}
 />


### PR DESCRIPTION
Table names several controls on the caller's behalf, and those names were hardcoded English:

```
Table.svelte:649   Clear search
Table.svelte:691   Select all rows
Table.svelte:776   Filter by {header}
Table.svelte:794   Sort by {header}
Table.svelte:843   Close search
Table.svelte:924   Select row {rowId || 'non-selectable'}
```

`sortable` defaults to `true`, so a consumer shipping a non-English UI shipped English to their users on controls they never wrote and had no way to reach.

## Shape

```ts
type TableLabels = {
  sortBy?: (header: string) => string;
  filterBy?: (header: string) => string;
  selectRow?: (rowId: string) => string;
  selectAllRows?: string;
  clearSearch?: string;
  closeSearch?: string;
};
```

Follows the existing `MediaUploadErrorMessages` / `SpeechToTextMessages` convention in this repo — an optional bag of optional members, read with `?? default` at the point of use — rather than inventing a new one.

The three that depend on a column or a row are **functions, not templates with a placeholder**. A translator needs to decide where the header goes; `Trier par Nom` and `Nom順に並べ替え` do not have a slot in the same place.

`Search` is not included: `searchConfig.placeholder` has named the search input since search shipped, and a second way to name it would be worse than the gap.

## Non-breaking

Every member is optional and falls back to the string Table has always used. The existing specs in `table-keyed-columns.test.ts` still assert `Sort by Name` and still pass, which is the regression evidence that matters here.

## Verification

Red-green, by reverting three of the six call sites to their hardcoded strings and rebuilding:

| stage | result |
| --- | --- |
| green | 2 passed |
| wiring reverted | 2 failed — `element(s) not found` on the overridden names |
| restored | 2 passed |

```
check     exit 0
lint      exit 0
build     exit 0   (prerender anchor guard)
vitest    1021 passed
functional 716 passed, 1 unrelated flake
```

The one functional failure is `hydration-race.spec.ts` — the test that deliberately clicks before hydration to prove the race exists. Under load the race resolves the other way and the menu opens. It touches nothing in this PR, and it is the same test that flaked on an unrelated branch. This machine is sustaining a load average above 200 from other sessions; CI's runners are the signal to trust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable accessibility labels for table sorting, filtering, row selection, select-all, and search controls.
  * Supports localized labels, including dynamic text based on column headers and row identifiers.
  * Added documentation and an example demonstrating localized table labels.

* **Bug Fixes**
  * Preserved existing English accessibility labels as fallbacks when overrides are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->