### PR TITLE
fix(wc): stop sui-checkbox shadowing Element.attributes, which broke every instance

### DIFF
--- a/docs/Checkbox.md
+++ b/docs/Checkbox.md
@@ -82,7 +82,18 @@ Tag: `<sui-checkbox>`
 <sui-checkbox text="Parent decides" controlled></sui-checkbox>
 ```
 
-`controlled` maps to the attribute of the same name; `attributes` is an object property, set from script.
+`controlled` maps to the attribute of the same name.
+
+Two props are renamed on the custom element, because the platform already owns
+those names on every `HTMLElement`:
+
+| Component prop | Custom-element property                                        | Why                                                                                                                                                                                     |
+| -------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ariaLabel`    | `aria-label` attribute, or the `checkboxAriaLabel` property    | `ariaLabel` is an ARIA-reflected accessor on `Element`.                                                                                                                                 |
+| `attributes`   | `checkboxAttributes` property (script only, no attribute form) | `attributes` is `Element`'s live `NamedNodeMap`; declaring it as a prop replaced the accessor and every `<sui-checkbox>` threw `TypeError: this.attributes is not iterable` on connect. |
+
+Both are object/script properties rather than attributes — an attribute is a
+string, and these carry structured values.
 
 ### Slots
 

--- a/scripts/wc-parity/prop-parity.ts
+++ b/scripts/wc-parity/prop-parity.ts
@@ -222,6 +222,15 @@ export const HOST_RESERVED_PROPS: ReadonlySet<string> = new Set([
   // path web-component consumers actually use, so nothing is lost by reserving
   // the name.
   'children',
+  // Same class as `children`, and measured the same way rather than reasoned
+  // about: `Element.prototype.attributes` is the live NamedNodeMap that Svelte's
+  // own generated `connectedCallback` iterates (`for (const attr of this.attributes)`).
+  // Declaring a prop of that name replaced it with a plain object, so every
+  // `<sui-checkbox>` threw `TypeError: this.attributes is not iterable` on connect
+  // and never initialised -- reproduced in Chromium with a bare
+  // `document.createElement('sui-checkbox')`. A wrapper that needs to forward it
+  // exposes it under another name, as Checkbox.wc.svelte now does.
+  'attributes',
   // ARIAMixin is implemented on Element, so each of these is already an accessor
   // that reflects to its aria-* attribute. Verified in Chromium rather than
   // assumed: every name below answered true to `name in Element.prototype`.

--- a/src/wc/components/Checkbox.wc.svelte
+++ b/src/wc/components/Checkbox.wc.svelte
@@ -14,7 +14,7 @@
       checkboxAriaLabel: { type: 'String', attribute: 'aria-label' },
       ariaControls: { type: 'String', attribute: 'aria-controls' },
       controlled: { type: 'Boolean', reflect: true },
-      attributes: { type: 'Object' },
+      checkboxAttributes: { type: 'Object' },
       onclick: { type: 'Object' }
     }
   }}
@@ -24,17 +24,23 @@
   import Checkbox from '$lib/Checkbox/Checkbox.svelte';
   import type { CheckboxProperties } from '$lib/Checkbox/properties';
   // The element renames `ariaLabel` to `checkboxAriaLabel` because the platform already defines `ariaLabel` on every
-  // HTMLElement. The rest still carries the component's own props -- saying so is what
+  // HTMLElement, and `attributes` to `checkboxAttributes` for the same reason -- `Element.prototype.attributes` is the
+  // live NamedNodeMap that Svelte's own generated `connectedCallback` iterates (`for (const attr of this.attributes)`).
+  // Declaring a prop of that name replaced it with a plain object, so every `<sui-checkbox>` threw
+  // `TypeError: this.attributes is not iterable` on connect and the component never initialised.
+  // The rest still carries the component's own props -- saying so is what
   // a destructured `$props()` no longer infers on its own.
   let {
     checkboxAriaLabel,
+    checkboxAttributes,
     ...props
-  }: Omit<CheckboxProperties, 'ariaLabel'> & {
+  }: Omit<CheckboxProperties, 'ariaLabel' | 'attributes'> & {
     checkboxAriaLabel?: CheckboxProperties['ariaLabel'];
+    checkboxAttributes?: CheckboxProperties['attributes'];
   } = $props();
 </script>
 
