### PR TITLE
feat(table): let a consumer choose the container's overflow

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -532,16 +532,17 @@ Override these custom properties to theme the component.
 
 ### Container & Layout
 
-| Variable                     | Default             | CSS Property          | Description                                                                                                |
-| ---------------------------- | ------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `--table-border`             | `1px solid #e5e7eb` | border                | Border of the table container.                                                                             |
-| `--table-border-radius`      | `8px`               | border-radius         | Border radius of the table container.                                                                      |
-| `--table-container-width`    | `100%`              | width                 | Width of the table container.                                                                              |
-| `--table-container-height`   | `143px`             | height                | Height of the scrollable table container (when isTableScrollable).                                         |
-| `--table-width`              | `100%`              | width                 | Width of the table element.                                                                                |
-| `--table-border-collapse`    | `collapse`          | border-collapse       | Border collapse mode of the table.                                                                         |
-| `--table-scroll-scrim-width` | `32px`              | width                 | Width of the fade-out gradient hint shown at the leading/trailing edge of a horizontally scrollable table. |
-| `--table-scroll-scrim-color` | `#ffffff`           | background (gradient) | Color the scroll scrim fades from — set to match the table's background when it isn't white.               |
+| Variable                     | Default             | CSS Property          | Description                                                                                                                                                     |
+| ---------------------------- | ------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--table-border`             | `1px solid #e5e7eb` | border                | Border of the table container.                                                                                                                                  |
+| `--table-border-radius`      | `8px`               | border-radius         | Border radius of the table container.                                                                                                                           |
+| `--table-container-width`    | `100%`              | width                 | Width of the table container.                                                                                                                                   |
+| `--table-container-height`   | `143px`             | height                | Height of the scrollable table container (when isTableScrollable).                                                                                              |
+| `--table-container-overflow` | `hidden`            | overflow              | Overflow of the table container. `hidden` clips the corners to `--table-border-radius`; set `auto` to let a wide table scroll sideways in the container itself. |
+| `--table-width`              | `100%`              | width                 | Width of the table element.                                                                                                                                     |
+| `--table-border-collapse`    | `collapse`          | border-collapse       | Border collapse mode of the table.                                                                                                                              |
+| `--table-scroll-scrim-width` | `32px`              | width                 | Width of the fade-out gradient hint shown at the leading/trailing edge of a horizontally scrollable table.                                                      |
+| `--table-scroll-scrim-color` | `#ffffff`           | background (gradient) | Color the scroll scrim fades from — set to match the table's background when it isn't white.                                                                    |
 
 ### Cell Grid
 
@@ -707,25 +708,25 @@ A second search-input mode (`searchConfig.displayMode: 'inline'`) — a trigger 
 
 These variables style the leading checkbox column that appears when `checkboxSelection` is set. The column renders the library `Checkbox` in controlled mode; every `--table-checkbox-*` token below is bridged onto the matching `--checkbox-*` variable inside the column, so theming the table keeps working and an app-wide `Checkbox` theme is overridden only there.
 
-| Variable                                      | Default                          | CSS Property     | Description                                                                |
-| --------------------------------------------- | -------------------------------- | ---------------- | -------------------------------------------------------------------------- |
-| `--table-checkbox-col-width`                  | `44px`                           | width            | Width of the checkbox column header and data cells.                        |
-| `--table-checkbox-col-padding`                | `12px 12px`                      | padding          | Padding of the checkbox column cells.                                      |
-| `--table-checkbox-size`                       | `18px`                           | width, height    | Size (width and height) of the checkbox box element.                       |
-| `--table-checkbox-border`                     | `2px solid #9ca3af`              | border           | Border of the unchecked checkbox.                                          |
-| `--table-checkbox-border-radius`              | `4px`                            | border-radius    | Border radius of the checkbox box. Falls back to `--radius` when unset.    |
-| `--table-checkbox-background`                 | `transparent`                    | background-color | Background of the unchecked checkbox.                                      |
-| `--table-checkbox-hover-border-color`         | `#6b7280`                        | border-color     | Border color of the checkbox on hover (when not disabled).                 |
-| `--table-checkbox-checked-background`         | `#2563eb`                        | background-color | Background of the checked checkbox.                                        |
-| `--table-checkbox-checked-border-color`       | `#2563eb`                        | border-color     | Border color of the checked checkbox.                                      |
+| Variable                                      | Default                          | CSS Property     | Description                                                                                                                                       |
+| --------------------------------------------- | -------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--table-checkbox-col-width`                  | `44px`                           | width            | Width of the checkbox column header and data cells.                                                                                               |
+| `--table-checkbox-col-padding`                | `12px 12px`                      | padding          | Padding of the checkbox column cells.                                                                                                             |
+| `--table-checkbox-size`                       | `18px`                           | width, height    | Size (width and height) of the checkbox box element.                                                                                              |
+| `--table-checkbox-border`                     | `2px solid #9ca3af`              | border           | Border of the unchecked checkbox.                                                                                                                 |
+| `--table-checkbox-border-radius`              | `4px`                            | border-radius    | Border radius of the checkbox box. Falls back to `--radius` when unset.                                                                           |
+| `--table-checkbox-background`                 | `transparent`                    | background-color | Background of the unchecked checkbox.                                                                                                             |
+| `--table-checkbox-hover-border-color`         | `#6b7280`                        | border-color     | Border color of the checkbox on hover (when not disabled).                                                                                        |
+| `--table-checkbox-checked-background`         | `#2563eb`                        | background-color | Background of the checked checkbox.                                                                                                               |
+| `--table-checkbox-checked-border-color`       | `#2563eb`                        | border-color     | Border color of the checked checkbox.                                                                                                             |
 | `--table-checkbox-checked-border`             | `2px solid #2563eb`              | border           | Whole border of the checked checkbox. Set it when the checked width must differ from `2px`; it wins over `--table-checkbox-checked-border-color`. |
