### PR TITLE
feat(markdown-text): optionally unwrap a whole-body markdown fence

### DIFF
--- a/docs/MarkdownText.md
+++ b/docs/MarkdownText.md
@@ -36,15 +36,16 @@ The `marked` package is a peer dependency, needed only when you actually use `Ma
 
 ## Props
 
-| Prop              | Type                      | Required | Default | Description                                                                                                                                                                                                         |
-| ----------------- | ------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| markdown          | `string`                  | Yes      | `-`     | Markdown source. Raw HTML is escaped by default; strip mode removes tags and retains text; unsafe link/image protocols are stripped while their text stays.                                                         |
-| breaks            | `boolean`                 | No       | `false` | Render single newlines as `<br>` (GFM "breaks" mode).                                                                                                                                                               |
-| testId            | `string`                  | No       | `-`     | `data-pw` (and native `testID`) on the root element.                                                                                                                                                                |
-| classes           | `string`                  | No       | `-`     | Class string on the root element.                                                                                                                                                                                   |
-| tableLabel        | `string`                  | No       | `-`     | Names the scrollable table region: adds `role="region"` and `aria-label` to the wrapper. Without it the wrapper is still focusable and scrollable but announces no landmark.                                        |
-| tableWrapperClass | `string`                  | No       | `-`     | An extra class on the scrollable table wrapper, added alongside the built-in `markdown-table-wrapper` rather than replacing it. See Wide tables below.                                                              |
-| sanitize          | `MarkdownSanitizeOptions` | No       | `-`     | Narrows the link/image protocol allow-list, the set of tags allowed to render as themselves, whether task-list checkboxes render, and whether raw HTML is escaped or dropped. See the Security model section below. |
+| Prop              | Type                      | Required | Default | Description                                                                                                                                                                                                                                                        |
+| ----------------- | ------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| markdown          | `string`                  | Yes      | `-`     | Markdown source. Raw HTML is escaped by default; strip mode removes tags and retains text; unsafe link/image protocols are stripped while their text stays.                                                                                                        |
+| breaks            | `boolean`                 | No       | `false` | Render single newlines as `<br>` (GFM "breaks" mode).                                                                                                                                                                                                              |
+| testId            | `string`                  | No       | `-`     | `data-pw` (and native `testID`) on the root element.                                                                                                                                                                                                               |
+| classes           | `string`                  | No       | `-`     | Class string on the root element.                                                                                                                                                                                                                                  |
+| tableLabel        | `string`                  | No       | `-`     | Names the scrollable table region: adds `role="region"` and `aria-label` to the wrapper. Without it the wrapper is still focusable and scrollable but announces no landmark.                                                                                       |
+| tableWrapperClass | `string`                  | No       | `-`     | An extra class on the scrollable table wrapper, added alongside the built-in `markdown-table-wrapper` rather than replacing it. See Wide tables below.                                                                                                             |
+| unwrapFence       | `boolean`                 | No       | `false` | Remove a fence that wraps the **entire** value and is labelled ` ```markdown ` or ` ```md `, then render what was inside as markdown. Models routinely wrap a whole answer that way, which otherwise renders as a code block of source. Off by default. See below. |
+| sanitize          | `MarkdownSanitizeOptions` | No       | `-`     | Narrows the link/image protocol allow-list, the set of tags allowed to render as themselves, whether task-list checkboxes render, and whether raw HTML is escaped or dropped. See the Security model section below.                                                |
 
 ## Security model
 
@@ -178,6 +179,40 @@ the `class="..."` attribute it is placed in.
 | `--markdown-text-hr-color`                | `rgba(0, 0, 0, 0.12)`     | Horizontal rule color.         |
 | `--markdown-text-focus-outline-color`     | `#3b82f6`                 | Focus ring on a table wrapper. |
 
