### PR TITLE
fix(tests): make two timing-dependent specs independent of machine load

### DIFF
--- a/tests/hydration-race.spec.ts
+++ b/tests/hydration-race.spec.ts
@@ -18,6 +18,36 @@ import { gotoHydrated } from './support/hydrated';
  * cases pin the race deterministically instead of waiting for a bad day.
  */
 
+/**
+ * Holds every module script until the test releases it, rather than delaying
+ * them by a fixed 2000ms.
+ *
+ * The fixed delay was a bet that the click below would land inside the window,
+ * and on a loaded machine it lost: hydration completed first, the menu opened,
+ * and `toHaveCount(0)` failed -- the test that exists to prove the race is
+ * real became the suite's own most reliable flake. A hold the test controls
+ * cannot expire early, so the case is pinned rather than probable.
+ */
+const holdScripts = async (
+  page: Parameters<typeof gotoHydrated>[0]
+): Promise<{ release: () => void }> => {
+  let release = (): void => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route('**/*.js', async (route) => {
+    await held;
+    await route.continue();
+  });
+  return { release };
+};
+
+/**
+ * A bounded delay is still right for the second case: it only has to prove that
+ * `gotoHydrated` waits, and a delay that runs long makes that case pass more
+ * firmly rather than less. Only the first case is falsified by the delay
+ * expiring early.
+ */
 const delayScripts = async (page: Parameters<typeof gotoHydrated>[0]): Promise<void> => {
   await page.route('**/*.js', async (route) => {
     await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -27,16 +57,23 @@ const delayScripts = async (page: Parameters<typeof gotoHydrated>[0]): Promise<v
 
 test.describe('demo pages are only driven once they are interactive', () => {
   test('a click before hydration is lost, which is what made the suite flaky', async ({ page }) => {
-    await delayScripts(page);
-    await page.goto('/components/menu', { waitUntil: 'commit' });
+    const { release } = await holdScripts(page);
+    try {
+      await page.goto('/components/menu', { waitUntil: 'commit' });
 
-    const menu = page.locator('[data-pw="menu-default-demo"]');
-    const trigger = menu.locator('.menu-trigger');
+      const menu = page.locator('[data-pw="menu-default-demo"]');
+      const trigger = menu.locator('.menu-trigger');
 
-    // Passes every actionability check Playwright makes, while inert.
-    await expect(trigger).toBeVisible();
-    await trigger.click();
-    await expect(menu.locator('.menu-dropdown')).toHaveCount(0);
+      // Passes every actionability check Playwright makes, while inert. The
+      // scripts are still held at this point, so this is a fact about the page
+      // rather than a race the machine's load decides.
+      await expect(trigger).toBeVisible();
+      await trigger.click();
+      await expect(menu.locator('.menu-dropdown')).toHaveCount(0);
+    } finally {
+      // Let the held requests finish so teardown does not wait on them.
+      release();
+    }
   });
 
   test('the same click through gotoHydrated opens the menu', async ({ page }) => {

--- a/tests/typewriter-text-reduced-motion.test.ts
+++ b/tests/typewriter-text-reduced-motion.test.ts
@@ -28,6 +28,17 @@ const BASELINE_TEST_ID = 'typewriter-default-pacing';
 const PROGRESS_TEXT = 'Progress reporting keeps a scroll container pinned to the newest character.';
 const PROGRESS_TEST_ID = 'typewriter-progress-demo';
 
+// The behaviour assertion allows at most 2 mutations after the flip, so a
+// remainder above 2 is what makes "kept typing" and "stopped" distinguishable.
+// Anything at or below it is a void measurement rather than a failure.
+const MIN_DISTINGUISHABLE_REMAINDER = 2;
+
+// A void measurement means the emulateMedia round-trip outran the reveal, which
+// is a fact about the machine rather than about the component. Re-measuring is
+// the correct response; giving up after a bounded number of tries keeps a real
+// regression from retrying forever.
+const MAX_MEASUREMENT_ATTEMPTS = 4;
+
 type RevealTiming = {
   firstAt: number | null;
   lastAt: number | null;
@@ -137,55 +148,85 @@ test('reduced motion reveals the whole string at once instead of typing it', asy
 // the switch is picked up on the very next character — within one `speed` interval, 20ms on
 // this fixture. A subscription would buy nothing here and would add a listener to unregister.
 test('a mid-stream switch to reduced motion stops the typing immediately', async ({ page }) => {
-  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  // Installed once, not per attempt: addInitScript persists for the page's
+  // lifetime and re-runs on every navigation, so a retry's reload re-arms the
+  // observer with a fresh zeroed timing object. Calling it inside the loop
+  // would stack a new init script each time.
   await installRevealObserver(page, PROGRESS_TEST_ID, '__midStreamTiming');
-  await gotoHydrated(page, '/components/typewriter-text');
 
-  const typewriter = page.locator(`[data-pw="${PROGRESS_TEST_ID}"]`);
+  const measure = async (attempt: number): Promise<boolean | null> => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await gotoHydrated(page, '/components/typewriter-text');
 
-  /*
-   * Waiting in the page rather than polling `textContent` from here. The whole
-   * string reveals in roughly 450ms, and every `expect.poll` iteration costs a
-   * round-trip; on a loaded machine those spent most of the window, so the flip
-   * below landed after typing had already finished and the guard on `remaining`
-   * failed. `waitForFunction` evaluates in the page, so the wait ends on the
-   * first revealed character and the only round-trip left in the critical path
-   * is the `emulateMedia` call itself.
-   */
-  await page.waitForFunction(
-    (key: string) => {
-      const timing = (window as unknown as Record<string, RevealTiming>)[key];
-      return Boolean(timing) && timing.mutations > 0;
-    },
-    '__midStreamTiming',
-    { polling: 'raf' }
-  );
+    const typewriter = page.locator(`[data-pw="${PROGRESS_TEST_ID}"]`);
 
-  await page.emulateMedia({ reducedMotion: 'reduce' });
-  await expect(typewriter).toHaveText(PROGRESS_TEXT);
+    /*
+     * Waiting in the page rather than polling `textContent` from here. The whole
+     * string reveals in roughly 450ms, and every `expect.poll` iteration costs a
+     * round-trip; on a loaded machine those spent most of the window, so the flip
+     * below landed after typing had already finished and the guard on `remaining`
+     * failed. `waitForFunction` evaluates in the page, so the wait ends on the
+     * first revealed character and the only round-trip left in the critical path
+     * is the `emulateMedia` call itself.
+     */
+    await page.waitForFunction(
+      (key: string) => {
+        const timing = (window as unknown as Record<string, RevealTiming>)[key];
+        return Boolean(timing) && timing.mutations > 0;
+      },
+      '__midStreamTiming',
+      { polling: 'raf' }
+    );
 
-  const timing = await readTiming(page, '__midStreamTiming');
-  // A missing count would mean the flip was never observed in the page, so the
-  // number below would be measuring the whole reveal and quietly passing for the
-  // wrong reason. Asserting a real number catches that, and also catches the
-  // field being dropped by `readTiming`'s projection -- which is exactly the
-  // mistake this guard was first written too loosely to catch.
-  const flippedAt = timing.mutationsAtReduceFlip;
-  expect(typeof flippedAt).toBe('number');
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await expect(typewriter).toHaveText(PROGRESS_TEXT);
 
-  // The flip has to land with more left to type than the bound below, or the
-  // assertion would pass for the wrong reason. Taken from the in-page count at
-  // the flip, so it measures where the reveal actually was rather than where a
-  // sample taken a round-trip earlier said it was.
-  expect(PROGRESS_TEXT.length - (flippedAt ?? 0)).toBeGreaterThan(12);
+    const timing = await readTiming(page, '__midStreamTiming');
+    // A missing count would mean the flip was never observed in the page, so the
+    // number below would be measuring the whole reveal and quietly passing for the
+    // wrong reason. Asserting a real number catches that, and also catches the
+    // field being dropped by `readTiming`'s projection -- which is exactly the
+    // mistake this guard was first written too loosely to catch.
+    const flippedAt = timing.mutationsAtReduceFlip;
+    expect(typeof flippedAt).toBe('number');
 
-  const mutationsAfterToggle = timing.mutations - (flippedAt ?? 0);
+    // The flip has to land with enough left to type that the two outcomes are
+    // still distinguishable, or the assertion would pass for the wrong reason.
+    //
+    // That bound is 2, not a comfort margin: the behaviour assertion below allows
+    // at most 2 mutations after the flip, so any remaining count above 2 makes
+    // "kept typing" and "stopped" different measurements. This was 12, which is
+    // a margin rather than a threshold, and on a loaded machine the emulateMedia
+    // round-trip regularly consumed more than 12 of the 74 characters -- failing
+    // the guard while the behaviour under test was perfectly correct.
+    //
+    // At or below 2 the reveal had essentially finished before the flip landed,
+    // and the run genuinely cannot tell the two apart. That is a void
+    // measurement, so the retry above re-runs it rather than reporting either
+    // result.
+    const remainingAtFlip = PROGRESS_TEXT.length - (flippedAt ?? 0);
+    if (remainingAtFlip <= MIN_DISTINGUISHABLE_REMAINDER && attempt < MAX_MEASUREMENT_ATTEMPTS) {
+      return null;
+    }
+    expect(remainingAtFlip).toBeGreaterThan(MIN_DISTINGUISHABLE_REMAINDER);
 
-  // The bound is absolute rather than scaled, because the two behaviours differ in kind:
-  // disclosing is ONE mutation, whereas continuing to type is one mutation per remaining
-  // character. Measuring from the in-page flip rather than from before the CDP call keeps
-  // this independent of how loaded the machine is.
-  expect(mutationsAfterToggle).toBeLessThanOrEqual(2);
+    const mutationsAfterToggle = timing.mutations - (flippedAt ?? 0);
+
+    // The bound is absolute rather than scaled, because the two behaviours differ in kind:
+    // disclosing is ONE mutation, whereas continuing to type is one mutation per remaining
+    // character. Measuring from the in-page flip rather than from before the CDP call keeps
+    // this independent of how loaded the machine is.
+    expect(mutationsAfterToggle).toBeLessThanOrEqual(2);
+    return true;
+  };
+
+  for (let attempt = 1; attempt <= MAX_MEASUREMENT_ATTEMPTS; attempt += 1) {
+    if ((await measure(attempt)) !== null) {
+      return;
+    }
+    // Void measurement: reload so the reveal starts over and try again.
+    await page.reload();
+  }
 });
 
 // The control. Without it, `mutations === 1` would also pass if the reveal were broken


### PR DESCRIPTION
Two specs asserted an outcome a loaded machine could decide differently. Both became the suite's own most reliable failures, and both were identified by name as the single failure in otherwise-green full runs on unrelated branches.

## `hydration-race.spec.ts`

It delays module scripts, then clicks inside that window to prove a click on an un-hydrated page is lost. The delay was a fixed `2000ms` — a bet that the click lands first. Under load it lost: hydration completed, the menu opened, `toHaveCount(0)` failed.

The delay is now a hold the test releases, so there is no window to expire:

```ts
const held = new Promise<void>((resolve) => { release = resolve; });
await page.route('**/*.js', async (route) => { await held; await route.continue(); });
```

Narrowing the old fixed delay to `40ms` reproduces the production failure exactly — `Expected: 0, Received: 1`.

The second case in that file keeps the bounded delay deliberately: it only has to prove `gotoHydrated` waits, and a delay running long makes it pass more firmly, not less.

## `typewriter-text-reduced-motion.test.ts`

Its guard required **more than 12 characters** left to type at the moment reduced motion is flipped. That is a comfort margin, not a threshold — the behaviour assertion below it allows at most **2** mutations after the flip, so any remainder above 2 already makes "kept typing" and "stopped" different measurements.

On a busy host the `emulateMedia` CDP round-trip regularly consumed more than 12 of the fixture's 74 characters, so the guard failed while the behaviour under test was perfectly correct. The bound is now the one the logic actually needs, and a remainder at or below it is a **void measurement** — re-measured via a bounded retry rather than reported as either a pass or a failure.

## Evidence

| run | load avg | result |
| --- | --- | --- |
| fixed specs, 5 repeats each | **203** | **25 passed, 0 failed** |
| unfixed specs, 5 repeats each | 103 | 3 failed, 22 passed |

All three control failures were the 12-character guard, with remainders of `1`, `1` and `4`. The threshold change covers the `4`; the retry covers the `1`s. Note the fixed run was measured at roughly **twice the load** of the control and still went clean.

One methodological note: my first control run reported 20 failures and I did not use it. Its preview server was serving a stale asset manifest after a rebuild, so every failure was a 404, not the flake — it would have flattered this change by a factor of 20. The numbers above are from a server verified healthy first.

## Not included here

A condition-based drain for the **visual** suite is the other half of this and is deliberately in a separate PR: it cannot be verified on this machine (the container's build and preview exceed the 180s webServer budget at this load), so it should stand or fall on CI rather than ride along with work that has local evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for pages loading scripts during navigation and interaction.
  - Strengthened coverage for reduced-motion behavior while animated text is in progress.
  - Added retry handling for timing-sensitive measurements to reduce flaky test results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->