-| `--table-checkbox-indeterminate-background`   | `#2563eb`                        | background-color | Background of the header checkbox in indeterminate (partial-select) state. |
-| `--table-checkbox-indeterminate-border-color` | `#2563eb`                        | border-color     | Border color of the header checkbox in indeterminate state.                |
-| `--table-checkbox-indeterminate-border`       | `2px solid #2563eb`              | border           | Whole border of the header checkbox in indeterminate state; wins over `--table-checkbox-indeterminate-border-color`. |
-| `--table-checkbox-disabled-opacity`           | `0.4`                            | opacity          | Opacity of a disabled checkbox row.                                        |
-| `--table-checkbox-focus-ring`                 | `0 0 0 3px rgba(59,130,246,0.3)` | box-shadow       | Focus ring shown on the checkbox element when focused via keyboard.        |
-| `--table-checkbox-icon-size`                  | `12px`                           | width, height    | Size of the checkmark / minus SVG icon inside the checkbox box.            |
-| `--table-checkbox-icon-color`                 | `#ffffff`                        | color            | Color of the checkmark / minus icon.                                       |
+| `--table-checkbox-indeterminate-background`   | `#2563eb`                        | background-color | Background of the header checkbox in indeterminate (partial-select) state.                                                                        |
+| `--table-checkbox-indeterminate-border-color` | `#2563eb`                        | border-color     | Border color of the header checkbox in indeterminate state.                                                                                       |
+| `--table-checkbox-indeterminate-border`       | `2px solid #2563eb`              | border           | Whole border of the header checkbox in indeterminate state; wins over `--table-checkbox-indeterminate-border-color`.                              |
+| `--table-checkbox-disabled-opacity`           | `0.4`                            | opacity          | Opacity of a disabled checkbox row.                                                                                                               |
+| `--table-checkbox-focus-ring`                 | `0 0 0 3px rgba(59,130,246,0.3)` | box-shadow       | Focus ring shown on the checkbox element when focused via keyboard.                                                                               |
+| `--table-checkbox-icon-size`                  | `12px`                           | width, height    | Size of the checkmark / minus SVG icon inside the checkbox box.                                                                                   |
+| `--table-checkbox-icon-color`                 | `#ffffff`                        | color            | Color of the checkmark / minus icon.                                                                                                              |
 
 ### Search Bar
 
@@ -761,12 +762,12 @@ each one.
 
 ```ts
 type TableLabels = {
-  sortBy?: (header: string) => string;        // default: `Sort by ${header}`
-  filterBy?: (header: string) => string;      // default: `Filter by ${header}`
-  selectRow?: (rowId: string) => string;      // default: `Select row ${rowId || 'non-selectable'}`
-  selectAllRows?: string;                     // default: 'Select all rows'
-  clearSearch?: string;                       // default: 'Clear search'
-  closeSearch?: string;                       // default: 'Close search'
+  sortBy?: (header: string) => string; // default: `Sort by ${header}`
+  filterBy?: (header: string) => string; // default: `Filter by ${header}`
+  selectRow?: (rowId: string) => string; // default: `Select row ${rowId || 'non-selectable'}`
+  selectAllRows?: string; // default: 'Select all rows'
+  clearSearch?: string; // default: 'Clear search'
+  closeSearch?: string; // default: 'Close search'
 };
 ```
 