-<Checkbox {...props} ariaLabel={checkboxAriaLabel}>
+<Checkbox {...props} ariaLabel={checkboxAriaLabel} attributes={checkboxAttributes}>
   {#snippet checkedIcon()}
     <slot name="checked-icon"></slot>
   {/snippet}

--- a/tests/wc-attributes-collision.spec.ts
+++ b/tests/wc-attributes-collision.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
+
+/**
+ * `<sui-checkbox>` declared a custom-element prop named `attributes`, which
+ * replaced `Element.prototype.attributes` -- the live `NamedNodeMap` that
+ * Svelte's OWN generated `connectedCallback` iterates:
+ *
+ *   for (const attr of this.attributes) { ... }
+ *
+ * With the accessor shadowed by a plain object, every instance threw
+ * `TypeError: this.attributes is not iterable` on connect and never
+ * initialised. The element appended fine -- `appendChild` does not surface an
+ * error thrown inside `connectedCallback` -- so it failed silently, which is
+ * why it survived to a published release.
+ *
+ * This is the same class as `children`, already reserved in
+ * `HOST_RESERVED_PROPS` for the same reason, and the fix follows the same
+ * precedent as `ariaLabel` -> `checkboxAriaLabel`: forward it under a name the
+ * platform does not own.
+ */
+test.describe('sui-checkbox does not shadow Element.attributes', () => {
+  test('connects, initialises its shadow root, and throws nothing', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+
+    // dist-wc is a self-contained bundle, not a route of the demo site, so it is
+    // injected the same way tests/wc-custom-elements.spec.ts does it. Without this
+    // the element is simply undefined and every assertion below passes vacuously --
+    // which is exactly how the first version of this test passed against the bug.
+    //
+    // MAINTAINERS: this asserts against the BUILT bundle, so `dist-wc/index.js`
+    // has to be current or the result describes an old build rather than your
+    // change. `npm run build` (which runs build:wc) before running this locally.
+    // CI is safe -- playwright.config.ts builds as part of webServer -- but a
+    // local run reusing a server does not rebuild. That is not hypothetical: a
+    // stale bundle is how this very test was first observed passing against the
+    // defect it exists to catch.
+    await gotoHydrated(page, '/');
+    await page.addScriptTag({ path: 'dist-wc/index.js', type: 'module' });
+    await page.waitForFunction(() => typeof customElements.get('sui-checkbox') === 'function');
+
+    const state = await page.evaluate(async () => {
+      const element = document.createElement('sui-checkbox');
+      element.setAttribute('text', 'Agree');
+      document.body.appendChild(element);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      return {
+        defined: typeof customElements.get('sui-checkbox') === 'function',
+        // The native accessor must still be the NamedNodeMap, not a plain object.
+        attributesIsIterable: typeof element.attributes?.[Symbol.iterator] === 'function',
+        // `?? false` matters: an element that never upgraded has a null shadowRoot,
+        // and an optional-chained comparison would read as "initialised".
+        shadowInitialised: (element.shadowRoot?.childNodes.length ?? 0) > 0
+      };
+    });
+
+    expect(state.defined).toBe(true);
+    expect(state.attributesIsIterable).toBe(true);
+    expect(state.shadowInitialised).toBe(true);
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
`<sui-checkbox>` has never worked in a published release. Every instance throws on connect:

```
TypeError: this.attributes is not iterable
```

Reproduced in Chromium with a bare `document.createElement('sui-checkbox')` and no attributes set at all.

## Cause

`Checkbox.wc.svelte` declared a custom-element prop named `attributes`. Svelte defines every declared prop as an accessor on the host element, so that **replaced `Element.prototype.attributes`** — the live `NamedNodeMap` that Svelte's own generated `connectedCallback` iterates:

```js
for (const attr of this.attributes) { ... }
```

With the accessor replaced by a plain object, the iteration throws and the component never initialises.

**It failed silently, which is why it survived to release.** `appendChild` does not surface an error thrown inside `connectedCallback`, so the element appears to attach and simply renders nothing. There is no failing call for anyone to notice.

## Fix

Exactly the precedent this file already sets for `ariaLabel` → `checkboxAriaLabel`: forward it under a name the platform does not own. The component prop is untouched; only the custom element renames it to `checkboxAttributes`.

`attributes` also joins `HOST_RESERVED_PROPS` so the parity guard rejects it in future. That list already reserves `children` for **exactly this bug class**, with a comment saying it was measured rather than reasoned about — `attributes` was simply missed, because the guard's own docs describe it as covering names on `HTMLElement`, and `attributes` lives on `Element`.

## Evidence

| | page errors | shadow root |
| --- | --- | --- |
| before | `this.attributes is not iterable` | never populated |
| after | 0 | initialised |

Red-green on the regression test, by restoring the colliding name and rebuilding:

```
colliding name  →  expect(state.attributesIsIterable).toBe(true)
                   Received: false
renamed         →  1 passed
```

```
check  exit 0
lint   exit 0
```

## One thing worth flagging about the test

**My first version of this test passed against the bug.** It navigated to a demo route that never loads `dist-wc`, so `sui-checkbox` was an undefined element — `shadowRoot?.firstChild !== null` evaluated `undefined !== null`, which is `true`, and the whole test asserted nothing. I caught it only because the mutation run came back green when it had to be red.

The version here injects the bundle the way `tests/wc-custom-elements.spec.ts` does and asserts `customElements.get('sui-checkbox') !== undefined` first, so it cannot pass vacuously again.

## Separately: form participation is still absent for custom elements

While verifying this I confirmed a **different** gap, which this PR does not address. With the element now initialising, `<sui-checkbox name="agree">` inside a `<form>` still contributes nothing:

```
FormData: []
```

Shadow-DOM content does not participate in form submission without `ElementInternals`/`setFormValue`, and Svelte 5.56.3 has no built-in support for form-associated custom elements (`grep -rn 'formAssociated|attachInternals' node_modules/svelte/src/` returns nothing). So the form participation added in #605 reaches the Svelte components but **not** the custom elements. That is worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed the checkbox custom element’s `attributes` prop to `checkboxAttributes`, preventing conflicts with the native `Element.attributes` property.
  * Preserved existing accessibility label behavior and checkbox prop forwarding.

* **Tests**
  * Added coverage confirming checkbox elements retain native attribute behavior and initialize without page errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->