### PR TITLE
fix(migrate): bound the whole-repo scan tests on their own timeout, not vitest's default

### DIFF
--- a/scripts/migrate/alias-wc-props.test.ts
+++ b/scripts/migrate/alias-wc-props.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { REPO_SCAN_TIMEOUT_MS } from './repo-scan-timeout.ts';
 import {
   declareProps,
   isEventProp,
@@ -28,14 +29,18 @@ ${props}
 `;
 
 describe('phase 1 wrapper declarations', () => {
-  it('has nothing left to do, because every declaration is already applied', () => {
-    // The idempotence check, and the reason the transform is safe to keep in the
-    // tree: it plans from the parity ratchet's `missing` list, which is empty
-    // once the declarations exist, so a second --apply rewrites nothing.
-    const { additions } = planWrapperProps(root);
+  it(
+    'has nothing left to do, because every declaration is already applied',
+    () => {
+      // The idempotence check, and the reason the transform is safe to keep in the
+      // tree: it plans from the parity ratchet's `missing` list, which is empty
+      // once the declarations exist, so a second --apply rewrites nothing.
+      const { additions } = planWrapperProps(root);
 
-    expect(additions).toEqual([]);
-  });
+      expect(additions).toEqual([]);
+    },
+    REPO_SCAN_TIMEOUT_MS
+  );
 
   it('appends a declaration at the indentation the existing entries use', () => {
     const source = wrapper("      checked: { type: 'Boolean', reflect: true }");

--- a/scripts/migrate/lowercase-event-props.test.ts
+++ b/scripts/migrate/lowercase-event-props.test.ts
@@ -7,6 +7,7 @@ import {
   groupDeclarations
 } from './lowercase-event-props.ts';
 import type { ComponentNote } from './lowercase-event-props.ts';
+import { REPO_SCAN_TIMEOUT_MS } from './repo-scan-timeout.ts';
 
 const PROPERTIES = [
   'export type ToggleEventProperties = {',
@@ -187,9 +188,13 @@ describe('lowercaseComponent', () => {
 });
 
 describe('the repository', () => {
-  it('has nothing left for the generator to do', () => {
-    const { changes, notes } = planLowercase(process.cwd());
-    expect(changes.map((change) => change.file)).toEqual([]);
-    expect(notes).toEqual([]);
-  });
+  it(
+    'has nothing left for the generator to do',
+    () => {
+      const { changes, notes } = planLowercase(process.cwd());
+      expect(changes.map((change) => change.file)).toEqual([]);
+      expect(notes).toEqual([]);
+    },
+    REPO_SCAN_TIMEOUT_MS
+  );
 });

--- a/scripts/migrate/remove-event-aliases.test.ts
+++ b/scripts/migrate/remove-event-aliases.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { REPO_SCAN_TIMEOUT_MS } from './repo-scan-timeout.ts';
 import { groupDeclarations, scanDeclarations } from './lowercase-event-props.ts';
 import type { ComponentNote } from './lowercase-event-props.ts';
 import {
@@ -325,9 +326,13 @@ describe('removeAliasesFromComponent', () => {
 });
 
 describe('the repository', () => {
-  it('has nothing left for the generator to do', () => {
-    const { changes, notes } = planRemoval(process.cwd());
-    expect(changes.map((change) => change.file)).toEqual([]);
-    expect(notes).toEqual([]);
-  });
+  it(
+    'has nothing left for the generator to do',
+    () => {
+      const { changes, notes } = planRemoval(process.cwd());
+      expect(changes.map((change) => change.file)).toEqual([]);
+      expect(notes).toEqual([]);
+    },
+    REPO_SCAN_TIMEOUT_MS
+  );
 });

--- a/scripts/migrate/rename-doc-usages.test.ts
+++ b/scripts/migrate/rename-doc-usages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { configCallbackNames, planDocRenames, rewriteDoc } from './rename-doc-usages.ts';
+import { REPO_SCAN_TIMEOUT_MS } from './repo-scan-timeout.ts';
 
 // Names that also appear as callback keys on config objects, so are
 // ambiguous in prose; `planDocRenames` derives the real set from src/lib.
@@ -79,9 +80,13 @@ describe('the reference docs', () => {
     expect(rewriteDoc('/x/docs/SpeechSynthesis.md', doc, ambiguous)).toBe(doc);
   });
 
-  it('never recommend a spelling the library deprecates', () => {
-    // docs/ is what the MCP server serves to consumers: a deprecated name
-    // here is an instruction to use something 4.0.0 removes.
-    expect(planDocRenames(process.cwd()).map((item) => item.file)).toEqual([]);
-  });
+  it(
+    'never recommend a spelling the library deprecates',
+    () => {
+      // docs/ is what the MCP server serves to consumers: a deprecated name
+      // here is an instruction to use something 4.0.0 removes.
+      expect(planDocRenames(process.cwd()).map((item) => item.file)).toEqual([]);
+    },
+    REPO_SCAN_TIMEOUT_MS
+  );
 });

--- a/scripts/migrate/rename-internal-usages.test.ts
+++ b/scripts/migrate/rename-internal-usages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { transformSvelte } from '../codemod/transform.ts';
 import { INTERNAL_OPTIONS, planInternalRenames } from './rename-internal-usages.ts';
+import { REPO_SCAN_TIMEOUT_MS } from './repo-scan-timeout.ts';
 
 describe('internal import resolution', () => {
   it('treats a default import of $lib/X/X.svelte as component X', () => {
@@ -45,11 +46,15 @@ describe('internal import resolution', () => {
 });
 
 describe('the repository itself', () => {
-  it('never uses a spelling it deprecates', () => {
-    // Anything listed here is a call site that would warn in a consumer's
-    // console for code they did not write, and break outright in 4.0.0.
-    const plan = planInternalRenames(process.cwd());
+  it(
+    'never uses a spelling it deprecates',
+    () => {
+      // Anything listed here is a call site that would warn in a consumer's
+      // console for code they did not write, and break outright in 4.0.0.
+      const plan = planInternalRenames(process.cwd());
 
-    expect(plan.map((item) => `${item.file}: ${item.propsRenamed}`)).toEqual([]);
-  });
+      expect(plan.map((item) => `${item.file}: ${item.propsRenamed}`)).toEqual([]);
+    },
+    REPO_SCAN_TIMEOUT_MS
+  );
 });

--- a/scripts/migrate/repo-scan-timeout.ts
+++ b/scripts/migrate/repo-scan-timeout.ts
@@ -1,0 +1,20 @@
+/**
+ * Timeout for the tests that scan the whole repository.
+ *
+ * Each of them parses every component, doc or wrapper in the tree to assert
+ * the repo has nothing left for its generator to rewrite. That work scales
+ * with the size of the repo and with how busy the machine is: 1.0s to 3.0s
+ * per test on an idle one, which leaves the slowest under 2x headroom against
+ * vitest's 5000ms default. A loaded machine closes that gap --
+ * `rename-internal-usages` was observed failing at 5538ms against a 2140ms
+ * idle baseline, reported as `Test timed out in 5000ms`, which reads as a
+ * code failure and is not one.
+ *
+ * A timeout on these is a hang detector, not a performance budget: they have
+ * no timing behaviour to assert, so the bound only needs to be far enough out
+ * that a real hang still fails the run rather than stalling it. Raising
+ * vitest's global `testTimeout` instead would buy the same headroom for these
+ * five at the cost of weakening it for the ~1000 tests that genuinely should
+ * finish in milliseconds.
+ */
+export const REPO_SCAN_TIMEOUT_MS = 60_000;


### PR DESCRIPTION
Five tests parse the entire repository to assert it has nothing left for its
generator to rewrite -- every component for the internal rename, every doc for
the doc rename, every wrapper for the wc aliasing, and so on. They are the
guards that stop the library shipping a spelling it deprecates.

They also take 1.0s to 3.0s each on an idle machine, against vitest's 5000ms
default. Measured, serially, on this tree:

  alias-wc-props          2976ms
  rename-internal-usages  2140ms
  rename-doc-usages       1634ms
  remove-event-aliases    1429ms
  lowercase-event-props   1338ms

The slowest has under 2x headroom, which a busy machine erases:
`rename-internal-usages` was observed failing as `Test timed out in 5000ms` at
5538ms while the host sat at a load average of ~180. Nothing was wrong with it.
The scan had simply been descheduled, and the run reported a code failure.

That is the worst shape a CI failure can take. It names a real guard, it points
at a real file, and it is noise -- so the cost is not the red build, it is that
the next genuine failure in one of these five reads as "that flaky timeout
again".

A timeout here is a hang detector, not a performance budget: these tests assert
nothing about how long they take, so the bound only has to be far enough out
that a real hang still fails the run. 60s is roughly 20x the slowest measured
time and still fails a genuine hang inside one test's runtime.

Raising vitest's global `testTimeout` instead would buy the same headroom for
these five and quietly weaken it for the ~1000 tests that genuinely should
finish in milliseconds, so the constant is applied per test and lives in one
place with the reasoning attached.

Verified by inversion rather than by the change passing: with the constant set
to 100ms, exactly these five fail with `Test timed out in 100ms` and no others
do, which shows the argument is wired to the timeout and that the set is the
one intended. At 60_000 the migrate suite is 76 passing in 8 files.

Gate on this commit: prettier clean, eslint 0, event-casing 0, svelte-check 0
errors across both tsconfigs, check:migrate 0, 1054 unit tests passing.

Prompted by review of #610, which fixed this same class of load-sensitivity in
two Playwright specs. These five are the unit-suite equivalent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability for repository-wide migration tests by applying a dedicated 60-second timeout.
  * Reduced the risk of false test failures on slower or heavily loaded machines.
  * Test assertions and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->