@@ -790,7 +791,6 @@ while leaving the filter trigger and the search buttons in English.
 
 `Search` is not here. The search input has always been named by
 `searchConfig.placeholder`, which is the right place for it.
-
 
 ```typescript
 type SortDirection = 'asc' | 'desc';

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -1188,11 +1188,18 @@
   }
 
   /* ── Container ──────────────────────────────────────────────────────────── */
+  /* `hidden` is the default because it is what clips the table's corners to
+     this element's border-radius; without it the first and last cells square
+     off over the rounded border. A consumer who needs the container itself to
+     scroll sideways sets this to `auto` and accepts that trade. Note the
+     scrollable variant below sets `overflow-y`, and per the CSS overflow spec
+     a `visible` on one axis computes to `auto` when the other is not visible,
+     so `visible` here does not survive on a scrollable table. */
   .table-container {
     border: var(--table-border, 1px solid #e5e7eb);
     border-radius: var(--table-border-radius, var(--radius, 4px));
     width: var(--table-container-width, 100%);
-    overflow: hidden;
+    overflow: var(--table-container-overflow, hidden);
   }
 
   .scrollable-table {

--- a/tests/table-container-overflow.spec.ts
+++ b/tests/table-container-overflow.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './support/hydrated';
+
+/*
+ * `.table-container` was hard-coded `overflow: hidden`, which exists to clip the
+ * table's corners to the container's `border-radius`. The scrollable variant
+ * adds `overflow-y: auto` on top, so the vertical axis had a seam and the
+ * horizontal one had none -- a consumer wanting a wide table to scroll sideways
+ * had to reach into `.table-container` from their own stylesheet, which is what
+ * this replaces.
+ *
+ * The default stays `hidden`, so nothing about an existing table changes.
+ */
+test.describe('Table container overflow', () => {
+  test('defaults to hidden, which is what clips the rounded corners', async ({ page }) => {
+    await gotoHydrated(page, '/components/table');
+
+    const container = page.getByTestId('table-keyed-basic');
+    await expect(container).toHaveCSS('overflow-x', 'hidden');
+  });
+
+  test('a consumer can opt the container into horizontal scrolling', async ({ page }) => {
+    await gotoHydrated(page, '/components/table');
+    await page.addStyleTag({
+      content: '[data-pw="table-keyed-basic"] { --table-container-overflow: auto; }'
+    });
+
+    const container = page.getByTestId('table-keyed-basic');
+    await expect(container).toHaveCSS('overflow-x', 'auto');
+  });
+});


### PR DESCRIPTION
`.table-container` was hard-coded `overflow: hidden`. That default is load
bearing -- it is what clips the first and last cells to the container's
`border-radius`, and without it they square off over the rounded border -- but
it was also the only option, so a consumer wanting a wide table to scroll
sideways in the container had to reach past the component and restyle
`.table-container` from their own stylesheet.

The vertical axis already had a seam: `isTableScrollable` adds `overflow-y:
auto` with `--table-container-height`. The horizontal one had none. This adds
`--table-container-overflow`, defaulting to `hidden`, so every existing table
renders exactly as before and `auto` is now expressible without reaching in.

Found while auditing a consumer's stylesheet against this library's actual API.
That app carries 68 CSS references into 21 Select and Table internals, and this
is the only one of them that turned out to be a real gap -- `.select-dropdown`'s
`z-index`/`width`/`min-width`/`margin-top` all already have documented custom
properties on that exact selector, sticky headers are already a `stickyHeader`
prop, and the header-bar spacing that app was chasing is already
`--table-toolbar-gap`/`-padding`/`-margin-bottom`. The rest of that audit is a
documentation problem, not a missing-API one, and is not in this PR.

One interaction is worth knowing and is in the comment rather than left to be
discovered: the scrollable variant sets `overflow-y`, and per the CSS overflow
spec `visible` on one axis computes to `auto` when the other axis is not
visible. So `visible` does not survive on a scrollable table. `hidden` and
`auto` behave as written.

Verified red-green rather than by the suite going green: with the property
still hard-coded, the opt-in case fails and the default case passes; after the
change both pass. That ordering matters here, because a test that only asserted
the default would have passed against the bug.

Gate on this commit: prettier clean, eslint 0, event-casing 0, svelte-check 0
errors across both tsconfigs, and the new spec 2/2 under Playwright.