### PR TITLE
fix(migrate): stop the doc rename treating a controller option as a component prop

### DIFF
--- a/scripts/migrate/rename-doc-usages.test.ts
+++ b/scripts/migrate/rename-doc-usages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { planDocRenames, rewriteDoc } from './rename-doc-usages.ts';
+import { configCallbackNames, planDocRenames, rewriteDoc } from './rename-doc-usages.ts';
 
 // Names that also appear as callback keys on config objects, so are
 // ambiguous in prose; `planDocRenames` derives the real set from src/lib.
@@ -66,6 +66,19 @@ describe('rewriteDoc', () => {
 });
 
 describe('the reference docs', () => {
+  it('treats a headless controller option as ambiguous, not as a component prop', () => {
+    // `onError` is a deprecated prop on Input/Table AND a live option on
+    // SpeechToTextOptions/ChatOptions, which live in types.ts. Scanning only
+    // properties.ts missed the second kind, so a bare prose mention in any doc
+    // was rewritten as though it were the deprecated prop -- which is why
+    // SpeechSynthesisOptions had to misspell its own callback to get past this.
+    const ambiguous = configCallbackNames(process.cwd());
+    expect(ambiguous.has('onError')).toBe(true);
+
+    const doc = 'The `onError` option fires when synthesis fails.\n';
+    expect(rewriteDoc('/x/docs/SpeechSynthesis.md', doc, ambiguous)).toBe(doc);
+  });
+
   it('never recommend a spelling the library deprecates', () => {
     // docs/ is what the MCP server serves to consumers: a deprecated name
     // here is an instruction to use something 4.0.0 removes.

--- a/scripts/migrate/rename-doc-usages.ts
+++ b/scripts/migrate/rename-doc-usages.ts
@@ -33,30 +33,46 @@ const escapeRegExp = (literal: string): string => literal.replace(/[.*+?^${}()|[
 
 /**
  * Every `on*` callback declared somewhere other than a component's own props
- * — a config object's key, or a nested member — across `src/lib`. Ambiguous
- * in prose, see rule 3.
+ * — a config object's key, a nested member, or a headless controller's options
+ * bag — across `src/lib`. Ambiguous in prose, see rule 3.
+ *
+ * Both `properties.ts` and `types.ts` are read. `properties.ts` alone missed an
+ * entire category: a controller's options live in `types.ts`
+ * (`SpeechToTextOptions.onError`, `ChatOptions.onError`), so those names were
+ * never marked ambiguous and every bare prose mention of them anywhere in
+ * `docs/` was rewritten as though it were a deprecated component prop. That is
+ * not theoretical — it is why `SpeechSynthesisOptions` had to spell its error
+ * callback `onerror`, inconsistently with its own sibling, purely to get past
+ * this check.
  */
-function configCallbackNames(root: string): ReadonlySet<string> {
+export function configCallbackNames(root: string): ReadonlySet<string> {
   const names = new Set<string>();
   const lib = join(root, 'src', 'lib');
   for (const entry of readdirSync(lib)) {
-    const file = join(lib, entry, 'properties.ts');
-    if (!existsSync(file)) {
-      continue;
-    }
-    let owner = '';
-    for (const line of readFileSync(file, 'utf8').split('\n')) {
-      const typeLine = /^(?:export )?type (\w+)\b/.exec(line);
-      if (typeLine !== null) {
-        owner = typeLine[1];
+    for (const source of ['properties.ts', 'types.ts']) {
+      const file = join(lib, entry, source);
+      if (!existsSync(file)) {
+        continue;
       }
-      const declaration = /^(\s*)(on[A-Za-z]+)\??:/.exec(line);
-      if (declaration !== null && (!owner.endsWith('Properties') || declaration[1].length !== 2)) {
-        names.add(declaration[2]);
-      }
+      collectCallbackNames(readFileSync(file, 'utf8'), names);
     }
   }
   return names;
+}
+
+/** Shared by both source files; `owner` resets per file, never across them. */
+function collectCallbackNames(text: string, names: Set<string>): void {
+  let owner = '';
+  for (const line of text.split('\n')) {
+    const typeLine = /^(?:export )?type (\w+)\b/.exec(line);
+    if (typeLine !== null) {
+      owner = typeLine[1];
+    }
+    const declaration = /^(\s*)(on[A-Za-z]+)\??:/.exec(line);
+    if (declaration !== null && (!owner.endsWith('Properties') || declaration[1].length !== 2)) {
+      names.add(declaration[2]);
+    }
+  }
 }
 
 // A tag's attributes, up to but not across its closing `>`. An arrow inside an


### PR DESCRIPTION
`configCallbackNames` exists to mark an `on*` callback **ambiguous** when it is declared somewhere other than a component's own props, so a bare prose mention is left alone instead of being rewritten as a deprecated prop spelling.

It only ever read `properties.ts`.

That misses an entire category: a headless controller's options live in `types.ts`.

```
onError declared as a component prop   →  Input, InputButton, Table   (properties.ts)
onError declared as a controller option →  SpeechToText, Chat          (types.ts)  ← never scanned
```

So `onError` was never marked ambiguous, and every bare mention of it anywhere under `docs/` was rewritten as though it were the deprecated prop.

## The cost was real, not theoretical

`SpeechSynthesisOptions` spells its error callback **`onerror`** — inconsistent with the sibling controller it mirrors (`SpeechToTextOptions.onError`) and with `onSpeakingChange` / `onDiagnostic` sitting beside it in the same type. It carries a comment saying it is spelled that way *"to match what scripts/migrate/rename-doc-usages.ts forces docs/SpeechSynthesis.md to say."*

An API was bent to fit a lint rule that was wrong. Fixing the rule is what unblocks straightening the API — see #604, where I attempted the rename, hit this guard, and reverted rather than smuggle a tooling change into a feature PR.

## Nothing else changes

The design already distinguishes the cases correctly; only the input to it was incomplete.

- **Tag rewriting** is untouched — position already disambiguates `<Input onError={…}>`.
- **A component's own doc** still rewrites via `ownPairs`, so `docs/Input.md` and `docs/Table.md` keep being corrected.
- Only **bare prose in an unrelated doc** stops being rewritten, which is exactly the bug.

## Verification

Red-green, by reverting the scan to `properties.ts` only:

```
properties.ts only  →  × treats a headless controller option as ambiguous, not as a component prop
                       AssertionError: expected false to be true
both files          →  9 passed
```

```
check   exit 0
lint    exit 0
build   exit 0
vitest  1022 passed
```

The existing `never recommend a spelling the library deprecates` test still passes, which is the guard against this change loosening anything it should not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation migration accuracy for callback options, preventing ambiguous names such as `onError` from being rewritten incorrectly.
  * Ensured callback names are evaluated consistently across controller configuration and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->