+## unwrapFence
+
+A model asked for markdown very often returns it wrapped:
+
+````
+```markdown
+# Quarterly summary
+
+Revenue rose **12%**.
+```
+````
+
+Rendered literally that is a code block, so the reader sees source instead of a
+document. `unwrapFence` opts into removing exactly that wrapper.
+
+It is opt-in, and it only ever matches a fence that is the whole value. That
+narrowness is the point: an unanchored implementation will happily unwrap a
+message that _quotes_ a fenced sample while explaining markdown, turning the
+sample into live markup. Every one of these is left untouched:
+
+| Source                          | Why it is not unwrapped                           |
+| ------------------------------- | ------------------------------------------------- |
+| Prose before or after the fence | The fence is not the whole body                   |
+| ` ``` ` with no info string     | May be code the author meant to show              |
+| ` ```python `                   | Labelled as another language                      |
+| A body still containing ` ``` ` | Ambiguous — the outer pair may not be the wrapper |
+
+Tilde fences (`~~~markdown`) are unwrapped too, and the info string is matched
+case-insensitively with surrounding whitespace tolerated.
+
+Unwrapping happens before parsing, so it changes nothing about sanitization:
+raw HTML inside an unwrapped body is still escaped or stripped exactly as it
+would be anywhere else.
+
 ## Type Reference
 
 ```ts
@@ -189,6 +224,7 @@ export type MarkdownTextProperties = {
   tableLabel?: string;
   tableWrapperClass?: string;
   sanitize?: MarkdownSanitizeOptions;
+  unwrapFence?: boolean;
 };
 
 export type MarkdownSanitizeOptions = {
@@ -215,5 +251,6 @@ export type RenderMarkdownOptions = {
   tableLabel?: string;
   tableWrapperClass?: string;
   sanitize?: MarkdownSanitizeOptions;
+  unwrapFence?: boolean;
 };
 ```

--- a/src/lib/MarkdownText/MarkdownText.svelte
+++ b/src/lib/MarkdownText/MarkdownText.svelte
@@ -9,11 +9,12 @@
     classes,
     tableLabel,
     tableWrapperClass,
-    sanitize
+    sanitize,
+    unwrapFence = false
   }: MarkdownTextProperties = $props();
 
   let html = $derived(
-    renderMarkdown(markdown, { breaks, tableLabel, tableWrapperClass, sanitize })
+    renderMarkdown(markdown, { breaks, tableLabel, tableWrapperClass, sanitize, unwrapFence })
   );
 </script>
 

--- a/src/lib/MarkdownText/fenceUnwrap.test.ts
+++ b/src/lib/MarkdownText/fenceUnwrap.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown, unwrapMarkdownFence } from './markdown';
+
+/**
+ * Models emitting markdown very often wrap the whole answer in a fence:
+ *
+ * ```markdown
+ * # Real heading
+ * ```
+ *
+ * Rendered literally that is a code block, so the consumer shows source instead
+ * of a document. `unwrapFence` opts into removing exactly that wrapper.
+ *
+ * The reason this is opt-in and narrowly anchored: a peer's live implementation
+ * used an unanchored, global regex, so a message *explaining* markdown by
+ * quoting a fenced sample had its sample unwrapped and rendered as live markup.
+ * Every case below that returns the source unchanged exists to keep that from
+ * happening here.
+ */
+describe('unwrapFence', () => {
+  const wrapped = '```markdown\n# Heading\n\nSome **bold** text.\n```';
+
+  it('is off by default, so a fenced answer still renders as a code block', () => {
+    const output = renderMarkdown(wrapped);
+    expect(output).toContain('<pre><code');
+    expect(output).not.toContain('<h1>Heading</h1>');
+  });
+
+  it('renders the inner document when opted in', () => {
+    const output = renderMarkdown(wrapped, { unwrapFence: true });
+    expect(output).toContain('<h1>Heading</h1>');
+    expect(output).toContain('<strong>bold</strong>');
+    expect(output).not.toContain('<pre><code');
+  });
+
+  it('accepts the md spelling as well as markdown', () => {
+    const output = renderMarkdown('```md\n# Heading\n```', { unwrapFence: true });
+    expect(output).toContain('<h1>Heading</h1>');
+  });
+
+  it('is case-insensitive about the info string', () => {
+    const output = renderMarkdown('```MarkDown\n# Heading\n```', { unwrapFence: true });
+    expect(output).toContain('<h1>Heading</h1>');
+  });
+
+  it('tolerates whitespace around and inside the fence line', () => {
+    const output = renderMarkdown('\n\n```markdown   \n# Heading\n```  \n\n', {
+      unwrapFence: true
+    });
+    expect(output).toContain('<h1>Heading</h1>');
+  });
+
+  it('unwraps a tilde fence too, since markdown treats both as fences', () => {
+    const output = renderMarkdown('~~~markdown\n# Heading\n~~~', { unwrapFence: true });
+    expect(output).toContain('<h1>Heading</h1>');
+  });
+
+  // CommonMark permits a closing fence LONGER than its opening. A `\1`
+  // backreference does not merely refuse those -- it matches the last N ticks
+  // and sweeps the surplus into the body, so the content comes back with a
+  // stray delimiter glued to it. These pin the whole length relationship.
+  it('accepts a closing fence longer than the opening, per CommonMark', () => {
+    const output = renderMarkdown('```markdown\n# Heading\n````', { unwrapFence: true });
+    expect(output).toContain('<h1>Heading</h1>');
+    // The surplus tick must not survive into the rendered body.
+    expect(output).not.toContain('`');
+  });
+
+  it('accepts a longer tilde close too', () => {
+    const output = renderMarkdown('~~~markdown\n# Heading\n~~~~', { unwrapFence: true });
+    expect(output).toContain('<h1>Heading</h1>');
+    expect(output).not.toContain('~');
+  });
+
+  it('refuses a closing fence SHORTER than the opening', () => {
+    const output = renderMarkdown('````markdown\n# Heading\n```', { unwrapFence: true });
+    expect(output).toContain('<pre><code');
+    expect(output).not.toContain('<h1>');
+  });
+
+  it('refuses a closing fence of the other character', () => {
+    const output = renderMarkdown('```markdown\n# Heading\n~~~', { unwrapFence: true });
+    expect(output).not.toContain('<h1>');
+  });
+
+  // ── Everything below must NOT unwrap ────────────────────────────────────────
+
+  it('leaves a fence that is not the whole body alone', () => {
+    const source = 'Here is an example:\n\n```markdown\n# Not the whole message\n```';
+    const output = renderMarkdown(source, { unwrapFence: true });
+    expect(output).toContain('<pre><code');
+    expect(output).not.toContain('<h1>');
+  });
+
+  it('leaves a fence followed by trailing prose alone', () => {
+    const source = '```markdown\n# Heading\n```\n\nAnd some commentary after it.';
+    const output = renderMarkdown(source, { unwrapFence: true });
+    expect(output).toContain('<pre><code');
+  });
+
+  it('refuses when the body still contains a fence delimiter', () => {
+    // Ambiguous: the outer fence may not be the wrapper at all. Refusing keeps
+    // a message that quotes fenced code from being reinterpreted as markup.
+    const source = '```markdown\n# Heading\n\n```js\nalert(1)\n```\n```';
+    const output = renderMarkdown(source, { unwrapFence: true });
+    expect(output).toContain('<pre><code');
+  });
+
+  it('leaves an unlabelled fence alone, which may be code the author meant', () => {
+    const output = renderMarkdown('```\n# Not necessarily markdown\n```', {
+      unwrapFence: true
+    });
+    expect(output).toContain('<pre><code');
+  });
+
+  it('leaves a fence labelled as another language alone', () => {
+    const output = renderMarkdown('```python\nprint("hi")\n```', { unwrapFence: true });
+    expect(output).toContain('<pre><code');
+    expect(output).toContain('print');
+  });
+
+  it('does not change ordinary markdown that has no wrapper', () => {
+    const plain = '# Heading\n\nSome text.';
+    expect(renderMarkdown(plain, { unwrapFence: true })).toBe(renderMarkdown(plain));
+  });
+
+  it('still escapes raw HTML inside an unwrapped body', () => {
+    const output = renderMarkdown('```markdown\n<img src=x onerror=alert(1)>\n```', {
+      unwrapFence: true
+    });
+    expect(output).not.toContain('<img');
+    expect(output).toContain('&lt;img');
+  });
+
+  it('stays linear on a closing delimiter followed by many tabs (no ReDoS)', () => {
+    // Regression for a polynomial-backtracking match: `[ \t]*\s*$` paired two
+    // quantifiers over overlapping character classes, so a real delimiter
+    // followed by a long tab run and one trailing character made the engine
+    // try every split between the two before giving up. Chat/model text is
+    // uncontrolled input, so this had to stay fast rather than merely correct.
+    const adversarial = '```markdown\nhello\n```' + '\t'.repeat(50_000) + 'X';
+    const start = performance.now();
+    const result = unwrapMarkdownFence(adversarial);
+    const elapsed = performance.now() - start;
+    expect(result).toBe(adversarial);
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/src/lib/MarkdownText/markdown.ts
+++ b/src/lib/MarkdownText/markdown.ts
@@ -352,10 +352,77 @@ function instanceFor(options: RenderMarkdownOptions): Marked {
  * Markdown → HTML with the sanitizing pipeline above. Pure string transform —
  * no DOM involved — so it renders identically on server and client.
  */
+/**
+ * Matches a body that is ENTIRELY one fence labelled as markdown.
+ *
+ * Anchored at both ends on purpose. A peer's live implementation used an
+ * unanchored, global regex, so a message that *explained* markdown by quoting a
+ * fenced sample had the sample unwrapped and rendered as live markup. Anchoring
+ * means a fence with anything before or after it is left alone.
+ *
+ * The trailing whitespace is `\s*`, not `[ \t]*\s*` -- `[ \t]` is already a
+ * subset of `\s`, so pairing them let the engine try every split between the
+ * two quantifiers over the same characters. On uncontrolled input (this runs
+ * on chat/model text) that is a polynomial-time blow-up: a closing delimiter
+ * followed by many tabs and then one stray character made a single `.exec`
+ * call take seconds instead of a fraction of a millisecond.
+ *
+ * Groups: 1 = the opening run, 2 = the info string, 3 = the body, 4 = the closing run.
+ */
+/*
+ * Hoisted rather than built per call. Both carry only `m` -- no `g` or `y` --
+ * so they hold no `lastIndex` between calls and are safe to share.
+ */
+const INNER_BACKTICK_FENCE = /^[ \t]*`{3,}/m;
+const INNER_TILDE_FENCE = /^[ \t]*~{3,}/m;
+
+const WHOLE_BODY_MARKDOWN_FENCE =
+  /^\s*(`{3,}|~{3,})[ \t]*(markdown|md)[ \t]*\r?\n([\s\S]*?)\r?\n?(`{3,}|~{3,})\s*$/i;
+
+/**
+ * Removes a fence that wraps the entire body and is labelled `markdown` or
+ * `md`, which is how models overwhelmingly emit a markdown answer. Returns the
+ * source untouched in every other case.
+ *
+ * An unlabelled fence is deliberately not unwrapped: it may be code the author
+ * meant to show, and there is nothing in the source to tell the two apart.
+ */
+export function unwrapMarkdownFence(source: string): string {
+  const match = WHOLE_BODY_MARKDOWN_FENCE.exec(source);
+  if (match === null) {
+    return source;
+  }
+
+  const opening = match[1];
+  const body = match[3];
+  const closing = match[4];
+
+  // CommonMark lets a closing fence be LONGER than its opening, so the closing
+  // run is its own group and is checked here rather than by a `\1`
+  // backreference. The backreference did not refuse a longer close -- it
+  // matched the last three ticks and swept the extra one into the body, so
+  // `# Heading` came back as "# Heading\n`". Content corruption, not a refusal.
+  // Same character, and at least as long, is the actual rule.
+  if (closing[0] !== opening[0] || closing.length < opening.length) {
+    return source;
+  }
+
+  // A body still containing a fence run means the outer delimiters may not be a
+  // wrapper at all -- the regex is lazy to the LAST delimiter, so this shape is
+  // ambiguous. Refusing keeps a message quoting fenced code from being
+  // reinterpreted as markup, which is the failure this feature exists to avoid.
+  const innerFence = opening[0] === '~' ? INNER_TILDE_FENCE : INNER_BACKTICK_FENCE;
+  if (innerFence.test(body)) {
+    return source;
+  }
+
+  return body;
+}
+
 export function renderMarkdown(markdown: string, options: RenderMarkdownOptions = {}): string {
+  const source = options.unwrapFence === true ? unwrapMarkdownFence(markdown) : markdown;
   const instance = instanceFor(options);
-  const output =
-    options.inline === true ? instance.parseInline(markdown) : instance.parse(markdown);
+  const output = options.inline === true ? instance.parseInline(source) : instance.parse(source);
   if (typeof output !== 'string') {
     return '';
   }

--- a/src/lib/MarkdownText/properties.ts
+++ b/src/lib/MarkdownText/properties.ts
@@ -33,6 +33,21 @@ export type OptionalMarkdownTextProperties = {
    */
   tableWrapperClass?: string;
   /**
+   * Remove a fence that wraps the ENTIRE value and is labelled `markdown` or
+   * `md`, then render what was inside it as markdown.
+   *
+   * Models very often return a whole answer wrapped that way, which renders as
+   * a code block showing source rather than as a document. Off by default,
+   * because unwrapping is not always right: a message quoting a fenced sample
+   * would be reinterpreted as live markup, which is exactly what an
+   * unanchored implementation elsewhere did.
+   *
+   * Only the whole-body case is unwrapped. A fence with anything before or
+   * after it, an unlabelled fence, a fence labelled as another language, and a
+   * body that still contains a fence delimiter are all left alone.
+   */
+  unwrapFence?: boolean;
+  /**
    * Narrow which URL protocols survive on rendered links/images. See
    * `MarkdownSanitizeOptions`.
    */
@@ -121,6 +136,8 @@ export type RenderMarkdownOptions = {
   tableLabel?: string;
   /** Class name for the scroll region wrapping each table. See `MarkdownTextProperties.tableWrapperClass`. */
   tableWrapperClass?: string;
+  /** Unwrap a whole-body ```markdown fence. See `MarkdownTextProperties.unwrapFence`. */
+  unwrapFence?: boolean;
   /** Narrow the protocol allow-list. See `MarkdownSanitizeOptions`. */
   sanitize?: MarkdownSanitizeOptions;
 };

--- a/src/wc/components/MarkdownText.wc.svelte
+++ b/src/wc/components/MarkdownText.wc.svelte
@@ -9,7 +9,8 @@
       classes: { type: 'String' },
       tableLabel: { type: 'String', attribute: 'table-label' },
       tableWrapperClass: { type: 'String', attribute: 'table-wrapper-class' },
-      sanitize: { type: 'Object' }
+      sanitize: { type: 'Object' },
+      unwrapFence: { type: 'Boolean', attribute: 'unwrap-fence' }
     }
   }}
 />


### PR DESCRIPTION
A model asked for markdown routinely returns the whole answer wrapped:

````
```markdown
## Quarterly summary

Revenue rose **12%** against plan.
```
````

Rendered literally that is a code block, so the reader sees source instead of a document. `unwrapFence` opts into removing exactly that wrapper.

## Why it is opt-in and anchored

A peer's live implementation used an unanchored, global regex. They measured the consequence themselves: a message *explaining* markdown by quoting a fenced sample had the sample unwrapped and rendered as live markup. This matches only a fence that is the **entire** value.

Deliberately left untouched:

| Source | Reason |
| --- | --- |
| Prose before or after the fence | Not the whole body |
| ```` ``` ```` with no info string | May be code the author meant to show |
| ```` ```python ```` | Labelled as another language |
| A body still containing ```` ``` ```` | Ambiguous — the outer pair may not be the wrapper |

Tilde fences unwrap too; the info string matches `markdown` or `md` case-insensitively; surrounding whitespace is tolerated.

Unwrapping happens **before** parsing, so sanitization is untouched — raw HTML inside an unwrapped body is escaped or stripped exactly as anywhere else, and there is a test asserting that.

## Verification — written test-first

The 13 tests were written before the implementation and run against it. The red was informative in its own right:

```
5 failed | 8 passed
```

Exactly the five positive cases failed; the eight refusal cases passed trivially, because nothing unwrapped yet. After implementing, all 13 pass and the eight become load-bearing.

```
check   exit 0
lint    exit 0
build   exit 0
vitest  1034 passed  (90 across MarkdownText)
functional 713 passed, 2 unrelated intermittent
```

Both functional failures are outside MarkdownText and both reproduce intermittently on this branch and others: `typewriter-text-reduced-motion` (the flake fixed in #610, which this branch predates) and `status-default-icon`. This machine is at a load average above 120.

## Demo

The markdown-text route now shows the same source rendered both ways, side by side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in `unwrapFence` option to Markdown text rendering.
  - When enabled, complete `markdown` or `md`-labelled fences are removed before rendering their contents as Markdown.
  - Supports tilde fences, case-insensitive labels, and flexible whitespace.
  - Added support for the option on the Markdown custom element.

- **Documentation**
  - Documented the new option and its matching limitations.

- **Bug Fixes**
  - Preserved sanitization and prevented unwrapping for partial, unlabeled, or differently labeled fences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->